### PR TITLE
fix: address PR #340 review bot findings

### DIFF
--- a/src/agent/tools/grepMatcher.ts
+++ b/src/agent/tools/grepMatcher.ts
@@ -222,46 +222,177 @@ function hasAdjacentOverlappingQuantifiers(neutralized: string): boolean {
 	return false;
 }
 
+/**
+ * Index of the `)` that closes the group whose `(` is at `open`, tracking paren
+ * depth so nested groups are handled correctly. Returns -1 if unbalanced.
+ * Operates on a *neutralized* pattern, so every `(`/`)` is real group structure
+ * (literal parens are already `L`, class contents are `C`).
+ */
+function matchingParen(s: string, open: number): number {
+	let depth = 0;
+	for (let i = open; i < s.length; i++) {
+		if (s[i] === "(") depth++;
+		else if (s[i] === ")") {
+			depth--;
+			if (depth === 0) return i;
+		}
+	}
+	return -1;
+}
+
+/** Strip a leading group prefix — `?:`, `?=`, `?!`, `?<name>`, `?<=`, `?<!`. */
+function stripGroupPrefix(body: string): string {
+	return body.replace(/^\?[:=!]|^\?<[=!]|^\?<[^>]*>/, "");
+}
+
+/**
+ * Whether a quantified group's *body* is "unfenced" — i.e. it reduces to a
+ * single unbounded-quantified unit (`a+`, `(a+)`, `((a+))`, …) with nothing else
+ * at the top level to fence a repetition. This is the property that makes an
+ * outer unbounded quantifier catastrophic: `(a+)+` and `((a+))+` explode, but
+ * `(a+b)+` (fenced by `b`), `(a(b)c)+` (no top-level quantifier), and
+ * `(?:\(a+\))+` → `(?:La+L)+` (fenced by literal `L`) do not.
+ *
+ * Verified empirically: `((a+))+$` is exponential (>1s at ~24 chars) while every
+ * fenced form stays linear. Recurses through redundant group wrappers so
+ * `(((a+)))+` is still caught. Operates on a neutralized pattern.
+ */
+function bodyIsUnfenced(body: string): boolean {
+	const tokens = splitTopLevel(body);
+	// More than one top-level token means something fences the repetition (a
+	// sibling atom, a separator, an alternation) — not the catastrophic shape.
+	if (tokens.length !== 1) return false;
+	const t = tokens[0];
+	if (t.kind === "atom") return t.unbounded;
+	if (t.kind === "group") {
+		// A single nested group: dangerous if the group's own unbounded quantifier
+		// wraps an unfenced body, or (an unquantified wrapper) its body is unfenced.
+		if (t.unbounded) return bodyIsUnfenced(t.inner);
+		if (!t.quantified) return bodyIsUnfenced(t.inner);
+	}
+	return false;
+}
+
+type TopLevelToken =
+	| { kind: "atom"; quantified: boolean; unbounded: boolean }
+	| { kind: "group"; quantified: boolean; unbounded: boolean; inner: string }
+	| { kind: "alt" };
+
+/**
+ * Split a neutralized regex body into its top-level tokens (depth 0 only):
+ * ordinary atoms, groups (with their inner text), and `|` alternation markers.
+ * Each atom/group carries whether it is quantified and, if so, whether by an
+ * unbounded quantifier (`*`/`+`, not `?` and not a bounded `{n,m}`).
+ */
+function splitTopLevel(body: string): TopLevelToken[] {
+	const tokens: TopLevelToken[] = [];
+	let i = 0;
+	while (i < body.length) {
+		const c = body[i];
+		if (c === "|") {
+			tokens.push({ kind: "alt" });
+			i++;
+			continue;
+		}
+		if (c === "(") {
+			const close = matchingParen(body, i);
+			if (close === -1) {
+				i++;
+				continue;
+			}
+			const inner = stripGroupPrefix(body.slice(i + 1, close));
+			const after = body[close + 1];
+			if (after === "*" || after === "+") {
+				tokens.push({ kind: "group", quantified: true, unbounded: true, inner });
+				i = close + 2;
+			} else if (after === "?") {
+				tokens.push({ kind: "group", quantified: true, unbounded: false, inner });
+				i = close + 2;
+			} else if (after === "{") {
+				const end = body.indexOf("}", close);
+				tokens.push({ kind: "group", quantified: true, unbounded: false, inner });
+				i = end === -1 ? close + 1 : end + 1;
+			} else {
+				tokens.push({ kind: "group", quantified: false, unbounded: false, inner });
+				i = close + 1;
+			}
+			continue;
+		}
+		// Ordinary atom (one neutralized char). Read its trailing quantifier.
+		const after = body[i + 1];
+		if (after === "*" || after === "+") {
+			tokens.push({ kind: "atom", quantified: true, unbounded: true });
+			i += 2;
+		} else if (after === "?") {
+			tokens.push({ kind: "atom", quantified: true, unbounded: false });
+			i += 2;
+		} else if (after === "{") {
+			const end = body.indexOf("}", i);
+			tokens.push({ kind: "atom", quantified: true, unbounded: false });
+			i = end === -1 ? i + 1 : end + 1;
+		} else {
+			tokens.push({ kind: "atom", quantified: false, unbounded: false });
+			i++;
+		}
+	}
+	return tokens;
+}
+
+/**
+ * Depth-aware scan for the two catastrophic quantified-group shapes that a flat
+ * `[^)]*` regex cannot see because it can't balance parens:
+ *
+ *  - An unbounded-quantified group with an unfenced body: `(a+)+`, `((a+))+`,
+ *    `(C+)+` (from `([^)]+)+`). The old `\([^)]*[*+][^)]*\)[*+]` regex stopped at
+ *    the first inner `)`, so `((a+))+` slipped through.
+ *  - A quantified group containing a top-level alternation: `(a|a)*`, `(a|b)+`.
+ *
+ * Returns a reason string if the neutralized pattern contains either shape.
+ */
+function findDangerousQuantifiedGroup(neutralized: string): string | null {
+	for (let i = 0; i < neutralized.length; i++) {
+		if (neutralized[i] !== "(") continue;
+		const close = matchingParen(neutralized, i);
+		if (close === -1) break;
+		const after = neutralized[close + 1];
+		if (after !== "*" && after !== "+") continue; // only unbounded group quantifiers here
+		const body = stripGroupPrefix(neutralized.slice(i + 1, close));
+		if (bodyIsUnfenced(body)) {
+			return "quantifier applied to a group whose body is itself unbounded (e.g. `(a+)+`, `((a+))+`)";
+		}
+		// A quantified group with a top-level alternation backtracks badly when the
+		// branches overlap: `(a|a)*`, `(\w|\d)+`.
+		if (splitTopLevel(body).some((t) => t.kind === "alt")) {
+			return "quantifier applied to an alternation group (e.g. `(a|a)*`) — prone to catastrophic backtracking";
+		}
+	}
+	return null;
+}
+
 function screenRegexForRedos(pattern: string): string | null {
 	// The structural checks below look for real regex *structure* — group parens,
 	// quantifiers, braces, alternation. Two things masquerade as structure but are
-	// not, and must be neutralized first or the screen both misses real dangers
-	// and rejects safe patterns:
+	// not, and are neutralized first (see `neutralizeLiterals`) so the screen
+	// neither misses real dangers nor rejects safe patterns:
 	//
-	//  1. Escaped metacharacters (`\)`, `\(`, `\{`, `\|`) are literals. Replace
-	//     each `\X` pair with a neutral literal placeholder so the escaped char
-	//     becomes an ordinary character rather than vanishing. Deleting it (an
-	//     earlier approach) let neighbours fuse: `\(a+\)+` → `(a+)+`, a false
-	//     positive. Placeholder-ing yields `Ea+E+` — not a group — correctly safe.
-	//  2. Character-class contents (`[...]`) are a single atom; a `)`/`(`/`|`
-	//     inside a class is literal, not group structure. Replace each class with
-	//     a single placeholder atom so, e.g., `([^)]+)+$` presents as `(C+)+$` and
-	//     the nested-quantifier check can see the real `(…+)+` shape. Without this
-	//     the `)` inside `[^)]` was read as the group terminator and the pattern
-	//     slipped through to catastrophic backtracking.
+	//  1. Escaped metacharacters (`\)`, `\(`, `\{`, `\|`) are literals → `L`/`E`,
+	//     so `\(a+\)+` → `La+L+` (not a group) is correctly safe.
+	//  2. Character-class contents (`[...]`) are a single atom → `C`, so
+	//     `([^)]+)+$` → `(C+)+$` presents its real `(…+)+` shape.
 	//
-	// Placeholders are letters (no regex meaning) so downstream checks treat them
-	// as ordinary atoms.
+	// After neutralization every `(`/`)` is genuine group structure, which lets
+	// the depth-aware `findDangerousQuantifiedGroup` scan balance parens correctly
+	// — catching nested shapes like `((a+))+` that a flat `[^)]*` regex misses.
 	const stripped = neutralizeLiterals(pattern);
 
-	// A group that is quantified, whose body contains an unbounded quantifier:
-	// (a+)+, (a*)*, (a+)*, (.*)+, (\d+){2,} etc. This is the classic exponential
-	// nested-quantifier form.
-	const nestedQuantifier = /\([^)]*[*+][^)]*\)\s*[*+]|\([^)]*[*+][^)]*\)\s*\{\d+,?\d*\}/;
-	if (nestedQuantifier.test(stripped)) {
-		return "quantifier applied to a group that already contains an unbounded quantifier (e.g. `(a+)+`)";
-	}
-
-	// Quantified alternation of single-char classes that overlap, e.g. (a|a)*,
-	// (\w|\d)+ — overlapping branches under a quantifier backtrack badly.
-	const quantifiedAlternation = /\([^)]*\|[^)]*\)\s*[*+]/;
-	if (quantifiedAlternation.test(stripped)) {
-		return "quantifier applied to an alternation group (e.g. `(a|a)*`) — prone to catastrophic backtracking";
+	// Catastrophic quantified-group shapes (nested/unfenced body, or quantified
+	// alternation), detected with real paren balancing rather than a flat regex.
+	const dangerousGroup = findDangerousQuantifiedGroup(stripped);
+	if (dangerousGroup) {
+		return dangerousGroup;
 	}
 
 	// A group followed by a bounded repetition, e.g. (a+){10,} or (ab){50,100} —
-	// bounded but still explodes the match tree. Any `{n,m}` (or `{n,}`) applied
-	// directly to a group is treated as unsafe.
 	const boundedQuantifiedGroup = /\)\s*\{\d+(?:,\d*)?\}/;
 	if (boundedQuantifiedGroup.test(stripped)) {
 		return "bounded repetition applied to a group (e.g. `(a+){10,}`) — prone to catastrophic backtracking";

--- a/src/agent/tools/grepMatcher.ts
+++ b/src/agent/tools/grepMatcher.ts
@@ -28,8 +28,31 @@ export interface GrepMatcher {
 	 * Whether the compiled needle can match the empty string (e.g. `x*`, `a?`).
 	 * Such patterns make find-and-replace nonsensical (they "match" at every
 	 * position), so callers should reject them rather than count/replace.
+	 *
+	 * NOTE: this is a *structural* signal (does the pattern match `""`?). It does
+	 * NOT catch zero-width patterns that only match at a position inside real
+	 * text — `\b`, `(?=x)`, `^`, `$` all have `matchesEmpty === false` for some
+	 * flag combinations yet still match *zero characters*, so replacing them
+	 * inserts the replacement at every boundary. Use `hasZeroWidthMatch(text)` on
+	 * the actual content to gate replace operations; `matchesEmpty` remains only
+	 * as the fast structural pre-check that keeps `count` from inflating.
 	 */
 	readonly matchesEmpty: boolean;
+	/**
+	 * Whether running this matcher against `text` produces at least one
+	 * **zero-length** match — a match that consumes no characters (`\b`, `(?=x)`,
+	 * `^`, `$`, `x*`, `a?`, …). Such a match makes find-and-replace nonsensical:
+	 * `String.prototype.replace` would insert the replacement at that position
+	 * without removing anything, scattering it across every boundary. This is the
+	 * exact, content-aware guard that `matchesEmpty` (a structural `""` test)
+	 * cannot provide — `\bworld` and `(?=world)world` correctly return `false`
+	 * (they consume `world`), while a bare `\b` returns `true`.
+	 *
+	 * Literal needles never match zero-width (an escaped literal always consumes
+	 * its characters, and an empty literal is already rejected upstream), so this
+	 * is always `false` for them.
+	 */
+	hasZeroWidthMatch(text: string): boolean;
 	/**
 	 * Longest input `test`/`count` will run this matcher against. For a regex
 	 * matcher this is the ReDoS backtracking bound (`MAX_REGEX_INPUT_LENGTH`);
@@ -328,6 +351,26 @@ export function buildGrepMatcher(pattern: string, isRegex: boolean, caseSensitiv
 					for (const _ of text.matchAll(new RegExp(source.source, globalFlags))) n++;
 					return n;
 				},
+				hasZeroWidthMatch: (text: string) => {
+					// A zero-length match means replace would insert without consuming
+					// — nonsensical. Detected against the actual content because it is
+					// input-dependent (`\bworld` consumes text; a bare `\b` does not).
+					// The length backstop mirrors count/test: over-ceiling input is not
+					// scanned, and reporting "no zero-width match" there is safe because
+					// the caller has already refused the over-length note.
+					if (matchesEmpty) return true;
+					if (text.length > MAX_REGEX_INPUT_LENGTH) return false;
+					const g = new RegExp(source.source, globalFlags);
+					let m: RegExpExecArray | null;
+					// biome-ignore lint/suspicious/noAssignInExpressions: standard exec-loop idiom
+					while ((m = g.exec(text)) !== null) {
+						if (m[0].length === 0) return true;
+						// Guard against an infinite loop should a non-empty match ever
+						// report length 0 via flags; advance past a zero-width position.
+						if (m.index === g.lastIndex) g.lastIndex++;
+					}
+					return false;
+				},
 				matchesEmpty,
 				maxInputLength: MAX_REGEX_INPUT_LENGTH,
 			},
@@ -351,6 +394,9 @@ export function buildGrepMatcher(pattern: string, isRegex: boolean, caseSensitiv
 				const matches = text.match(new RegExp(escaped, globalFlags));
 				return matches ? matches.length : 0;
 			},
+			// A non-empty literal always consumes its characters; an empty literal
+			// is rejected upstream. Either way a literal never matches zero-width.
+			hasZeroWidthMatch: () => matchesEmpty,
 			matchesEmpty,
 			// A literal needle is matched by `String.includes` / an escaped-literal
 			// regex with no quantifiers — it cannot backtrack, so no length bound.

--- a/src/agent/tools/grepMatcher.ts
+++ b/src/agent/tools/grepMatcher.ts
@@ -41,18 +41,26 @@ export type BuildMatcherResult = { ok: true; matcher: GrepMatcher } | { ok: fals
  * longer than this are treated as non-matching (they are almost always minified
  * blobs / data URIs, not prose the agent means to search).
  */
-const MAX_SCANNED_LINE_LENGTH = 20000;
+const MAX_SCANNED_LINE_LENGTH = 5000;
 
 /**
  * Reject regex patterns whose structure is prone to catastrophic backtracking
  * (ReDoS). A user- or agent-supplied pattern is compiled and then `.test()`ed
  * line-by-line across the whole vault on the only UI thread with no timeout, so
  * a pattern like `(a+)+$` against a long non-matching line would hard-lock
- * Obsidian. Detecting ReDoS in general is undecidable; we screen for the common
- * dangerous shapes (a quantified group whose body is itself quantified, and
- * quantified alternations with overlapping branches). Returns an error message
- * if the pattern looks unsafe, or `null` if it passes.
+ * Obsidian.
+ *
+ * Detecting ReDoS in general is undecidable and pure syntactic screening can
+ * never be exhaustive — so this is defense-in-depth, paired with the input-size
+ * cap (`MAX_SCANNED_LINE_LENGTH`) that bounds the worst case even for a pattern
+ * that slips through. We reject the well-known dangerous shapes: a quantified
+ * group whose body is itself quantified (`(a+)+`), quantified alternations with
+ * overlapping branches (`(a|a)*`), large bounded repetitions (`a{5000,}`), and
+ * bounded repetition applied to a quantified group (`(a+){10,}`). Returns an
+ * error message if the pattern looks unsafe, or `null` if it passes.
  */
+const MAX_SAFE_QUANTIFIER_BOUND = 1000;
+
 function screenRegexForRedos(pattern: string): string | null {
 	// A group that is quantified, whose body contains an unbounded quantifier:
 	// (a+)+, (a*)*, (a+)*, (.*)+, (\d+){2,} etc. This is the classic exponential
@@ -67,6 +75,25 @@ function screenRegexForRedos(pattern: string): string | null {
 	const quantifiedAlternation = /\([^)]*\|[^)]*\)\s*[*+]/;
 	if (quantifiedAlternation.test(pattern)) {
 		return "quantifier applied to an alternation group (e.g. `(a|a)*`) — prone to catastrophic backtracking";
+	}
+
+	// A group followed by a bounded repetition, e.g. (a+){10,} or (ab){50,100} —
+	// bounded but still explodes the match tree. Any `{n,m}` (or `{n,}`) applied
+	// directly to a group is treated as unsafe.
+	const boundedQuantifiedGroup = /\)\s*\{\d+(?:,\d*)?\}/;
+	if (boundedQuantifiedGroup.test(pattern)) {
+		return "bounded repetition applied to a group (e.g. `(a+){10,}`) — prone to catastrophic backtracking";
+	}
+
+	// A single large bounded repetition, e.g. a{5000} / .{2000,} — even without
+	// nesting, a huge explicit bound makes each line scan O(bound) and stacks up
+	// across the whole vault. Reject bounds above a conservative ceiling.
+	for (const m of pattern.matchAll(/\{(\d+)(?:,(\d*))?\}/g)) {
+		const lower = Number(m[1]);
+		const upper = m[2] === undefined ? lower : m[2] === "" ? Number.POSITIVE_INFINITY : Number(m[2]);
+		if (lower > MAX_SAFE_QUANTIFIER_BOUND || upper > MAX_SAFE_QUANTIFIER_BOUND) {
+			return `repetition bound greater than ${MAX_SAFE_QUANTIFIER_BOUND} (e.g. \`a{${m[1]}}\`) — too expensive to scan the whole vault`;
+		}
 	}
 
 	return null;

--- a/src/agent/tools/grepMatcher.ts
+++ b/src/agent/tools/grepMatcher.ts
@@ -30,6 +30,17 @@ export interface GrepMatcher {
 	 * position), so callers should reject them rather than count/replace.
 	 */
 	readonly matchesEmpty: boolean;
+	/**
+	 * Longest input `test`/`count` will run this matcher against. For a regex
+	 * matcher this is the ReDoS backtracking bound (`MAX_REGEX_INPUT_LENGTH`);
+	 * for a literal needle it is `Infinity` (literals cannot backtrack). Callers
+	 * that operate on whole-note content should check `text.length` against this
+	 * and surface a clear "input too large" error instead of running the regex —
+	 * `test`/`count` return `false`/`0` for over-length input as a safety
+	 * backstop, but that is indistinguishable from a genuine non-match, so the
+	 * caller-side check is what keeps the failure visible.
+	 */
+	readonly maxInputLength: number;
 }
 
 export type BuildMatcherResult = { ok: true; matcher: GrepMatcher } | { ok: false; error: string };
@@ -50,6 +61,24 @@ export type BuildMatcherResult = { ok: true; matcher: GrepMatcher } | { ok: fals
 export const MAX_SCANNED_LINE_LENGTH = 5000;
 
 /**
+ * Hard ceiling on the input length a *regex* matcher will run against, enforced
+ * inside `buildGrepMatcher` so every caller inherits it (no caller can forget).
+ *
+ * The ReDoS structural screen (`screenRegexForRedos`) is provably incomplete —
+ * regex-safety screening is undecidable — so a pattern with catastrophic
+ * backtracking can slip through. Without a length bound, such a pattern run
+ * against whole-note content (`manage_notes` does exactly this) backtracks
+ * super-linearly and freezes the single UI thread. This ceiling caps the worst
+ * case regardless of what the screen missed.
+ *
+ * Chosen large enough that every realistic note passes untouched (a 200k-char
+ * note is ~40k words), but small enough that even an exponential pattern can't
+ * run long. Literal needles are exempt (they use `String.includes` / an escaped
+ * literal regex and cannot backtrack) — their `maxInputLength` is `Infinity`.
+ */
+export const MAX_REGEX_INPUT_LENGTH = 200_000;
+
+/**
  * Reject regex patterns whose structure is prone to catastrophic backtracking
  * (ReDoS). A user- or agent-supplied pattern is compiled and then `.test()`ed
  * line-by-line across the whole vault on the only UI thread with no timeout, so
@@ -67,13 +96,72 @@ export const MAX_SCANNED_LINE_LENGTH = 5000;
  */
 const MAX_SAFE_QUANTIFIER_BOUND = 1000;
 
+/**
+ * Rewrite a regex source so the ReDoS structural screen only sees genuine
+ * structure. Two constructs are collapsed to inert letter placeholders in a
+ * single left-to-right pass (a regex-based replace can't do this correctly
+ * because `]` at class start is literal and escapes may appear inside a class):
+ *
+ *  - An escaped char `\X` → `E` (the escaped metacharacter is a literal).
+ *  - A character class `[...]` → `C` (the whole class is one atom; parens,
+ *    pipes and braces inside it are literal, not structure).
+ *
+ * Placeholders are letters, which carry no regex meaning, so quantifiers/groups
+ * around them read exactly as they would around any literal character.
+ */
+function neutralizeLiterals(pattern: string): string {
+	let out = "";
+	let i = 0;
+	while (i < pattern.length) {
+		const ch = pattern[i];
+		if (ch === "\\") {
+			// Escaped char (or a trailing lone backslash) → one literal atom.
+			out += "E";
+			i += 2;
+			continue;
+		}
+		if (ch === "[") {
+			// Consume a full character class. A `]` immediately after `[` or `[^`
+			// is a literal member, not the terminator; escapes are skipped whole.
+			let j = i + 1;
+			if (pattern[j] === "^") j++;
+			if (pattern[j] === "]") j++; // leading literal ']'
+			while (j < pattern.length && pattern[j] !== "]") {
+				if (pattern[j] === "\\") j += 2;
+				else j++;
+			}
+			// j is at the closing ']' (or end of string if unterminated).
+			out += "C";
+			i = j + 1;
+			continue;
+		}
+		out += ch;
+		i++;
+	}
+	return out;
+}
+
 function screenRegexForRedos(pattern: string): string | null {
-	// Structural checks below look for real regex metacharacters — group parens,
-	// quantifiers, braces. An *escaped* metacharacter (`\)`, `\(`, `\{`) is a
-	// literal, not structure, so strip every `\X` pair first. Without this, a
-	// pattern like `\){5,10}` (a literal `)` repeated) would be misread as a
-	// bounded group repetition and wrongly rejected.
-	const stripped = pattern.replace(/\\./g, "");
+	// The structural checks below look for real regex *structure* — group parens,
+	// quantifiers, braces, alternation. Two things masquerade as structure but are
+	// not, and must be neutralized first or the screen both misses real dangers
+	// and rejects safe patterns:
+	//
+	//  1. Escaped metacharacters (`\)`, `\(`, `\{`, `\|`) are literals. Replace
+	//     each `\X` pair with a neutral literal placeholder so the escaped char
+	//     becomes an ordinary character rather than vanishing. Deleting it (an
+	//     earlier approach) let neighbours fuse: `\(a+\)+` → `(a+)+`, a false
+	//     positive. Placeholder-ing yields `Ea+E+` — not a group — correctly safe.
+	//  2. Character-class contents (`[...]`) are a single atom; a `)`/`(`/`|`
+	//     inside a class is literal, not group structure. Replace each class with
+	//     a single placeholder atom so, e.g., `([^)]+)+$` presents as `(C+)+$` and
+	//     the nested-quantifier check can see the real `(…+)+` shape. Without this
+	//     the `)` inside `[^)]` was read as the group terminator and the pattern
+	//     slipped through to catastrophic backtracking.
+	//
+	// Placeholders are letters (no regex meaning) so downstream checks treat them
+	// as ordinary atoms.
+	const stripped = neutralizeLiterals(pattern);
 
 	// A group that is quantified, whose body contains an unbounded quantifier:
 	// (a+)+, (a*)*, (a+)*, (.*)+, (\d+){2,} etc. This is the classic exponential
@@ -152,7 +240,12 @@ export function buildGrepMatcher(pattern: string, isRegex: boolean, caseSensitiv
 			ok: true,
 			matcher: {
 				// A non-global clone avoids the stateful `lastIndex` trap when reusing `.test()` in a loop.
-				test: (text: string) => new RegExp(source.source, singleFlags).test(text),
+				// The length guard is a backstop for patterns the ReDoS screen missed:
+				// refusing to run against over-length input caps worst-case backtracking.
+				// Callers should check `maxInputLength` and surface a clear error;
+				// returning false here is only a last-resort safety net.
+				test: (text: string) =>
+					text.length <= MAX_REGEX_INPUT_LENGTH && new RegExp(source.source, singleFlags).test(text),
 				globalRegex: () => new RegExp(source.source, globalFlags),
 				singleRegex: () => new RegExp(source.source, singleFlags),
 				count: (text: string) => {
@@ -161,11 +254,13 @@ export function buildGrepMatcher(pattern: string, isRegex: boolean, caseSensitiv
 					// which for an empty-matchable pattern returns one entry per
 					// character and inflates the count).
 					if (matchesEmpty) return 0;
+					if (text.length > MAX_REGEX_INPUT_LENGTH) return 0;
 					let n = 0;
 					for (const _ of text.matchAll(new RegExp(source.source, globalFlags))) n++;
 					return n;
 				},
 				matchesEmpty,
+				maxInputLength: MAX_REGEX_INPUT_LENGTH,
 			},
 		};
 	}
@@ -188,6 +283,9 @@ export function buildGrepMatcher(pattern: string, isRegex: boolean, caseSensitiv
 				return matches ? matches.length : 0;
 			},
 			matchesEmpty,
+			// A literal needle is matched by `String.includes` / an escaped-literal
+			// regex with no quantifiers — it cannot backtrack, so no length bound.
+			maxInputLength: Number.POSITIVE_INFINITY,
 		},
 	};
 }

--- a/src/agent/tools/grepMatcher.ts
+++ b/src/agent/tools/grepMatcher.ts
@@ -102,21 +102,31 @@ const MAX_SAFE_QUANTIFIER_BOUND = 1000;
  * single left-to-right pass (a regex-based replace can't do this correctly
  * because `]` at class start is literal and escapes may appear inside a class):
  *
- *  - An escaped char `\X` → `E` (the escaped metacharacter is a literal).
- *  - A character class `[...]` → `C` (the whole class is one atom; parens,
+ *  - An escaped shorthand *class* `\d \w \s \D \W \S \p \P` → `E` (a broad atom
+ *    that can overlap its neighbours).
+ *  - Any other escaped char `\X` (`\)`, `\.`, `\{`, …) → `L` (a narrow literal
+ *    atom — it matches exactly one specific character, so it does NOT overlap a
+ *    different literal). Keeping this distinct from `E` is what stops `\(a+\)+`
+ *    (literal parens around `a+`) from being misread as adjacent overlapping
+ *    quantifiers.
+ *  - A character class `[...]` → `C` (the whole class is one broad atom; parens,
  *    pipes and braces inside it are literal, not structure).
  *
  * Placeholders are letters, which carry no regex meaning, so quantifiers/groups
  * around them read exactly as they would around any literal character.
  */
+const ESCAPED_CLASS_CHARS = new Set(["d", "D", "w", "W", "s", "S", "p", "P"]);
+
 function neutralizeLiterals(pattern: string): string {
 	let out = "";
 	let i = 0;
 	while (i < pattern.length) {
 		const ch = pattern[i];
 		if (ch === "\\") {
-			// Escaped char (or a trailing lone backslash) → one literal atom.
-			out += "E";
+			// Escaped shorthand class (\d,\w,\s,…) is a broad atom (`E`); any other
+			// escaped char (or a trailing lone backslash) is one narrow literal (`L`).
+			const next = pattern[i + 1];
+			out += next !== undefined && ESCAPED_CLASS_CHARS.has(next) ? "E" : "L";
 			i += 2;
 			continue;
 		}
@@ -139,6 +149,54 @@ function neutralizeLiterals(pattern: string): string {
 		i++;
 	}
 	return out;
+}
+
+/**
+ * Detect two unbounded quantifiers (`*`/`+`) applied to *adjacent, overlapping*
+ * atoms in a neutralized pattern — e.g. `a+a+`, `.+.+`, `\d+\d+` (→ `E+E+`),
+ * `[a-z]+[a-z]+` (→ `C+C+`). This is the sequential-quantifier ReDoS shape the
+ * nested-quantifier check misses because there is no enclosing group.
+ *
+ * "Adjacent" means the second quantified atom starts exactly where the first
+ * ended (no separator between them). "Overlapping" means the two atoms can match
+ * the same characters — approximated as: the atoms are identical, OR either is a
+ * broad atom (`.`, a character class `C`, or an escaped shorthand class `\d`/`\w`
+ * → `E`). A narrow literal placeholder (`L`, from an escaped literal like `\)`)
+ * only overlaps an identical `L`. Because neutralization collapses all escaped
+ * shorthand classes to `E`, a safe disjoint pair like `\w+\s+` (→ `E+E+`) is
+ * conservatively rejected too; that is an accepted false-positive — such a
+ * pattern is trivially rewritten (`\w+\s`), and erring toward rejection keeps the
+ * UI thread safe.
+ *
+ * Distinct literals with quantifiers (`a+b+`), a required separator (`\d+-\d+`),
+ * or escaped literal parens around a quantifier (`\(a+\)+` → `La+L+`) are NOT
+ * flagged — they cannot backtrack catastrophically.
+ */
+function hasAdjacentOverlappingQuantifiers(neutralized: string): boolean {
+	// Match each `<atom><*|+>`; an atom is a single ordinary char, `.`, or a
+	// neutralization placeholder (`C` = char class, `E` = escaped class, `L` =
+	// escaped literal).
+	const atomQuantifier = /([A-Za-z0-9._]|C|E|L)([*+])/g;
+	// Broad atoms overlap (almost) anything; a narrow literal `L` overlaps only an
+	// identical `L`, handled by the `atom === prevAtom` check.
+	const BROAD = new Set([".", "C", "E"]);
+	let match: RegExpExecArray | null;
+	let prevAtom: string | null = null;
+	let prevEnd = -1;
+	// biome-ignore lint/suspicious/noAssignInExpressions: standard exec-loop idiom
+	while ((match = atomQuantifier.exec(neutralized))) {
+		const atom = match[1];
+		const start = match.index;
+		if (prevAtom !== null && start === prevEnd) {
+			// The two quantified atoms are directly adjacent (no separator).
+			if (atom === prevAtom || BROAD.has(atom) || BROAD.has(prevAtom)) {
+				return true;
+			}
+		}
+		prevAtom = atom;
+		prevEnd = atomQuantifier.lastIndex;
+	}
+	return false;
 }
 
 function screenRegexForRedos(pattern: string): string | null {
@@ -184,6 +242,17 @@ function screenRegexForRedos(pattern: string): string | null {
 	const boundedQuantifiedGroup = /\)\s*\{\d+(?:,\d*)?\}/;
 	if (boundedQuantifiedGroup.test(stripped)) {
 		return "bounded repetition applied to a group (e.g. `(a+){10,}`) — prone to catastrophic backtracking";
+	}
+
+	// Two unbounded quantifiers applied back-to-back to overlapping atoms, e.g.
+	// `a+a+`, `.+.+`, `\d+\d+`, `\w+\w+`. When adjacent greedy quantifiers can both
+	// consume the same characters, the number of ways to split the input explodes
+	// (super-linear/exponential) — the classic `a+a+a+X`-against-`"aaaa…"` freeze,
+	// which is NOT caught by the nested-quantifier check (there is no group). This
+	// is distinct from safe adjacency like `a+b+` (disjoint literals) or `\d+-\d+`
+	// (a required separator between them), which are not flagged.
+	if (hasAdjacentOverlappingQuantifiers(stripped)) {
+		return "adjacent unbounded quantifiers on overlapping atoms (e.g. `a+a+`, `\\d+\\d+`) — prone to catastrophic backtracking";
 	}
 
 	// A single large bounded repetition, e.g. a{5000} / .{2000,} — even without

--- a/src/agent/tools/grepMatcher.ts
+++ b/src/agent/tools/grepMatcher.ts
@@ -35,13 +35,19 @@ export interface GrepMatcher {
 export type BuildMatcherResult = { ok: true; matcher: GrepMatcher } | { ok: false; error: string };
 
 /**
- * Longest line we will run a user-supplied regex against. `grep_notes` and
- * `manage_notes` scan every vault file synchronously on the UI thread, so an
- * unbounded line length turns even a linear regex into a visible freeze. Lines
- * longer than this are treated as non-matching (they are almost always minified
- * blobs / data URIs, not prose the agent means to search).
+ * Longest line `grep_notes` will run a user-supplied regex against. It scans
+ * every vault file line-by-line synchronously on the UI thread, so a
+ * pathological line length would turn even a screened regex into a visible
+ * freeze (backtracking cost scales super-linearly with input length). The
+ * caller skips lines longer than this and reports how many were skipped, so the
+ * bound is a visible safety limit rather than a silent wrong answer.
+ *
+ * This is a `grep_notes` line-scan concern only — it is NOT applied inside the
+ * matcher. `manage_notes` runs `count`/replace against whole-note content
+ * (which routinely exceeds this), and capping there silently dropped valid
+ * matches. ReDoS protection for those paths comes from `screenRegexForRedos`.
  */
-const MAX_SCANNED_LINE_LENGTH = 5000;
+export const MAX_SCANNED_LINE_LENGTH = 5000;
 
 /**
  * Reject regex patterns whose structure is prone to catastrophic backtracking
@@ -62,18 +68,25 @@ const MAX_SCANNED_LINE_LENGTH = 5000;
 const MAX_SAFE_QUANTIFIER_BOUND = 1000;
 
 function screenRegexForRedos(pattern: string): string | null {
+	// Structural checks below look for real regex metacharacters — group parens,
+	// quantifiers, braces. An *escaped* metacharacter (`\)`, `\(`, `\{`) is a
+	// literal, not structure, so strip every `\X` pair first. Without this, a
+	// pattern like `\){5,10}` (a literal `)` repeated) would be misread as a
+	// bounded group repetition and wrongly rejected.
+	const stripped = pattern.replace(/\\./g, "");
+
 	// A group that is quantified, whose body contains an unbounded quantifier:
 	// (a+)+, (a*)*, (a+)*, (.*)+, (\d+){2,} etc. This is the classic exponential
 	// nested-quantifier form.
 	const nestedQuantifier = /\([^)]*[*+][^)]*\)\s*[*+]|\([^)]*[*+][^)]*\)\s*\{\d+,?\d*\}/;
-	if (nestedQuantifier.test(pattern)) {
+	if (nestedQuantifier.test(stripped)) {
 		return "quantifier applied to a group that already contains an unbounded quantifier (e.g. `(a+)+`)";
 	}
 
 	// Quantified alternation of single-char classes that overlap, e.g. (a|a)*,
 	// (\w|\d)+ — overlapping branches under a quantifier backtrack badly.
 	const quantifiedAlternation = /\([^)]*\|[^)]*\)\s*[*+]/;
-	if (quantifiedAlternation.test(pattern)) {
+	if (quantifiedAlternation.test(stripped)) {
 		return "quantifier applied to an alternation group (e.g. `(a|a)*`) — prone to catastrophic backtracking";
 	}
 
@@ -81,18 +94,18 @@ function screenRegexForRedos(pattern: string): string | null {
 	// bounded but still explodes the match tree. Any `{n,m}` (or `{n,}`) applied
 	// directly to a group is treated as unsafe.
 	const boundedQuantifiedGroup = /\)\s*\{\d+(?:,\d*)?\}/;
-	if (boundedQuantifiedGroup.test(pattern)) {
+	if (boundedQuantifiedGroup.test(stripped)) {
 		return "bounded repetition applied to a group (e.g. `(a+){10,}`) — prone to catastrophic backtracking";
 	}
 
 	// A single large bounded repetition, e.g. a{5000} / .{2000,} — even without
-	// nesting, a huge explicit bound makes each line scan O(bound) and stacks up
-	// across the whole vault. Reject bounds above a conservative ceiling.
-	for (const m of pattern.matchAll(/\{(\d+)(?:,(\d*))?\}/g)) {
+	// nesting, a huge explicit bound makes each scan O(bound). Reject bounds
+	// above a conservative ceiling.
+	for (const m of stripped.matchAll(/\{(\d+)(?:,(\d*))?\}/g)) {
 		const lower = Number(m[1]);
 		const upper = m[2] === undefined ? lower : m[2] === "" ? Number.POSITIVE_INFINITY : Number(m[2]);
 		if (lower > MAX_SAFE_QUANTIFIER_BOUND || upper > MAX_SAFE_QUANTIFIER_BOUND) {
-			return `repetition bound greater than ${MAX_SAFE_QUANTIFIER_BOUND} (e.g. \`a{${m[1]}}\`) — too expensive to scan the whole vault`;
+			return `repetition bound greater than ${MAX_SAFE_QUANTIFIER_BOUND} (e.g. \`a{${m[1]}}\`) — too expensive to scan`;
 		}
 	}
 
@@ -139,12 +152,10 @@ export function buildGrepMatcher(pattern: string, isRegex: boolean, caseSensitiv
 			ok: true,
 			matcher: {
 				// A non-global clone avoids the stateful `lastIndex` trap when reusing `.test()` in a loop.
-				test: (text: string) =>
-					text.length <= MAX_SCANNED_LINE_LENGTH && new RegExp(source.source, singleFlags).test(text),
+				test: (text: string) => new RegExp(source.source, singleFlags).test(text),
 				globalRegex: () => new RegExp(source.source, globalFlags),
 				singleRegex: () => new RegExp(source.source, singleFlags),
 				count: (text: string) => {
-					if (text.length > MAX_SCANNED_LINE_LENGTH) return 0;
 					// Count non-overlapping matches. `matchAll` advances past
 					// zero-length matches correctly (unlike `String.match(/g/)`,
 					// which for an empty-matchable pattern returns one entry per

--- a/src/agent/tools/grepNotes.ts
+++ b/src/agent/tools/grepNotes.ts
@@ -12,6 +12,18 @@ import { buildGrepMatcher, MAX_SCANNED_LINE_LENGTH } from "./grepMatcher";
 
 const DEFAULT_LIMIT = 50;
 
+/**
+ * Upper bound on how many files a single vault-wide grep will read + scan. The
+ * scan is O(total bytes) and runs synchronously on the UI thread, so a very
+ * large vault would otherwise turn every call into a multi-second freeze. When
+ * the eligible file set exceeds this, we scan the first `MAX_SCANNED_FILES` (in
+ * stable path order), return the matches found so far, and set
+ * `scan_truncated: true` so the agent knows the search was partial and can
+ * narrow with `path_prefix`. A scoped (`path`) search is a single file and is
+ * never subject to this bound.
+ */
+export const MAX_SCANNED_FILES = 5000;
+
 interface FlatMatch {
 	path: string;
 	line_number: number;
@@ -36,6 +48,11 @@ interface GrepNotesPayload {
 	next_offset?: number;
 	/** Number of lines skipped because they exceeded the scan-length limit. */
 	lines_skipped?: number;
+	/**
+	 * True when a vault-wide search hit `MAX_SCANNED_FILES` and stopped early, so
+	 * the results are partial. Never set for a scoped (`path`) search.
+	 */
+	scan_truncated?: boolean;
 	results: GrepNotesResultItem[];
 	message?: string;
 }
@@ -127,16 +144,25 @@ export function createGrepNotesTool(app: App) {
 			scope = "vault";
 		}
 
-		// Scan every file into a flat match list (stable order for paging).
+		// Scan the file set into a flat match list (stable order for paging).
+		// Vault-wide scans are bounded by MAX_SCANNED_FILES so a huge vault can't
+		// freeze the UI thread; a scoped (single-file) search is never bounded.
 		const currentProvider = pluginData.getSelectedAgent().chatModel?.provider;
 		const store = getPendingChangesStore();
 		const flat: FlatMatch[] = [];
 		let filesSearched = 0;
 		let linesSkipped = 0;
+		let scanTruncated = false;
 
 		for (const file of files) {
 			if (currentProvider && store.shouldBlockFile(file.path, currentProvider)) {
 				continue;
+			}
+			// Bound the total scan work. `filesSearched` counts files we actually
+			// read (post privacy filter), so blocked files don't consume budget.
+			if (scope === "vault" && filesSearched >= MAX_SCANNED_FILES) {
+				scanTruncated = true;
+				break;
 			}
 			filesSearched++;
 			let content: string;
@@ -194,6 +220,7 @@ export function createGrepNotesTool(app: App) {
 			has_more: hasMore,
 			next_offset: hasMore ? safeOffset + returned : undefined,
 			lines_skipped: linesSkipped || undefined,
+			scan_truncated: scanTruncated || undefined,
 			results,
 		};
 
@@ -202,12 +229,16 @@ export function createGrepNotesTool(app: App) {
 				? ` (${linesSkipped} line${linesSkipped === 1 ? "" : "s"} longer than ${MAX_SCANNED_LINE_LENGTH} chars were skipped)`
 				: "";
 
+		const truncatedNote = scanTruncated
+			? ` Search stopped after scanning ${MAX_SCANNED_FILES} files — results are partial. Narrow the search with path_prefix to cover the rest.`
+			: "";
+
 		if (totalMatches === 0) {
-			payload.message = `No matches for "${pattern}" across ${filesSearched} note(s) searched.${skippedNote}`;
+			payload.message = `No matches for "${pattern}" across ${filesSearched} note(s) searched.${skippedNote}${truncatedNote}`;
 		} else if (hasMore) {
-			payload.message = `Showing matches ${safeOffset + 1}-${safeOffset + returned} of ${totalMatches}. Call again with offset=${safeOffset + returned} for more.${skippedNote}`;
-		} else if (skippedNote) {
-			payload.message = `${totalMatches} match${totalMatches === 1 ? "" : "es"} found.${skippedNote}`;
+			payload.message = `Showing matches ${safeOffset + 1}-${safeOffset + returned} of ${totalMatches}. Call again with offset=${safeOffset + returned} for more.${skippedNote}${truncatedNote}`;
+		} else if (skippedNote || truncatedNote) {
+			payload.message = `${totalMatches} match${totalMatches === 1 ? "" : "es"} found.${skippedNote}${truncatedNote}`;
 		}
 
 		return JSON.stringify(payload);

--- a/src/agent/tools/grepNotes.ts
+++ b/src/agent/tools/grepNotes.ts
@@ -12,18 +12,6 @@ import { buildGrepMatcher, MAX_SCANNED_LINE_LENGTH } from "./grepMatcher";
 
 const DEFAULT_LIMIT = 50;
 
-/**
- * Upper bound on how many files a single vault-wide grep will read + scan. The
- * scan is O(total bytes) and runs synchronously on the UI thread, so a very
- * large vault would otherwise turn every call into a multi-second freeze. When
- * the eligible file set exceeds this, we scan the first `MAX_SCANNED_FILES` (in
- * stable path order), return the matches found so far, and set
- * `scan_truncated: true` so the agent knows the search was partial and can
- * narrow with `path_prefix`. A scoped (`path`) search is a single file and is
- * never subject to this bound.
- */
-export const MAX_SCANNED_FILES = 5000;
-
 interface FlatMatch {
 	path: string;
 	line_number: number;
@@ -48,11 +36,6 @@ interface GrepNotesPayload {
 	next_offset?: number;
 	/** Number of lines skipped because they exceeded the scan-length limit. */
 	lines_skipped?: number;
-	/**
-	 * True when a vault-wide search hit `MAX_SCANNED_FILES` and stopped early, so
-	 * the results are partial. Never set for a scoped (`path`) search.
-	 */
-	scan_truncated?: boolean;
 	results: GrepNotesResultItem[];
 	message?: string;
 }
@@ -144,25 +127,19 @@ export function createGrepNotesTool(app: App) {
 			scope = "vault";
 		}
 
-		// Scan the file set into a flat match list (stable order for paging).
-		// Vault-wide scans are bounded by MAX_SCANNED_FILES so a huge vault can't
-		// freeze the UI thread; a scoped (single-file) search is never bounded.
+		// Scan the file set into a flat match list (stable order for paging). A
+		// vault-wide grep reads every eligible note — the search is exhaustive.
+		// Freeze protection comes from the per-line length guard below (pathological
+		// lines are skipped and reported), not from bounding the file count.
 		const currentProvider = pluginData.getSelectedAgent().chatModel?.provider;
 		const store = getPendingChangesStore();
 		const flat: FlatMatch[] = [];
 		let filesSearched = 0;
 		let linesSkipped = 0;
-		let scanTruncated = false;
 
 		for (const file of files) {
 			if (currentProvider && store.shouldBlockFile(file.path, currentProvider)) {
 				continue;
-			}
-			// Bound the total scan work. `filesSearched` counts files we actually
-			// read (post privacy filter), so blocked files don't consume budget.
-			if (scope === "vault" && filesSearched >= MAX_SCANNED_FILES) {
-				scanTruncated = true;
-				break;
 			}
 			filesSearched++;
 			let content: string;
@@ -220,7 +197,6 @@ export function createGrepNotesTool(app: App) {
 			has_more: hasMore,
 			next_offset: hasMore ? safeOffset + returned : undefined,
 			lines_skipped: linesSkipped || undefined,
-			scan_truncated: scanTruncated || undefined,
 			results,
 		};
 
@@ -229,16 +205,12 @@ export function createGrepNotesTool(app: App) {
 				? ` (${linesSkipped} line${linesSkipped === 1 ? "" : "s"} longer than ${MAX_SCANNED_LINE_LENGTH} chars were skipped)`
 				: "";
 
-		const truncatedNote = scanTruncated
-			? ` Search stopped after scanning ${MAX_SCANNED_FILES} files — results are partial. Narrow the search with path_prefix to cover the rest.`
-			: "";
-
 		if (totalMatches === 0) {
-			payload.message = `No matches for "${pattern}" across ${filesSearched} note(s) searched.${skippedNote}${truncatedNote}`;
+			payload.message = `No matches for "${pattern}" across ${filesSearched} note(s) searched.${skippedNote}`;
 		} else if (hasMore) {
-			payload.message = `Showing matches ${safeOffset + 1}-${safeOffset + returned} of ${totalMatches}. Call again with offset=${safeOffset + returned} for more.${skippedNote}${truncatedNote}`;
-		} else if (skippedNote || truncatedNote) {
-			payload.message = `${totalMatches} match${totalMatches === 1 ? "" : "es"} found.${skippedNote}${truncatedNote}`;
+			payload.message = `Showing matches ${safeOffset + 1}-${safeOffset + returned} of ${totalMatches}. Call again with offset=${safeOffset + returned} for more.${skippedNote}`;
+		} else if (skippedNote) {
+			payload.message = `${totalMatches} match${totalMatches === 1 ? "" : "es"} found.${skippedNote}`;
 		}
 
 		return JSON.stringify(payload);

--- a/src/agent/tools/grepNotes.ts
+++ b/src/agent/tools/grepNotes.ts
@@ -8,7 +8,7 @@ import { getIndexableVaultFiles, isTextIndexableFile, shouldProcessVaultPath } f
 import { Logger } from "../../utils/logging";
 import { normalizeVaultPath } from "../../utils/pathUtils";
 import { resolveFileReferenceDetailed } from "../../utils/pathResolution";
-import { buildGrepMatcher } from "./grepMatcher";
+import { buildGrepMatcher, MAX_SCANNED_LINE_LENGTH } from "./grepMatcher";
 
 const DEFAULT_LIMIT = 50;
 
@@ -34,6 +34,8 @@ interface GrepNotesPayload {
 	returned: number;
 	has_more: boolean;
 	next_offset?: number;
+	/** Number of lines skipped because they exceeded the scan-length limit. */
+	lines_skipped?: number;
 	results: GrepNotesResultItem[];
 	message?: string;
 }
@@ -130,6 +132,7 @@ export function createGrepNotesTool(app: App) {
 		const store = getPendingChangesStore();
 		const flat: FlatMatch[] = [];
 		let filesSearched = 0;
+		let linesSkipped = 0;
 
 		for (const file of files) {
 			if (currentProvider && store.shouldBlockFile(file.path, currentProvider)) {
@@ -145,6 +148,13 @@ export function createGrepNotesTool(app: App) {
 			}
 			const lines = content.split("\n");
 			for (let i = 0; i < lines.length; i++) {
+				// Skip pathologically long lines (minified blobs, data URIs) rather
+				// than run the regex against them on the UI thread. Counted and
+				// reported so this is a visible limit, not a silent wrong answer.
+				if (lines[i].length > MAX_SCANNED_LINE_LENGTH) {
+					linesSkipped++;
+					continue;
+				}
 				if (matcher.test(lines[i])) {
 					flat.push({
 						path: file.path,
@@ -183,13 +193,21 @@ export function createGrepNotesTool(app: App) {
 			returned,
 			has_more: hasMore,
 			next_offset: hasMore ? safeOffset + returned : undefined,
+			lines_skipped: linesSkipped || undefined,
 			results,
 		};
 
+		const skippedNote =
+			linesSkipped > 0
+				? ` (${linesSkipped} line${linesSkipped === 1 ? "" : "s"} longer than ${MAX_SCANNED_LINE_LENGTH} chars were skipped)`
+				: "";
+
 		if (totalMatches === 0) {
-			payload.message = `No matches for "${pattern}" across ${filesSearched} note(s) searched.`;
+			payload.message = `No matches for "${pattern}" across ${filesSearched} note(s) searched.${skippedNote}`;
 		} else if (hasMore) {
-			payload.message = `Showing matches ${safeOffset + 1}-${safeOffset + returned} of ${totalMatches}. Call again with offset=${safeOffset + returned} for more.`;
+			payload.message = `Showing matches ${safeOffset + 1}-${safeOffset + returned} of ${totalMatches}. Call again with offset=${safeOffset + returned} for more.${skippedNote}`;
+		} else if (skippedNote) {
+			payload.message = `${totalMatches} match${totalMatches === 1 ? "" : "es"} found.${skippedNote}`;
 		}
 
 		return JSON.stringify(payload);

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -298,6 +298,11 @@ export async function stageNoteOperations(
 	// regex input length. Accumulated across ops so a partial-success summary can
 	// still surface the skip (the pure-skip case is reported per-op below).
 	let tooLargeSkippedTotal = 0;
+	// Notes a vault-wide replace skipped because an *earlier* operation in this
+	// same batch already staged a change to them. Skipping avoids staging two
+	// conflicting diffs for one file (the second would be un-appliable), but the
+	// skip must be surfaced — otherwise a multi-op batch silently under-applies.
+	const conflictSkippedPaths = new Set<string>();
 
 	for (let i = 0; i < operations.length; i++) {
 		const operation = operations[i];
@@ -463,13 +468,21 @@ export async function stageNoteOperations(
 		let notesSearched = 0;
 		let notesChanged = 0;
 		let notesTooLarge = 0;
+		let notesConflictSkipped = 0;
 
 		for (const file of candidateFiles) {
 			if (!store.isPathAllowed(file.path)) continue;
 			if (replaceProvider && store.shouldBlockFile(file.path, replaceProvider)) continue;
 
-			// Guard against conflicting with another op in this same batch.
-			if (seenPaths.has(file.path)) continue;
+			// Guard against conflicting with another op in this same batch: an
+			// earlier op already staged a change to this file, so staging a second
+			// diff from the same original content would be un-appliable. Record the
+			// skip so it is surfaced rather than silently under-applied.
+			if (seenPaths.has(file.path)) {
+				conflictSkippedPaths.add(file.path);
+				notesConflictSkipped++;
+				continue;
+			}
 
 			notesSearched++;
 			const originalContent = await app.vault.read(file);
@@ -504,6 +517,14 @@ export async function stageNoteOperations(
 		}
 
 		if (notesChanged === 0) {
+			// If the only reason nothing staged is that every candidate was
+			// conflict-skipped (an earlier op in this batch already changed those
+			// files), do NOT abort the batch — the earlier op's change is valid and
+			// the conflict is surfaced in the final summary. Aborting here would
+			// discard that valid change. Only hard-error on a genuine no-match.
+			if (notesConflictSkipped > 0) {
+				continue;
+			}
 			const tooLargeNote =
 				notesTooLarge > 0
 					? ` ${notesTooLarge} note(s) were skipped as too large to search with a regex safely — use a literal find or split them.`
@@ -522,6 +543,9 @@ export async function stageNoteOperations(
 	}
 	if (tooLargeSkippedTotal > 0) {
 		summary += ` ${tooLargeSkippedTotal} note(s) were skipped as too large to search with a regex safely — use a literal find or split them.`;
+	}
+	if (conflictSkippedPaths.size > 0) {
+		summary += ` ${conflictSkippedPaths.size} note(s) matched a later replace operation but were skipped because an earlier operation in this batch already modified them — run those replacements in a separate manage_notes call to apply them.`;
 	}
 	return summary;
 }

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -199,6 +199,13 @@ function applySequentialEdits(
 					error: `Error in operation ${operationNumber}, edit ${i + 1}: The regex can match an empty string, which matches everywhere in "${path}". Use a pattern that matches concrete text.`,
 				};
 			}
+			// A regex over an over-length note can backtrack catastrophically past
+			// what the ReDoS screen catches. Refuse rather than freeze the UI.
+			if (content.length > matcher.maxInputLength) {
+				return {
+					error: `Error in operation ${operationNumber}, edit ${i + 1}: "${path}" is ${content.length} characters, too large to search safely with a regex (limit ${matcher.maxInputLength}). Use a literal (non-regex) find, or split the note.`,
+				};
+			}
 			const occurrences = matcher.count(content);
 			if (occurrences === 0) {
 				return {
@@ -287,6 +294,10 @@ export async function stageNoteOperations(
 	// result so the model knows a concurrent chat is editing the same file — the
 	// update-dedup only collapses same-thread duplicates, not cross-thread ones.
 	const crossThreadPaths = new Set<string>();
+	// Notes skipped by a vault-wide regex replace because they exceed the safe
+	// regex input length. Accumulated across ops so a partial-success summary can
+	// still surface the skip (the pure-skip case is reported per-op below).
+	let tooLargeSkippedTotal = 0;
 
 	for (let i = 0; i < operations.length; i++) {
 		const operation = operations[i];
@@ -451,6 +462,7 @@ export async function stageNoteOperations(
 		const replaceProvider = (getData().getAgent(agentId) ?? getData().getSelectedAgent()).chatModel?.provider;
 		let notesSearched = 0;
 		let notesChanged = 0;
+		let notesTooLarge = 0;
 
 		for (const file of candidateFiles) {
 			if (!store.isPathAllowed(file.path)) continue;
@@ -461,6 +473,15 @@ export async function stageNoteOperations(
 
 			notesSearched++;
 			const originalContent = await app.vault.read(file);
+			// Skip notes too large to regex safely (unbounded backtracking would
+			// freeze the UI). Only regex ops are affected — a literal find is a
+			// plain string scan with no backtracking. Counted and surfaced below
+			// so the skip is visible, not a silent wrong answer.
+			if (operation.is_regex && originalContent.length > matcher.maxInputLength) {
+				notesTooLarge++;
+				tooLargeSkippedTotal++;
+				continue;
+			}
 			if (!matcher.test(originalContent)) continue;
 
 			const newContent = operation.is_regex
@@ -483,7 +504,11 @@ export async function stageNoteOperations(
 		}
 
 		if (notesChanged === 0) {
-			return `Error in operation ${operationNumber}: No occurrences of "${operation.find}" found across ${notesSearched} note(s) searched${operation.path_prefix ? ` under "${operation.path_prefix}"` : ""}. Nothing was staged.`;
+			const tooLargeNote =
+				notesTooLarge > 0
+					? ` ${notesTooLarge} note(s) were skipped as too large to search with a regex safely — use a literal find or split them.`
+					: "";
+			return `Error in operation ${operationNumber}: No occurrences of "${operation.find}" found across ${notesSearched} note(s) searched${operation.path_prefix ? ` under "${operation.path_prefix}"` : ""}. Nothing was staged.${tooLargeNote}`;
 		}
 	}
 
@@ -494,6 +519,9 @@ export async function stageNoteOperations(
 	if (crossThreadPaths.size > 0) {
 		const paths = [...crossThreadPaths].map((p) => `"${p}"`).join(", ");
 		summary += ` Note: another chat already has a pending update to ${paths}. Both proposals target the same file — whichever is accepted first wins, and the other may then be un-appliable (its expected original content will no longer match). Coordinate or avoid duplicating edits across chats.`;
+	}
+	if (tooLargeSkippedTotal > 0) {
+		summary += ` ${tooLargeSkippedTotal} note(s) were skipped as too large to search with a regex safely — use a literal find or split them.`;
 	}
 	return summary;
 }

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -194,16 +194,22 @@ function applySequentialEdits(
 				};
 			}
 			const matcher = built.matcher;
-			if (matcher.matchesEmpty) {
-				return {
-					error: `Error in operation ${operationNumber}, edit ${i + 1}: The regex can match an empty string, which matches everywhere in "${path}". Use a pattern that matches concrete text.`,
-				};
-			}
 			// A regex over an over-length note can backtrack catastrophically past
-			// what the ReDoS screen catches. Refuse rather than freeze the UI.
+			// what the ReDoS screen catches. Refuse rather than freeze the UI. This
+			// runs before the zero-width check so we never scan an over-length note.
 			if (content.length > matcher.maxInputLength) {
 				return {
 					error: `Error in operation ${operationNumber}, edit ${i + 1}: "${path}" is ${content.length} characters, too large to search safely with a regex (limit ${matcher.maxInputLength}). Use a literal (non-regex) find, or split the note.`,
+				};
+			}
+			// Reject patterns whose match consumes no characters (`\b`, `(?=x)`, `^`,
+			// `$`, `x*`, …). Replacing a zero-width match inserts the replacement at
+			// every boundary instead of substituting text — never what the caller
+			// intends. Checked against the actual content so anchored patterns that
+			// DO consume text (`\bword`) are allowed.
+			if (matcher.hasZeroWidthMatch(content)) {
+				return {
+					error: `Error in operation ${operationNumber}, edit ${i + 1}: The regex matches an empty (zero-width) position in "${path}", so replacing it would insert text at every boundary rather than substitute. Use a pattern that matches concrete text.`,
 				};
 			}
 			const occurrences = matcher.count(content);
@@ -455,6 +461,14 @@ export async function stageNoteOperations(
 		}
 		const matcher = built.matcher;
 
+		// Structurally empty-matchable patterns (`x*`, `^`, `$`, `a?`) match at
+		// every position regardless of content, so reject upfront before scanning
+		// the vault. Content-dependent zero-width patterns (`\b`, `(?=x)`) can only
+		// be detected against real text and are caught in the loop below.
+		if (operation.is_regex && matcher.matchesEmpty) {
+			return `Error in operation ${operationNumber}: The regex "${operation.find}" matches an empty (zero-width) position, so replacing it would insert text everywhere rather than substitute. Use a pattern that matches concrete text.`;
+		}
+
 		let candidateFiles = getIndexableVaultFiles(app.vault).filter(
 			(f) => f.extension.toLowerCase() === "md" && isTextIndexableFile(f),
 		);
@@ -494,6 +508,14 @@ export async function stageNoteOperations(
 				notesTooLarge++;
 				tooLargeSkippedTotal++;
 				continue;
+			}
+			// Content-dependent zero-width guard: `\b`, `(?=x)` etc. match without
+			// consuming characters, so replacing them scatters the replacement across
+			// every boundary. This is a property of the pattern, not the file — the
+			// first note that exhibits it proves the pattern is wrong for a replace —
+			// so abort the whole operation rather than silently skipping notes.
+			if (operation.is_regex && matcher.hasZeroWidthMatch(originalContent)) {
+				return `Error in operation ${operationNumber}: The regex "${operation.find}" matches an empty (zero-width) position in "${file.path}", so replacing it would insert text at every boundary rather than substitute. Use a pattern that matches concrete text.`;
 			}
 			if (!matcher.test(originalContent)) continue;
 

--- a/src/utils/computeWorkerManager.ts
+++ b/src/utils/computeWorkerManager.ts
@@ -83,9 +83,28 @@ function postRequest<T extends ComputeWorkerResponse>(request: ComputeWorkerRequ
 	}
 
 	return new Promise<T>((resolve, reject) => {
-		pending.set(request.id, { resolve, reject, request });
+		// Store a recovery copy whose vector buffer is NOT the one we transfer.
+		// `getTransferList` hands the buffer to the worker, which detaches it on
+		// this thread; recomputing on the main thread from a detached buffer
+		// would throw. Cloning first keeps the recovery path intact while the
+		// worker still gets a zero-copy transfer of the original.
+		pending.set(request.id, { resolve, reject, request: cloneRequestForRecovery(request) });
 		w.postMessage(request, getTransferList(request));
 	});
+}
+
+/**
+ * Deep-copy the transferable vector buffer of a request so a retained copy
+ * survives the `postMessage` transfer (which detaches the original's buffer on
+ * this thread). Non-vector requests (e.g. `leiden`) transfer nothing and are
+ * returned as-is.
+ */
+function cloneRequestForRecovery(request: ComputeWorkerRequest): ComputeWorkerRequest {
+	if (request.type === "leiden") return request;
+	const { data, count, dim } = request.vectors;
+	// `data.slice()` allocates a fresh backing buffer, decoupled from the one
+	// about to be transferred.
+	return { ...request, vectors: { data: data.slice(), count, dim } };
 }
 
 /**

--- a/test/agent/grepMatcher.test.ts
+++ b/test/agent/grepMatcher.test.ts
@@ -90,6 +90,26 @@ describe("buildGrepMatcher — ReDoS protection", () => {
 		expect(built.ok).toBe(false);
 	});
 
+	it("rejects bounded repetition applied to a group", () => {
+		const built = buildGrepMatcher("(a+){10,}", true, false);
+		expect(built.ok).toBe(false);
+		if (built.ok) return;
+		expect(built.error).toContain("rejected");
+	});
+
+	it("rejects a large explicit repetition bound", () => {
+		expect(buildGrepMatcher("a{5000}", true, false).ok).toBe(false);
+		expect(buildGrepMatcher("x{0,9999}", true, false).ok).toBe(false);
+		expect(buildGrepMatcher("y{2000,}", true, false).ok).toBe(false);
+	});
+
+	it("still accepts a modest bounded repetition", () => {
+		const built = buildGrepMatcher("a{2,5}", true, false);
+		expect(built.ok).toBe(true);
+		if (!built.ok) return;
+		expect(built.matcher.test("aaa")).toBe(true);
+	});
+
 	it("still accepts ordinary quantifiers", () => {
 		const built = buildGrepMatcher("\\d+", true, false);
 		expect(built.ok).toBe(true);
@@ -100,7 +120,8 @@ describe("buildGrepMatcher — ReDoS protection", () => {
 	it("does not run a regex against an over-long line", () => {
 		const built = buildGrepMatcher("a", true, false);
 		if (!built.ok) return;
-		const huge = "a".repeat(20001);
+		// Comfortably over MAX_SCANNED_LINE_LENGTH (5000).
+		const huge = "a".repeat(6000);
 		expect(built.matcher.test(huge)).toBe(false);
 		expect(built.matcher.count(huge)).toBe(0);
 		// A normal-length line still matches.

--- a/test/agent/grepMatcher.test.ts
+++ b/test/agent/grepMatcher.test.ts
@@ -222,6 +222,48 @@ describe("buildGrepMatcher — empty-match handling", () => {
 	});
 });
 
+describe("buildGrepMatcher — zero-width match detection (hasZeroWidthMatch)", () => {
+	const text = "hello world";
+
+	it("flags patterns that match zero-width against real content", () => {
+		// These consume no characters at their match position, so a replace would
+		// insert at every boundary rather than substitute. matchesEmpty (a `""`
+		// test) catches x*/^/$ but NOT \b or (?=x) — hasZeroWidthMatch catches all.
+		for (const p of ["\\b", "(?=o)", "^", "$", "x*", "\\d*", "a?"]) {
+			const built = buildGrepMatcher(p, true, false);
+			expect(built.ok).toBe(true);
+			if (!built.ok) continue;
+			expect(built.matcher.hasZeroWidthMatch(text)).toBe(true);
+		}
+	});
+
+	it("does NOT flag anchored/lookahead patterns that consume real text", () => {
+		// `\bworld` and `(?=world)world` both consume `world`; `\d+`/`l+` consume
+		// digits/letters. A replace on these is meaningful and must be allowed.
+		for (const p of ["\\bworld", "(?=world)world", "\\d+", "l+", "hello"]) {
+			const built = buildGrepMatcher(p, true, false);
+			expect(built.ok).toBe(true);
+			if (!built.ok) continue;
+			expect(built.matcher.hasZeroWidthMatch(text)).toBe(false);
+		}
+	});
+
+	it("never flags a literal needle as zero-width", () => {
+		const built = buildGrepMatcher("world", false, false);
+		if (!built.ok) return;
+		expect(built.matcher.hasZeroWidthMatch(text)).toBe(false);
+	});
+
+	it("reports no zero-width match for over-ceiling input (backstop, not scanned)", () => {
+		const built = buildGrepMatcher("\\b", true, false);
+		if (!built.ok) return;
+		// Over the ceiling the matcher refuses to scan; callers reject on
+		// maxInputLength first, so returning false here is a safe backstop.
+		const over = "a ".repeat(MAX_REGEX_INPUT_LENGTH);
+		expect(built.matcher.hasZeroWidthMatch(over)).toBe(false);
+	});
+});
+
 describe("buildGrepMatcher — input-length ceiling (ReDoS backstop)", () => {
 	it("exposes MAX_REGEX_INPUT_LENGTH as maxInputLength for a regex matcher", () => {
 		const built = buildGrepMatcher("needle", true, false);

--- a/test/agent/grepMatcher.test.ts
+++ b/test/agent/grepMatcher.test.ts
@@ -150,6 +150,29 @@ describe("buildGrepMatcher — ReDoS protection", () => {
 		expect(buildGrepMatcher("([^x]+)*$", true, false).ok).toBe(false);
 	});
 
+	it("catches nested quantified groups that a flat [^)]* scan misses", () => {
+		// `((a+))+$` is exponential (verified: >1s at ~24 chars), but the old flat
+		// `\([^)]*[*+][^)]*\)[*+]` regex stopped at the inner `)` and let it pass.
+		// The depth-aware screen balances parens and rejects the whole family.
+		expect(buildGrepMatcher("((a+))+$", true, false).ok).toBe(false);
+		expect(buildGrepMatcher("(([a-z]+))+$", true, false).ok).toBe(false);
+		expect(buildGrepMatcher("(((a+)))+", true, false).ok).toBe(false);
+		expect(buildGrepMatcher("(a*)*", true, false).ok).toBe(false);
+	});
+
+	it("still accepts nested groups whose repetition is fenced", () => {
+		// A literal/atom between the inner quantifier and the group boundary fences
+		// each repetition, so these stay linear and must NOT be rejected.
+		expect(buildGrepMatcher("((a+)b)+$", true, false).ok).toBe(true);
+		expect(buildGrepMatcher("(a(b)c)+", true, false).ok).toBe(true);
+		expect(buildGrepMatcher("((ab))+", true, false).ok).toBe(true);
+		expect(buildGrepMatcher("(a+b)+", true, false).ok).toBe(true);
+		expect(buildGrepMatcher("(\\w+)@(\\w+)", true, false).ok).toBe(true);
+		// A non-capturing group of literal-fenced content — the `(?:\(a+\))+` shape
+		// the flat screen wrongly rejected. Depth-aware analysis accepts it.
+		expect(buildGrepMatcher("(?:\\(a+\\))+", true, false).ok).toBe(true);
+	});
+
 	it("rejects adjacent unbounded quantifiers on overlapping atoms", () => {
 		// Sequential quantifiers (no enclosing group) backtrack catastrophically:
 		// `a+a+a+X` against a long run of `a` is the canonical freeze. These must
@@ -180,6 +203,14 @@ describe("buildGrepMatcher — ReDoS protection", () => {
 		expect(built.ok).toBe(true);
 		if (!built.ok) return;
 		expect(built.matcher.test("(aaa))")).toBe(true);
+	});
+
+	it("accepts a backreference pattern that is not catastrophic in V8", () => {
+		// `^(a+)\1+$` looks ReDoS-shaped but the backreference *constrains* the
+		// match (the second run must equal the first), so V8 runs it in ~0.02ms
+		// regardless of input length — verified empirically. Rejecting it would be
+		// a false positive that blocks a legitimate "doubled run" search.
+		expect(buildGrepMatcher("^(a+)\\1+$", true, false).ok).toBe(true);
 	});
 
 	it("does not screen literal needles (parens are literal there)", () => {

--- a/test/agent/grepMatcher.test.ts
+++ b/test/agent/grepMatcher.test.ts
@@ -150,6 +150,28 @@ describe("buildGrepMatcher — ReDoS protection", () => {
 		expect(buildGrepMatcher("([^x]+)*$", true, false).ok).toBe(false);
 	});
 
+	it("rejects adjacent unbounded quantifiers on overlapping atoms", () => {
+		// Sequential quantifiers (no enclosing group) backtrack catastrophically:
+		// `a+a+a+X` against a long run of `a` is the canonical freeze. These must
+		// be rejected even though the nested-quantifier check does not fire.
+		expect(buildGrepMatcher("a+a+a+X", true, false).ok).toBe(false);
+		expect(buildGrepMatcher("\\d+\\d+\\d+x", true, false).ok).toBe(false);
+		expect(buildGrepMatcher(".+.+", true, false).ok).toBe(false);
+		expect(buildGrepMatcher("\\w+\\w+", true, false).ok).toBe(false);
+		expect(buildGrepMatcher("a*a*b", true, false).ok).toBe(false);
+		expect(buildGrepMatcher("[a-z]+[a-z]+", true, false).ok).toBe(false);
+	});
+
+	it("still accepts safe adjacent quantifiers on disjoint/separated atoms", () => {
+		// Distinct literals or a required separator between quantifiers cannot
+		// backtrack — these must NOT be rejected.
+		expect(buildGrepMatcher("a+b+c", true, false).ok).toBe(true);
+		expect(buildGrepMatcher("\\d+-\\d+", true, false).ok).toBe(true);
+		expect(buildGrepMatcher("\\d+\\.\\d+", true, false).ok).toBe(true);
+		expect(buildGrepMatcher("https?://\\S+", true, false).ok).toBe(true);
+		expect(buildGrepMatcher("\\d{4}-\\d{2}", true, false).ok).toBe(true);
+	});
+
 	it("accepts a safe pattern with escaped parens around a quantifier", () => {
 		// `\(a+\)+` is a literal '(' , a+, literal ')', repeated — NOT a quantified
 		// group. Neutralizing escapes to placeholders (not deleting them) keeps it

--- a/test/agent/grepMatcher.test.ts
+++ b/test/agent/grepMatcher.test.ts
@@ -5,7 +5,7 @@ vi.mock("../../src/utils/logging", () => ({
 	Logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() },
 }));
 
-import { buildGrepMatcher, escapeRegExp } from "../../src/agent/tools/grepMatcher";
+import { buildGrepMatcher, escapeRegExp, MAX_REGEX_INPUT_LENGTH } from "../../src/agent/tools/grepMatcher";
 
 describe("escapeRegExp", () => {
 	it("escapes regex metacharacters", () => {
@@ -142,6 +142,24 @@ describe("buildGrepMatcher — ReDoS protection", () => {
 		expect(buildGrepMatcher("price\\{\\d+\\}", true, false).ok).toBe(true);
 	});
 
+	it("catches nested quantifiers hidden inside a character class", () => {
+		// The `)` lives inside `[^)]`, so a screen that scans group bodies with
+		// `[^)]*` would stop early and miss the real `(…+)+` shape. The class-aware
+		// screen must still reject these.
+		expect(buildGrepMatcher("([^)]+)+$", true, false).ok).toBe(false);
+		expect(buildGrepMatcher("([^x]+)*$", true, false).ok).toBe(false);
+	});
+
+	it("accepts a safe pattern with escaped parens around a quantifier", () => {
+		// `\(a+\)+` is a literal '(' , a+, literal ')', repeated — NOT a quantified
+		// group. Neutralizing escapes to placeholders (not deleting them) keeps it
+		// from collapsing to `(a+)+` and being wrongly rejected.
+		const built = buildGrepMatcher("\\(a+\\)+", true, false);
+		expect(built.ok).toBe(true);
+		if (!built.ok) return;
+		expect(built.matcher.test("(aaa))")).toBe(true);
+	});
+
 	it("does not screen literal needles (parens are literal there)", () => {
 		const built = buildGrepMatcher("(a+)+", false, false);
 		expect(built.ok).toBe(true);
@@ -179,5 +197,37 @@ describe("buildGrepMatcher — empty-match handling", () => {
 		const built = buildGrepMatcher("foo", false, false);
 		if (!built.ok) return;
 		expect(built.matcher.matchesEmpty).toBe(false);
+	});
+});
+
+describe("buildGrepMatcher — input-length ceiling (ReDoS backstop)", () => {
+	it("exposes MAX_REGEX_INPUT_LENGTH as maxInputLength for a regex matcher", () => {
+		const built = buildGrepMatcher("needle", true, false);
+		if (!built.ok) return;
+		expect(built.matcher.maxInputLength).toBe(MAX_REGEX_INPUT_LENGTH);
+	});
+
+	it("does not run a regex against input longer than the ceiling", () => {
+		const built = buildGrepMatcher("needle", true, false);
+		if (!built.ok) return;
+		// Over-length input: the matcher refuses to run (backstop), so it reports
+		// no match / zero count even though the needle is present. Callers detect
+		// this via maxInputLength and surface a clear error instead.
+		const over = `${"x".repeat(MAX_REGEX_INPUT_LENGTH + 1)}needle`;
+		expect(built.matcher.test(over)).toBe(false);
+		expect(built.matcher.count(over)).toBe(0);
+		// At/under the ceiling it still matches normally.
+		const under = `${"x".repeat(1000)}needle`;
+		expect(built.matcher.test(under)).toBe(true);
+		expect(built.matcher.count(under)).toBe(1);
+	});
+
+	it("does not cap literal needles (they cannot backtrack)", () => {
+		const built = buildGrepMatcher("needle", false, false);
+		if (!built.ok) return;
+		expect(built.matcher.maxInputLength).toBe(Number.POSITIVE_INFINITY);
+		const over = `${"x".repeat(MAX_REGEX_INPUT_LENGTH + 1)}needle`;
+		expect(built.matcher.test(over)).toBe(true);
+		expect(built.matcher.count(over)).toBe(1);
 	});
 });

--- a/test/agent/grepMatcher.test.ts
+++ b/test/agent/grepMatcher.test.ts
@@ -117,15 +117,29 @@ describe("buildGrepMatcher — ReDoS protection", () => {
 		expect(built.matcher.test("abc123")).toBe(true);
 	});
 
-	it("does not run a regex against an over-long line", () => {
-		const built = buildGrepMatcher("a", true, false);
+	it("matches against long content (no length cap inside the matcher)", () => {
+		// The matcher no longer caps input length — grep_notes enforces its own
+		// per-line limit. manage_notes runs count/replace against whole notes,
+		// which routinely exceed 5000 chars, so the matcher must still match.
+		const built = buildGrepMatcher("needle", true, false);
 		if (!built.ok) return;
-		// Comfortably over MAX_SCANNED_LINE_LENGTH (5000).
-		const huge = "a".repeat(6000);
-		expect(built.matcher.test(huge)).toBe(false);
-		expect(built.matcher.count(huge)).toBe(0);
-		// A normal-length line still matches.
-		expect(built.matcher.test("a")).toBe(true);
+		const bigNote = `${"x".repeat(6000)}needle${"y".repeat(6000)}`;
+		expect(built.matcher.test(bigNote)).toBe(true);
+		expect(built.matcher.count(bigNote)).toBe(1);
+	});
+
+	it("does not treat an escaped paren as a group terminator", () => {
+		// `\){5,10}` repeats a literal ')' — it is NOT a bounded group repetition
+		// and must be accepted.
+		const built = buildGrepMatcher("\\){5,10}", true, false);
+		expect(built.ok).toBe(true);
+		if (!built.ok) return;
+		expect(built.matcher.test(")))))")).toBe(true);
+	});
+
+	it("accepts escaped braces and parens generally", () => {
+		expect(buildGrepMatcher("\\(a\\)", true, false).ok).toBe(true);
+		expect(buildGrepMatcher("price\\{\\d+\\}", true, false).ok).toBe(true);
 	});
 
 	it("does not screen literal needles (parens are literal there)", () => {

--- a/test/agent/grepNotes.test.ts
+++ b/test/agent/grepNotes.test.ts
@@ -31,7 +31,7 @@ vi.mock("../../src/utils/pathResolution", () => ({
 }));
 
 import type { App } from "obsidian";
-import { createGrepNotesTool } from "../../src/agent/tools/grepNotes";
+import { createGrepNotesTool, MAX_SCANNED_FILES } from "../../src/agent/tools/grepNotes";
 
 function makeFile(path: string, ext = "md") {
 	return { path, name: path.split("/").pop()!, extension: ext };
@@ -134,6 +134,37 @@ describe("grep_notes tool", () => {
 		expect(payload.results[0].matches[0].line_number).toBe(1);
 		expect(payload.lines_skipped).toBe(1);
 		expect(payload.message).toContain("skipped");
+	});
+
+	it("bounds a vault-wide scan and flags truncation past the file budget", async () => {
+		// One more file than the budget, each containing a match. The scan must
+		// stop at MAX_SCANNED_FILES, so the last file's match is never found and
+		// scan_truncated is reported.
+		const files = Array.from({ length: MAX_SCANNED_FILES + 1 }, (_, i) =>
+			makeFile(`n${String(i).padStart(5, "0")}.md`),
+		);
+		mockGetIndexableVaultFiles.mockReturnValue(files);
+		const app = createMockApp(() => "needle");
+		const tool = createGrepNotesTool(app);
+
+		const payload = JSON.parse((await tool.invoke({ pattern: "needle" })) as string);
+
+		expect(payload.files_searched).toBe(MAX_SCANNED_FILES);
+		expect(payload.total_matches).toBe(MAX_SCANNED_FILES);
+		expect(payload.scan_truncated).toBe(true);
+		expect(payload.message).toContain("path_prefix");
+	});
+
+	it("does not flag truncation when the file set fits within the budget", async () => {
+		const files = Array.from({ length: 3 }, (_, i) => makeFile(`m${i}.md`));
+		mockGetIndexableVaultFiles.mockReturnValue(files);
+		const app = createMockApp(() => "needle");
+		const tool = createGrepNotesTool(app);
+
+		const payload = JSON.parse((await tool.invoke({ pattern: "needle" })) as string);
+
+		expect(payload.files_searched).toBe(3);
+		expect(payload.scan_truncated).toBeUndefined();
 	});
 
 	it("returns an error for an invalid regex", async () => {

--- a/test/agent/grepNotes.test.ts
+++ b/test/agent/grepNotes.test.ts
@@ -31,7 +31,7 @@ vi.mock("../../src/utils/pathResolution", () => ({
 }));
 
 import type { App } from "obsidian";
-import { createGrepNotesTool, MAX_SCANNED_FILES } from "../../src/agent/tools/grepNotes";
+import { createGrepNotesTool } from "../../src/agent/tools/grepNotes";
 
 function makeFile(path: string, ext = "md") {
 	return { path, name: path.split("/").pop()!, extension: ext };
@@ -136,34 +136,20 @@ describe("grep_notes tool", () => {
 		expect(payload.message).toContain("skipped");
 	});
 
-	it("bounds a vault-wide scan and flags truncation past the file budget", async () => {
-		// One more file than the budget, each containing a match. The scan must
-		// stop at MAX_SCANNED_FILES, so the last file's match is never found and
-		// scan_truncated is reported.
-		const files = Array.from({ length: MAX_SCANNED_FILES + 1 }, (_, i) =>
-			makeFile(`n${String(i).padStart(5, "0")}.md`),
-		);
+	it("scans every note in a large vault (grep is exhaustive, no file cap)", async () => {
+		// A vault-wide grep must read every eligible note — there is no file-count
+		// cap that would silently drop the tail of a large vault. 6000 files, each
+		// with one match: all 6000 are found and files_searched equals the total.
+		const total = 6000;
+		const files = Array.from({ length: total }, (_, i) => makeFile(`n${String(i).padStart(5, "0")}.md`));
 		mockGetIndexableVaultFiles.mockReturnValue(files);
 		const app = createMockApp(() => "needle");
 		const tool = createGrepNotesTool(app);
 
 		const payload = JSON.parse((await tool.invoke({ pattern: "needle" })) as string);
 
-		expect(payload.files_searched).toBe(MAX_SCANNED_FILES);
-		expect(payload.total_matches).toBe(MAX_SCANNED_FILES);
-		expect(payload.scan_truncated).toBe(true);
-		expect(payload.message).toContain("path_prefix");
-	});
-
-	it("does not flag truncation when the file set fits within the budget", async () => {
-		const files = Array.from({ length: 3 }, (_, i) => makeFile(`m${i}.md`));
-		mockGetIndexableVaultFiles.mockReturnValue(files);
-		const app = createMockApp(() => "needle");
-		const tool = createGrepNotesTool(app);
-
-		const payload = JSON.parse((await tool.invoke({ pattern: "needle" })) as string);
-
-		expect(payload.files_searched).toBe(3);
+		expect(payload.files_searched).toBe(total);
+		expect(payload.total_matches).toBe(total);
 		expect(payload.scan_truncated).toBeUndefined();
 	});
 

--- a/test/agent/grepNotes.test.ts
+++ b/test/agent/grepNotes.test.ts
@@ -119,6 +119,23 @@ describe("grep_notes tool", () => {
 		expect(payload.results[0].matches[0].line_number).toBe(1);
 	});
 
+	it("skips lines over the scan-length limit and reports the count", async () => {
+		const file = makeFile("mixed.md");
+		mockGetIndexableVaultFiles.mockReturnValue([file]);
+		// One normal matching line, one 6000-char line that also contains the
+		// needle but must be skipped (over the 5000-char limit).
+		const longLine = `${"z".repeat(6000)}needle`;
+		const app = createMockApp(() => `needle here\n${longLine}\nno match`);
+		const tool = createGrepNotesTool(app);
+
+		const payload = JSON.parse((await tool.invoke({ pattern: "needle" })) as string);
+		// Only the short line matched; the long line was skipped, not scanned.
+		expect(payload.total_matches).toBe(1);
+		expect(payload.results[0].matches[0].line_number).toBe(1);
+		expect(payload.lines_skipped).toBe(1);
+		expect(payload.message).toContain("skipped");
+	});
+
 	it("returns an error for an invalid regex", async () => {
 		const app = createMockApp(() => "");
 		const tool = createGrepNotesTool(app);

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -507,6 +507,30 @@ describe("manageNotes tool", () => {
 			expect(result).toContain("too large to search safely with a regex");
 			expect(mockAddChanges).not.toHaveBeenCalled();
 		});
+
+		it("refuses a zero-width regex edit that would insert at every boundary", async () => {
+			const file = makeFile("Notes/zw.md");
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file });
+			// `\b` matches zero-width at word boundaries — replacing it would scatter
+			// the replacement across the note rather than substitute text.
+			vi.mocked(app.vault.read).mockResolvedValue("hello world");
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/zw.md",
+							edits: [{ oldText: "\\b", newText: "X", is_regex: true, replace_all: true }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("zero-width");
+			expect(mockAddChanges).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("vault-wide replace operation", () => {
@@ -604,6 +628,38 @@ describe("manageNotes tool", () => {
 			expect(staged).toHaveLength(1);
 			expect(staged[0].path).toBe("Notes/small.md");
 			expect(result).toContain("skipped as too large");
+		});
+
+		it("refuses a zero-width regex in a vault-wide replace", async () => {
+			const a = makeFile("Notes/a.md");
+			mockGetIndexableVaultFiles.mockReturnValue([a]);
+			vi.mocked(app.vault.read).mockResolvedValue("hello world");
+
+			const result = await tool.invoke(
+				{
+					operations: [{ type: "replace", find: "\\b", replace: "X", is_regex: true }],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("zero-width");
+			expect(mockAddChanges).not.toHaveBeenCalled();
+		});
+
+		it("refuses a structurally empty-matchable regex upfront in a vault-wide replace", async () => {
+			const a = makeFile("Notes/a.md");
+			mockGetIndexableVaultFiles.mockReturnValue([a]);
+			vi.mocked(app.vault.read).mockResolvedValue("anything");
+
+			const result = await tool.invoke(
+				{
+					operations: [{ type: "replace", find: "x*", replace: "Y", is_regex: true }],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("zero-width");
+			expect(mockAddChanges).not.toHaveBeenCalled();
 		});
 
 		it("returns an error and stages nothing when there are zero matches", async () => {

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -557,6 +557,32 @@ describe("manageNotes tool", () => {
 			expect(staged[0].path).toBe("Projects/a.md");
 		});
 
+		it("surfaces files a later replace op skips because an earlier op changed them", async () => {
+			// Two replace ops in one batch. Op A rewrites foo→bar in shared.md; op B
+			// would rewrite baz→qux in the same file, but it is skipped to avoid
+			// staging a conflicting second diff. The skip must be surfaced, not silent.
+			const shared = makeFile("Notes/shared.md");
+			mockGetIndexableVaultFiles.mockReturnValue([shared]);
+			vi.mocked(app.vault.read).mockResolvedValue("foo and baz together");
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{ type: "replace", find: "foo", replace: "bar" },
+						{ type: "replace", find: "baz", replace: "qux" },
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			// Op A staged one change; op B's match in the same file was skipped and
+			// the summary must say so rather than silently under-applying.
+			const staged = mockAddChanges.mock.calls[0][0];
+			expect(staged).toHaveLength(1);
+			expect(staged[0].newContent).toBe("bar and baz together");
+			expect(result).toMatch(/skipped because an earlier operation/);
+		});
+
 		it("skips oversized notes in a vault-wide regex replace and reports the skip", async () => {
 			const small = makeFile("Notes/small.md");
 			const huge = makeFile("Notes/huge.md");

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -44,6 +44,7 @@ vi.mock("../../src/utils/fileFiltering", () => ({
 const THREAD_CONFIG = { configurable: { thread_id: "test-thread-id" } };
 
 import type { App } from "obsidian";
+import { MAX_REGEX_INPUT_LENGTH } from "../../src/agent/tools/grepMatcher";
 import { createManageNotesTool } from "../../src/agent/tools/manageNotes";
 
 function makeFile(path: string, ext = "md") {
@@ -482,6 +483,30 @@ describe("manageNotes tool", () => {
 				expect.anything(),
 			);
 		});
+
+		it("refuses a regex edit on a note larger than the safe regex ceiling", async () => {
+			const file = makeFile("Notes/huge.md");
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file });
+			// A note past the ceiling: a screen-bypassing pattern could freeze the UI,
+			// so the tool must refuse rather than run the regex.
+			vi.mocked(app.vault.read).mockResolvedValue("x".repeat(MAX_REGEX_INPUT_LENGTH + 1));
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/huge.md",
+							edits: [{ oldText: "x+", newText: "y", is_regex: true }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("too large to search safely with a regex");
+			expect(mockAddChanges).not.toHaveBeenCalled();
+		});
 	});
 
 	describe("vault-wide replace operation", () => {
@@ -530,6 +555,29 @@ describe("manageNotes tool", () => {
 			const staged = mockAddChanges.mock.calls[0][0];
 			expect(staged).toHaveLength(1);
 			expect(staged[0].path).toBe("Projects/a.md");
+		});
+
+		it("skips oversized notes in a vault-wide regex replace and reports the skip", async () => {
+			const small = makeFile("Notes/small.md");
+			const huge = makeFile("Notes/huge.md");
+			mockGetIndexableVaultFiles.mockReturnValue([small, huge]);
+			vi.mocked(app.vault.read).mockImplementation(async (f: { path: string }) =>
+				f.path === "Notes/small.md" ? "foo here" : "foo".repeat(MAX_REGEX_INPUT_LENGTH),
+			);
+
+			const result = await tool.invoke(
+				{
+					operations: [{ type: "replace", find: "foo", replace: "bar", is_regex: true }],
+				},
+				THREAD_CONFIG,
+			);
+
+			// The small note is staged; the huge note is skipped, not scanned, and
+			// the skip is surfaced in the summary rather than silently dropped.
+			const staged = mockAddChanges.mock.calls[0][0];
+			expect(staged).toHaveLength(1);
+			expect(staged[0].path).toBe("Notes/small.md");
+			expect(result).toContain("skipped as too large");
 		});
 
 		it("returns an error and stages nothing when there are zero matches", async () => {


### PR DESCRIPTION
- computeWorkerManager: clone the vector buffer for the recovery copy before postMessage transfers (and detaches) the original. The prior code retained the transferred request, so main-thread recovery rebuilt typed arrays from a detached buffer and rejected instead of recomputing clustering/projection.
- grepMatcher: strengthen ReDoS screening — also reject bounded repetition applied to a group (e.g. `(a+){10,}`) and large explicit repetition bounds (`a{5000}`), and lower the scanned-line cap from 20k to 5k as the backstop for patterns the syntactic screen can't catch. Syntactic screening can't be exhaustive; the input-size cap bounds the worst case regardless.

Adds tests for bounded-quantifier rejection.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._