### PR TITLE
feat: simplify Setup Provider modal (#332)

### DIFF
--- a/src/components/settings/AuthConfigFields.svelte
+++ b/src/components/settings/AuthConfigFields.svelte
@@ -1,21 +1,24 @@
 <script lang="ts">
+import type { Snippet } from "svelte";
 import { createAuthStateQuery, invalidateAuthState } from "../../lib/query";
 import { type AuthFieldDefinition, getProviderDefinition } from "../../providers/index";
 import { getData } from "../../stores/dataStore.svelte";
 import Text from "../ui/Text.svelte";
-import Toggle from "../ui/Toggle.svelte";
 import SecretSelect from "./SecretSelect.svelte";
 import SettingItem from "./SettingItem.svelte";
 
 interface Props {
 	provider: string;
+	// Optional content rendered after the required fields (and setup link) but before the
+	// Advanced disclosure — e.g. the "Trusted with private notes" toggle in provider setup.
+	afterRequired?: Snippet;
 }
 
-const { provider }: Props = $props();
+const { provider, afterRequired }: Props = $props();
 
 const data = getData();
 
-// Local state for advanced toggle
+// Local state for advanced disclosure
 let showAdvanced = $state(false);
 
 // Query for provider auth state
@@ -30,6 +33,9 @@ let storedAuth = $derived(data.getStoredAuthState(provider));
 
 // Get auth fields from provider definition
 let authFields = $derived(providerDefinition?.auth ?? null);
+
+// Optional link to where the user can obtain credentials (e.g. an API-key page)
+let setupLink = $derived(providerDefinition?.setupInstructions?.link ?? null);
 
 // Split fields into required and optional
 let requiredFields = $derived((): [string, AuthFieldDefinition][] => {
@@ -87,6 +93,10 @@ function handleFieldChange(fieldKey: string, value: string) {
 
 // Get validation state styling for a field
 function getFieldStyles(fieldKey: string): string {
+	// The base URL isn't validated on its own — the auth query checks the whole
+	// connection — so don't paint a success/error border on it; it reads as if the
+	// URL itself passed/failed. Keep the status border on the credential fields.
+	if (fieldKey === "baseUrl") return "";
 	const value = getFieldValue(fieldKey);
 	if (value === "") return "";
 	if (isCheckingAuth || !query.data) {
@@ -138,20 +148,48 @@ function getFieldStyles(fieldKey: string): string {
         {@render fieldRenderer(fieldKey, field)}
     {/each}
 
-    <!-- Advanced toggle (only if there are optional fields) -->
-    {#if hasOptionalFields}
-        <SettingItem
-            name="Advanced Options"
-            desc="Show optional configuration fields"
-        >
-            <Toggle bind:checked={showAdvanced} />
-        </SettingItem>
+    <!-- Link to where credentials can be obtained (e.g. API-key page) -->
+    {#if setupLink}
+        <div class="auth-setup-link">
+            <a href={setupLink.url} target="_blank" rel="noopener noreferrer">
+                → {setupLink.text}
+            </a>
+        </div>
     {/if}
 
-    <!-- Optional fields (only when showAdvanced) -->
-    {#if showAdvanced}
-        {#each optionalFields() as [fieldKey, field]}
-            {@render fieldRenderer(fieldKey, field)}
-        {/each}
+    <!-- Caller-supplied content between the required fields and Advanced. -->
+    {@render afterRequired?.()}
+
+    <!-- Advanced disclosure (only if there are optional fields) -->
+    {#if hasOptionalFields}
+        <details class="auth-advanced" bind:open={showAdvanced}>
+            <summary class="auth-advanced-summary">Advanced</summary>
+            {#each optionalFields() as [fieldKey, field]}
+                {@render fieldRenderer(fieldKey, field)}
+            {/each}
+        </details>
     {/if}
 {/if}
+
+<style>
+    .auth-setup-link {
+        padding: 0 var(--size-4-3) var(--size-4-2);
+        font-size: var(--font-smaller);
+    }
+
+    .auth-advanced {
+        margin-top: var(--size-4-2);
+    }
+
+    .auth-advanced-summary {
+        cursor: pointer;
+        color: var(--text-muted);
+        font-size: var(--font-smaller);
+        padding: var(--size-4-1) var(--size-4-3);
+        user-select: none;
+    }
+
+    .auth-advanced-summary:hover {
+        color: var(--text-normal);
+    }
+</style>

--- a/src/components/settings/ManagedEntityItem.svelte
+++ b/src/components/settings/ManagedEntityItem.svelte
@@ -166,7 +166,10 @@ function handleKeyDown(event: KeyboardEvent) {
     align-items: center;
     justify-content: center;
     min-width: 18px;
-    padding-top: 2px;
+    /* Match the header's first-line box so the icon centers on the name line even when
+       the body has extra rows below (desc/meta). align-items: flex-start on -main keeps
+       it pinned to the first line; this height + centering aligns it with the text. */
+    min-height: 1lh;
   }
 
   .managed-entity-item-body {

--- a/src/components/settings/ProviderItem.svelte
+++ b/src/components/settings/ProviderItem.svelte
@@ -166,6 +166,13 @@ async function handleRemoveProvider() {
     background: transparent;
     box-shadow: none;
     cursor: pointer;
+    /* Size the button to its icon — the theme's default button height (30px) would
+       otherwise inflate the header row and push the leading logo off-center. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 16px;
+    line-height: 1;
   }
 
   .provider-icon-button:disabled {

--- a/src/components/settings/ProviderItem.svelte
+++ b/src/components/settings/ProviderItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Notice } from "obsidian";
 import type { Component } from "svelte";
-import { createProviderStateQuery, invalidateProviderState } from "../../lib/query";
+import { createProviderStateQuery, invalidateProviderState, removeProviderQueries } from "../../lib/query";
 import { type LogoProps, getProviderDefinition } from "../../providers/index";
 import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
@@ -49,7 +49,9 @@ async function handleRemoveProvider() {
 	if (!(await confirmDelete(plugin.app, displayName))) return;
 	try {
 		await data.deleteProvider(provider);
-		invalidateProviderState(provider);
+		// Drop cached auth/state entirely (not just invalidate) so re-adding a provider with
+		// the same slug ID doesn't inherit this one's stale "connected" verdict from cache.
+		removeProviderQueries(provider);
 	} catch (error) {
 		new Notice(error instanceof Error ? error.message : "Failed to remove provider");
 	}

--- a/src/components/ui/SlidingTabs.svelte
+++ b/src/components/ui/SlidingTabs.svelte
@@ -16,6 +16,8 @@ interface Props {
 	/** Bindable active tab id. */
 	value: T;
 	tabs: SlidingTab<T>[];
+	/** Called when the active tab changes (in addition to updating the bound value). */
+	onValueChange?: (value: T) => void;
 	/** Optional extra trigger content rendered after the label (e.g. a count badge). */
 	trailing?: Snippet<[SlidingTab<T>]>;
 	/** Tab panels (e.g. Tabs.Content) rendered below the tab strip. */
@@ -24,7 +26,7 @@ interface Props {
 	class?: string;
 }
 
-let { value = $bindable(), tabs, trailing, children, class: className = "" }: Props = $props();
+let { value = $bindable(), tabs, onValueChange, trailing, children, class: className = "" }: Props = $props();
 
 // The list element + a live map of trigger elements, used to measure the active
 // tab so the sliding indicator can be positioned over it.
@@ -133,7 +135,7 @@ function registerTrigger(node: HTMLElement, id: T) {
 }
 </script>
 
-<Tabs.Root bind:value class={className}>
+<Tabs.Root bind:value onValueChange={(v) => onValueChange?.(v as T)} class={className}>
 	<Tabs.List
 		bind:ref={listEl}
 		class="s2b-sliding-tabs flex flex-wrap justify-center gap-1 border-b border-t-0 border-x-0 border-solid border-[--background-modifier-border] pb-2 mb-4"

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -174,6 +174,19 @@ export function invalidateAuthState(provider: string) {
 }
 
 /**
+ * Remove all cached state for a provider (auth + combined). Use on delete: provider IDs
+ * are deterministic (slug-based), so re-adding a same-named provider would otherwise serve
+ * the deleted provider's stale cached auth verdict — showing it "connected" and even
+ * auto-committing it before the user enters any credentials. removeQueries drops the
+ * entries entirely (invalidate only marks them stale, and staleTime keeps them served).
+ */
+export function removeProviderQueries(provider: string) {
+	const plugin = getPlugin();
+	plugin.queryClient.removeQueries({ queryKey: ["authState", provider] });
+	plugin.queryClient.removeQueries({ queryKey: ["provider", provider] });
+}
+
+/**
  * Query for model discovery - returns all available models.
  *
  * @param provider - Function returning the provider ID (e.g., "openai", "anthropic")

--- a/src/main.ts
+++ b/src/main.ts
@@ -244,6 +244,20 @@ export default class SecondBrainPlugin extends Plugin {
 		setPlugin(this);
 		this.pluginData = await StartupProfiler.measure("data:load", () => createData(this), true);
 
+		// Sweep orphaned draft providers. A "draft" (an unconfigured provider instance)
+		// only lives for the duration of an open Setup Provider modal, which deletes it on
+		// close if never configured. Any unconfigured provider present at load leaked from a
+		// modal that never ran its onClose cleanup (app reload / crash mid-draft). It's
+		// invisible everywhere the UI gates on getConfiguredProviders(), but it pollutes the
+		// provider ID/name space — causing new instances to be named "OpenAI 2" etc. — so
+		// reclaim it here, before any view or modal can open.
+		const orphanedDrafts = this.pluginData
+			.getAllProviderIds()
+			.filter((id) => !this.pluginData.isProviderConfigured(id));
+		for (const id of orphanedDrafts) {
+			await this.pluginData.deleteProvider(id);
+		}
+
 		// Create Skills Service instance (discovery deferred to onLayoutReady)
 		this.skillsService = new SkillsService(this);
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -21,14 +21,14 @@ export interface ProviderTemplateDefinition {
 
 export const PROVIDER_TEMPLATES: readonly ProviderTemplateDefinition[] = [
 	{
-		id: "openai-compatible",
-		displayName: "OpenAI-Compatible",
-		description: "Flexible OpenAI-style provider for OpenAI and compatible endpoints.",
+		id: "openai",
+		displayName: "OpenAI",
+		description: "OpenAI models via ChatGPT sign-in or an API key.",
 	},
 	{
-		id: "openai-codex",
-		displayName: "OpenAI Codex",
-		description: "ChatGPT/Codex sign-in flow for Codex-backed OpenAI models.",
+		id: "openai-compatible",
+		displayName: "Custom",
+		description: "Flexible OpenAI-style provider for OpenAI and compatible endpoints.",
 	},
 	{
 		id: "anthropic",
@@ -57,6 +57,12 @@ function createTemplateDefinition(
 	meta: ProviderInstanceMeta,
 ): BaseProviderDefinition | undefined {
 	switch (templateId) {
+		case "openai":
+			return {
+				...openaiProvider,
+				id: instanceId,
+				displayName: meta.displayName,
+			};
 		case "openai-compatible":
 			return createOpenAICompatibleProvider({
 				id: instanceId,

--- a/src/providers/openai-codex.ts
+++ b/src/providers/openai-codex.ts
@@ -7,6 +7,7 @@ import type {
 	ChatModelConfig,
 } from "../types/provider/index";
 import {
+	cancelOpenAICodexSignIn,
 	clearOpenAICodexSession,
 	createOpenAICodexFetch,
 	getValidOpenAICodexSession,
@@ -64,6 +65,7 @@ export function openAICodexProvider(providerId: string, displayName = "OpenAI Co
 				await signInWithOpenAICodex();
 				return { kind: "session" };
 			},
+			cancelSignIn: cancelOpenAICodexSignIn,
 			isSignedIn: () => !!getCodexSession(),
 			disconnect: clearOpenAICodexSession,
 			supportsApiKey: false,

--- a/src/providers/openai-codex.ts
+++ b/src/providers/openai-codex.ts
@@ -6,7 +6,13 @@ import type {
 	BaseProviderDefinition,
 	ChatModelConfig,
 } from "../types/provider/index";
-import { createOpenAICodexFetch, getValidOpenAICodexSession } from "./openaiCodex";
+import {
+	clearOpenAICodexSession,
+	createOpenAICodexFetch,
+	getValidOpenAICodexSession,
+	signInWithOpenAICodex,
+} from "./openaiCodex";
+import { getCodexSession } from "../stores/providerRuntime.svelte";
 import { fetchOpenRouterModels, isEmbeddingModel, type OpenRouterModelInfo } from "./openrouterModels";
 
 const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
@@ -49,6 +55,18 @@ export function openAICodexProvider(providerId: string, displayName = "OpenAI Co
 				"Complete the browser-based sign-in flow",
 				"Select one of the discovered Codex-backed chat models",
 			],
+		},
+		oauth: {
+			label: "ChatGPT",
+			icon: "log-in",
+			description: "Open a browser window to complete ChatGPT/Codex authorization.",
+			signIn: async () => {
+				await signInWithOpenAICodex();
+				return { kind: "session" };
+			},
+			isSignedIn: () => !!getCodexSession(),
+			disconnect: clearOpenAICodexSession,
+			supportsApiKey: false,
 		},
 		auth: {
 			apiKey: {

--- a/src/providers/openai-compatible.ts
+++ b/src/providers/openai-compatible.ts
@@ -136,19 +136,19 @@ export function createOpenAICompatibleProvider(
 			],
 		},
 		auth: {
-			apiKey: {
-				label: "API Key",
-				description: "API key for authentication (if required)",
-				kind: "secret",
-				required: true,
-				placeholder: "sk-...",
-			},
 			baseUrl: {
 				label: "Base URL",
 				description: "The base URL for the OpenAI-compatible API endpoint",
 				kind: "text",
-				required: false,
-				placeholder: defaultBaseUrl,
+				required: true,
+				placeholder: "https://your-endpoint.example/v1",
+			},
+			apiKey: {
+				label: "API Key",
+				description: "API key for authentication (leave empty if your endpoint needs none)",
+				kind: "secret",
+				required: true,
+				placeholder: "sk-...",
 			},
 			headers: {
 				label: "Custom Headers",

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -197,6 +197,27 @@ export const openaiProvider: EmbeddingProviderDefinition = {
 	},
 
 	createSubAgentChatInstance: (auth: AuthObject, modelId: string, options?: Partial<ChatModelConfig>) => {
+		// Codex (ChatGPT sign-in) has no API key — authenticate via the Codex session
+		// transport, mirroring createChatInstance. Without this branch the subagent reads
+		// the absent auth.apiKey and fails with missing authentication.
+		if (auth.authMode === "codex") {
+			return createTransportedChatOpenAIResponses("openai", {
+				model: modelId,
+				apiKey: async () => {
+					const session = await getValidOpenAICodexSession();
+					if (!session) {
+						throw new Error("ChatGPT sign-in required");
+					}
+					return session.accessToken;
+				},
+				configuration: {
+					baseURL: OPENAI_DEFAULT_BASE_URL,
+					fetch: createOpenAICodexFetch(),
+				},
+				temperature: options?.temperature,
+			});
+		}
+
 		const config: Record<string, unknown> = { model: modelId, apiKey: auth.apiKey };
 		if (options?.temperature !== undefined) {
 			config.temperature = options.temperature;

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -20,6 +20,7 @@ import type {
 	EmbeddingProviderDefinition,
 } from "../types/provider/index";
 import {
+	cancelOpenAICodexSignIn,
 	clearOpenAICodexSession,
 	createOpenAICodexFetch,
 	getValidOpenAICodexSession,
@@ -114,6 +115,7 @@ export const openaiProvider: EmbeddingProviderDefinition = {
 			await signInWithOpenAICodex();
 			return { kind: "session" };
 		},
+		cancelSignIn: cancelOpenAICodexSignIn,
 		isSignedIn: () => !!getCodexSession(),
 		disconnect: clearOpenAICodexSession,
 		supportsApiKey: true,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -19,7 +19,13 @@ import type {
 	ChatModelConfig,
 	EmbeddingProviderDefinition,
 } from "../types/provider/index";
-import { createOpenAICodexFetch, getValidOpenAICodexSession } from "./openaiCodex";
+import {
+	clearOpenAICodexSession,
+	createOpenAICodexFetch,
+	getValidOpenAICodexSession,
+	signInWithOpenAICodex,
+} from "./openaiCodex";
+import { getCodexSession } from "../stores/providerRuntime.svelte";
 import {
 	createBufferedTransportedChatOpenAI,
 	createTransportedChatOpenAI,
@@ -95,6 +101,22 @@ export const openaiProvider: EmbeddingProviderDefinition = {
 			url: "https://platform.openai.com/api-keys",
 			text: "OpenAI Dashboard",
 		},
+	},
+
+	// =========================================================================
+	// OAuth (ChatGPT sign-in) capability
+	// =========================================================================
+	oauth: {
+		label: "ChatGPT",
+		icon: "log-in",
+		description: "Open a browser window to complete ChatGPT/Codex authorization.",
+		signIn: async () => {
+			await signInWithOpenAICodex();
+			return { kind: "session" };
+		},
+		isSignedIn: () => !!getCodexSession(),
+		disconnect: clearOpenAICodexSession,
+		supportsApiKey: true,
 	},
 
 	// =========================================================================

--- a/src/providers/openaiCodex.ts
+++ b/src/providers/openaiCodex.ts
@@ -57,6 +57,14 @@ interface PendingOpenAICodexAuth {
 let pendingOpenAICodexAuth: PendingOpenAICodexAuth | null = null;
 let pendingOpenAICodexRefresh: Promise<CodexSession | null> | null = null;
 
+/** Thrown when the user explicitly cancels an in-progress sign-in (vs. a real failure). */
+export class OpenAICodexSignInCancelledError extends Error {
+	constructor() {
+		super("ChatGPT sign-in cancelled");
+		this.name = "OpenAICodexSignInCancelledError";
+	}
+}
+
 const HTML_SUCCESS = `<!doctype html>
 <html>
   <head><title>Smart2Brain - Authorization Successful</title></head>
@@ -448,6 +456,18 @@ export async function signInWithOpenAICodex(): Promise<CodexSession> {
 
 	saveOpenAICodexSession(session);
 	return session;
+}
+
+/**
+ * Aborts an in-progress ChatGPT (Codex) sign-in: rejects the pending promise with a
+ * cancellation marker and tears down the callback server (freeing the port), so the user
+ * can retry immediately instead of waiting out the timeout. No-op if none pending.
+ */
+export function cancelOpenAICodexSignIn(): void {
+	const pending = pendingOpenAICodexAuth;
+	if (!pending) return;
+	pending.reject(new OpenAICodexSignInCancelledError());
+	cleanupPendingOpenAICodexAuth();
 }
 
 function buildHeaders(initHeaders: HeadersInit | undefined, accountId?: string): Headers {

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -23,7 +23,7 @@ import type {
 } from "../types/provider/index";
 import OpenRouterLogo from "../components/ui/logos/OpenRouterLogo.svelte";
 import { populateOpenRouterCache, type OpenRouterModelInfo } from "./openrouterModels";
-import { signInWithOpenRouter } from "./openrouterOAuth";
+import { signInWithOpenRouter, cancelOpenRouterSignIn } from "./openrouterOAuth";
 import {
 	createBufferedTransportedChatOpenAI,
 	createTransportedChatOpenAI,
@@ -96,6 +96,7 @@ export const openrouterProvider: EmbeddingProviderDefinition = {
 		icon: "log-in",
 		description: "Authorize in your browser to connect without manually creating an API key.",
 		signIn: async () => ({ kind: "apiKey", apiKey: await signInWithOpenRouter() }),
+		cancelSignIn: cancelOpenRouterSignIn,
 		supportsApiKey: true,
 	},
 

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -23,6 +23,7 @@ import type {
 } from "../types/provider/index";
 import OpenRouterLogo from "../components/ui/logos/OpenRouterLogo.svelte";
 import { populateOpenRouterCache, type OpenRouterModelInfo } from "./openrouterModels";
+import { signInWithOpenRouter } from "./openrouterOAuth";
 import {
 	createBufferedTransportedChatOpenAI,
 	createTransportedChatOpenAI,
@@ -85,6 +86,17 @@ export const openrouterProvider: EmbeddingProviderDefinition = {
 			url: "https://openrouter.ai/keys",
 			text: "OpenRouter Keys",
 		},
+	},
+
+	// =========================================================================
+	// OAuth (browser sign-in) capability
+	// =========================================================================
+	oauth: {
+		label: "OpenRouter",
+		icon: "log-in",
+		description: "Authorize in your browser to connect without manually creating an API key.",
+		signIn: async () => ({ kind: "apiKey", apiKey: await signInWithOpenRouter() }),
+		supportsApiKey: true,
 	},
 
 	// =========================================================================

--- a/src/providers/openrouterOAuth.ts
+++ b/src/providers/openrouterOAuth.ts
@@ -30,6 +30,14 @@ interface OpenRouterKeyResponse {
 
 let pendingOpenRouterAuth: PendingOpenRouterAuth | null = null;
 
+/** Thrown when the user explicitly cancels an in-progress sign-in (vs. a real failure). */
+export class OpenRouterSignInCancelledError extends Error {
+	constructor() {
+		super("OpenRouter sign-in cancelled");
+		this.name = "OpenRouterSignInCancelledError";
+	}
+}
+
 const HTML_SUCCESS = `<!doctype html>
 <html>
   <head><title>Smart2Brain - OpenRouter Connected</title></head>
@@ -282,4 +290,16 @@ export async function signInWithOpenRouter(): Promise<string> {
 			cleanupPendingOpenRouterAuth();
 		}, OAUTH_TIMEOUT_MS);
 	});
+}
+
+/**
+ * Aborts an in-progress OpenRouter sign-in: rejects the pending promise with a
+ * cancellation marker and tears down the callback server (freeing port 3000), so the
+ * user can retry immediately instead of waiting out the timeout. No-op if none pending.
+ */
+export function cancelOpenRouterSignIn(): void {
+	const pending = pendingOpenRouterAuth;
+	if (!pending) return;
+	pending.reject(new OpenRouterSignInCancelledError());
+	cleanupPendingOpenRouterAuth();
 }

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -145,9 +145,17 @@ function buildManagedSecretId(providerId: string, fieldName: string): string {
 }
 
 function createProviderState(templateId: ProviderTemplateId): StoredProviderState {
+	// Base URL pre-seed. Only Ollama is seeded: its baseUrl is a REQUIRED field (shown in
+	// the main section), and Ollama runs on a well-known local default, so filling it in
+	// saves the user typing without side effects.
+	//
+	// Anthropic is intentionally NOT seeded even though it has a default endpoint: its
+	// baseUrl is an OPTIONAL (Advanced) field, and a stored value there forces the Advanced
+	// section open on a fresh provider. The provider falls back to its default at runtime
+	// (auth.baseUrl || DEFAULT) and the field placeholder shows it, so seeding adds nothing.
+	// openai-compatible ("Custom") is likewise not seeded — a generic endpoint shouldn't
+	// bias toward one vendor.
 	const baseUrlByTemplate: Partial<Record<ProviderTemplateId, string>> = {
-		anthropic: "https://api.anthropic.com",
-		"openai-compatible": "https://api.openai.com",
 		ollama: "http://localhost:11434",
 	};
 	const authMode = templateId === "openai-codex" ? "codex" : "apiKey";

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -1798,7 +1798,11 @@ export class PluginDataStore {
 	}
 
 	isProviderUsingCodexAuth(providerId: string): boolean {
-		return this.getProviderMeta(providerId)?.templateId === "openai-codex";
+		// Covers both the legacy "openai-codex" template and the first-class "openai"
+		// template switched to ChatGPT sign-in (auth.authMode === "codex"). A template-only
+		// check would miss the latter, letting codex-mode providers be offered for
+		// embeddings — which they don't support (createEmbeddingInstance throws).
+		return this.getProviderAuthMode(providerId) === "codex";
 	}
 
 	isProviderEmbeddingAvailable(providerId: string): boolean {

--- a/src/types/provider/definition.ts
+++ b/src/types/provider/definition.ts
@@ -63,6 +63,14 @@ export interface ProviderOAuthCapability {
 	signIn: () => Promise<OAuthSignInResult>;
 
 	/**
+	 * Aborts an in-progress signIn(): rejects its promise and tears down any callback
+	 * server so the user can retry immediately (e.g. after closing the browser tab). The
+	 * rejected signIn() error is a cancellation marker the modal treats as "not an error".
+	 * Omit for flows that can't be cancelled.
+	 */
+	cancelSignIn?: () => void;
+
+	/**
 	 * True when a session-backed flow is currently signed in (drives Reconnect/Disconnect
 	 * and the connection status). API-key-backed flows omit this — their status comes from
 	 * the auth-validation query instead.

--- a/src/types/provider/definition.ts
+++ b/src/types/provider/definition.ts
@@ -39,6 +39,48 @@ export interface ProviderSetupInstructions {
 export type AuthValidationResult = { valid: true } | { valid: false; error: string };
 
 /**
+ * Result of a completed OAuth sign-in flow, describing how the modal must persist it.
+ *  - `apiKey`: store the returned key in the provider's `apiKey` auth field (e.g. OpenRouter).
+ *  - `session`: the flow already persisted its own session store (e.g. Codex) — nothing to store.
+ */
+export type OAuthSignInResult = { kind: "apiKey"; apiKey: string } | { kind: "session" };
+
+/**
+ * Declares that a provider supports a browser-based OAuth sign-in flow, so the setup
+ * modal can render a uniform sign-in UI without hard-coding per-provider branches.
+ */
+export interface ProviderOAuthCapability {
+	/** Label for the sign-in tab + CTA button, e.g. "ChatGPT", "OpenRouter". */
+	label: string;
+
+	/** Lucide icon id for the sign-in tab (optional; the modal defaults to "log-in"). */
+	icon?: string;
+
+	/** Copy shown under the sign-in CTA. */
+	description?: string;
+
+	/** Runs the browser OAuth flow and returns how the result must be persisted. */
+	signIn: () => Promise<OAuthSignInResult>;
+
+	/**
+	 * True when a session-backed flow is currently signed in (drives Reconnect/Disconnect
+	 * and the connection status). API-key-backed flows omit this — their status comes from
+	 * the auth-validation query instead.
+	 */
+	isSignedIn?: () => boolean;
+
+	/** Session-backed disconnect (omit for API-key flows). */
+	disconnect?: () => void;
+
+	/**
+	 * Whether the provider ALSO supports a manual API-key path. When true the modal shows
+	 * the `[ Sign in ] | [ API key ]` switcher; when false it shows the sign-in CTA only
+	 * (OAuth-only providers such as Codex).
+	 */
+	supportsApiKey: boolean;
+}
+
+/**
  * Base interface for all provider definitions.
  */
 export interface BaseProviderDefinition {
@@ -53,6 +95,9 @@ export interface BaseProviderDefinition {
 
 	/** Instructions for setting up this provider. */
 	setupInstructions: ProviderSetupInstructions;
+
+	/** Optional browser-based OAuth sign-in capability (rendered by the setup modal). */
+	oauth?: ProviderOAuthCapability;
 
 	/** Authentication field definitions for this provider. At least one field must be required. */
 	auth: ProviderAuthConfig;

--- a/src/types/provider/index.ts
+++ b/src/types/provider/index.ts
@@ -23,6 +23,8 @@ export type {
 export type {
 	LogoProps,
 	ProviderSetupInstructions,
+	ProviderOAuthCapability,
+	OAuthSignInResult,
 	AuthValidationResult,
 	BaseProviderDefinition,
 	EmbeddingProviderDefinition,

--- a/src/types/provider/stored.ts
+++ b/src/types/provider/stored.ts
@@ -7,7 +7,13 @@
 /**
  * Code-defined provider template identifiers.
  */
-export type ProviderTemplateId = "openai-compatible" | "openai-codex" | "anthropic" | "ollama" | "openrouter";
+export type ProviderTemplateId =
+	| "openai"
+	| "openai-compatible"
+	| "openai-codex"
+	| "anthropic"
+	| "ollama"
+	| "openrouter";
 
 /**
  * Persisted metadata for a configured provider instance.

--- a/src/views/onboarding/Onboarding.svelte
+++ b/src/views/onboarding/Onboarding.svelte
@@ -63,7 +63,7 @@ let selectedAgent = $derived(data.getSelectedAgent());
 let hasChatModel = $derived(Boolean(selectedAgent?.chatModel));
 
 function openProviderSetup() {
-	new ProviderSetupModal(plugin, { templateId: "openai-compatible" }).open();
+	new ProviderSetupModal(plugin, {}).open();
 }
 
 function buildPersistedChatModel(provider: string, model: string, existing?: ChatModel | null): ChatModel {

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -119,6 +119,11 @@ async function handleOAuthSignIn() {
 			// Store the OAuth-obtained key as a managed secret so validation re-runs and Save enables.
 			data.setProviderAuthField(providerId, "apiKey", result.apiKey, true);
 		}
+		// A completed OAuth sign-in is a clear terminal action — once the connection
+		// validates and the provider commits, auto-close the modal so the user gets
+		// unambiguous feedback (the provider appears in the list) rather than having to
+		// spot the small green header icon. The commit effect honors this flag.
+		closeAfterCommit = true;
 		invalidateAuthState(providerId);
 	} catch (error) {
 		// A user-initiated cancel isn't a failure — clear the flow silently so the CTA
@@ -193,6 +198,11 @@ async function handleSelectTemplate(id: ProviderTemplateId) {
 // or while a commit is already in flight (the effect can re-fire mid-await).
 let isCommitting = false;
 
+// Set by a completed OAuth sign-in: once the provider commits, auto-close the modal after
+// a short beat so the "Connected" check is briefly visible. Manual API-key entry doesn't
+// set this — the modal stays open so the user can still adjust trusted/advanced fields.
+let closeAfterCommit = false;
+
 // Promotes a draft to a fully configured provider the moment its connection validates.
 // This replaces the old "Add Provider" button: display name / auth / trusted all
 // autosave as they change, so the only remaining commit steps are slug-finalizing the
@@ -233,6 +243,14 @@ async function commitProvider() {
 		invalidateProviderState(providerId);
 	} finally {
 		isCommitting = false;
+	}
+
+	// OAuth sign-in path: the provider is now committed and shows "Connected". Close the
+	// modal after a short beat so the green check is briefly visible — the provider then
+	// appears in the list, which is the clearest confirmation.
+	if (closeAfterCommit) {
+		closeAfterCommit = false;
+		setTimeout(() => modal.close(), 800);
 	}
 }
 

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -2,12 +2,16 @@
 import type { Component } from "svelte";
 import { mount, unmount, untrack } from "svelte";
 import AuthConfigFields from "../../components/settings/AuthConfigFields.svelte";
-import Dropdown from "../../components/ui/Dropdown.svelte";
 import SettingItem from "../../components/settings/SettingItem.svelte";
 import Button from "../../components/ui/Button.svelte";
 import Text from "../../components/ui/Text.svelte";
 import Toggle from "../../components/ui/Toggle.svelte";
+import ProviderSetupHeader from "./ProviderSetupHeader.svelte";
 import GenericAIIcon from "../../components/ui/logos/GenericAIIcon.svelte";
+import AnthropicLogo from "../../components/ui/logos/AnthropicLogo.svelte";
+import OllamaLogo from "../../components/ui/logos/OllamaLogo.svelte";
+import OpenAILogo from "../../components/ui/logos/OpenAILogo.svelte";
+import OpenRouterLogo from "../../components/ui/logos/OpenRouterLogo.svelte";
 import {
 	createAuthStateQuery,
 	getProviderStateQueryOptions,
@@ -17,15 +21,12 @@ import {
 import type SecondBrainPlugin from "../../main";
 import {
 	getAllProviderTemplates,
-	getProviderTemplate,
 	type LogoProps,
+	type OpenAIAuthMode,
 	type ProviderTemplateId,
 	getProviderDefinition,
 } from "../../providers/index";
-import { clearOpenAICodexSession, signInWithOpenAICodex } from "../../providers/openaiCodex";
 import { getData, slugifyProviderName } from "../../stores/dataStore.svelte";
-import { getCodexSession } from "../../stores/providerRuntime.svelte";
-import { icon } from "../../utils/utils";
 import type { ProviderSetupModal } from "./ProviderSetup";
 
 interface Props {
@@ -37,43 +38,165 @@ interface Props {
 const { modal }: Props = $props();
 const data = getData();
 
-// providerId only changes once: when a new provider is committed (renamed to slug on submit).
-// During editing it never changes.
+// Two-step flow: "pick" shows the provider grid, "configure" shows the setup form.
+// Editing an existing provider skips straight to "configure".
+let step = $state<"pick" | "configure">(untrack(() => (modal.startInPicker ? "pick" : "configure")));
+
+// providerId only changes once: when a new provider is committed (renamed to slug on submit),
+// or when a template is chosen from the picker. During editing it never changes.
 let providerId = $state(untrack(() => modal.selectedProvider));
 
 const query = createAuthStateQuery(() => providerId);
 const providerDefinition = $derived(getProviderDefinition(providerId, data.getAllProviderMeta()));
-const templateId = $derived(data.getProviderTemplateId(providerId));
 const providerMeta = $derived(data.getProviderMeta(providerId));
-const isCodex = $derived(templateId === "openai-codex");
+// OAuth capability drives the sign-in UI uniformly (no per-provider template checks).
+const oauth = $derived(providerDefinition?.oauth);
 const isConfigured = $derived(data.isProviderConfigured(providerId));
-const providerTemplates = getAllProviderTemplates();
-const providerTemplateOptions = providerTemplates.map((template) => ({
-	display: template.displayName,
-	value: template.id,
-}));
+
+// Picker display order: lead with the most-used providers so the grid scans fast.
+// Templates not listed fall to the end in their registry order.
+const PICKER_ORDER: ProviderTemplateId[] = ["openai-compatible", "openrouter", "openai", "anthropic"];
+const providerTemplates = [...getAllProviderTemplates()].sort((a, b) => {
+	const ai = PICKER_ORDER.indexOf(a.id);
+	const bi = PICKER_ORDER.indexOf(b.id);
+	return (ai === -1 ? PICKER_ORDER.length : ai) - (bi === -1 ? PICKER_ORDER.length : bi);
+});
 let isSigningIn = $state(false);
-let codexActionError = $state<string | null>(null);
+let signInError = $state<string | null>(null);
+
+// OAuth-capable providers expose two auth paths on one instance (sign-in vs API key).
+// Sign-in is the primary path; the API-key field is revealed on demand via a link.
+// Seed the revealed state from the stored mode so editing an instance that was set up
+// with a key reopens with the field shown. New instances default to sign-in (codex).
+let authMode = $state<OpenAIAuthMode>(untrack(() => data.getProviderAuthMode(providerId)));
+
+// The API-key section is revealed when the user opted into the key path.
+const revealApiKey = $derived(authMode === "apiKey");
+
+function toggleApiKey() {
+	handleAuthModeChange(revealApiKey ? "codex" : "apiKey");
+}
+
+function handleAuthModeChange(mode: OpenAIAuthMode) {
+	authMode = mode;
+	data.setProviderAuthMode(providerId, mode);
+	signInError = null;
+	invalidateAuthState(providerId);
+}
+
+// For OAuth-capable providers the sign-in CTA is always shown (it's the primary path);
+// the API-key field is an optional reveal below it. For OAuth-only providers there's no
+// key path at all. Non-OAuth providers show neither (plain AuthConfigFields).
+const showSignIn = $derived(!!oauth);
+const isSignedIn = $derived(showSignIn ? (oauth?.isSignedIn?.() ?? false) : false);
+
+// Whether the user has actually supplied credentials yet. Suppresses the connection
+// status on an untouched form (an empty required field validates to a scary "API key is
+// required" error otherwise). True once any required auth field has a stored value/secret,
+// once an OAuth session exists, once a sign-in attempt errored, or on the edit path where
+// the provider is already configured.
+const hasCredentials = $derived.by(() => {
+	if (isConfigured || signInError) return true;
+	if (isSignedIn) return true;
+	// For an OAuth provider still on the sign-in path (key field not revealed), the only
+	// credential is the OAuth session — which we've already checked above.
+	if (showSignIn && !revealApiKey) return false;
+	const stored = data.getStoredAuthState(providerId);
+	const authFields = providerDefinition?.auth;
+	if (!stored || !authFields) return false;
+	return Object.entries(authFields).some(
+		([key, field]) => field.required && (!!stored.values[key] || !!stored.secretIds[key]),
+	);
+});
+
+async function handleOAuthSignIn() {
+	if (!oauth) return;
+	isSigningIn = true;
+	signInError = null;
+	try {
+		const result = await oauth.signIn();
+		if (result.kind === "apiKey") {
+			// Store the OAuth-obtained key as a managed secret so validation re-runs and Save enables.
+			data.setProviderAuthField(providerId, "apiKey", result.apiKey, true);
+		}
+		invalidateAuthState(providerId);
+	} catch (error) {
+		signInError = error instanceof Error ? error.message : String(error);
+	} finally {
+		isSigningIn = false;
+	}
+}
+
+function handleOAuthDisconnect() {
+	oauth?.disconnect?.();
+	signInError = null;
+	invalidateAuthState(providerId);
+}
 let headerLogoHost: HTMLSpanElement | null = null;
 let headerLogoComponent: ReturnType<typeof mount> | null = null;
-const codexSession = $derived(isCodex ? getCodexSession() : null);
+let headerStatusHost: HTMLSpanElement | null = null;
+let headerStatusComponent: ReturnType<typeof mount> | null = null;
+// Reactive prop bag for the imperatively-mounted header status component. Mutating these
+// fields propagates to the mounted subtree (Svelte 5 mount props are reactive via $state).
+const headerStatusProps = $state<{ provider: string; showStatus: boolean }>({
+	provider: untrack(() => providerId),
+	showStatus: false,
+});
 let displayName = $state("");
 let displayNameError = $state<string | null>(null);
 const isTrusted = $derived(data.isProviderTrusted(providerId));
+
+// Logos per template for the picker grid. Templates without a dedicated logo
+// (openai-compatible) fall back to the generic AI icon.
+const TEMPLATE_LOGOS: Partial<Record<ProviderTemplateId, Component<LogoProps>>> = {
+	openai: OpenAILogo,
+	"openai-codex": OpenAILogo,
+	anthropic: AnthropicLogo,
+	ollama: OllamaLogo,
+	openrouter: OpenRouterLogo,
+};
+
+function getTemplateLogo(id: ProviderTemplateId): Component<LogoProps> {
+	return TEMPLATE_LOGOS[id] ?? GenericAIIcon;
+}
 
 $effect(() => {
 	displayName = providerMeta?.displayName ?? "";
 });
 
-async function handleAddProvider() {
-	if (!isConfigured) {
+async function handleSelectTemplate(id: ProviderTemplateId) {
+	const newId = await modal.selectTemplate(id);
+	providerId = newId;
+	step = "configure";
+	// Promote the no-API-key path: a freshly picked OAuth provider opens on the sign-in tab.
+	const def = getProviderDefinition(newId, data.getAllProviderMeta());
+	if (def?.oauth) {
+		handleAuthModeChange("codex");
+	}
+}
+
+// Guards the one-time live commit so it never re-runs once the provider is configured
+// or while a commit is already in flight (the effect can re-fire mid-await).
+let isCommitting = false;
+
+// Promotes a draft to a fully configured provider the moment its connection validates.
+// This replaces the old "Add Provider" button: display name / auth / trusted all
+// autosave as they change, so the only remaining commit steps are slug-finalizing the
+// ID and flipping isConfigured — done here, exactly once, on first successful connection.
+async function commitProvider() {
+	if (isConfigured || isCommitting) return;
+	isCommitting = true;
+	try {
 		// Rename the draft to a slug derived from the final display name — this is the
-		// only point where the ID changes. Doing it here (not on blur) keeps the setup
-		// flow stable while still producing a human-readable, recovery-friendly ID.
+		// only point where the ID changes. Doing it once (not on every name edit) keeps
+		// downstream references stable while producing a human-readable, recoverable ID.
 		const name = displayName.trim() || (providerMeta?.displayName ?? "");
 		const base = slugifyProviderName(name);
 		if (base && base !== providerId) {
-			const otherIds = new Set(Object.keys(data.getAllProviderMeta()).filter((id) => id !== providerId));
+			// Collide only against configured providers (minus this draft). Unconfigured
+			// providers are stale drafts, not real conflicts — counting them would push a
+			// legitimately-named provider to "openai-2".
+			const otherIds = new Set(data.getConfiguredProviders().filter((id) => id !== providerId));
 			let finalId = base;
 			let n = 2;
 			while (otherIds.has(finalId)) finalId = `${base}-${n++}`;
@@ -86,11 +209,15 @@ async function handleAddProvider() {
 			}
 		}
 		data.setProviderConfigured(providerId, true);
+		// The auth query re-keys on providerId, so it re-fires under the new ID after a
+		// rename — refetch so the inline status stays "Connected" rather than flashing.
+		await modal.plugin.queryClient.fetchQuery(getProviderStateQueryOptions(providerId));
+		invalidateProviderState(providerId);
+		// Prevent onClose from auto-deleting the now-committed provider.
+		modal.markSubmitted();
+	} finally {
+		isCommitting = false;
 	}
-	await modal.plugin.queryClient.fetchQuery(getProviderStateQueryOptions(providerId));
-	invalidateProviderState(providerId);
-	modal.markSubmitted();
-	modal.close();
 }
 
 async function handleDisplayNameBlur(nextName: string) {
@@ -110,50 +237,8 @@ async function handleDisplayNameBlur(nextName: string) {
 	}
 }
 
-async function handleTemplateChange(nextTemplateId: string) {
-	const resolvedTemplateId = nextTemplateId as ProviderTemplateId;
-	if (!templateId || resolvedTemplateId === templateId) return;
-
-	const currentDefaultName = getProviderTemplate(templateId)?.displayName ?? providerMeta?.displayName ?? "";
-	const nextTemplate = getProviderTemplate(resolvedTemplateId);
-	const shouldUpdateDisplayName = !providerMeta?.displayName || providerMeta.displayName === currentDefaultName;
-
-	await data.updateProviderMeta(providerId, {
-		templateId: resolvedTemplateId,
-		...(shouldUpdateDisplayName
-			? { displayName: nextTemplate?.displayName ?? providerMeta?.displayName ?? "" }
-			: {}),
-	});
-
-	if (shouldUpdateDisplayName) {
-		displayName = nextTemplate?.displayName ?? "";
-	}
-
-	invalidateAuthState(providerId);
-	invalidateProviderState(providerId);
-}
-
 function handleTrustedChange(trusted: boolean) {
 	data.setProviderTrusted(providerId, trusted);
-}
-
-async function handleCodexSignIn() {
-	isSigningIn = true;
-	codexActionError = null;
-	try {
-		await signInWithOpenAICodex();
-		invalidateAuthState(providerId);
-	} catch (error) {
-		codexActionError = error instanceof Error ? error.message : String(error);
-	} finally {
-		isSigningIn = false;
-	}
-}
-
-function handleCodexDisconnect() {
-	clearOpenAICodexSession();
-	codexActionError = null;
-	invalidateAuthState(providerId);
 }
 
 function getProviderLogo(): Component<LogoProps> {
@@ -161,18 +246,26 @@ function getProviderLogo(): Component<LogoProps> {
 }
 
 function renderHeaderLogo() {
-	if (!isConfigured) return;
+	if (step !== "configure") return;
 	const title = modal.titleEl;
 	const header = title.parentElement;
-	title.setCssStyles({ marginBlock: "0" });
+	// Don't let the title stretch — it would push the status/trust icons onto a new
+	// line, where they collide with the absolutely-positioned .modal-close-button.
+	// Zero the inline margins too: Obsidian's .modal-title uses auto side-margins that
+	// resolve to a large value in a flex row, opening a gap on either side of the title.
+	title.setCssStyles({ margin: "0", flex: "0 0 auto" });
 	header?.setCssStyles({
 		display: "flex",
 		flexDirection: "row",
+		flexWrap: "nowrap",
 		gap: "0.5rem",
 		alignItems: "center",
-		justifyItems: "start",
+		justifyContent: "flex-start",
+		// Clear the absolutely-positioned close button in the top-right corner.
+		paddingInlineEnd: "2rem",
 	});
 	if (header) {
+		// Logo before the title.
 		if (!headerLogoHost || headerLogoHost.parentElement !== header) {
 			headerLogoHost?.remove();
 			headerLogoHost = header.createSpan({ cls: "provider-setup-header-logo" });
@@ -189,11 +282,25 @@ function renderHeaderLogo() {
 			target: headerLogoHost,
 			props: { width: 32, height: 32 },
 		});
+
+		// Status + trust icons after the title (icon → name → status → trust).
+		if (!headerStatusHost || headerStatusHost.parentElement !== header) {
+			headerStatusHost?.remove();
+			headerStatusHost = header.createSpan({ cls: "provider-setup-header-status" });
+			title.after(headerStatusHost);
+		}
+
+		if (!headerStatusComponent) {
+			headerStatusComponent = mount(ProviderSetupHeader, {
+				target: headerStatusHost,
+				props: headerStatusProps,
+			});
+		}
 	}
 }
 
 $effect(() => {
-	if (!isConfigured) return;
+	if (step !== "configure") return;
 	providerDefinition;
 	renderHeaderLogo();
 
@@ -204,102 +311,207 @@ $effect(() => {
 		}
 		headerLogoHost?.remove();
 		headerLogoHost = null;
+		if (headerStatusComponent) {
+			unmount(headerStatusComponent);
+			headerStatusComponent = null;
+		}
+		headerStatusHost?.remove();
+		headerStatusHost = null;
 	};
+});
+
+// Keep the imperatively-mounted header status component's props in sync with the modal's
+// reactive state (provider id after rename, and the empty-state gate).
+$effect(() => {
+	headerStatusProps.provider = providerId;
+	headerStatusProps.showStatus = hasCredentials;
+});
+
+// Live commit: once the connection validates on the configure step, promote the draft to
+// a configured provider (no button). The commitProvider guard makes this a one-shot —
+// it no-ops once configured, so later validation failures never un-configure it.
+$effect(() => {
+	if (step !== "configure") return;
+	if (query.data?.success && !isConfigured && !displayNameError) {
+		untrack(() => void commitProvider());
+	}
 });
 </script>
 
-<div class="modal-content">
-  <SettingItem name="Provider Type" desc="Choose the provider template to configure in this modal.">
-    <Dropdown
-      type="options"
-      dropdown={providerTemplateOptions}
-      selected={templateId}
-      onchange={(value) => void handleTemplateChange(value)}
-    />
-  </SettingItem>
-
-  <SettingItem
-    name="Provider Name"
-    desc="Name this provider instance so you can distinguish it later."
-  >
-    <Text
-      inputType="text"
-      value={displayName}
-      placeholder={providerDefinition?.displayName ?? "New Provider"}
-      onblur={(value: string) => void handleDisplayNameBlur(value)}
-    />
-  </SettingItem>
-  {#if displayNameError}
-    <div
-      style="color: var(--text-error); font-size: var(--font-smaller); padding: 0 var(--size-4-3) var(--size-4-2);"
-    >
-      {displayNameError}
+{#if step === "pick"}
+  <div class="modal-content">
+    <p class="provider-picker-desc">Choose a provider to connect.</p>
+    <div class="provider-picker-grid">
+      {#each providerTemplates as template (template.id)}
+        {@const Logo = getTemplateLogo(template.id)}
+        <button
+          type="button"
+          class="provider-picker-tile"
+          onclick={() => void handleSelectTemplate(template.id)}
+        >
+          <span class="provider-picker-logo">
+            <Logo width={32} height={32} />
+          </span>
+          <span class="provider-picker-name">{template.displayName}</span>
+        </button>
+      {/each}
     </div>
-  {/if}
+  </div>
+{:else}
+  <div class="modal-content">
+    <SettingItem
+      name="Provider Name"
+      desc="Name this provider instance so you can distinguish it later."
+    >
+      <Text
+        inputType="text"
+        value={displayName}
+        placeholder={providerDefinition?.displayName ?? "New Provider"}
+        onblur={(value: string) => void handleDisplayNameBlur(value)}
+      />
+    </SettingItem>
+    {#if displayNameError}
+      <div
+        style="color: var(--text-error); font-size: var(--font-smaller); padding: 0 var(--size-4-3) var(--size-4-2);"
+      >
+        {displayNameError}
+      </div>
+    {/if}
 
+    {#if oauth && oauth.supportsApiKey}
+      <!-- OAuth + API key: sign-in is the primary path; the key field is revealed on
+           demand via a link, so the common (no-key) flow stays a single clean button. -->
+      {@render oauthSignIn()}
+
+      <div class="auth-alt-toggle">
+        <button type="button" class="auth-alt-link" onclick={toggleApiKey}>
+          {revealApiKey ? "Hide API key field" : "Use an API key instead →"}
+        </button>
+      </div>
+
+      {#if revealApiKey}
+        <AuthConfigFields provider={providerId} />
+      {/if}
+
+      {@render trustedToggle()}
+    {:else if oauth}
+      <!-- OAuth-only provider (no manual API key): sign-in CTA only. -->
+      {#if oauth.description}
+        <div class="setting-item">
+          <div class="setting-item-description">{oauth.description}</div>
+        </div>
+      {/if}
+
+      {@render oauthSignIn()}
+      {@render trustedToggle()}
+    {:else}
+      <AuthConfigFields provider={providerId} afterRequired={trustedToggle} />
+    {/if}
+  </div>
+{/if}
+
+{#snippet trustedToggle()}
   <SettingItem
     name="Trusted with private notes"
     desc="Allow this provider to access notes that remain private for untrusted providers."
   >
     <Toggle checked={isTrusted} onchange={handleTrustedChange} />
   </SettingItem>
+{/snippet}
 
-  {#if isCodex}
-    <div class="setting-item">
-      <div class="setting-item-description">
-        Sign in with your ChatGPT/Codex account to use Codex-backed OpenAI chat models locally.
-      </div>
-    </div>
-
-    <SettingItem
-      name="ChatGPT Sign-In"
-      desc={codexSession?.accountId
-        ? `Signed in (${codexSession.accountId})`
-        : "Open a browser window to complete ChatGPT/Codex authorization."}
-    >
+{#snippet oauthSignIn()}
+  {#if oauth}
+    <SettingItem name={`${oauth.label} Sign-In`} desc={oauth.description ?? ""}>
       <div class="flex gap-2">
         <Button
-          buttonText={codexSession ? "Reconnect" : "Sign in with ChatGPT"}
+          buttonText={isSignedIn ? "Reconnect" : `Sign in with ${oauth.label}`}
           disabled={isSigningIn}
           cta={true}
-          onClick={() => void handleCodexSignIn()}
+          onClick={() => void handleOAuthSignIn()}
         />
-        {#if codexSession}
-          <Button buttonText="Disconnect" onClick={handleCodexDisconnect} />
+        {#if oauth.disconnect && isSignedIn}
+          <Button buttonText="Disconnect" onClick={handleOAuthDisconnect} />
         {/if}
       </div>
     </SettingItem>
-
-    {#if codexActionError}
-      <SettingItem name="Authorization Error" desc={codexActionError} />
-    {/if}
-  {:else}
-    <AuthConfigFields provider={providerId} />
   {/if}
-</div>
+{/snippet}
 
-<div class="modal-button-container">
-  {#if query.data !== undefined}
-    <div
-      class="flex items-center gap-2 rounded px-[--pill-padding-x] mr-auto"
-      class:bg-green-100={query.data.success}
-      class:bg-red-100={!query.data.success}
-      use:icon={query.data.success ? "check" : "x"}
-    >
-      <span>
-        {#if query.data.success}
-          Provider authentication successful
-        {:else}
-          {query.data.message}
-        {/if}
-      </span>
-    </div>
-  {/if}
-  <Button buttonText="Cancel" onClick={() => modal.close()} />
-  <Button
-    buttonText={isConfigured ? "Save Provider" : "Add Provider"}
-    cta={true}
-    disabled={!query.data?.success || !!displayNameError}
-    onClick={() => void handleAddProvider()}
-  />
-</div>
+<style>
+  .auth-alt-toggle {
+    padding: 0 var(--size-4-3) var(--size-4-2);
+  }
+
+  .auth-alt-link {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    color: var(--text-muted);
+    font-size: var(--font-smaller);
+    cursor: pointer;
+  }
+
+  .auth-alt-link:hover {
+    color: var(--text-accent);
+  }
+
+  .provider-picker-desc {
+    color: var(--text-muted);
+    margin: 0 0 var(--size-4-3);
+  }
+
+  .provider-picker-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: var(--size-4-3);
+  }
+
+  .provider-picker-tile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--size-4-2);
+    min-height: 96px;
+    padding: var(--size-4-3) var(--size-4-2);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m);
+    background: var(--background-secondary);
+    cursor: pointer;
+    transition: border-color 0.1s ease, background 0.1s ease;
+  }
+
+  .provider-picker-tile:hover {
+    border-color: var(--interactive-accent);
+    background: var(--background-modifier-hover);
+  }
+
+  .provider-picker-logo {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    overflow: hidden;
+  }
+
+  .provider-picker-logo :global(svg) {
+    width: 32px;
+    height: 32px;
+  }
+
+  /* GenericAIIcon renders a div (Lucide action) rather than a bare <svg>. */
+  .provider-picker-logo :global(> div) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .provider-picker-name {
+    font-size: var(--font-smaller);
+    text-align: center;
+    color: var(--text-normal);
+  }
+</style>

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -90,6 +90,17 @@ function handleAuthModeChange(mode: OpenAIAuthMode) {
 const showSignIn = $derived(!!oauth);
 const isSignedIn = $derived(showSignIn ? (oauth?.isSignedIn?.() ?? false) : false);
 
+// Whether this OAuth provider is already connected, so the edit view shows a "Connected"
+// state instead of a misleading "Sign in" CTA. Two flavors:
+//  - session-backed (Codex): connected == an active session (oauth.isSignedIn()).
+//  - api-key-backed (OpenRouter): no session to check — connected == a stored apiKey.
+const oauthConnected = $derived.by(() => {
+	if (!oauth) return false;
+	if (oauth.isSignedIn) return isSignedIn;
+	const stored = data.getStoredAuthState(providerId);
+	return !!(stored?.values.apiKey || stored?.secretIds.apiKey);
+});
+
 // Whether the user has actually supplied credentials yet. Suppresses the connection
 // status on an untouched form (an empty required field validates to a scary "API key is
 // required" error otherwise). True once any required auth field has a stored value/secret,
@@ -456,21 +467,30 @@ $effect(() => {
 {#snippet oauthSignIn()}
   {#if oauth}
     <SettingItem name={`${oauth.label} Sign-In`} desc={oauth.description ?? ""}>
-      <div class="flex gap-2">
+      <div class="flex gap-2 items-center">
         {#if isSigningIn && oauth.cancelSignIn}
           <!-- While a sign-in is pending, let the user abort it (e.g. they closed the
                browser tab) and retry, instead of waiting out the timeout. -->
           <Button buttonText="Cancel sign-in" onClick={handleCancelSignIn} />
+        {:else if oauthConnected && !oauth.disconnect}
+          <!-- API-key-backed OAuth (e.g. OpenRouter): the minted key doesn't expire, so
+               reconnecting is needless. Show a plain connected status, no button. -->
+          <span class="oauth-connected-label">Connected via {oauth.label}</span>
+        {:else if oauthConnected}
+          <!-- Session-backed OAuth (e.g. Codex/ChatGPT): tokens can expire or be revoked,
+               so keep Reconnect (re-auth) and Disconnect available. -->
+          <span class="oauth-connected-label">Connected via {oauth.label}</span>
+          <Button buttonText="Reconnect" disabled={isSigningIn} onClick={() => void handleOAuthSignIn()} />
+          {#if oauth.disconnect}
+            <Button buttonText="Disconnect" onClick={handleOAuthDisconnect} />
+          {/if}
         {:else}
           <Button
-            buttonText={isSignedIn ? "Reconnect" : `Sign in with ${oauth.label}`}
+            buttonText={`Sign in with ${oauth.label}`}
             disabled={isSigningIn}
             cta={true}
             onClick={() => void handleOAuthSignIn()}
           />
-        {/if}
-        {#if oauth.disconnect && isSignedIn && !isSigningIn}
-          <Button buttonText="Disconnect" onClick={handleOAuthDisconnect} />
         {/if}
       </div>
     </SettingItem>
@@ -478,6 +498,14 @@ $effect(() => {
 {/snippet}
 
 <style>
+  .oauth-connected-label {
+    display: inline-flex;
+    align-items: center;
+    color: var(--text-success, #4caf50);
+    font-size: var(--font-ui-small);
+    font-weight: 500;
+  }
+
   .auth-alt-toggle {
     padding: 0 var(--size-4-3) var(--size-4-2);
   }

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -121,10 +121,24 @@ async function handleOAuthSignIn() {
 		}
 		invalidateAuthState(providerId);
 	} catch (error) {
-		signInError = error instanceof Error ? error.message : String(error);
+		// A user-initiated cancel isn't a failure — clear the flow silently so the CTA
+		// returns to "Sign in" and the user can retry. Cancellation markers set their name.
+		const name = error instanceof Error ? error.name : "";
+		if (name === "OpenRouterSignInCancelledError" || name === "OpenAICodexSignInCancelledError") {
+			signInError = null;
+		} else {
+			signInError = error instanceof Error ? error.message : String(error);
+		}
 	} finally {
 		isSigningIn = false;
 	}
+}
+
+// Abort an in-progress sign-in (e.g. the user closed the browser tab before authorizing).
+// This rejects the pending signIn() promise and frees its callback server/port so the flow
+// can be retried immediately instead of hanging until the timeout.
+function handleCancelSignIn() {
+	oauth?.cancelSignIn?.();
 }
 
 function handleOAuthDisconnect() {
@@ -423,13 +437,19 @@ $effect(() => {
   {#if oauth}
     <SettingItem name={`${oauth.label} Sign-In`} desc={oauth.description ?? ""}>
       <div class="flex gap-2">
-        <Button
-          buttonText={isSignedIn ? "Reconnect" : `Sign in with ${oauth.label}`}
-          disabled={isSigningIn}
-          cta={true}
-          onClick={() => void handleOAuthSignIn()}
-        />
-        {#if oauth.disconnect && isSignedIn}
+        {#if isSigningIn && oauth.cancelSignIn}
+          <!-- While a sign-in is pending, let the user abort it (e.g. they closed the
+               browser tab) and retry, instead of waiting out the timeout. -->
+          <Button buttonText="Cancel sign-in" onClick={handleCancelSignIn} />
+        {:else}
+          <Button
+            buttonText={isSignedIn ? "Reconnect" : `Sign in with ${oauth.label}`}
+            disabled={isSigningIn}
+            cta={true}
+            onClick={() => void handleOAuthSignIn()}
+          />
+        {/if}
+        {#if oauth.disconnect && isSignedIn && !isSigningIn}
           <Button buttonText="Disconnect" onClick={handleOAuthDisconnect} />
         {/if}
       </div>

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -223,12 +223,14 @@ async function commitProvider() {
 			}
 		}
 		data.setProviderConfigured(providerId, true);
+		// Mark submitted BEFORE any await — the provider is now committed. Otherwise closing
+		// the modal during the fetchQuery below (e.g. right after seeing "Connected") would
+		// hit onClose with isSubmitted still false and delete the just-configured provider.
+		modal.markSubmitted();
 		// The auth query re-keys on providerId, so it re-fires under the new ID after a
 		// rename — refetch so the inline status stays "Connected" rather than flashing.
 		await modal.plugin.queryClient.fetchQuery(getProviderStateQueryOptions(providerId));
 		invalidateProviderState(providerId);
-		// Prevent onClose from auto-deleting the now-committed provider.
-		modal.markSubmitted();
 	} finally {
 		isCommitting = false;
 	}

--- a/src/views/provider-setup/ProviderSetup.ts
+++ b/src/views/provider-setup/ProviderSetup.ts
@@ -1,6 +1,7 @@
 import { Modal } from "obsidian";
 import { mount } from "svelte";
 import ModalProvider from "../../lib/QueryClientProvider.svelte";
+import { removeProviderQueries } from "../../lib/query";
 import type SecondBrainPlugin from "../../main";
 import { getProviderTemplate, type ProviderTemplateId } from "../../providers/index";
 import { slugifyProviderName } from "../../stores/dataStore.svelte";
@@ -94,7 +95,11 @@ export class ProviderSetupModal extends Modal {
 			!this.isSubmitted &&
 			!this.plugin.pluginData.isProviderConfigured(this.selectedProvider)
 		) {
-			void this.plugin.pluginData.deleteProvider(this.selectedProvider);
+			const draftId = this.selectedProvider;
+			void this.plugin.pluginData.deleteProvider(draftId);
+			// Drop the draft's cached auth/state so re-adding the same template (which reuses
+			// the slug ID) doesn't inherit this abandoned draft's stale validation verdict.
+			removeProviderQueries(draftId);
 		}
 	}
 

--- a/src/views/provider-setup/ProviderSetup.ts
+++ b/src/views/provider-setup/ProviderSetup.ts
@@ -85,7 +85,15 @@ export class ProviderSetupModal extends Modal {
 		this.isClosed = true;
 		const { contentEl } = this;
 		contentEl.empty();
-		if (this.createdDraft && this.draftCreated && !this.isSubmitted) {
+		// Only auto-delete a draft that was never committed. Guard on isConfigured too (not
+		// just isSubmitted): a live commit flips isConfigured before its async status refetch
+		// finishes, so a close mid-commit must not delete an already-configured provider.
+		if (
+			this.createdDraft &&
+			this.draftCreated &&
+			!this.isSubmitted &&
+			!this.plugin.pluginData.isProviderConfigured(this.selectedProvider)
+		) {
 			void this.plugin.pluginData.deleteProvider(this.selectedProvider);
 		}
 	}

--- a/src/views/provider-setup/ProviderSetup.ts
+++ b/src/views/provider-setup/ProviderSetup.ts
@@ -15,11 +15,14 @@ export class ProviderSetupModal extends Modal {
 	component!: ProviderSetupComponent;
 	plugin: SecondBrainPlugin;
 	selectedProvider: string;
-	private readonly templateId?: ProviderTemplateId;
+	private templateId?: ProviderTemplateId;
 	private readonly createdDraft: boolean;
 	private isSubmitted = false;
 	private isClosed = false;
 	private draftCreated = false;
+	// Whether the modal opens on the provider-picker step (the "Add Provider" path
+	// with no pre-selected template). Editing an existing provider skips the picker.
+	readonly startInPicker: boolean;
 
 	constructor(plugin: SecondBrainPlugin, target: string | ProviderSetupTarget) {
 		super(plugin.app);
@@ -33,13 +36,19 @@ export class ProviderSetupModal extends Modal {
 		}
 		this.templateId = typeof target === "string" ? undefined : target.templateId;
 		this.createdDraft = typeof target !== "string" && !target.selectedProvider;
+		// Show the picker when adding a provider without a concrete template chosen up front.
+		this.startInPicker = this.createdDraft && !this.templateId;
 		this.refreshTitle();
 	}
 
 	private generateDraftId(templateId?: ProviderTemplateId): string {
 		const baseName = templateId ? (getProviderTemplate(templateId)?.displayName ?? "provider") : "provider";
 		const baseSlug = slugifyProviderName(baseName);
-		const existingIds = new Set(Object.keys(this.plugin.pluginData.getAllProviderMeta()));
+		// Collide only against CONFIGURED providers. An unconfigured provider is a stale
+		// draft (see ensureDraftProvider), which we reclaim rather than avoid — so it must
+		// not push a fresh draft to "openai-2". A same-slug stale draft is deleted in
+		// ensureDraftProvider before the new instance is created.
+		const existingIds = new Set(this.plugin.pluginData.getConfiguredProviders());
 		if (!existingIds.has(baseSlug)) return baseSlug;
 		let n = 2;
 		while (existingIds.has(`${baseSlug}-${n}`)) n++;
@@ -55,6 +64,11 @@ export class ProviderSetupModal extends Modal {
 	}
 
 	refreshTitle(displayName = this.resolveDisplayName()) {
+		// While picking a provider, keep a neutral title.
+		if (this.createdDraft && !this.templateId) {
+			this.setTitle("Add Provider");
+			return;
+		}
 		if (this.createdDraft) {
 			this.setTitle("Setup Provider");
 			return;
@@ -80,6 +94,19 @@ export class ProviderSetupModal extends Modal {
 		this.isSubmitted = true;
 	}
 
+	/**
+	 * Called from the picker step once the user chooses a provider template. Generates
+	 * a fresh draft ID for the template, creates the draft instance, and refreshes the
+	 * title. The component then advances to the configure step.
+	 */
+	async selectTemplate(templateId: ProviderTemplateId): Promise<string> {
+		this.templateId = templateId;
+		this.selectedProvider = this.generateDraftId(templateId);
+		await this.ensureDraftProvider();
+		this.refreshTitle();
+		return this.selectedProvider;
+	}
+
 	private async ensureDraftProvider() {
 		if (!this.createdDraft || !this.templateId || this.plugin.pluginData.getProviderMeta(this.selectedProvider)) {
 			return;
@@ -91,6 +118,22 @@ export class ProviderSetupModal extends Modal {
 		// If draft ID has a numeric suffix (e.g. "openai-compatible-2"), reflect it in the display name
 		const suffix = this.selectedProvider.slice(baseSlug.length); // "" or "-2"
 		const displayName = suffix ? `${baseName} ${suffix.slice(1)}` : baseName;
+
+		// Reclaim any stale draft holding the ID or display name we're about to use. A leaked
+		// unconfigured draft (from a prior modal that skipped onClose) would otherwise block
+		// addProviderInstance — it throws on a duplicate ID or case-insensitive display name.
+		// Only unconfigured providers are eligible; a configured provider is a real conflict
+		// and is left alone (generateDraftId already suffixed around it).
+		const data = this.plugin.pluginData;
+		const wantedName = displayName.trim().toLowerCase();
+		const staleDrafts = Object.entries(data.getAllProviderMeta()).filter(
+			([id, meta]) =>
+				!data.isProviderConfigured(id) &&
+				(id === this.selectedProvider || meta.displayName.trim().toLowerCase() === wantedName),
+		);
+		for (const [id] of staleDrafts) {
+			await data.deleteProvider(id);
+		}
 
 		await this.plugin.pluginData.addProviderInstance(this.selectedProvider, {
 			templateId: this.templateId,
@@ -105,7 +148,10 @@ export class ProviderSetupModal extends Modal {
 	}
 
 	private async openWithProvider() {
-		await this.ensureDraftProvider();
+		// In picker mode the draft is created only once the user picks a template.
+		if (!this.startInPicker) {
+			await this.ensureDraftProvider();
+		}
 		if (this.isClosed) return;
 		this.component = mount(
 			ModalProvider<{

--- a/src/views/provider-setup/ProviderSetupHeader.svelte
+++ b/src/views/provider-setup/ProviderSetupHeader.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+import CircularLoader from "../../components/ui/CircularLoader.svelte";
+import { createAuthStateQuery } from "../../lib/query";
+import { getData } from "../../stores/dataStore.svelte";
+import { icon } from "../../utils/utils";
+
+interface Props {
+	provider: string;
+	// Gate the status icon so it stays hidden on an untouched form (mirrors the modal's
+	// hasCredentials logic). When false, only the trust icon (if trusted) can show.
+	showStatus: boolean;
+}
+
+const { provider, showStatus }: Props = $props();
+
+const data = getData();
+const query = createAuthStateQuery(() => provider);
+const isChecking = $derived(query.isPending || query.isFetching);
+const isTrusted = $derived(data.isProviderTrusted(provider));
+const failureMessage = $derived(query.data && !query.data.success ? query.data.message : "Authentication failed");
+</script>
+
+<span class="provider-status-group">
+  {#if showStatus}
+    {#if isChecking}
+      <span class="provider-status-indicator" title="Checking connection" aria-label="Checking connection">
+        <CircularLoader size={18} color="var(--text-muted)" />
+      </span>
+    {:else if query.data?.success}
+      <span
+        class="provider-status-indicator provider-icon-indicator-success"
+        title="Connected"
+        aria-label="Connected"
+      >
+        <span class="provider-status-icon" use:icon={"check-circle"}></span>
+      </span>
+    {:else if query.data !== undefined}
+      <span
+        class="provider-status-indicator provider-icon-indicator-error"
+        title={failureMessage}
+        aria-label={failureMessage}
+      >
+        <span class="provider-status-icon" use:icon={"x-circle"}></span>
+      </span>
+    {/if}
+  {/if}
+
+  {#if isTrusted}
+    <span
+      class="provider-icon-indicator provider-icon-indicator-accent"
+      title="Trusted with private notes"
+      aria-label="Trusted with private notes"
+    >
+      <span class="provider-status-icon" use:icon={"shield"}></span>
+    </span>
+  {/if}
+</span>
+
+<style>
+  .provider-status-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
+  .provider-status-indicator,
+  .provider-icon-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    min-width: 20px;
+    min-height: 20px;
+  }
+
+  .provider-icon-indicator-error {
+    color: var(--text-error);
+  }
+
+  .provider-icon-indicator-accent {
+    color: var(--text-accent);
+  }
+
+  .provider-icon-indicator-success {
+    color: var(--text-success, #4caf50);
+  }
+
+  .provider-status-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+  }
+
+  /* Scale the injected Lucide SVG to fill the (now larger) icon box. */
+  .provider-status-icon :global(svg) {
+    width: 20px;
+    height: 20px;
+  }
+</style>

--- a/src/views/settings/GeneralSettings.svelte
+++ b/src/views/settings/GeneralSettings.svelte
@@ -19,7 +19,7 @@ const privacyListModal = new PrivacyListModal(plugin.app);
 let configuredProviderIds = $derived(pluginData.getConfiguredProviders());
 
 function handleOpenProviderSetup() {
-	new ProviderSetupModal(plugin, { templateId: "openai-compatible" }).open();
+	new ProviderSetupModal(plugin, {}).open();
 }
 </script>
 


### PR DESCRIPTION
Closes #332.

Reworks the provider setup flow to be leaner and autosaving, and promotes OpenAI to a first-class template alongside a renamed **Custom** (OpenAI-compatible).

## Modal UX
- **Remove Add/Cancel buttons.** Picking a template creates the provider immediately; everything autosaves. The draft is promoted to *configured* live on the first successful connection — no button press.
- **Status moved into the header** (icon → name → status → trust), matching the provider-list badge style: spinner while checking, green check when connected, red ✕ with the error on hover, accent shield when trusted. Hidden until the user supplies credentials.
- **OAuth vs API key** — replaced the centered sliding-tab switcher with a primary "Sign in with ChatGPT" CTA plus a subtle "Use an API key instead" reveal link; the sign-in button stays visible when the key field is shown.
- **Custom provider** — Base URL always visible (required) and above the API key; no OpenAI-biased pre-seed/placeholder. Trusted toggle sits below the credentials and above Advanced.

## Provider templates
- Add **OpenAI** as a first-class template (ChatGPT sign-in or API key); rename OpenAI-compatible to **Custom**. New provider OAuth-capability abstraction so the modal renders a uniform sign-in UI without per-vendor branches.

## Fixes
- **Provider-list alignment** — logo, name, and status/trust icons now share one centerline (status button no longer inherits the theme's 30px height; leading icon centers on the header line).
- **Anthropic Advanced auto-expand** — dropped Anthropic's `baseUrl` pre-seed (an optional/Advanced field); kept Ollama's (required, main-section) default.
- **Orphaned draft providers ("OpenAI 2" bug)** — sweep unconfigured drafts on startup, and collide draft IDs only against configured providers (reclaiming a stale same-slug draft).

## Verification
- `bun run check` clean (only 4 pre-existing GraphCanvas errors, untouched by this PR); `bun run format` clean.
- Verified live in the test vault (Obsidian CLI): add/edit paths, OAuth (OpenAI) + non-OAuth (Custom) flows, header status/trust icons, provider-list alignment, Anthropic/Ollama Advanced behavior, and the draft-sweep + duplicate-suffix cases. No console errors.
- No unit tests for the modal (coverage scope is `src/providers/**`); no store API changes.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._