### PR TITLE
feat: rename/delete context menu items for .chat files

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -1073,6 +1073,11 @@ export class AgentManager {
 		await this.chatManager.delete(this.normalizeThreadId(threadId));
 	}
 
+	/** Rename the chat thread's file to `title`. Returns the new vault path, or `undefined` on failure. */
+	async renameThread(threadId: string, title: string): Promise<string | undefined> {
+		return this.chatManager.renameChatFile(this.normalizeThreadId(threadId), title);
+	}
+
 	async setLastViewedCheckpoint(threadId: string, checkpointId: string): Promise<void> {
 		const snapshot = await this.chatManager.read(this.normalizeThreadId(threadId), true);
 		if (!snapshot) return;

--- a/src/components/modal/PromptModal.ts
+++ b/src/components/modal/PromptModal.ts
@@ -1,0 +1,79 @@
+import { type App, Modal } from "obsidian";
+
+/**
+ * Obsidian-native single-line text prompt that replaces `window.prompt()`.
+ * Resolves to the trimmed input value on confirm, or `null` on cancel/close.
+ */
+export class PromptModal extends Modal {
+	private resolved = false;
+	private resolve!: (value: string | null) => void;
+	readonly promise: Promise<string | null>;
+
+	constructor(
+		app: App,
+		private readonly title: string,
+		private readonly initialValue = "",
+		private readonly confirmLabel = "Confirm",
+	) {
+		super(app);
+		this.promise = new Promise<string | null>((resolve) => {
+			this.resolve = resolve;
+		});
+	}
+
+	onOpen(): void {
+		this.setTitle(this.title);
+
+		const input = this.contentEl.createEl("input", {
+			type: "text",
+			value: this.initialValue,
+		});
+		input.classList.add("s2b-prompt-input");
+		input.style.width = "100%";
+		input.focus();
+		input.select();
+
+		const submit = () => {
+			const value = input.value.trim();
+			if (!value) return;
+			this.resolved = true;
+			this.resolve(value);
+			this.close();
+		};
+
+		input.addEventListener("keydown", (evt) => {
+			if (evt.key === "Enter") {
+				evt.preventDefault();
+				submit();
+			}
+		});
+
+		const buttonRow = this.contentEl.createDiv({ cls: "modal-button-container" });
+
+		buttonRow.createEl("button", { text: "Cancel" }).addEventListener("click", () => {
+			this.resolved = true;
+			this.resolve(null);
+			this.close();
+		});
+
+		buttonRow.createEl("button", { text: this.confirmLabel, cls: "mod-cta" }).addEventListener("click", submit);
+	}
+
+	onClose(): void {
+		if (!this.resolved) {
+			this.resolve(null);
+		}
+	}
+}
+
+/** Show an Obsidian-native text prompt. Resolves to the trimmed value or `null`. */
+export function promptText(
+	app: App,
+	title: string,
+	initialValue = "",
+	confirmLabel = "Confirm",
+): Promise<string | null> {
+	const modal = new PromptModal(app, title, initialValue, confirmLabel);
+	modal.open();
+	return modal.promise;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { MarkdownView, Notice, Plugin, TFile, WorkspaceLeaf } from "obsidian";
+import { MarkdownView, Menu, Notice, Plugin, TFile, WorkspaceLeaf } from "obsidian";
 import "./lib/i18n";
 import { Logger as Log } from "./utils/logging";
 import "./styles.css";
@@ -8,6 +8,8 @@ import { selectionHighlightPlugin } from "./editor/selectionHighlightExtension";
 import { createReadingViewDiffPostProcessor } from "./editor/readingViewDiffProcessor";
 import { terminateWorker as terminateClusteringWorker } from "./utils/computeWorkerManager";
 import { SearchModal } from "./components/modal/SearchModal";
+import { confirmDelete } from "./components/modal/ConfirmModal";
+import { promptText } from "./components/modal/PromptModal";
 import { getQueryClient } from "./lib/query";
 import { SkillsService } from "./skills";
 import { createMessenger, getMessenger } from "./stores/chatStore.svelte";
@@ -48,6 +50,39 @@ export default class SecondBrainPlugin extends Plugin {
 			return "Add to Chat";
 		}
 		return `Add ${selectedCount} files to Chat`;
+	}
+
+	/** Add rename/delete actions to the right-click menu of a `.chat` file. */
+	private addChatFileMenuItems(menu: Menu, file: TFile): void {
+		menu.addItem((item) =>
+			item
+				.setTitle("Rename chat")
+				.setIcon("pencil")
+				.onClick(async () => {
+					const newTitle = await promptText(this.app, "Rename chat", file.basename, "Rename");
+					if (!newTitle || newTitle === file.basename) return;
+					try {
+						await this.agentManager.renameThread(file.path, newTitle);
+					} catch (error) {
+						new Notice(`Failed to rename chat: ${error instanceof Error ? error.message : String(error)}`);
+					}
+				}),
+		);
+
+		menu.addItem((item) =>
+			item
+				.setTitle("Delete chat")
+				.setIcon("trash")
+				.onClick(async () => {
+					const confirmed = await confirmDelete(this.app, file.basename);
+					if (!confirmed) return;
+					try {
+						await this.agentManager.deleteThread(file.path);
+					} catch (error) {
+						new Notice(`Failed to delete chat: ${error instanceof Error ? error.message : String(error)}`);
+					}
+				}),
+		);
 	}
 
 	private registerNotebookNavigatorMenus() {
@@ -308,6 +343,12 @@ export default class SecondBrainPlugin extends Plugin {
 			this.app.workspace.on("file-menu", (menu, file) => {
 				if (!(file instanceof TFile)) return;
 
+				// .chat files get chat-specific actions instead of "Add to Chat".
+				if (file.extension === "chat") {
+					this.addChatFileMenuItems(menu, file);
+					return;
+				}
+
 				menu.addItem((item) =>
 					item
 						.setTitle(this.getAddToChatMenuLabel(1))
@@ -330,13 +371,17 @@ export default class SecondBrainPlugin extends Plugin {
 				const selectedFiles = files.filter((file): file is TFile => file instanceof TFile);
 				if (selectedFiles.length === 0) return;
 
+				// Don't offer "Add to Chat" when the selection is only chat files.
+				const attachableFiles = selectedFiles.filter((file) => file.extension !== "chat");
+				if (attachableFiles.length === 0) return;
+
 				menu.addItem((item) =>
 					item
-						.setTitle(this.getAddToChatMenuLabel(selectedFiles.length))
+						.setTitle(this.getAddToChatMenuLabel(attachableFiles.length))
 						.setIcon("message-square-plus")
 						.onClick(async () => {
 							try {
-								await this.queueFilesForChatAttachment(selectedFiles);
+								await this.queueFilesForChatAttachment(attachableFiles);
 							} catch (error) {
 								new Notice(
 									`Failed to add files to chat: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## What

Adds right-click context menu items for `.chat` files in the file explorer.

- **Rename chat** — prompts for a new title (Obsidian-native `PromptModal`) and renames via `ObsidianChatManager.renameChatFile` (updates the thread key + file path).
- **Delete chat** — confirms via the existing `confirmDelete` modal, then removes the thread + file via `AgentManager.deleteThread`.

Previously `.chat` files showed the generic **Add to Chat** item, which never made sense for a chat file. That item is now:
- **hidden** on `.chat` files (single-file `file-menu`), replaced by the two actions above;
- **filtered out** of the multi-select `files-menu` (only non-`.chat` files count toward "Add to Chat").

## How

- New `src/components/modal/PromptModal.ts` — plain-DOM text prompt mirroring the style of `ConfirmModal.ts`. Resolves trimmed value or `null`.
- New `AgentManager.renameThread(threadId, title)` passthrough to `chatManager.renameChatFile`.
- New private `SecondBrainPlugin.addChatFileMenuItems(menu, file)` wired into the existing `file-menu` handler in `src/main.ts`.

## Verification

- `bun run format` — clean.
- `bun run check` — no errors in the touched files (`main.ts`, `AgentManager.ts`, `PromptModal.ts`). The 5 reported errors are pre-existing in untouched files (`pendingChangesStore.svelte.ts`, `GraphCanvas.svelte`).
- Bundle transforms all modules successfully. Note: a full `bun run build` can't complete from a git worktree because `src/providers/langchainOpenAIResponses.ts` imports via a relative `../../node_modules/...` path and worktrees have no `node_modules` — unrelated to this change.

Manual live-vault verification (right-click a `.chat` file, exercise rename/delete) still recommended before merge.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._