### PR TITLE
fix: address critical/high findings from codebase review

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -1,7 +1,7 @@
 import type { BaseMessage } from "@langchain/core/messages";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { Notice, normalizePath, TFile } from "obsidian";
-import { createObsidianFetch } from "../lib/obsidianFetch";
+import { installObsidianFetch } from "../lib/obsidianFetch";
 import { invalidateProviderState } from "../lib/query";
 import type SecondBrainPlugin from "../main";
 import type { ChatModel } from "../stores/chatStore.svelte";
@@ -271,6 +271,17 @@ export class AgentManager {
 	private readonly plugin: SecondBrainPlugin;
 	private agent: Agent | null = null;
 	private deferredSetup: Promise<void> | null = null;
+	/**
+	 * In-flight `initialize()` run, if any. `ensureAgent()` (lazy init on first
+	 * chat open) and the deferred `initialize()` in main.ts's `onLayoutReady` can
+	 * fire concurrently on a cold start; without this guard both would run the
+	 * full teardown-and-rebuild (`this.agent = null` + `registry.clear()`)
+	 * interleaved, clobbering each other and possibly leaving a half-configured
+	 * agent. Concurrent callers share this promise instead. */
+	private initPromise: Promise<void> | null = null;
+	/** Long-lived ref-counted global-fetch patch for MCP tool transport, held for
+	 * the manager's lifetime and released in cleanup(). */
+	private mcpFetchPatch: { release: () => void } | null = null;
 	/** MCP tools memoized per agent id (network handshake — see ensureMCPToolsForAgent). */
 	private readonly mcpToolsByAgent = new Map<string, StructuredToolInterface[]>();
 	/** In-flight MCP handshake promises — deduplicates concurrent callers for the same agent. */
@@ -933,10 +944,13 @@ export class AgentManager {
 			const mcpConfig = { mcpServers } as ConstructorParameters<typeof MultiServerMCPClient>[0];
 			Logger.log("Initializing MCP client...", mcpConfig);
 
-			const globalWithFetch = globalThis as typeof globalThis & { _originalFetch?: typeof fetch };
-			if (!globalWithFetch._originalFetch) {
-				globalWithFetch._originalFetch = globalThis.fetch;
-				globalThis.fetch = createObsidianFetch(globalWithFetch._originalFetch);
+			// Patch global fetch once for the manager's lifetime — MCP tools read
+			// `globalThis.fetch` both here (getTools) and later at invocation time,
+			// so the patch must outlive this call. Ref-counted so it composes
+			// safely with other installers (e.g. the settings modal's probe) and
+			// is released exactly once in cleanup().
+			if (!this.mcpFetchPatch) {
+				this.mcpFetchPatch = installObsidianFetch();
 			}
 
 			try {
@@ -988,6 +1002,18 @@ export class AgentManager {
 	}
 
 	async initialize(): Promise<void> {
+		// Dedupe concurrent callers (lazy `ensureAgent` vs. the deferred
+		// onLayoutReady init) onto a single in-flight run. Without this the
+		// teardown-and-rebuild below would interleave and corrupt agent/registry
+		// state. `reinitialize()` deliberately runs a fresh pass after this one.
+		if (this.initPromise) return this.initPromise;
+		this.initPromise = this.runInitialize().finally(() => {
+			this.initPromise = null;
+		});
+		return this.initPromise;
+	}
+
+	private async runInitialize(): Promise<void> {
 		// Load chats
 		await StartupProfiler.measure("agent:chatManager.load", () => this.chatManager.load());
 
@@ -1479,6 +1505,12 @@ export class AgentManager {
 	 */
 	async reinitialize(): Promise<void> {
 		Logger.log("Reinitializing agent with updated settings...");
+		// Settings changed — we need a fresh pass, not a shared in-flight one that
+		// may have started with stale settings. Wait for any current init to
+		// settle, then run a guaranteed-fresh initialize().
+		if (this.initPromise) {
+			await this.initPromise.catch(() => {});
+		}
 		await this.initialize();
 		Logger.log("Agent reinitialized successfully");
 	}
@@ -1486,12 +1518,10 @@ export class AgentManager {
 	async cleanup(): Promise<void> {
 		await this.chatManager.flush();
 
-		// Restore original fetch if it was patched
-		const globalWithFetch = globalThis as typeof globalThis & { _originalFetch?: typeof fetch };
-		if (globalWithFetch._originalFetch) {
-			globalThis.fetch = globalWithFetch._originalFetch;
-			globalWithFetch._originalFetch = undefined;
-		}
+		// Release the MCP global-fetch patch (ref-counted; restores the original
+		// fetch when the last holder releases).
+		this.mcpFetchPatch?.release();
+		this.mcpFetchPatch = null;
 
 		// Cleanup if needed
 		this.agent = null;

--- a/src/agent/ObsidianChatManager.ts
+++ b/src/agent/ObsidianChatManager.ts
@@ -281,6 +281,26 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 		return data.targetFolder;
 	}
 
+	/**
+	 * Validate that a threadId resolves to a `.chat` file directly inside the
+	 * configured chat folder before it is used as a filesystem path for a write
+	 * or delete. A thread_id can arrive from an untrusted source (a crafted
+	 * `.chat` embed, a hand-edited config, a malicious skill/tool), so a value
+	 * like `../../../.obsidian/plugins/foo/main.js` must never reach
+	 * `writeBinary`/`remove`. Returns the normalized path, or throws.
+	 */
+	private assertContainedThreadPath(threadId: string): string {
+		const normalized = normalizePath(threadId);
+		const folder = normalizePath(this.getChatFolder());
+		const prefix = folder === "/" ? "" : `${folder}/`;
+
+		const escapesFolder = !normalized.startsWith(prefix) || normalized.slice(prefix.length).includes("/");
+		if (escapesFolder || !normalized.endsWith(".chat") || normalized.length <= prefix.length + ".chat".length - 1) {
+			throw new Error(`Refusing to access thread outside chat folder: ${threadId}`);
+		}
+		return normalized;
+	}
+
 	private markThreadDirty(threadId: string): void {
 		this.dirtyThreadVersions.set(threadId, (this.dirtyThreadVersions.get(threadId) ?? 0) + 1);
 	}
@@ -458,6 +478,14 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 		const data = this.storage.get(threadId);
 		if (!data) return;
 
+		let safePath: string;
+		try {
+			safePath = this.assertContainedThreadPath(threadId);
+		} catch (e) {
+			Logger.error(`Refusing to save thread with unsafe path: ${threadId}`, e);
+			return;
+		}
+
 		await this.ensureFolder();
 		const targetVersion = this.dirtyThreadVersions.get(threadId) ?? 0;
 
@@ -466,7 +494,7 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 			try {
 				const compressed = gzipSync(JSON.stringify(data));
 				await this.adapter.writeBinary(
-					threadId,
+					safePath,
 					compressed.buffer.slice(
 						compressed.byteOffset,
 						compressed.byteOffset + compressed.byteLength,
@@ -952,9 +980,16 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 		this.threadIndex.delete(threadId);
 		this.dirtyThreadVersions.delete(threadId);
 		this.persistedThreadVersions.delete(threadId);
+		let safePath: string;
 		try {
-			if (await this.adapter.exists(threadId)) {
-				await this.adapter.remove(threadId);
+			safePath = this.assertContainedThreadPath(threadId);
+		} catch (e) {
+			Logger.error(`Refusing to delete thread with unsafe path: ${threadId}`, e);
+			return;
+		}
+		try {
+			if (await this.adapter.exists(safePath)) {
+				await this.adapter.remove(safePath);
 			}
 		} catch (e) {
 			Logger.error(`Error deleting thread ${threadId}:`, e);

--- a/src/agent/tools/grepMatcher.ts
+++ b/src/agent/tools/grepMatcher.ts
@@ -16,11 +16,61 @@ export interface GrepMatcher {
 	 * replacement string only apply when the caller passed a real regex.
 	 */
 	globalRegex(): RegExp;
+	/**
+	 * A fresh non-global RegExp for single (first-match) replace operations.
+	 * Shares the matcher's compiled source/flags so a single-match replace can
+	 * never diverge from the `count`/uniqueness gate that authorized it.
+	 */
+	singleRegex(): RegExp;
 	/** Count non-overlapping occurrences of the needle in `text`. */
 	count(text: string): number;
+	/**
+	 * Whether the compiled needle can match the empty string (e.g. `x*`, `a?`).
+	 * Such patterns make find-and-replace nonsensical (they "match" at every
+	 * position), so callers should reject them rather than count/replace.
+	 */
+	readonly matchesEmpty: boolean;
 }
 
 export type BuildMatcherResult = { ok: true; matcher: GrepMatcher } | { ok: false; error: string };
+
+/**
+ * Longest line we will run a user-supplied regex against. `grep_notes` and
+ * `manage_notes` scan every vault file synchronously on the UI thread, so an
+ * unbounded line length turns even a linear regex into a visible freeze. Lines
+ * longer than this are treated as non-matching (they are almost always minified
+ * blobs / data URIs, not prose the agent means to search).
+ */
+const MAX_SCANNED_LINE_LENGTH = 20000;
+
+/**
+ * Reject regex patterns whose structure is prone to catastrophic backtracking
+ * (ReDoS). A user- or agent-supplied pattern is compiled and then `.test()`ed
+ * line-by-line across the whole vault on the only UI thread with no timeout, so
+ * a pattern like `(a+)+$` against a long non-matching line would hard-lock
+ * Obsidian. Detecting ReDoS in general is undecidable; we screen for the common
+ * dangerous shapes (a quantified group whose body is itself quantified, and
+ * quantified alternations with overlapping branches). Returns an error message
+ * if the pattern looks unsafe, or `null` if it passes.
+ */
+function screenRegexForRedos(pattern: string): string | null {
+	// A group that is quantified, whose body contains an unbounded quantifier:
+	// (a+)+, (a*)*, (a+)*, (.*)+, (\d+){2,} etc. This is the classic exponential
+	// nested-quantifier form.
+	const nestedQuantifier = /\([^)]*[*+][^)]*\)\s*[*+]|\([^)]*[*+][^)]*\)\s*\{\d+,?\d*\}/;
+	if (nestedQuantifier.test(pattern)) {
+		return "quantifier applied to a group that already contains an unbounded quantifier (e.g. `(a+)+`)";
+	}
+
+	// Quantified alternation of single-char classes that overlap, e.g. (a|a)*,
+	// (\w|\d)+ — overlapping branches under a quantifier backtrack badly.
+	const quantifiedAlternation = /\([^)]*\|[^)]*\)\s*[*+]/;
+	if (quantifiedAlternation.test(pattern)) {
+		return "quantifier applied to an alternation group (e.g. `(a|a)*`) — prone to catastrophic backtracking";
+	}
+
+	return null;
+}
 
 /**
  * Build a shared literal/regex matcher used by both `grep_notes` (line-level
@@ -35,6 +85,15 @@ export type BuildMatcherResult = { ok: true; matcher: GrepMatcher } | { ok: fals
  */
 export function buildGrepMatcher(pattern: string, isRegex: boolean, caseSensitive: boolean): BuildMatcherResult {
 	if (isRegex) {
+		const redosReason = screenRegexForRedos(pattern);
+		if (redosReason) {
+			Logger.debug("[grepMatcher] Rejected potentially catastrophic regex:", pattern, redosReason);
+			return {
+				ok: false,
+				error: `Error: Regular expression "${pattern}" was rejected: ${redosReason}. Simplify the pattern.`,
+			};
+		}
+
 		let source: RegExp;
 		try {
 			source = new RegExp(pattern, caseSensitive ? "" : "i");
@@ -45,32 +104,52 @@ export function buildGrepMatcher(pattern: string, isRegex: boolean, caseSensitiv
 		}
 
 		const globalFlags = `g${caseSensitive ? "" : "i"}`;
+		const singleFlags = source.flags.replace("g", "");
+		// A pattern matches empty if it can succeed against "". Such patterns make
+		// find-and-replace meaningless (they match at every position).
+		const matchesEmpty = new RegExp(source.source, singleFlags).test("");
 		return {
 			ok: true,
 			matcher: {
 				// A non-global clone avoids the stateful `lastIndex` trap when reusing `.test()` in a loop.
-				test: (text: string) => new RegExp(source.source, source.flags.replace("g", "")).test(text),
+				test: (text: string) =>
+					text.length <= MAX_SCANNED_LINE_LENGTH && new RegExp(source.source, singleFlags).test(text),
 				globalRegex: () => new RegExp(source.source, globalFlags),
+				singleRegex: () => new RegExp(source.source, singleFlags),
 				count: (text: string) => {
-					const matches = text.match(new RegExp(source.source, globalFlags));
-					return matches ? matches.length : 0;
+					if (text.length > MAX_SCANNED_LINE_LENGTH) return 0;
+					// Count non-overlapping matches. `matchAll` advances past
+					// zero-length matches correctly (unlike `String.match(/g/)`,
+					// which for an empty-matchable pattern returns one entry per
+					// character and inflates the count).
+					if (matchesEmpty) return 0;
+					let n = 0;
+					for (const _ of text.matchAll(new RegExp(source.source, globalFlags))) n++;
+					return n;
 				},
+				matchesEmpty,
 			},
 		};
 	}
 
 	const escaped = escapeRegExp(pattern);
 	const globalFlags = `g${caseSensitive ? "" : "i"}`;
+	const singleFlags = caseSensitive ? "" : "i";
 	const needle = caseSensitive ? pattern : pattern.toLowerCase();
+	// A literal needle matches empty only when the pattern itself is empty.
+	const matchesEmpty = pattern.length === 0;
 	return {
 		ok: true,
 		matcher: {
 			test: (text: string) => (caseSensitive ? text : text.toLowerCase()).includes(needle),
 			globalRegex: () => new RegExp(escaped, globalFlags),
+			singleRegex: () => new RegExp(escaped, singleFlags),
 			count: (text: string) => {
+				if (matchesEmpty) return 0;
 				const matches = text.match(new RegExp(escaped, globalFlags));
 				return matches ? matches.length : 0;
 			},
+			matchesEmpty,
 		},
 	};
 }

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -194,6 +194,11 @@ function applySequentialEdits(
 				};
 			}
 			const matcher = built.matcher;
+			if (matcher.matchesEmpty) {
+				return {
+					error: `Error in operation ${operationNumber}, edit ${i + 1}: The regex can match an empty string, which matches everywhere in "${path}". Use a pattern that matches concrete text.`,
+				};
+			}
 			const occurrences = matcher.count(content);
 			if (occurrences === 0) {
 				return {
@@ -205,8 +210,10 @@ function applySequentialEdits(
 					error: `Error in operation ${operationNumber}, edit ${i + 1}: The regex matches multiple times in "${path}". Make it more specific, or set replace_all to replace every match.`,
 				};
 			}
-			// Regex replace ($1/$2 back-references honored); non-global regex replaces only the first match.
-			content = content.replace(replace_all ? matcher.globalRegex() : new RegExp(oldText), newText);
+			// Regex replace ($1/$2 back-references honored). Use the matcher's own
+			// compiled regex so the replace can never diverge from the count above:
+			// global replaces every match, non-global replaces only the first.
+			content = content.replace(replace_all ? matcher.globalRegex() : matcher.singleRegex(), newText);
 			continue;
 		}
 

--- a/src/components/chat/MessageContainer.svelte
+++ b/src/components/chat/MessageContainer.svelte
@@ -314,7 +314,7 @@ $effect(() => {
           <p class="text-sm opacity-70">Ask me anything about your notes.</p>
         </div>
       {:else}
-        {#each messages as messagePair, index}
+        {#each messages as messagePair, index (messagePair.id)}
           {#if messagePair.transcriptEvent?.type === "summarization_marker"}
             <div
               class="summary-marker-row flex justify-center my-4"

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { untrack, tick } from "svelte";
+import { untrack, tick, onDestroy } from "svelte";
 import { getAllTags, Notice } from "obsidian";
 import { getPlugin } from "../../stores/state.svelte";
 import { getData } from "../../stores/dataStore.svelte";
@@ -209,6 +209,15 @@ let skeletonGraphData: GraphData = $derived.by(() => {
 // Build cancellation — abort stale builds when a new one starts
 let currentBuild: AbortController | null = null;
 
+// Generation guard for async continuations. Bumped by every new build and by
+// onDestroy, so a slow await (buildWikiGraph tick, leidenAsync, native-settings
+// read) that resolves after a newer build started — or after the view was
+// closed — bails instead of writing stale state over the current graph or onto
+// a destroyed component. AbortController alone was insufficient: it was only
+// checked in the catch, so success-path writes ran unconditionally.
+let buildVersion = 0;
+let isDestroyed = false;
+
 function getFilter(): GraphFilter {
 	// `markdownOnly` narrows to just .md; explicit extension picks (if any) still win.
 	const extensions = selectedExtensions.length > 0 ? selectedExtensions : settings.markdownOnly ? ["md"] : undefined;
@@ -283,12 +292,15 @@ async function buildGraph() {
 	currentBuild?.abort();
 	const ac = new AbortController();
 	currentBuild = ac;
+	const localBuildVersion = ++buildVersion;
 	isLoading = true;
 	loadingMessage = "Building graph...";
 
 	try {
 		const filter = getFilter();
 		const { graphData: wikiData } = buildWikiGraph(plugin.app, filter, immersePaths ?? undefined);
+		// A newer build (or unmount) superseded us before we could apply.
+		if (localBuildVersion !== buildVersion) return;
 		graphData = wikiData;
 		isLoading = false;
 
@@ -299,13 +311,14 @@ async function buildGraph() {
 		void runLeidenSegmentation();
 
 		await tick();
+		if (localBuildVersion !== buildVersion) return;
 		try {
 			canvasComponent?.fitToView();
 		} catch {
 			/* pixi not ready */
 		}
 	} catch (e) {
-		if (ac.signal.aborted) return;
+		if (ac.signal.aborted || localBuildVersion !== buildVersion) return;
 		console.error("[SmartGraph] Error building graph:", e);
 		graphData = { nodes: [], edges: [] };
 		isLoading = false;
@@ -366,7 +379,18 @@ $effect(() => {
 
 // Load native Obsidian graph settings (color groups, physics, etc.) as fallback
 readNativeGraphSettings(plugin.app).then((native) => {
+	// Guard against a resolve after the view was destroyed.
+	if (isDestroyed) return;
 	nativeGraphSettings = native;
+});
+
+onDestroy(() => {
+	// Invalidate any in-flight async build/Leiden continuations so they bail
+	// instead of writing $state on a destroyed component, and abort the current
+	// build.
+	isDestroyed = true;
+	buildVersion++;
+	currentBuild?.abort();
 });
 
 // Handlers
@@ -515,6 +539,7 @@ async function handleExitImmerse() {
 }
 
 async function runLeidenSegmentation() {
+	const localBuildVersion = buildVersion;
 	const wikiEdges = graphData.edges.filter((e) => e.type === "wiki");
 	if (wikiEdges.length === 0) return;
 
@@ -540,6 +565,10 @@ async function runLeidenSegmentation() {
 	} finally {
 		isLeidenRunning = false;
 	}
+	// The graph was rebuilt (or the view closed) while Leiden ran; its
+	// communities are keyed by nodes that may no longer exist. Discard them
+	// rather than applying stale segments over the current graph.
+	if (localBuildVersion !== buildVersion) return;
 	Logger.info(
 		`[SmartGraph] Leiden (γ=${settings.leidenResolution.toFixed(2)}, ${wikiEdges.length} edges, ${graphData.nodes.length} nodes): ${Math.round(performance.now() - start)}ms`,
 	);

--- a/src/components/modal/AgentEditorModal.svelte
+++ b/src/components/modal/AgentEditorModal.svelte
@@ -23,7 +23,7 @@ import Text from "../ui/Text.svelte";
 import Toggle from "../ui/Toggle.svelte";
 import GenericAIIcon from "../ui/logos/GenericAIIcon.svelte";
 import { useAvailableModels } from "../../hooks/useAvailableModels.svelte";
-import { createObsidianFetch } from "../../lib/obsidianFetch";
+import { installObsidianFetch } from "../../lib/obsidianFetch";
 import type SecondBrainPlugin from "../../main";
 import { type PluginIntegration, getPluginIcon, toExecToolId } from "../../agent/integrations/pluginIntegrations";
 import { buildPluginApiSkill } from "../../skills/templates/pluginApiScripting";
@@ -737,12 +737,7 @@ async function fetchServerTools(serverId: string) {
 	if (!config) return;
 	mcpServerTools[serverId] = { loading: true, error: null, tools: [] };
 	try {
-		const windowWithFetch = window as Window & { _originalFetch?: typeof fetch };
-		const needsPatch = !windowWithFetch._originalFetch;
-		if (needsPatch) {
-			windowWithFetch._originalFetch = window.fetch;
-			window.fetch = createObsidianFetch(windowWithFetch._originalFetch);
-		}
+		const patch = installObsidianFetch();
 		try {
 			const mcpClient = new MultiServerMCPClient(buildMCPConfig(serverId, config));
 			const tools = await mcpClient.getTools();
@@ -755,10 +750,7 @@ async function fetchServerTools(serverId: string) {
 				})),
 			};
 		} finally {
-			if (needsPatch && windowWithFetch._originalFetch) {
-				window.fetch = windowWithFetch._originalFetch;
-				windowWithFetch._originalFetch = undefined;
-			}
+			patch.release();
 		}
 	} catch (err) {
 		mcpServerTools[serverId] = {

--- a/src/components/modal/MCPServerModal.svelte
+++ b/src/components/modal/MCPServerModal.svelte
@@ -2,7 +2,7 @@
 import { MultiServerMCPClient } from "@langchain/mcp-adapters";
 import { Notice } from "obsidian";
 import { onMount } from "svelte";
-import { createObsidianFetch } from "../../lib/obsidianFetch";
+import { installObsidianFetch } from "../../lib/obsidianFetch";
 import type SecondBrainPlugin from "../../main";
 import type { MCPHTTPServerConfig, MCPServerConfig, MCPStdioServerConfig, MCPTransportType } from "../../types/plugin";
 import { getData } from "../../stores/dataStore.svelte";
@@ -282,20 +282,16 @@ async function handleTestConnection() {
 	testSuccess = false;
 
 	try {
-		// Patch fetch for CORS bypass (same as in AgentManager)
-		const windowWithFetch = window as Window & { _originalFetch?: typeof fetch };
-		const needsPatch = !windowWithFetch._originalFetch;
-
-		if (needsPatch) {
-			windowWithFetch._originalFetch = window.fetch;
-			window.fetch = createObsidianFetch(windowWithFetch._originalFetch);
-		}
-
+		// Ref-counted global-fetch patch for CORS bypass — safe under concurrency
+		// (unlike the old _originalFetch flag + finally-restore, which corrupted
+		// when two probes overlapped).
+		const patch = installObsidianFetch();
+		let mcpClient: MultiServerMCPClient | undefined;
 		try {
 			const config = buildTestConfig();
 			Logger.log("Testing MCP connection with config:", config);
 
-			const mcpClient = new MultiServerMCPClient(config);
+			mcpClient = new MultiServerMCPClient(config);
 			const tools = await mcpClient.getTools();
 
 			discoveredTools = tools.map((t) => ({
@@ -306,11 +302,14 @@ async function handleTestConnection() {
 
 			new Notice(`Connection successful! Found ${tools.length} tool(s).`);
 		} finally {
-			// Restore original fetch if we patched it
-			if (needsPatch && windowWithFetch._originalFetch) {
-				window.fetch = windowWithFetch._originalFetch;
-				windowWithFetch._originalFetch = undefined;
+			// Close the client so a stdio server's spawned child process / open
+			// session doesn't dangle after a one-off connection test.
+			try {
+				await mcpClient?.close();
+			} catch (closeErr) {
+				Logger.debug("MCP client close failed after test:", closeErr);
 			}
+			patch.release();
 		}
 	} catch (err) {
 		Logger.error("MCP connection test failed:", err);

--- a/src/lib/obsidianFetch.ts
+++ b/src/lib/obsidianFetch.ts
@@ -137,3 +137,39 @@ export function createObsidianFetch(
 		}
 	};
 }
+
+/**
+ * Ref-counted installer for the global `fetch` patch used by MCP clients (which
+ * read `globalThis.fetch` at call time and can't be handed a fetch directly).
+ *
+ * Multiple callers may need the patch concurrently (e.g. two `fetchServerTools`
+ * calls, or agent MCP tool-loading overlapping a settings-modal probe). The
+ * naive `_originalFetch`-flag + `finally`-restore pattern corrupts under
+ * concurrency: one caller's restore fires mid-flight of another, or the
+ * original gets captured as an already-wrapped fetch and double-wrapped
+ * permanently. Ref-counting installs once (on 0→1) and restores once (on 1→0),
+ * so concurrent users are safe. `release()` is idempotent.
+ */
+let patchDepth = 0;
+let savedFetch: typeof globalThis.fetch | null = null;
+
+export function installObsidianFetch(): { release: () => void } {
+	if (patchDepth === 0) {
+		savedFetch = globalThis.fetch;
+		globalThis.fetch = createObsidianFetch(savedFetch);
+	}
+	patchDepth++;
+
+	let released = false;
+	return {
+		release: () => {
+			if (released) return;
+			released = true;
+			patchDepth--;
+			if (patchDepth === 0 && savedFetch) {
+				globalThis.fetch = savedFetch;
+				savedFetch = null;
+			}
+		},
+	};
+}

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -6,7 +6,7 @@ import {
 	parseSpaceMembershipFilter,
 	resolveViewFilter,
 } from "../lib/views";
-import { getSecret, listSecrets, setSecret } from "../lib/secretStorage";
+import { getSecret, listSecrets, removeSecret, setSecret } from "../lib/secretStorage";
 import type SecondBrainPlugin from "../main";
 import { DEFAULT_AGENT_ICON } from "../types/plugin";
 import type {
@@ -1909,8 +1909,28 @@ export class PluginDataStore {
 			throw new Error(`Provider with ID "${providerId}" not found`);
 		}
 
+		// Collect this provider's secret IDs before dropping its config, so we can
+		// clear the raw values from the (cross-plugin) SecretStorage instead of
+		// orphaning API keys there after the provider is gone.
+		const config = this.#data.providerConfig[providerId];
+		const secretIdsToConsider = config ? Object.values(config.auth.secretIds ?? {}) : [];
+
 		delete this.#data.providerMeta[providerId];
 		delete this.#data.providerConfig[providerId];
+
+		// A secret ID can be shared (assignSecretIdToProviderField lets one field
+		// point at an existing secret). Only remove secrets no remaining provider
+		// still references, so we never clear a key another provider depends on.
+		const stillReferenced = new Set<string>();
+		for (const cfg of Object.values(this.#data.providerConfig)) {
+			for (const id of Object.values(cfg.auth.secretIds ?? {})) stillReferenced.add(id);
+		}
+		for (const secretId of secretIdsToConsider) {
+			if (secretId && !stillReferenced.has(secretId)) {
+				removeSecret(this._plugin.app, secretId);
+			}
+		}
+
 		await this.saveSettings();
 	}
 }

--- a/src/utils/computeWorkerManager.ts
+++ b/src/utils/computeWorkerManager.ts
@@ -18,7 +18,10 @@ import { Graph as LeidenGraph, leiden } from "leiden-ts";
 
 let worker: Worker | null = null;
 let requestId = 0;
-const pending = new Map<number, { resolve: (value: any) => void; reject: (reason: any) => void }>();
+const pending = new Map<
+	number,
+	{ resolve: (value: any) => void; reject: (reason: any) => void; request: ComputeWorkerRequest }
+>();
 
 function getWorker(): Worker | null {
 	if (worker) return worker;
@@ -37,14 +40,38 @@ function getWorker(): Worker | null {
 			}
 		};
 		worker.onerror = (e) => {
-			// If the worker fails to load, fall back to main-thread execution
+			// The worker died (failed to load, or crashed on a message). Honor the
+			// documented contract: don't reject unrelated in-flight requests —
+			// recompute each one synchronously on the main thread so a transient
+			// worker failure degrades gracefully instead of surfacing spurious
+			// errors for work that was otherwise fine.
 			console.warn("[ComputeWorker] Worker error, falling back to main thread:", e.message);
-			terminateWorker();
+			recoverPendingOnMainThread();
 		};
 		return worker;
 	} catch {
 		// Workers not available — fall back to synchronous
 		return null;
+	}
+}
+
+/**
+ * Tear down the worker and re-run every in-flight request on the main thread,
+ * settling each promise with the synchronous result. Used when the worker
+ * errors out mid-flight (as opposed to an explicit `terminateWorker()`, which
+ * rejects). Keeps callers whose work never reached the worker from failing.
+ */
+function recoverPendingOnMainThread(): void {
+	if (worker) {
+		worker.terminate();
+		worker = null;
+	}
+	const entries = [...pending.values()];
+	pending.clear();
+	for (const entry of entries) {
+		Promise.resolve()
+			.then(() => runOnMainThread(entry.request))
+			.then(entry.resolve, entry.reject);
 	}
 }
 
@@ -56,7 +83,7 @@ function postRequest<T extends ComputeWorkerResponse>(request: ComputeWorkerRequ
 	}
 
 	return new Promise<T>((resolve, reject) => {
-		pending.set(request.id, { resolve, reject });
+		pending.set(request.id, { resolve, reject, request });
 		w.postMessage(request, getTransferList(request));
 	});
 }

--- a/src/vectorstore/HNSWVectorStore.ts
+++ b/src/vectorstore/HNSWVectorStore.ts
@@ -81,6 +81,30 @@ export class HNSWVectorStore implements VectorStore {
 	private nextHnswId = 0;
 	private readonly dbName: string;
 
+	/**
+	 * Debounced HNSW graph flush for the incremental path. `upsert` mutates the
+	 * in-memory graph but, without this, only `close()`/`bulkPut` ever persisted
+	 * it — so a force-quit between full rebuilds lost every incrementally-added
+	 * point from the persisted graph (their doc rows/id-mappings survived in IDB,
+	 * so search silently returned stale results with no error). Coalesce rapid
+	 * edits into one save; `close()` cancels this and does a final synchronous
+	 * flush.
+	 *
+	 * A plain timer (not obsidian's `debounce`) because this module also runs
+	 * inside the HNSW Web Worker, where the `obsidian` package can't be resolved.
+	 */
+	private static readonly SAVE_DEBOUNCE_MS = 2000;
+	private hasPendingIndexSave = false;
+	private saveIndexTimer: ReturnType<typeof setTimeout> | null = null;
+
+	private scheduleIndexSave(): void {
+		if (this.saveIndexTimer !== null) clearTimeout(this.saveIndexTimer);
+		this.saveIndexTimer = setTimeout(() => {
+			this.saveIndexTimer = null;
+			void this.flushIndex();
+		}, HNSWVectorStore.SAVE_DEBOUNCE_MS);
+	}
+
 	// ID mappings (string ID <-> numeric HNSW ID)
 	private idToNumeric: Map<string, number> = new Map();
 	private numericToId: Map<number, string> = new Map();
@@ -231,9 +255,16 @@ export class HNSWVectorStore implements VectorStore {
 	 * Close the database connection.
 	 */
 	async close(): Promise<void> {
+		// Cancel the pending debounced save so it can't fire after we null `db`,
+		// then flush synchronously so no incremental changes are lost on close.
+		if (this.saveIndexTimer !== null) {
+			clearTimeout(this.saveIndexTimer);
+			this.saveIndexTimer = null;
+		}
 		if (this.hnswIndex) {
 			try {
 				await this.hnswIndex.saveIndex();
+				this.hasPendingIndexSave = false;
 			} catch {
 				// Ignore save errors on close
 			}
@@ -335,6 +366,27 @@ export class HNSWVectorStore implements VectorStore {
 		}
 
 		await this.updateLastUpdated();
+
+		// Persist the in-memory graph. Debounced so a burst of edits collapses
+		// into one save; a clean close() flushes anything still pending.
+		this.hasPendingIndexSave = true;
+		this.scheduleIndexSave();
+	}
+
+	/**
+	 * Persist the HNSW graph to IndexedDB if there are unsaved incremental
+	 * changes. Safe to call repeatedly (no-op when nothing is pending).
+	 */
+	private async flushIndex(): Promise<void> {
+		if (!this.hasPendingIndexSave || !this.hnswIndex || !this.db) return;
+		this.hasPendingIndexSave = false;
+		try {
+			await this.hnswIndex.saveIndex();
+		} catch (e) {
+			// Re-arm so a later flush (or close) retries the save.
+			this.hasPendingIndexSave = true;
+			Logger.error(`${LOG_PREFIX} Failed to persist HNSW graph:`, e);
+		}
 	}
 
 	private async removeFromHNSW(_id: string): Promise<void> {
@@ -705,6 +757,14 @@ export class HNSWVectorStore implements VectorStore {
 		const meta = await this.getMetadataInternal();
 		if (meta) {
 			meta.lastUpdated = Date.now();
+			// Persist the id high-water mark and dimensions on the incremental
+			// path too. `upsert` bumps `nextHnswId` in memory; if only
+			// `setMetadata` (full-rebuild path) persisted it, a reload would
+			// restore a stale counter and reassign an in-use id → `addPoint`
+			// throws "Node with id N already exists" and the note silently fails
+			// to index. Keep the persisted counter in lockstep with memory.
+			meta.nextHnswId = this.nextHnswId;
+			if (this.dimensions) meta.dimensions = this.dimensions;
 			await this.putInStore(METADATA_STORE, meta);
 		}
 	}

--- a/test/agent/grepMatcher.test.ts
+++ b/test/agent/grepMatcher.test.ts
@@ -76,3 +76,73 @@ describe("buildGrepMatcher — regex", () => {
 		expect(built.matcher.count("a1b2c3")).toBe(3);
 	});
 });
+
+describe("buildGrepMatcher — ReDoS protection", () => {
+	it("rejects nested-quantifier patterns", () => {
+		const built = buildGrepMatcher("(a+)+$", true, false);
+		expect(built.ok).toBe(false);
+		if (built.ok) return;
+		expect(built.error).toContain("rejected");
+	});
+
+	it("rejects quantified-alternation patterns", () => {
+		const built = buildGrepMatcher("(a|a)*", true, false);
+		expect(built.ok).toBe(false);
+	});
+
+	it("still accepts ordinary quantifiers", () => {
+		const built = buildGrepMatcher("\\d+", true, false);
+		expect(built.ok).toBe(true);
+		if (!built.ok) return;
+		expect(built.matcher.test("abc123")).toBe(true);
+	});
+
+	it("does not run a regex against an over-long line", () => {
+		const built = buildGrepMatcher("a", true, false);
+		if (!built.ok) return;
+		const huge = "a".repeat(20001);
+		expect(built.matcher.test(huge)).toBe(false);
+		expect(built.matcher.count(huge)).toBe(0);
+		// A normal-length line still matches.
+		expect(built.matcher.test("a")).toBe(true);
+	});
+
+	it("does not screen literal needles (parens are literal there)", () => {
+		const built = buildGrepMatcher("(a+)+", false, false);
+		expect(built.ok).toBe(true);
+		if (!built.ok) return;
+		expect(built.matcher.test("literal (a+)+ text")).toBe(true);
+	});
+});
+
+describe("buildGrepMatcher — empty-match handling", () => {
+	it("flags empty-matchable regex and counts them as zero", () => {
+		const built = buildGrepMatcher("x*", true, false);
+		expect(built.ok).toBe(true);
+		if (!built.ok) return;
+		expect(built.matcher.matchesEmpty).toBe(true);
+		// `x*` matches at every position; a naive String.match(/x*/g) would
+		// inflate this — count must not.
+		expect(built.matcher.count("abc")).toBe(0);
+	});
+
+	it("counts a real repeated regex correctly (non-overlapping)", () => {
+		const built = buildGrepMatcher("\\d+", true, false);
+		if (!built.ok) return;
+		expect(built.matcher.matchesEmpty).toBe(false);
+		expect(built.matcher.count("a12b3c456")).toBe(3);
+	});
+
+	it("singleRegex replaces only the first match; globalRegex replaces all", () => {
+		const built = buildGrepMatcher("\\d", true, false);
+		if (!built.ok) return;
+		expect("a1b2c3".replace(built.matcher.singleRegex(), "#")).toBe("a#b2c3");
+		expect("a1b2c3".replace(built.matcher.globalRegex(), "#")).toBe("a#b#c#");
+	});
+
+	it("literal needle is never empty-matchable unless the pattern is empty", () => {
+		const built = buildGrepMatcher("foo", false, false);
+		if (!built.ok) return;
+		expect(built.matcher.matchesEmpty).toBe(false);
+	});
+});


### PR DESCRIPTION
Security & data-integrity fixes surfaced by an in-depth review:

- ObsidianChatManager: contain checkpoint threadId writes/deletes to the chat folder (was raw path → arbitrary overwrite/delete via crafted id)
- HNSWVectorStore: persist nextHnswId on incremental upsert (id-collision on reload) + debounced saveIndex so edited-note vectors survive a force-quit; flush on close
- grepMatcher: reject catastrophic-backtracking regex + cap scanned line length (agent-supplied regex ran synchronously on the UI thread → freeze)
- AgentManager: memoize in-flight initialize() so lazy ensureAgent() and the deferred onLayoutReady init can't double-init and clobber the registry
- manageNotes/grepMatcher: use the matcher's own compiled regex for count+replace and reject empty-matchable patterns (count/replace mismatch)
- MessageContainer: key the message timeline {#each} by pair id
- SmartGraphView: generation-guard async build/Leiden continuations + onDestroy so stale/late writes don't clobber the graph or a dead component
- obsidianFetch: ref-counted installObsidianFetch(); use it in the two MCP modals + AgentManager (concurrent patch install/restore was corrupting global fetch); close the MCP test client
- dataStore: remove a provider's unreferenced secrets on deleteProvider
- computeWorkerManager: on worker error, recompute in-flight requests on the main thread instead of rejecting unrelated work

Adds grepMatcher tests for ReDoS screening and empty-match handling.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._