### PR TITLE
feat: add focusEditor function and enhance Input component integration in Chat view

### DIFF
--- a/src/components/Chat/Input.svelte
+++ b/src/components/Chat/Input.svelte
@@ -27,6 +27,12 @@ let files: File[] = $state([]);
 
 const models = useAvailableModels();
 
+export function focusEditor() {
+	requestAnimationFrame(() => {
+		markdownEditor?.focus();
+	});
+}
+
 onMount(() => {
 	// Initialize the markdown editor once the container is ready
 	if (editorContainer) {
@@ -47,6 +53,7 @@ function initializeEditor() {
 		value: inputValue,
 		placeholder: "Type a message...",
 		cls: "chat-markdown-editor",
+		enterVimInsertMode: true,
 		onChange: (value) => {
 			inputValue = value;
 		},

--- a/src/views/Chat/Chat.svelte
+++ b/src/views/Chat/Chat.svelte
@@ -12,11 +12,25 @@ const messenger = getMessenger();
 
 let isInputFocused = $state(false);
 let messageContainer: ReturnType<typeof MessageContainer>;
+let input: ReturnType<typeof Input>;
+let lastSessionId: string | null = null;
+
+$effect(() => {
+	const sessionId = messenger?.session?.id ?? null;
+	if (!sessionId || sessionId === lastSessionId) return;
+	lastSessionId = sessionId;
+	input?.focusEditor();
+});
 </script>
 
 <QueryClientProvider client={plugin.queryClient}>
     <div class="chat-root h-full flex flex-col">
         <MessageContainer bind:this={messageContainer} messenger={messenger!!} {isInputFocused} />
-        <Input messenger={messenger!!} onFocusChange={(focused) => isInputFocused = focused} onMessageSent={() => messageContainer.scrollToLatestMessage()} />
+        <Input
+            bind:this={input}
+            messenger={messenger!!}
+            onFocusChange={(focused) => isInputFocused = focused}
+            onMessageSent={() => messageContainer.scrollToLatestMessage()}
+        />
     </div>
 </QueryClientProvider>


### PR DESCRIPTION
Resolves #226 
- Introduced focusEditor function in Input.svelte to programmatically focus the markdown editor.
- Updated Chat.svelte to bind the Input component and trigger focusEditor on session change.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._