### PR TITLE
feat: add Firecrawl keyless web search as default provider

### DIFF
--- a/src/agent/tools/webSearch.ts
+++ b/src/agent/tools/webSearch.ts
@@ -151,6 +151,68 @@ async function searchTavily(
 }
 
 // ============================================================================
+// Firecrawl Search
+// ============================================================================
+
+interface FirecrawlWebResult {
+	title?: string;
+	url?: string;
+	description?: string;
+	position?: number;
+}
+
+interface FirecrawlSearchResponse {
+	success?: boolean;
+	error?: string;
+	data?: { web?: FirecrawlWebResult[] };
+}
+
+/**
+ * Firecrawl search. Works keyless (the free tier); an optional API key raises
+ * rate limits. The Authorization header is only sent when a key is present.
+ */
+async function searchFirecrawl(
+	query: string,
+	apiKey: string,
+	count: number,
+	fetchImpl: ReturnType<typeof createObsidianFetch>,
+): Promise<WebSearchResult[]> {
+	const headers: Record<string, string> = { "Content-Type": "application/json" };
+	if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+	const controller = new AbortController();
+	const response = await fetchImpl("https://api.firecrawl.dev/v2/search", {
+		method: "POST",
+		headers,
+		body: JSON.stringify({
+			query,
+			limit: count,
+			sources: ["web"],
+		}),
+		signal: controller.signal,
+	});
+
+	if (!response.ok) {
+		if (response.status === 401) throw new Error("Invalid Firecrawl API key");
+		if (response.status === 429)
+			throw new Error("Firecrawl rate limit exceeded — try again shortly, or add an API key for higher limits");
+		throw new Error(`Firecrawl returned HTTP ${response.status}`);
+	}
+
+	const data = (await response.json()) as FirecrawlSearchResponse;
+	if (data.success === false) {
+		throw new Error(`Firecrawl search failed${data.error ? `: ${data.error}` : ""}`);
+	}
+
+	return (data.data?.web ?? []).map((r, i) => ({
+		rank: i + 1,
+		title: r.title ?? "",
+		url: r.url ?? "",
+		snippet: r.description ?? "",
+	}));
+}
+
+// ============================================================================
 // Tool factory
 // ============================================================================
 
@@ -173,7 +235,8 @@ export function createWebSearchTool() {
 		}
 
 		const apiKey = pluginData.webSearchApiKey;
-		if (!apiKey) {
+		// Firecrawl works keyless; Brave and Tavily require a key.
+		if (!apiKey && provider !== "firecrawl") {
 			return `Error: No API key configured for web search provider "${provider}". Go to Settings → General → Web Search and add an API key.`;
 		}
 
@@ -188,6 +251,8 @@ export function createWebSearchTool() {
 				results = await withTimeout(searchBrave(trimmed, apiKey, maxResults, fetchImpl), FETCH_TIMEOUT_MS);
 			} else if (provider === "tavily") {
 				results = await withTimeout(searchTavily(trimmed, apiKey, maxResults, fetchImpl), FETCH_TIMEOUT_MS);
+			} else if (provider === "firecrawl") {
+				results = await withTimeout(searchFirecrawl(trimmed, apiKey, maxResults, fetchImpl), FETCH_TIMEOUT_MS);
 			} else {
 				return `Error: Unknown web search provider "${provider}".`;
 			}

--- a/src/components/modal/ToolConfigModal.svelte
+++ b/src/components/modal/ToolConfigModal.svelte
@@ -105,7 +105,7 @@ const diffViewModeOptions = [
 ];
 
 const webSearchProviderOptions = [
-	{ display: "None", value: "" },
+	{ display: "Firecrawl (keyless)", value: "firecrawl" },
 	{ display: "Brave Search", value: "brave" },
 	{ display: "Tavily", value: "tavily" },
 ];
@@ -671,10 +671,12 @@ function handleResetToDefault() {
       </ModalField>
       {#if pluginData.webSearchProvider}
         <ModalField
-          label="API Key"
+          label={pluginData.webSearchProvider === "firecrawl" ? "API Key (optional)" : "API Key"}
           desc={pluginData.webSearchProvider === "brave"
             ? "Brave Search API key from api.search.brave.com."
-            : "Tavily API key from app.tavily.com."}
+            : pluginData.webSearchProvider === "tavily"
+              ? "Tavily API key from app.tavily.com."
+              : "Optional — add a Firecrawl API key (fc-…) for higher rate limits. Leave empty to use the keyless tier."}
         >
           <SecretSelect
             value={pluginData.webSearchApiKeyId}
@@ -682,19 +684,6 @@ function handleResetToDefault() {
           />
         </ModalField>
       {/if}
-      <ModalField
-        label="Max Results"
-        desc="Number of search results to return (max 20)."
-        for="tool-config-web-search-max-results"
-      >
-        <Text
-          id="tool-config-web-search-max-results"
-          inputType="number"
-          value={maxResults}
-          placeholder="10"
-          onblur={(v) => (maxResults = Math.min(Math.max(Number.parseInt(String(v)) || 10, 1), 20))}
-        />
-      </ModalField>
     </SettingGroup>
   {/if}
 

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -325,7 +325,7 @@ export const DEFAULT_TOOLS_CONFIG: ToolsConfig = {
 			"Use this only for URLs the user provided or for clearly public references. The tool sends the URL to the configured network — it does not send vault contents. Prefer searching the vault first; reach for fetch_url when the user explicitly references a link or when needed information cannot be in the vault.",
 	},
 	web_search: {
-		enabled: false,
+		enabled: true,
 		name: "web_search",
 		description:
 			"Search the web and return a list of relevant results (title, URL, snippet). Use this when the user asks about current events, external topics, or anything that cannot be in the vault. Always prefer searching the vault first with search_notes.",
@@ -414,7 +414,7 @@ export const DEFAULT_SETTINGS: PluginData = {
 	langSmithEndpoint: "https://api.smith.langchain.com",
 
 	// Web search
-	webSearchProvider: "",
+	webSearchProvider: "firecrawl",
 	webSearchApiKeyId: "",
 
 	// Other

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -455,7 +455,7 @@ export interface PluginData {
 	// Web Search
 	// ============================================================================
 
-	/** Selected web search provider ("brave" | "tavily" | "") */
+	/** Selected web search provider ("firecrawl" | "brave" | "tavily" | "") */
 	webSearchProvider: string;
 	/** Secret ID for the web search API key */
 	webSearchApiKeyId: string;


### PR DESCRIPTION
Web search previously required a Brave or Tavily API key and was disabled by default, so it did nothing out of the box. Firecrawl's search API works keyless, so make it the default provider and enable web_search by default — zero-config web search on a fresh install.

- Add searchFirecrawl backend (POST /v2/search); Authorization header sent only when an optional API key is present.
- Relax the API-key guard so it applies only to Brave/Tavily.
- Default webSearchProvider to "firecrawl" and enable the web_search tool.
- Settings UI: add Firecrawl option, mark its key field optional, and remove the "None" provider and the Max Results field to keep the panel minimal (maxResults still defaults to 10 internally).

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._