### PR TITLE
feat: dev-only Developer settings tab to replay onboarding intro

### DIFF
--- a/src/views/settings/DeveloperSettings.svelte
+++ b/src/views/settings/DeveloperSettings.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+import { Notice } from "obsidian";
+import SettingGroup from "../../components/settings/SettingGroup.svelte";
+import SettingItem from "../../components/settings/SettingItem.svelte";
+import Button from "../../components/ui/Button.svelte";
+import { getData } from "../../stores/dataStore.svelte";
+import { getPlugin } from "../../stores/state.svelte";
+
+const pluginData = getData();
+const plugin = getPlugin();
+
+function replayOnboardingIntro() {
+	pluginData.onboardingSplashSeen = false;
+	new Notice("Onboarding intro reset — it will play again next time the Welcome view opens.");
+}
+
+function openOnboardingView() {
+	void plugin.activateOnboardingView();
+}
+</script>
+
+<!-- Onboarding -->
+<SettingGroup heading="Onboarding">
+  <SettingItem
+    name="Replay onboarding intro"
+    desc="Reset the splash animation flag so the Welcome view plays its intro again the next time it opens."
+  >
+    <div class="flex gap-2 flex-wrap">
+      <Button buttonText="Reset intro" iconId="rotate-ccw" onClick={replayOnboardingIntro} />
+      <Button buttonText="Open Welcome view" iconId="zap" onClick={openOnboardingView} />
+    </div>
+  </SettingItem>
+</SettingGroup>

--- a/src/views/settings/Settings.svelte
+++ b/src/views/settings/Settings.svelte
@@ -3,6 +3,7 @@ import { Tabs } from "bits-ui";
 import { consumePendingSettingsTab } from "../../stores/state.svelte";
 import { icon } from "../../utils/utils";
 import AgentsSettings from "./AgentsSettings.svelte";
+import DeveloperSettings from "./DeveloperSettings.svelte";
 import GeneralSettings from "./GeneralSettings.svelte";
 import GraphSettings from "./GraphSettings.svelte";
 import SearchSettings from "./SearchSettings.svelte";
@@ -70,6 +71,17 @@ let activeTab = $state(pendingTab ?? "general");
         <span>Troubleshooting</span>
       </span>
     </Tabs.Trigger>
+    {#if import.meta.env.DEV}
+      <Tabs.Trigger
+        value="developer"
+        class="px-3 py-1.5 text-sm font-medium rounded-md border border-transparent transition-colors data-[state=active]:bg-[--interactive-accent] data-[state=active]:text-[--text-on-accent] data-[state=inactive]:text-[--text-muted] data-[state=inactive]:hover:bg-[--background-modifier-hover] data-[state=inactive]:hover:text-[--text-normal]"
+      >
+        <span class="settings-tab-label">
+          <span class="settings-tab-icon" use:icon={"code"} aria-hidden="true"></span>
+          <span>Developer</span>
+        </span>
+      </Tabs.Trigger>
+    {/if}
   </Tabs.List>
 
   <Tabs.Content value="general">
@@ -91,6 +103,12 @@ let activeTab = $state(pendingTab ?? "general");
   <Tabs.Content value="troubleshooting">
     <TroubleshootingSettings />
   </Tabs.Content>
+
+  {#if import.meta.env.DEV}
+    <Tabs.Content value="developer">
+      <DeveloperSettings />
+    </Tabs.Content>
+  {/if}
 </Tabs.Root>
 
 <style>


### PR DESCRIPTION
## What

Adds a **Developer** settings tab, gated behind `import.meta.env.DEV` so it only exists in development builds and is tree-shaken out of production.

It provides:
- **Reset intro** — resets the persisted `onboardingSplashSeen` flag so the Welcome view plays its splash intro again on next open.
- **Open Welcome view** — shortcut to open the onboarding view immediately.

## Why

The onboarding splash intro plays only on first open (gated by `onboardingSplashSeen`). During development there was previously no way to re-watch it short of hand-editing plugin data. This gives a one-click reset.

## Implementation notes

- New `src/views/settings/DeveloperSettings.svelte` reuses the standard `SettingGroup`/`SettingItem`/`Button` primitives (same as `TroubleshootingSettings.svelte`).
- Registered in `Settings.svelte` with both the `Tabs.Trigger` and `Tabs.Content` wrapped in `{#if import.meta.env.DEV}` — same dev-gate mechanism already used in `GraphControls.svelte`.

## Verification

- `bun run check` / `format` clean.
- Dev build (`--mode development`): dev string present in bundle; reset setter verified live (`onboardingSplashSeen` toggles `true → false`); `dev:errors` clean.
- **Prod build (`bun run build`): dev-only strings `grep -c` = 0 — fully tree-shaken, confirming it does not ship.**

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._