### PR TITLE
feat: enhance plugin prompt management and system prompt customization

### DIFF
--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -1,4 +1,10 @@
-export const createSystemPrompt = (hasChartsPlugin: boolean) => `# Role
+import type { PluginPromptExtension } from "../types/plugin";
+
+/**
+ * Base system prompt - core instructions without plugin-specific content.
+ * Plugin extensions are appended at runtime based on what's installed and enabled.
+ */
+export const BASE_SYSTEM_PROMPT = `# Role
 You are a privacy-aware assistant integrated into Obsidian. You help users search and understand their notes.
 
 # Important Formatting Rules
@@ -13,30 +19,32 @@ You are a privacy-aware assistant integrated into Obsidian. You help users searc
 - **read_note**: Reads the full content of a specific note. Use only after identifying it as relevant.
 - **get_all_tags**: Discovers available tags in the vault.
 - **get_properties**: Retrieves frontmatter properties from notes or discovers available property keys.
-- **execute_dataview_query**: Executes Dataview DQL queries for data analysis.
 
 # Strategy for Finding Notes
 1. **Unknown Organization**: If the user asks for a category of notes (e.g. "daily notes", "meetings", "books", "ideas") and you don't know how they are organized:
    - Call \`get_all_tags\` FIRST to check if a relevant tag exists (e.g. #daily, #meeting, #book).
    - ALSO call \`get_properties\` and omit 'note_name' to check if there are relevant frontmatter properties (e.g. "type", "category", "status").
-   - If you find a matching tag or property, use it to filter your Dataview query.
+   - If you find a matching tag or property, use it to filter your search or query.
    - If no relevant tag or property is found, call \`search_notes\` with a broad term to find example files and see their paths/names/properties.
    - **Do NOT guess** tag names, property keys, or folder paths without verifying first.
 
-2. **Verification**: Before constructing a Dataview query, ALWAYS verify which tags, properties, folders, or keywords actually exist using the steps above.
+2. **Verification**: Before constructing any query, ALWAYS verify which tags, properties, folders, or keywords actually exist using the steps above.
 
 3. **Reading Content**:
    - \`search_notes\` will give you a list of potential matches with metadata.
-   - If you need to read the full content of a note to answer a question, use \`read_note\` with the specific file path from the search results.
-   - If you need to aggregate data (e.g. list tasks, summarize properties), prefer using \`execute_dataview_query\`.
+   - If you need to read the full content of a note to answer a question, use \`read_note\` with the specific file path from the search results.`;
 
-# Output Options for Dataview & Math
+/**
+ * Default prompt extension for Dataview plugin.
+ */
+export const DEFAULT_DATAVIEW_PROMPT = `# Dataview Integration
+The user has the Dataview plugin installed. You have access to the \`execute_dataview_query\` tool.
 
 ## Default Result Size
 Always include \`LIMIT 10\` in Dataview DQL (queries you show or run) unless the user asks for more or specifies a different limit.
 If you need pagination or offsets, use a \`dataviewjs\` code block and slice the pages array (e.g., \`.slice(offset, offset + limit)\`).
 
-## (Dataview DQL Cheat Sheet)
+## Dataview DQL Cheat Sheet
 - Query types: \`LIST\` or \`TABLE field1, field2\`
 - FROM sources: \`#tag\`, \`"Folder"\`, \`"path/to/file"\`
 - Exclusions: \`AND !#tag\`, \`AND !"Folder"\`
@@ -57,18 +65,23 @@ SORT file.mtime desc
 LIMIT 10
 \`\`\`
 
-
-## 1. Data Analysis
+## Data Analysis
 If you need to SEE the results to answer a question or perform analysis, use the \`execute_dataview_query\` tool (supports DQL only).
 
-## 2. Displaying Lists/Tables
+## Displaying Lists/Tables
 If you want to SHOW the user a list or table (e.g. 'List all my books'), simply output the Dataview DQL query in a markdown code block. The chat interface will render the result automatically.
 - Do NOT repeat the rendered results in plain text.
 - Do NOT tell the user to run the query in a note; it has already been run and rendered here.
+- When generating a view, introduce it as "Here is the list:" or "I have generated the view below:".`;
 
-${hasChartsPlugin
-    ? `## 3. Displaying Charts
-You can create charts using \`dataviewjs\`. The user has the \`obsidian-charts\` plugin installed, so you can output a \`dataviewjs\` code block that uses \`window.renderChart\`.
+/**
+ * Default prompt extension for Obsidian Charts plugin.
+ */
+export const DEFAULT_CHARTS_PROMPT = `# Charts Integration
+The user has the Obsidian Charts plugin installed. You can create charts using \`dataviewjs\`.
+
+## Displaying Charts
+Output a \`dataviewjs\` code block that uses \`window.renderChart\`.
 **Important**: \`window.renderChart\` takes exactly two arguments: the chart data object and the container element. The chart data object must follow the standard Chart.js format (type, data, options). Use Obsidian CSS variables (e.g., \`var(--interactive-accent)\`) for chart colors to match the theme.
 
 Example:
@@ -92,19 +105,57 @@ const chartData = {
 }
 window.renderChart(chartData, this.container);
 \`\`\`
-The chat interface will render this chart automatically.`
-    : ""
-  }
+The chat interface will render this chart automatically.`;
 
-## ${hasChartsPlugin ? "4" : "3"}. Math/LaTeX
-Supports MathJax rendering.
+/**
+ * Default prompt extension for Math/LaTeX rendering.
+ */
+export const DEFAULT_MATH_PROMPT = `# Math/LaTeX Support
+The chat supports MathJax rendering.
 - Use single dollar signs for inline math: $E=mc^2$
 - Use double dollar signs for block math:
   $$
-  \int x dx
+  \\int x dx
   $$
-- **IMPORTANT**: Do NOT wrap the math in markdown code blocks (like \`\`\`latex or \` ). The renderer needs the raw $ or $$ delimiters to detect and render the math.
+- **IMPORTANT**: Do NOT wrap the math in markdown code blocks (like \`\`\`latex or \`). The renderer needs the raw $ or $$ delimiters to detect and render the math.`;
 
-When generating a view (list, table${hasChartsPlugin ? ", or chart" : ""}) for the user, introduce it as "Here is the list:" or "I have generated the view below:", rather than telling the user to run or use the query.`;
+/**
+ * Registry of supported plugins with their default prompt extensions.
+ * pluginId must match the Obsidian plugin ID used in app.plugins.enabledPlugins
+ */
+export const DEFAULT_PLUGIN_EXTENSIONS: Record<string, PluginPromptExtension> = {
+  dataview: {
+    pluginId: "dataview",
+    displayName: "Dataview",
+    enabled: true,
+    prompt: DEFAULT_DATAVIEW_PROMPT,
+  },
+  "obsidian-charts": {
+    pluginId: "obsidian-charts",
+    displayName: "Obsidian Charts",
+    enabled: true,
+    prompt: DEFAULT_CHARTS_PROMPT,
+  },
+  "math-latex": {
+    pluginId: "math-latex",
+    displayName: "Math / LaTeX",
+    enabled: true,
+    prompt: DEFAULT_MATH_PROMPT,
+  },
+};
 
-export const AGENT_SYSTEM_PROMPT = createSystemPrompt(false); // Default for backward compatibility
+/**
+ * Legacy function for backward compatibility.
+ * @deprecated Use assembleSystemPrompt() from AgentManager instead.
+ */
+export const createSystemPrompt = (hasChartsPlugin: boolean) => {
+  let prompt = BASE_SYSTEM_PROMPT;
+  prompt += "\n\n" + DEFAULT_DATAVIEW_PROMPT;
+  if (hasChartsPlugin) {
+    prompt += "\n\n" + DEFAULT_CHARTS_PROMPT;
+  }
+  prompt += "\n\n" + DEFAULT_MATH_PROMPT;
+  return prompt;
+};
+
+export const AGENT_SYSTEM_PROMPT = createSystemPrompt(false);

--- a/src/components/modal/PluginExtensionModal.svelte
+++ b/src/components/modal/PluginExtensionModal.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+import { onDestroy, onMount } from "svelte";
+import { DEFAULT_PLUGIN_EXTENSIONS } from "../../agent/prompts";
+import { EmbeddableMarkdownEditor } from "../../lib/editor";
+import type SecondBrainPlugin from "../../main";
+import { getData } from "../../stores/dataStore.svelte";
+import Button from "../ui/Button.svelte";
+import type { PluginExtensionModal } from "./PluginExtensionModal";
+
+interface Props {
+	modal: PluginExtensionModal;
+	plugin: SecondBrainPlugin;
+	pluginId: string;
+	onSave: () => void;
+}
+
+const { modal, plugin, pluginId, onSave }: Props = $props();
+const pluginData = getData();
+
+const extension = $derived(pluginData.getPluginExtension(pluginId));
+const displayName = $derived(extension?.displayName ?? pluginId);
+const hasDefault = $derived(!!DEFAULT_PLUGIN_EXTENSIONS[pluginId]);
+
+// biome-ignore lint/style/useConst: Svelte bind:this requires let
+let editorContainer: HTMLDivElement | undefined = $state();
+let editor: EmbeddableMarkdownEditor | undefined = $state();
+let promptValue = $state("");
+
+onMount(() => {
+	if (editorContainer) {
+		initializeEditor();
+	}
+	// Set modal title
+	modal.setTitle(`Edit: ${displayName}`);
+});
+
+onDestroy(() => {
+	editor?.destroy();
+});
+
+function initializeEditor() {
+	if (!editorContainer) return;
+	const ext = pluginData.getPluginExtension(pluginId);
+	if (!ext) return;
+	promptValue = ext.prompt;
+	editor = new EmbeddableMarkdownEditor(plugin.app, editorContainer, {
+		value: promptValue,
+		placeholder: `Enter instructions for ${ext.displayName}...`,
+		cls: "plugin-extension-editor",
+		onChange: (value) => {
+			promptValue = value;
+		},
+	});
+}
+
+function handleSave() {
+	pluginData.setPluginExtensionPrompt(pluginId, promptValue);
+	onSave();
+	modal.close();
+}
+
+function handleResetToDefault() {
+	if (hasDefault) {
+		pluginData.resetPluginExtensionToDefault(pluginId);
+		promptValue = DEFAULT_PLUGIN_EXTENSIONS[pluginId].prompt;
+		editor?.setValue(promptValue);
+	}
+}
+</script>
+
+<div class="plugin-extension-modal-content">
+	<p class="plugin-extension-description">
+		Customize the prompt instructions for the {displayName} plugin.
+		{#if !plugin.agentManager.isPluginInstalled(pluginId)}
+			<span class="text-[--text-warning]">(Plugin not installed)</span>
+		{/if}
+	</p>
+	<div
+		bind:this={editorContainer}
+		class="plugin-extension-editor-container"
+	></div>
+	<div class="plugin-extension-actions">
+		{#if hasDefault}
+			<Button buttonText="Reset to Default" onClick={handleResetToDefault} />
+		{/if}
+		<div class="flex-1"></div>
+		<Button buttonText="Cancel" onClick={() => modal.close()} />
+		<Button buttonText="Save" cta={true} onClick={handleSave} />
+	</div>
+</div>
+
+<style>
+	.plugin-extension-modal-content {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+	}
+
+	.plugin-extension-description {
+		flex-shrink: 0;
+		margin: 0 0 12px 0;
+		color: var(--text-muted);
+		font-size: var(--font-ui-small);
+	}
+
+	.plugin-extension-editor-container {
+		flex: 1 1 auto;
+		min-height: 0;
+		overflow-y: auto;
+		border-radius: 12px;
+	}
+
+	.plugin-extension-editor-container :global(.cm-editor) {
+		height: 100%;
+		background: var(--background-secondary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 12px;
+		font-family: var(--font-text);
+		font-size: 0.95rem;
+	}
+
+	.plugin-extension-editor-container :global(.cm-editor.cm-focused) {
+		outline: none;
+		border-color: var(--interactive-accent);
+		box-shadow: 0 0 0 1px var(--interactive-accent);
+	}
+
+	.plugin-extension-editor-container :global(.cm-scroller) {
+		padding: 12px 14px;
+	}
+
+	.plugin-extension-editor-container :global(.cm-content) {
+		min-height: 150px;
+		caret-color: var(--text-normal);
+	}
+
+	.plugin-extension-editor-container :global(.cm-line) {
+		line-height: 1.6;
+	}
+
+	.plugin-extension-editor-container :global(.cm-placeholder) {
+		color: var(--text-muted);
+	}
+
+	.plugin-extension-actions {
+		flex-shrink: 0;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-top: 16px;
+	}
+</style>

--- a/src/components/modal/PluginExtensionModal.ts
+++ b/src/components/modal/PluginExtensionModal.ts
@@ -1,0 +1,64 @@
+import { Modal } from "obsidian";
+import { mount, unmount } from "svelte";
+import type SecondBrainPlugin from "../../main";
+import PluginExtensionModalComponent from "./PluginExtensionModal.svelte";
+
+export class PluginExtensionModal extends Modal {
+	private component: ReturnType<typeof PluginExtensionModalComponent> | null = null;
+	private plugin: SecondBrainPlugin;
+	private pluginId: string;
+	private onSave: () => void;
+
+	constructor(plugin: SecondBrainPlugin, pluginId: string, onSave: () => void) {
+		super(plugin.app);
+		this.plugin = plugin;
+		this.pluginId = pluginId;
+		this.onSave = onSave;
+	}
+
+	onOpen() {
+		// Set modal dimensions directly
+		this.modalEl.style.width = "min(1000px, 90vw)";
+		this.modalEl.style.maxWidth = "90vw";
+		this.modalEl.style.height = "60vh";
+		this.modalEl.style.display = "flex";
+		this.modalEl.style.flexDirection = "column";
+
+		// Make contentEl fill available space for flex layout
+		this.contentEl.style.display = "flex";
+		this.contentEl.style.flexDirection = "column";
+		this.contentEl.style.flex = "1";
+		this.contentEl.style.minHeight = "0";
+		this.contentEl.style.overflow = "hidden";
+
+		this.component = mount(PluginExtensionModalComponent, {
+			target: this.contentEl,
+			props: {
+				modal: this,
+				plugin: this.plugin,
+				pluginId: this.pluginId,
+				onSave: this.onSave,
+			},
+		});
+	}
+
+	onClose() {
+		this.modalEl.style.removeProperty("width");
+		this.modalEl.style.removeProperty("max-width");
+		this.modalEl.style.removeProperty("height");
+		this.modalEl.style.removeProperty("display");
+		this.modalEl.style.removeProperty("flex-direction");
+
+		this.contentEl.style.removeProperty("display");
+		this.contentEl.style.removeProperty("flex-direction");
+		this.contentEl.style.removeProperty("flex");
+		this.contentEl.style.removeProperty("min-height");
+		this.contentEl.style.removeProperty("overflow");
+
+		if (this.component) {
+			unmount(this.component);
+			this.component = null;
+		}
+		this.contentEl.empty();
+	}
+}

--- a/src/components/modal/SystemPromptModal.svelte
+++ b/src/components/modal/SystemPromptModal.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+import { onDestroy, onMount } from "svelte";
+import { EmbeddableMarkdownEditor } from "../../lib/editor";
+import type SecondBrainPlugin from "../../main";
+import { getData } from "../../stores/dataStore.svelte";
+import Button from "../ui/Button.svelte";
+import type { SystemPromptModal } from "./SystemPromptModal";
+
+interface Props {
+	modal: SystemPromptModal;
+	plugin: SecondBrainPlugin;
+}
+
+const { modal, plugin }: Props = $props();
+const pluginData = getData();
+
+// biome-ignore lint/style/useConst: Svelte bind:this requires let
+let editorContainer: HTMLDivElement | undefined = $state();
+let editor: EmbeddableMarkdownEditor | undefined = $state();
+let promptValue = $state(pluginData.systemPrompt);
+
+onMount(() => {
+	if (editorContainer) {
+		initializeEditor();
+	}
+});
+
+onDestroy(() => {
+	editor?.destroy();
+});
+
+function initializeEditor() {
+	if (!editorContainer) return;
+	promptValue = pluginData.systemPrompt;
+	editor = new EmbeddableMarkdownEditor(plugin.app, editorContainer, {
+		value: promptValue,
+		placeholder: "Define the system prompt for the assistant...",
+		cls: "system-prompt-editor",
+		onChange: (value) => {
+			promptValue = value;
+		},
+	});
+}
+
+function handleSave() {
+	pluginData.systemPrompt = promptValue;
+	plugin.agentManager?.updateSystemPrompt();
+	modal.close();
+}
+</script>
+
+<div class="system-prompt-modal-content">
+	<p class="system-prompt-description">
+		Customize the system instructions used for every chat.
+	</p>
+	<div
+		bind:this={editorContainer}
+		class="system-prompt-editor-container"
+	></div>
+	<div class="system-prompt-actions">
+		<Button buttonText="Cancel" onClick={() => modal.close()} />
+		<Button buttonText="Save" cta={true} onClick={handleSave} />
+	</div>
+</div>
+
+<style>
+	.system-prompt-modal-content {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0; /* Required for nested flex to shrink properly */
+	}
+
+	.system-prompt-description {
+		flex-shrink: 0;
+		margin: 0 0 12px 0;
+		color: var(--text-muted);
+		font-size: var(--font-ui-small);
+	}
+
+	.system-prompt-editor-container {
+		flex: 1 1 auto;
+		min-height: 0; /* Required for flex child to shrink below content */
+		overflow-y: auto;
+		border-radius: 12px;
+	}
+
+	.system-prompt-editor-container :global(.cm-editor) {
+		height: 100%;
+		background: var(--background-secondary);
+		border: 1px solid var(--background-modifier-border);
+		border-radius: 12px;
+		font-family: var(--font-text);
+		font-size: 0.95rem;
+	}
+
+	.system-prompt-editor-container :global(.cm-editor.cm-focused) {
+		outline: none;
+		border-color: var(--interactive-accent);
+		box-shadow: 0 0 0 1px var(--interactive-accent);
+	}
+
+	.system-prompt-editor-container :global(.cm-scroller) {
+		padding: 12px 14px;
+	}
+
+	.system-prompt-editor-container :global(.cm-content) {
+		min-height: 200px;
+		caret-color: var(--text-normal);
+	}
+
+	.system-prompt-editor-container :global(.cm-line) {
+		line-height: 1.6;
+	}
+
+	.system-prompt-editor-container :global(.cm-placeholder) {
+		color: var(--text-muted);
+	}
+
+	.system-prompt-actions {
+		flex-shrink: 0;
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		margin-top: 16px;
+	}
+</style>

--- a/src/components/modal/SystemPromptModal.ts
+++ b/src/components/modal/SystemPromptModal.ts
@@ -1,0 +1,59 @@
+import { Modal } from "obsidian";
+import { mount, unmount } from "svelte";
+import type SecondBrainPlugin from "../../main";
+import SystemPromptModalComponent from "./SystemPromptModal.svelte";
+
+export class SystemPromptModal extends Modal {
+	private component: ReturnType<typeof SystemPromptModalComponent> | null = null;
+	private plugin: SecondBrainPlugin;
+
+	constructor(plugin: SecondBrainPlugin) {
+		super(plugin.app);
+		this.plugin = plugin;
+		this.setTitle("System Prompt");
+	}
+
+	onOpen() {
+		// Set modal dimensions directly - more reliable than CSS selectors
+		this.modalEl.style.width = "min(1200px, 94vw)";
+		this.modalEl.style.maxWidth = "94vw";
+		this.modalEl.style.height = "70vh";
+		this.modalEl.style.display = "flex";
+		this.modalEl.style.flexDirection = "column";
+
+		// Make contentEl fill available space for flex layout
+		this.contentEl.style.display = "flex";
+		this.contentEl.style.flexDirection = "column";
+		this.contentEl.style.flex = "1";
+		this.contentEl.style.minHeight = "0";
+		this.contentEl.style.overflow = "hidden";
+
+		this.component = mount(SystemPromptModalComponent, {
+			target: this.contentEl,
+			props: {
+				modal: this,
+				plugin: this.plugin,
+			},
+		});
+	}
+
+	onClose() {
+		this.modalEl.style.removeProperty("width");
+		this.modalEl.style.removeProperty("max-width");
+		this.modalEl.style.removeProperty("height");
+		this.modalEl.style.removeProperty("display");
+		this.modalEl.style.removeProperty("flex-direction");
+
+		this.contentEl.style.removeProperty("display");
+		this.contentEl.style.removeProperty("flex-direction");
+		this.contentEl.style.removeProperty("flex");
+		this.contentEl.style.removeProperty("min-height");
+		this.contentEl.style.removeProperty("overflow");
+
+		if (this.component) {
+			unmount(this.component);
+			this.component = null;
+		}
+		this.contentEl.empty();
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { ChatView, VIEW_TYPE_CHAT } from "./views/chat/Chat";
 import SettingsTab from "./views/settings/Settings";
 
 // Re-export types for backward compatibility
-export type { PluginData, SearchAlgorithm, PluginDataKey } from "./types/plugin";
+export type { PluginData, PluginPromptExtension, SearchAlgorithm, PluginDataKey } from "./types/plugin";
 
 export default class SecondBrainPlugin extends Plugin {
 	agentManager!: AgentManager;

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -4,8 +4,25 @@ import type { ProviderConfigs } from "./providers";
 
 export type SearchAlgorithm = "grep" | "omnisearch" | "embeddings";
 
+/**
+ * Configuration for a plugin-specific prompt extension.
+ * These are appended to the base system prompt when the plugin is installed and enabled.
+ */
+export interface PluginPromptExtension {
+	/** Internal plugin ID (e.g., "dataview", "obsidian-charts") */
+	pluginId: string;
+	/** Display name shown in settings (e.g., "Dataview") */
+	displayName: string;
+	/** Whether this extension is enabled by the user */
+	enabled: boolean;
+	/** The prompt content for this plugin */
+	prompt: string;
+}
+
 export interface PluginData {
 	providerConfig: ProviderConfigs;
+	systemPrompt: string;
+	pluginPromptExtensions: Record<string, PluginPromptExtension>;
 	initialAssistantMessageContent: string;
 	isUsingRag: boolean;
 	isGeneratingChatTitle: boolean;

--- a/src/views/settings/GeneralSettings.svelte
+++ b/src/views/settings/GeneralSettings.svelte
@@ -1,129 +1,165 @@
 <script lang="ts">
-import { AnthropicLogo, OllamaLogo, OpenAILogo } from "@selemondev/svgl-svelte";
-import type { TFolder } from "obsidian";
-import { t } from "svelte-i18n";
-import { ExcludeFoldersModal } from "../../components/modal/ExcludeFoldersModal";
-import FolderSuggest from "../../components/modal/FolderSuggest.svelte";
-import SettingGroup from "../../components/settings/SettingGroup.svelte";
-import SettingItem from "../../components/settings/SettingItem.svelte";
-import Button from "../../components/ui/Button.svelte";
-import Dropdown from "../../components/ui/Dropdown.svelte";
-import Icon from "../../components/ui/Icon.svelte";
-import SearchableDropdown from "../../components/ui/SearchableDropdown.svelte";
-import Text from "../../components/ui/Text.svelte";
-import Toggle from "../../components/ui/Toggle.svelte";
-import { useAvailableModels } from "../../hooks/useAvailableModels.svelte";
-import type { SearchAlgorithm } from "../../main";
-import type { ChatModel } from "../../stores/chatStore.svelte";
-import { getData } from "../../stores/dataStore.svelte";
-import { getPlugin } from "../../stores/state.svelte";
+	import {
+		AnthropicLogo,
+		OllamaLogo,
+		OpenAILogo,
+	} from "@selemondev/svgl-svelte";
+	import type { TFolder } from "obsidian";
+	import { t } from "svelte-i18n";
+	import { ExcludeFoldersModal } from "../../components/modal/ExcludeFoldersModal";
+	import FolderSuggest from "../../components/modal/FolderSuggest.svelte";
+	import { PluginExtensionModal } from "../../components/modal/PluginExtensionModal";
+	import { SystemPromptModal } from "../../components/modal/SystemPromptModal";
+	import SettingGroup from "../../components/settings/SettingGroup.svelte";
+	import SettingItem from "../../components/settings/SettingItem.svelte";
+	import Button from "../../components/ui/Button.svelte";
+	import Dropdown from "../../components/ui/Dropdown.svelte";
+	import Icon from "../../components/ui/Icon.svelte";
+	import IconButton from "../../components/ui/IconButton.svelte";
+	import SearchableDropdown from "../../components/ui/SearchableDropdown.svelte";
+	import Text from "../../components/ui/Text.svelte";
+	import Toggle from "../../components/ui/Toggle.svelte";
+	import { useAvailableModels } from "../../hooks/useAvailableModels.svelte";
+	import type { SearchAlgorithm } from "../../main";
+	import type { ChatModel } from "../../stores/chatStore.svelte";
+	import { getData } from "../../stores/dataStore.svelte";
+	import { getPlugin } from "../../stores/state.svelte";
 
-const pluginData = getData();
-const plugin = getPlugin();
-const models = useAvailableModels();
+	const pluginData = getData();
+	const plugin = getPlugin();
+	const models = useAvailableModels();
 
-let fuzzySuggestModel = new ExcludeFoldersModal(plugin.app);
+	let fuzzySuggestModel = new ExcludeFoldersModal(plugin.app);
+	let systemPromptModal = new SystemPromptModal(plugin);
 
-function suggestFolders(): TFolder[] {
-	return plugin.app.vault.getAllFolders(true);
-}
+	// Plugin extensions - reactive list
+	const pluginExtensions = $derived(
+		Object.values(pluginData.pluginPromptExtensions),
+	);
 
-// Check if Omnisearch plugin is installed
-const isOmnisearchInstalled = $derived(
-	// @ts-ignore - Obsidian plugin API
-	!!plugin.app.plugins?.getPlugin?.("omnisearch"),
-);
-
-// Search algorithm options
-const searchAlgorithmOptions: {
-	display: string;
-	value: SearchAlgorithm;
-	disabled?: boolean;
-}[] = $derived([
-	{ display: $t("settings.search_algorithm.grep"), value: "grep" },
-	{
-		display: isOmnisearchInstalled
-			? $t("settings.search_algorithm.omnisearch")
-			: $t("settings.search_algorithm.omnisearch_not_installed"),
-		value: "omnisearch",
-		disabled: !isOmnisearchInstalled,
-	},
-	{
-		display: $t("settings.search_algorithm.embeddings"),
-		value: "embeddings",
-		disabled: true,
-	},
-]);
-
-// Use $derived to read from store - no local state sync needed
-let selectedSearchAlgorithm = $derived(pluginData.searchAlgorithm);
-
-// Handle search algorithm change with validation
-function handleSearchAlgorithmChange(value: SearchAlgorithm) {
-	if (value === "omnisearch" && !isOmnisearchInstalled) {
-		console.warn("Omnisearch selected but plugin not available, switching to grep");
-		pluginData.searchAlgorithm = "grep";
-		return;
+	function openExtensionModal(pluginId: string) {
+		const modal = new PluginExtensionModal(plugin, pluginId, () => {
+			plugin.agentManager?.updateSystemPrompt();
+		});
+		modal.open();
 	}
-	pluginData.searchAlgorithm = value;
-}
 
-// Model dropdown options - grouped by provider
-const modelOptions = $derived(
-	models.modelOptions.map((opt) => ({
-		label: opt.label,
-		value: opt.value,
-		group: opt.chatModel.provider,
-		chatModel: opt.chatModel,
-	})),
-);
+	function toggleExtension(pluginId: string, enabled: boolean) {
+		pluginData.setPluginExtensionEnabled(pluginId, enabled);
+		plugin.agentManager?.updateSystemPrompt();
+	}
 
-// Track selected model value
-let selectedModelValue = $state<string>("");
+	function isPluginInstalled(pluginId: string): boolean {
+		return plugin.agentManager?.isPluginInstalled(pluginId) ?? false;
+	}
 
-// Initialize from stored default chat model
-let _initialized = $state(false);
-$effect(() => {
-	if (_initialized) return;
-	const opts = models.modelOptions;
-	if (!opts.length) return;
+	function suggestFolders(): TFolder[] {
+		return plugin.app.vault.getAllFolders(true);
+	}
 
-	const sel = pluginData.getDefaultChatModel();
-	if (sel) {
-		const key = `${sel.provider}:${sel.model}`;
-		if (opts.some((o) => o.value === key)) {
-			selectedModelValue = key;
-			_initialized = true;
+	// Check if Omnisearch plugin is installed
+	const isOmnisearchInstalled = $derived(
+		// @ts-ignore - Obsidian plugin API
+		!!plugin.app.plugins?.getPlugin?.("omnisearch"),
+	);
+
+	// Search algorithm options
+	const searchAlgorithmOptions: {
+		display: string;
+		value: SearchAlgorithm;
+		disabled?: boolean;
+	}[] = $derived([
+		{ display: $t("settings.search_algorithm.grep"), value: "grep" },
+		{
+			display: isOmnisearchInstalled
+				? $t("settings.search_algorithm.omnisearch")
+				: $t("settings.search_algorithm.omnisearch_not_installed"),
+			value: "omnisearch",
+			disabled: !isOmnisearchInstalled,
+		},
+		{
+			display: $t("settings.search_algorithm.embeddings"),
+			value: "embeddings",
+			disabled: true,
+		},
+	]);
+
+	// Use $derived to read from store - no local state sync needed
+	let selectedSearchAlgorithm = $derived(pluginData.searchAlgorithm);
+
+	// Handle search algorithm change with validation
+	function handleSearchAlgorithmChange(value: SearchAlgorithm) {
+		if (value === "omnisearch" && !isOmnisearchInstalled) {
+			console.warn(
+				"Omnisearch selected but plugin not available, switching to grep",
+			);
+			pluginData.searchAlgorithm = "grep";
 			return;
 		}
+		pluginData.searchAlgorithm = value;
 	}
-	selectedModelValue = opts[0].value;
-	pluginData.setDefaultChatModel(opts[0].chatModel as ChatModel);
-	_initialized = true;
-});
 
-function handleModelSelect(value: string) {
-	selectedModelValue = value;
-	const opt = models.modelOptions.find((o) => o.value === value);
-	if (opt) pluginData.setDefaultChatModel(opt.chatModel as ChatModel);
-}
+	// Model dropdown options - grouped by provider
+	const modelOptions = $derived(
+		models.modelOptions.map((opt) => ({
+			label: opt.label,
+			value: opt.value,
+			group: opt.chatModel.provider,
+			chatModel: opt.chatModel,
+		})),
+	);
 
-// Helper to get provider from value
-function getProvider(value: string): string {
-	const opt = models.modelOptions.find((o) => o.value === value);
-	return opt?.chatModel.provider ?? "";
-}
+	// Track selected model value
+	let selectedModelValue = $state<string>("");
+
+	// Initialize from stored default chat model
+	let _initialized = $state(false);
+	$effect(() => {
+		if (_initialized) return;
+		const opts = models.modelOptions;
+		if (!opts.length) return;
+
+		const sel = pluginData.getDefaultChatModel();
+		if (sel) {
+			const key = `${sel.provider}:${sel.model}`;
+			if (opts.some((o) => o.value === key)) {
+				selectedModelValue = key;
+				_initialized = true;
+				return;
+			}
+		}
+		selectedModelValue = opts[0].value;
+		pluginData.setDefaultChatModel(opts[0].chatModel as ChatModel);
+		_initialized = true;
+	});
+
+	function handleModelSelect(value: string) {
+		selectedModelValue = value;
+		const opt = models.modelOptions.find((o) => o.value === value);
+		if (opt) pluginData.setDefaultChatModel(opt.chatModel as ChatModel);
+	}
+
+	// Helper to get provider from value
+	function getProvider(value: string): string {
+		const opt = models.modelOptions.find((o) => o.value === value);
+		return opt?.chatModel.provider ?? "";
+	}
 </script>
 
 <!-- Chat Settings -->
 <SettingGroup heading="Chat Settings">
-	<SettingItem name="Chats Folder" desc="Folder to store chat files and related data">
+	<SettingItem
+		name="Chats Folder"
+		desc="Folder to store chat files and related data"
+	>
 		<FolderSuggest
 			app={plugin.app}
 			value={pluginData.targetFolder}
 			placeholder="Chats"
 			suggestionFn={(q) =>
-				suggestFolders().filter((f) => f.path.toLowerCase().includes(q.toLowerCase()))}
+				suggestFolders().filter((f) =>
+					f.path.toLowerCase().includes(q.toLowerCase()),
+				)}
 			onSelected={(path: string) => (pluginData.targetFolder = path)}
 			onSubmit={(path: string) => (pluginData.targetFolder = path)}
 		/>
@@ -148,11 +184,16 @@ function getProvider(value: string): string {
 		/>
 	</SettingItem>
 
-	<SettingItem name="Default Chat Model" desc="Model selected by default for new chats">
+	<SettingItem
+		name="Default Chat Model"
+		desc="Model selected by default for new chats"
+	>
 		{#if !models.hasProviders || !models.hasModels}
 			<Button
 				onClick={models.openSettings}
-				buttonText={!models.hasProviders ? "Configure Provider" : "Configure Models"}
+				buttonText={!models.hasProviders
+					? "Configure Provider"
+					: "Configure Models"}
 				iconId="settings"
 			/>
 		{:else}
@@ -166,13 +207,29 @@ function getProvider(value: string): string {
 				{#snippet renderGroupHeader({ group })}
 					<div class="flex items-center gap-2">
 						{#if group === "OpenAI"}
-							<OpenAILogo style="fill: var(--text-muted)" height={12} width={12} />
+							<OpenAILogo
+								style="fill: var(--text-muted)"
+								height={12}
+								width={12}
+							/>
 						{:else if group === "Anthropic"}
-							<AnthropicLogo style="fill: var(--text-muted)" height={12} width={12} />
+							<AnthropicLogo
+								style="fill: var(--text-muted)"
+								height={12}
+								width={12}
+							/>
 						{:else if group === "Ollama"}
-							<OllamaLogo style="fill: var(--text-muted)" height={12} width={12} />
+							<OllamaLogo
+								style="fill: var(--text-muted)"
+								height={12}
+								width={12}
+							/>
 						{:else}
-							<Icon name="sparkles" size="xs" class="text-[--text-muted]" />
+							<Icon
+								name="sparkles"
+								size="xs"
+								class="text-[--text-muted]"
+							/>
 						{/if}
 						<span>{group}</span>
 					</div>
@@ -181,18 +238,34 @@ function getProvider(value: string): string {
 				{#snippet renderOption({ option, selected })}
 					<span class="flex-1">{option.label}</span>
 					{#if selected}
-						<Icon name="check" size="xs" class="text-[--text-accent]" />
+						<Icon
+							name="check"
+							size="xs"
+							class="text-[--text-accent]"
+						/>
 					{/if}
 				{/snippet}
 
 				{#snippet renderSelected({ option })}
 					{@const provider = getProvider(option.value)}
 					{#if provider === "OpenAI"}
-						<OpenAILogo style="fill: var(--text-normal)" height={14} width={14} />
+						<OpenAILogo
+							style="fill: var(--text-normal)"
+							height={14}
+							width={14}
+						/>
 					{:else if provider === "Anthropic"}
-						<AnthropicLogo style="fill: var(--text-normal)" height={14} width={14} />
+						<AnthropicLogo
+							style="fill: var(--text-normal)"
+							height={14}
+							width={14}
+						/>
 					{:else if provider === "Ollama"}
-						<OllamaLogo style="fill: var(--text-normal)" height={14} width={14} />
+						<OllamaLogo
+							style="fill: var(--text-normal)"
+							height={14}
+							width={14}
+						/>
 					{:else}
 						<Icon name="sparkles" size="xs" />
 					{/if}
@@ -201,11 +274,63 @@ function getProvider(value: string): string {
 			</SearchableDropdown>
 		{/if}
 	</SettingItem>
+
+	<SettingItem
+		name="System Prompt"
+		desc="Customize the base system instructions used for every chat."
+	>
+		<Button
+			buttonText="Edit Base Prompt"
+			onClick={() => systemPromptModal.open()}
+		/>
+	</SettingItem>
+</SettingGroup>
+
+<!-- Plugin Extensions -->
+<SettingGroup heading="Plugin Extensions">
+	<div class="setting-item-description mb-3">
+		Plugin-specific instructions are appended to your base prompt when the
+		plugin is installed and enabled.
+	</div>
+	{#each pluginExtensions as ext (ext.pluginId)}
+		{@const installed = isPluginInstalled(ext.pluginId)}
+		<div class="plugin-extension-item">
+			<div class="plugin-extension-info">
+				<div class="plugin-extension-header">
+					<span class="plugin-extension-name">{ext.displayName}</span>
+					{#if installed}
+						<span class="plugin-extension-badge installed"
+							>Installed</span
+						>
+					{:else}
+						<span class="plugin-extension-badge not-installed"
+							>Not installed</span
+						>
+					{/if}
+				</div>
+			</div>
+			<div class="plugin-extension-controls">
+				<Toggle
+					isToggled={ext.enabled}
+					changeFunc={() =>
+						toggleExtension(ext.pluginId, !ext.enabled)}
+				/>
+				<IconButton
+					icon="pencil"
+					label="Edit {ext.displayName} prompt"
+					onclick={() => openExtensionModal(ext.pluginId)}
+				/>
+			</div>
+		</div>
+	{/each}
 </SettingGroup>
 
 <!-- RAG Settings -->
 <SettingGroup heading="RAG Settings">
-	<SettingItem name={$t("settings.search_algorithm.title")} desc={$t("settings.search_algorithm.desc")}>
+	<SettingItem
+		name={$t("settings.search_algorithm.title")}
+		desc={$t("settings.search_algorithm.desc")}
+	>
 		<Dropdown
 			type="options"
 			dropdown={searchAlgorithmOptions}
@@ -214,15 +339,83 @@ function getProvider(value: string): string {
 		/>
 	</SettingItem>
 
-	<SettingItem name={$t("settings.autostart")} desc={$t("settings.autostart_desc")}>
-		<Toggle isToggled={pluginData.isAutostart} changeFunc={() => pluginData.toggleAutostart()} />
+	<SettingItem
+		name={$t("settings.autostart")}
+		desc={$t("settings.autostart_desc")}
+	>
+		<Toggle
+			isToggled={pluginData.isAutostart}
+			changeFunc={() => pluginData.toggleAutostart()}
+		/>
 	</SettingItem>
 
 	<SettingItem name="File Indexing" desc={$t("settings.excludeff_desc")}>
-		<Button onClick={() => fuzzySuggestModel.open()} buttonText="Manage Exclusions" />
+		<Button
+			onClick={() => fuzzySuggestModel.open()}
+			buttonText="Manage Exclusions"
+		/>
 	</SettingItem>
 
-	<SettingItem name={$t("settings.num_docs_retrieve")} desc={$t("settings.num_docs_retrieve_desc")}>
-		<Text inputType="number" value={100} onchange={(docNum) => console.log("Not set up")} />
+	<SettingItem
+		name={$t("settings.num_docs_retrieve")}
+		desc={$t("settings.num_docs_retrieve_desc")}
+	>
+		<Text
+			inputType="number"
+			value={100}
+			onchange={(docNum) => console.log("Not set up")}
+		/>
 	</SettingItem>
 </SettingGroup>
+
+<style>
+	.plugin-extension-item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 12px 0;
+		border-bottom: 1px solid var(--background-modifier-border);
+	}
+
+	.plugin-extension-item:last-child {
+		border-bottom: none;
+	}
+
+	.plugin-extension-info {
+		flex: 1;
+	}
+
+	.plugin-extension-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.plugin-extension-name {
+		font-weight: 500;
+	}
+
+	.plugin-extension-badge {
+		font-size: 0.7rem;
+		padding: 2px 6px;
+		border-radius: 4px;
+		text-transform: uppercase;
+		font-weight: 500;
+	}
+
+	.plugin-extension-badge.installed {
+		background: var(--background-modifier-success);
+		color: var(--text-on-accent);
+	}
+
+	.plugin-extension-badge.not-installed {
+		background: var(--background-modifier-border);
+		color: var(--text-muted);
+	}
+
+	.plugin-extension-controls {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+</style>


### PR DESCRIPTION
Resolves #220
- Added support for plugin-specific prompt extensions, allowing dynamic assembly of prompts based on installed plugins.
- Introduced methods for managing plugin extensions, including enabling/disabling and editing prompts.
- Updated the system prompt to utilize a base prompt and append relevant plugin extensions.
- Enhanced settings UI to allow users to customize the base system prompt and manage plugin extensions directly.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._