### PR TITLE
feat: add ETA to indexing progress bar and clean up index list UI

### DIFF
--- a/src/components/settings/EmbeddingIndexSection.svelte
+++ b/src/components/settings/EmbeddingIndexSection.svelte
@@ -12,8 +12,7 @@ import { confirmDelete } from "../modal/ConfirmModal";
 import { getProviderDefinition } from "../../providers/index";
 import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
-import { isVectorStoreInitialized, getVectorStoreService, type IndexingProgress } from "../../vectorstore";
-import { getDefaultEmbeddingBatchSize } from "../../vectorstore/batchSize";
+import { isVectorStoreInitialized, getVectorStoreService, formatEta, type IndexingProgress } from "../../vectorstore";
 
 interface Props {
 	/** Which feature this embedding index is for */
@@ -35,6 +34,7 @@ let indexProgress = $state<IndexingProgress>({
 	skipped: 0,
 	currentFile: null,
 	percentage: 0,
+	etaMs: null,
 });
 
 // Document count derived from reactive pluginData
@@ -55,6 +55,7 @@ function subscribeToIndex(id: string | null) {
 			skipped: 0,
 			currentFile: null,
 			percentage: 0,
+			etaMs: null,
 		};
 		return;
 	}
@@ -107,6 +108,7 @@ function clearSelectedIndex() {
 		skipped: 0,
 		currentFile: null,
 		percentage: 0,
+		etaMs: null,
 	};
 }
 
@@ -136,6 +138,7 @@ async function deleteIndex(targetIndexId: string) {
 			skipped: 0,
 			currentFile: null,
 			percentage: 0,
+			etaMs: null,
 		};
 	}
 }
@@ -178,13 +181,6 @@ function usedBy(targetIndexId: string): string[] {
 	return purposes;
 }
 
-function describeUsage(targetIndexId: string): string {
-	const users = usedBy(targetIndexId);
-	if (users.length === 2) return "Shared by Search and Graph";
-	if (users.length === 1) return `Used by ${users[0]} only`;
-	return "";
-}
-
 function describeCurrentSelection(): string {
 	return purpose === "search"
 		? "Embedding indexes power semantic search across your notes."
@@ -213,6 +209,9 @@ function getSelectionGroupLabel(): string {
             {#if indexProgress.skipped > 0}
               ({indexProgress.skipped} skipped)
             {/if}
+            {#if indexProgress.etaMs !== null}
+              (~{formatEta(indexProgress.etaMs)} left)
+            {/if}
           </span>
         </div>
         <Button buttonText="Cancel" onClick={cancelIndexing} />
@@ -239,18 +238,14 @@ function getSelectionGroupLabel(): string {
           entryProviderDef && "logo" in entryProviderDef && entryProviderDef.logo
             ? entryProviderDef.logo
             : GenericAIIcon}
-        {@const entryBatchSize = entry.batchSize ?? getDefaultEmbeddingBatchSize(entry.provider)}
         {@const selected = entry.id === indexId}
         <ManagedEntityItem
           class="embedding-index-option"
           name={entry.model}
-          desc={[`${entry.documentCount} notes indexed`, `batch ${entryBatchSize}`]
-            .filter(Boolean)
-            .join(" · ")}
           meta={[
             entryProviderDef?.displayName ?? entry.provider,
             formatDate(entry.lastBuiltAt),
-            describeUsage(entry.id),
+            `${entry.documentCount} notes indexed`,
           ]
             .filter(Boolean)
             .join(" · ")}

--- a/src/vectorstore/HNSWVectorStore.ts
+++ b/src/vectorstore/HNSWVectorStore.ts
@@ -601,6 +601,33 @@ export class HNSWVectorStore implements VectorStore {
 	}
 
 	/**
+	 * Count distinct notes (unique paths). Walks the `path` index with a
+	 * unique-key cursor so it never deserializes vectors.
+	 */
+	async countNotes(): Promise<number> {
+		const db = this.requireDb();
+
+		return new Promise((resolve, reject) => {
+			const tx = db.transaction(DOCUMENTS_STORE, "readonly");
+			const store = tx.objectStore(DOCUMENTS_STORE);
+			const index = store.index("path");
+			const request = index.openKeyCursor(null, "nextunique");
+
+			let notes = 0;
+			request.onerror = () => reject(request.error);
+			request.onsuccess = () => {
+				const cursor = request.result;
+				if (cursor) {
+					notes++;
+					cursor.continue();
+				} else {
+					resolve(notes);
+				}
+			};
+		});
+	}
+
+	/**
 	 * Search for similar vectors using HNSW approximate nearest neighbor.
 	 * O(log n) complexity - much faster than brute-force for large datasets.
 	 */

--- a/src/vectorstore/HNSWWorkerProxy.ts
+++ b/src/vectorstore/HNSWWorkerProxy.ts
@@ -118,6 +118,10 @@ export class HNSWWorkerProxy implements VectorStore {
 		return (await this.call("count")) as number;
 	}
 
+	async countNotes(): Promise<number> {
+		return (await this.call("countNotes")) as number;
+	}
+
 	async search(queryVector: Float32Array, topK: number, threshold?: number): Promise<ScoredDocument[]> {
 		return (await this.call("search", queryVector, topK, threshold)) as ScoredDocument[];
 	}

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -885,8 +885,8 @@ export class VectorStoreService {
 		// run was aborted (e.g. the index was deleted mid-build) since the store
 		// may have been closed out from under us.
 		if (!inst.abortController?.signal.aborted && this.instances.has(inst.indexId)) {
-			const count = await inst.store.count();
-			getData().updateEmbeddingIndexStats(inst.indexId, { documentCount: count });
+			const noteCount = await inst.store.countNotes();
+			getData().updateEmbeddingIndexStats(inst.indexId, { documentCount: noteCount });
 		}
 
 		Logger.log(`[VectorStore] Validation complete for ${inst.indexId}`);
@@ -1320,12 +1320,12 @@ export class VectorStoreService {
 			// A cancelled run may have had its store torn down (e.g. index deleted
 			// mid-build); skip the post-run store read/stats update in that case.
 			if (!cancelled) {
-				// Update cached stats in plugin data using actual store count
-				const actualCount = await inst.store.count();
+				// Update cached stats in plugin data using the distinct-note count
+				const noteCount = await inst.store.countNotes();
 				const data = getData();
 				data.updateEmbeddingIndexStats(inst.indexId, {
 					lastBuiltAt: Date.now(),
-					documentCount: actualCount,
+					documentCount: noteCount,
 				});
 			}
 
@@ -1603,13 +1603,13 @@ export class VectorStoreService {
 
 		const inst = await this.getOrCreateInstance(resolvedId);
 
-		const count = await inst.store.count();
+		const noteCount = await inst.store.countNotes();
 		const metadata = await inst.store.getMetadata();
 		const model = this.getModelForInstance(inst);
 		const isReady = this.isInitialized && model !== null;
 
 		return {
-			documentCount: count,
+			documentCount: noteCount,
 			providerId: metadata?.providerId ?? inst.currentProviderId,
 			modelId: metadata?.modelId ?? inst.currentModelId,
 			isReady,
@@ -1818,8 +1818,8 @@ export class VectorStoreService {
 	 * Update the cached document count in pluginData after a file event.
 	 */
 	private async notifyStatsChanged(inst: IndexInstance): Promise<void> {
-		const count = await inst.store.count();
-		getData().updateEmbeddingIndexStats(inst.indexId, { documentCount: count });
+		const noteCount = await inst.store.countNotes();
+		getData().updateEmbeddingIndexStats(inst.indexId, { documentCount: noteCount });
 	}
 
 	/**

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -207,6 +207,10 @@ interface IndexInstance {
 	hasValidatedThisSession: boolean;
 	isIndexing: boolean;
 	progress: IndexingProgress;
+	/** Timestamp (ms) when the current indexing run started, for ETA estimation */
+	indexingStartedAt: number | null;
+	/** `indexed` count when the current run started, so ETA measures only this run's rate */
+	indexingStartCount: number;
 	abortController: AbortController | null;
 	maxInputTokensCache: {
 		provider: string;
@@ -214,6 +218,23 @@ interface IndexInstance {
 		maxInputTokens: number;
 	} | null;
 	report: IndexingReport | null;
+}
+
+/**
+ * Format an estimated-time-remaining duration (in ms) as a short human string,
+ * e.g. "45s", "3m", "1h 12m". Rounds up so the estimate never reads as "0s"
+ * while work is still in flight.
+ */
+export function formatEta(ms: number): string {
+	const totalSeconds = Math.max(1, Math.ceil(ms / 1000));
+	if (totalSeconds < 60) return `${totalSeconds}s`;
+
+	const totalMinutes = Math.ceil(totalSeconds / 60);
+	if (totalMinutes < 60) return `${totalMinutes}m`;
+
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+	return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
 }
 
 export interface ValidationProgressCountsInput {
@@ -280,7 +301,10 @@ export class VectorStoreService {
 				skipped: 0,
 				currentFile: null,
 				percentage: 0,
+				etaMs: null,
 			},
+			indexingStartedAt: null,
+			indexingStartCount: 0,
 			abortController: null,
 			maxInputTokensCache: null,
 			report: null,
@@ -1106,6 +1130,7 @@ export class VectorStoreService {
 			skipped: skippedFiles.length,
 			currentFile: null,
 			percentage: 0,
+			etaMs: null,
 		});
 
 		const notice = new Notice("", 0);
@@ -1277,8 +1302,9 @@ export class VectorStoreService {
 	 * Update the indexing notice with current progress.
 	 */
 	private updateNotice(notice: Notice, progress: IndexingProgress): void {
-		const { indexed, skipped, total, percentage } = progress;
+		const { indexed, skipped, total, percentage, etaMs } = progress;
 		const skippedText = skipped > 0 ? ` (${skipped} skipped)` : "";
+		const etaText = etaMs !== null ? ` (~${formatEta(etaMs)} left)` : "";
 
 		const el = notice.noticeEl;
 		el.empty();
@@ -1287,7 +1313,7 @@ export class VectorStoreService {
 
 		container.createDiv({
 			cls: "s2b-indexing-status",
-			text: `Indexing: ${indexed}/${total}${skippedText}`,
+			text: `Indexing: ${indexed}/${total}${skippedText}${etaText}`,
 		});
 
 		const progressContainer = container.createDiv({ cls: "s2b-indexing-progress" });
@@ -1552,11 +1578,27 @@ export class VectorStoreService {
 			indexId = data.searchEmbedIndex ?? undefined;
 		}
 		if (!indexId) {
-			return { isIndexing: false, total: 0, indexed: 0, skipped: 0, currentFile: null, percentage: 0 };
+			return {
+				isIndexing: false,
+				total: 0,
+				indexed: 0,
+				skipped: 0,
+				currentFile: null,
+				percentage: 0,
+				etaMs: null,
+			};
 		}
 		const inst = this.instances.get(indexId);
 		if (!inst) {
-			return { isIndexing: false, total: 0, indexed: 0, skipped: 0, currentFile: null, percentage: 0 };
+			return {
+				isIndexing: false,
+				total: 0,
+				indexed: 0,
+				skipped: 0,
+				currentFile: null,
+				percentage: 0,
+				etaMs: null,
+			};
 		}
 		return { ...inst.progress };
 	}
@@ -1633,7 +1675,15 @@ export class VectorStoreService {
 			indexId = data.searchEmbedIndex ?? undefined;
 		}
 		if (!indexId) {
-			callback({ isIndexing: false, total: 0, indexed: 0, skipped: 0, currentFile: null, percentage: 0 });
+			callback({
+				isIndexing: false,
+				total: 0,
+				indexed: 0,
+				skipped: 0,
+				currentFile: null,
+				percentage: 0,
+				etaMs: null,
+			});
 			return () => {};
 		}
 
@@ -1648,7 +1698,15 @@ export class VectorStoreService {
 		callback(
 			inst
 				? { ...inst.progress }
-				: { isIndexing: false, total: 0, indexed: 0, skipped: 0, currentFile: null, percentage: 0 },
+				: {
+						isIndexing: false,
+						total: 0,
+						indexed: 0,
+						skipped: 0,
+						currentFile: null,
+						percentage: 0,
+						etaMs: null,
+					},
 		);
 
 		return () => {
@@ -1664,10 +1722,22 @@ export class VectorStoreService {
 	 * Update progress state for a specific instance and notify listeners.
 	 */
 	private updateInstanceProgress(inst: IndexInstance, partial: Partial<IndexingProgress>): void {
+		const wasIndexing = inst.progress.isIndexing;
 		Object.assign(inst.progress, partial);
+
+		// Track the start of an indexing run so ETA measures only this run's rate.
+		if (inst.progress.isIndexing && !wasIndexing) {
+			inst.indexingStartedAt = Date.now();
+			inst.indexingStartCount = inst.progress.indexed;
+		} else if (!inst.progress.isIndexing) {
+			inst.indexingStartedAt = null;
+			inst.indexingStartCount = 0;
+		}
+
 		if (inst.progress.total > 0) {
 			inst.progress.percentage = Math.round((inst.progress.indexed / inst.progress.total) * 100);
 		}
+		inst.progress.etaMs = this.estimateEtaMs(inst);
 		const progress = { ...inst.progress };
 		const listeners = this.progressListeners.get(inst.indexId);
 		if (listeners) {
@@ -1675,6 +1745,26 @@ export class VectorStoreService {
 				listener(progress);
 			}
 		}
+	}
+
+	/**
+	 * Estimate milliseconds remaining for the current indexing run based on the
+	 * rate of files processed so far. Returns null until enough progress has been
+	 * made to produce a stable estimate.
+	 */
+	private estimateEtaMs(inst: IndexInstance): number | null {
+		const { isIndexing, indexed, total } = inst.progress;
+		if (!isIndexing || inst.indexingStartedAt === null || total <= 0) return null;
+
+		const doneThisRun = indexed - inst.indexingStartCount;
+		const remaining = total - indexed;
+		if (doneThisRun <= 0 || remaining <= 0) return null;
+
+		const elapsed = Date.now() - inst.indexingStartedAt;
+		if (elapsed <= 0) return null;
+
+		const msPerFile = elapsed / doneThisRun;
+		return Math.round(msPerFile * remaining);
 	}
 
 	/**

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -745,6 +745,17 @@ export class VectorStoreService {
 						indexed: startingIndexedCount + indexedValidationPaths.size,
 					});
 				};
+				// `skipped` is likewise counted in files (starting from the pre-filter
+				// count) so it stays comparable with `total`/`indexed`; a note failing
+				// any chunk is counted once.
+				const skippedValidationPaths = new Set<string>();
+				const noteSkipped = (path: string) => {
+					if (skippedValidationPaths.has(path)) return;
+					skippedValidationPaths.add(path);
+					this.updateInstanceProgress(inst, {
+						skipped: preFilterSkipped + skippedValidationPaths.size,
+					});
+				};
 				const showNotice = validFileCount > 5;
 				let notice: Notice | null = null;
 				if (showNotice) {
@@ -795,7 +806,7 @@ export class VectorStoreService {
 						if (inst.abortController?.signal.aborted) break;
 						if (!vectors || vectors.length === 0) {
 							Logger.error(`[VectorStore] embedDocuments returned empty result for ${inst.indexId}`);
-							this.updateInstanceProgress(inst, { skipped: inst.progress.skipped + batch.length });
+							for (const entry of batch) noteSkipped(entry.file.path);
 							continue;
 						}
 						for (let j = 0; j < batch.length; j++) {
@@ -828,7 +839,7 @@ export class VectorStoreService {
 									Logger.error(
 										`[VectorStore] embedQuery returned empty result for ${entry.file.path}`,
 									);
-									this.updateInstanceProgress(inst, { skipped: inst.progress.skipped + 1 });
+									noteSkipped(entry.file.path);
 									continue;
 								}
 								await purgeIfNeeded(entry);
@@ -847,7 +858,7 @@ export class VectorStoreService {
 								Logger.error(`[VectorStore] Failed to index ${entry.file.path}:`, entryError);
 								const reason = entryError instanceof Error ? entryError.message : String(entryError);
 								new Notice(`Failed to embed ${entry.file.basename}: ${reason}`);
-								this.updateInstanceProgress(inst, { skipped: inst.progress.skipped + 1 });
+								noteSkipped(entry.file.path);
 							}
 						}
 						if (notice) this.updateNotice(notice, inst.progress);
@@ -1204,6 +1215,18 @@ export class VectorStoreService {
 					this.updateInstanceProgress(inst, { indexed: indexedPaths.size });
 				}
 			};
+			// Track in-loop skips per distinct file so `skipped` stays in the same
+			// (file) units as `total`/`indexed`; a note failing any chunk is counted
+			// once. Starts from the pre-filter skip count captured above.
+			const preFilterSkippedCount = skippedFiles.length;
+			const skippedPaths = new Set<string>();
+			const noteSkipped = (path: string, reason: SkipReason) => {
+				skippedFiles.push({ path, reason });
+				if (!skippedPaths.has(path)) {
+					skippedPaths.add(path);
+					this.updateInstanceProgress(inst, { skipped: preFilterSkippedCount + skippedPaths.size });
+				}
+			};
 
 			for (let i = 0; i < validChunks.length; i += batchSize) {
 				if (inst.abortController?.signal.aborted) {
@@ -1228,8 +1251,7 @@ export class VectorStoreService {
 					if (inst.abortController?.signal.aborted) break;
 					if (!vectors || vectors.length === 0) {
 						Logger.error(`[VectorStore] embedDocuments returned empty result for ${inst.indexId}`);
-						for (const entry of batch) skippedFiles.push({ path: entry.file.path, reason: "embed-error" });
-						this.updateInstanceProgress(inst, { skipped: inst.progress.skipped + batch.length });
+						for (const entry of batch) noteSkipped(entry.file.path, "embed-error");
 						this.updateNotice(notice, inst.progress);
 						continue;
 					}
@@ -1237,7 +1259,7 @@ export class VectorStoreService {
 					for (let j = 0; j < batch.length; j++) {
 						if (!vectors[j]) {
 							Logger.error(`[VectorStore] Empty vector for ${batch[j].file.path}`);
-							skippedFiles.push({ path: batch[j].file.path, reason: "embed-error" });
+							noteSkipped(batch[j].file.path, "embed-error");
 							continue;
 						}
 						const entry = batch[j];
@@ -1266,8 +1288,7 @@ export class VectorStoreService {
 							const vector = await embeddings.embedQuery(entry.embedText);
 							if (!vector || vector.length === 0) {
 								Logger.error(`[VectorStore] embedQuery returned empty result for ${entry.file.path}`);
-								skippedFiles.push({ path: entry.file.path, reason: "embed-error" });
-								this.updateInstanceProgress(inst, { skipped: inst.progress.skipped + 1 });
+								noteSkipped(entry.file.path, "embed-error");
 								continue;
 							}
 							const doc: DocumentVector = {
@@ -1284,8 +1305,7 @@ export class VectorStoreService {
 							Logger.error(`[VectorStore] Failed to index ${entry.file.path}:`, entryError);
 							const reason = entryError instanceof Error ? entryError.message : String(entryError);
 							new Notice(`Failed to embed ${entry.file.basename}: ${reason}`);
-							skippedFiles.push({ path: entry.file.path, reason: "embed-error" });
-							this.updateInstanceProgress(inst, { skipped: inst.progress.skipped + 1 });
+							noteSkipped(entry.file.path, "embed-error");
 						}
 					}
 					this.updateNotice(notice, inst.progress);

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -734,6 +734,17 @@ export class VectorStoreService {
 					validPendingFileCount: validFileCount,
 				});
 				let indexed = 0;
+				// Progress is tracked in files (matching `total`), not chunks: a note is
+				// counted once its final chunk is written, so a multi-chunk note advances
+				// the bar by one, keeping `indexed <= total` and the ETA well-defined.
+				const indexedValidationPaths = new Set<string>();
+				const noteValidated = (path: string) => {
+					if (indexedValidationPaths.has(path)) return;
+					indexedValidationPaths.add(path);
+					this.updateInstanceProgress(inst, {
+						indexed: startingIndexedCount + indexedValidationPaths.size,
+					});
+				};
 				const showNotice = validFileCount > 5;
 				let notice: Notice | null = null;
 				if (showNotice) {
@@ -767,7 +778,6 @@ export class VectorStoreService {
 					}
 
 					const batch = validChunks.slice(i, i + batchSize);
-					const batchEnd = Math.min(i + batchSize, validChunks.length);
 
 					this.updateInstanceProgress(inst, {
 						currentFile:
@@ -800,9 +810,9 @@ export class VectorStoreService {
 								vector: new Float32Array(vectors[j]),
 							};
 							await inst.store.upsert(doc);
+							if (entry.chunkIndex === entry.chunkCount - 1) noteValidated(entry.file.path);
 						}
 						indexed += batch.length;
-						this.updateInstanceProgress(inst, { indexed: startingIndexedCount + batchEnd });
 						if (notice) this.updateNotice(notice, inst.progress);
 					} catch (error) {
 						Logger.error("[VectorStore] Batch validation indexing failed:", error);
@@ -828,7 +838,7 @@ export class VectorStoreService {
 								};
 								await inst.store.upsert(doc);
 								indexed++;
-								this.updateInstanceProgress(inst, { indexed: inst.progress.indexed + 1 });
+								if (entry.chunkIndex === entry.chunkCount - 1) noteValidated(entry.file.path);
 							} catch (entryError) {
 								Logger.error(`[VectorStore] Failed to index ${entry.file.path}:`, entryError);
 								const reason = entryError instanceof Error ? entryError.message : String(entryError);

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -789,6 +789,10 @@ export class VectorStoreService {
 					try {
 						const texts = batch.map((entry) => entry.embedText);
 						const vectors = await embeddings.embedDocuments(texts);
+						// The run may have been aborted (e.g. index deleted) while the
+						// embedding call was in flight; bail before writing to a store
+						// that could now be closed.
+						if (inst.abortController?.signal.aborted) break;
 						if (!vectors || vectors.length === 0) {
 							Logger.error(`[VectorStore] embedDocuments returned empty result for ${inst.indexId}`);
 							this.updateInstanceProgress(inst, { skipped: inst.progress.skipped + batch.length });
@@ -866,9 +870,13 @@ export class VectorStoreService {
 			} // end else (validChunks.length > 0)
 		}
 
-		// Sync document count to pluginData for reactive UI updates
-		const count = await inst.store.count();
-		getData().updateEmbeddingIndexStats(inst.indexId, { documentCount: count });
+		// Sync document count to pluginData for reactive UI updates. Skip when the
+		// run was aborted (e.g. the index was deleted mid-build) since the store
+		// may have been closed out from under us.
+		if (!inst.abortController?.signal.aborted && this.instances.has(inst.indexId)) {
+			const count = await inst.store.count();
+			getData().updateEmbeddingIndexStats(inst.indexId, { documentCount: count });
+		}
 
 		Logger.log(`[VectorStore] Validation complete for ${inst.indexId}`);
 	}
@@ -1214,6 +1222,10 @@ export class VectorStoreService {
 				try {
 					const texts = batch.map((entry) => entry.embedText);
 					const vectors = await embeddings.embedDocuments(texts);
+					// The run may have been aborted (e.g. index deleted) while the
+					// embedding call was in flight; bail before writing to a store
+					// that could now be closed.
+					if (inst.abortController?.signal.aborted) break;
 					if (!vectors || vectors.length === 0) {
 						Logger.error(`[VectorStore] embedDocuments returned empty result for ${inst.indexId}`);
 						for (const entry of batch) skippedFiles.push({ path: entry.file.path, reason: "embed-error" });
@@ -1283,16 +1295,21 @@ export class VectorStoreService {
 			// Save the indexing report
 			inst.report = { indexedFiles, skippedFiles, timestamp: Date.now() };
 
-			// Update cached stats in plugin data using actual store count
-			const actualCount = await inst.store.count();
-			const data = getData();
-			data.updateEmbeddingIndexStats(inst.indexId, {
-				lastBuiltAt: Date.now(),
-				documentCount: actualCount,
-			});
+			const cancelled = inst.abortController?.signal.aborted;
+
+			// A cancelled run may have had its store torn down (e.g. index deleted
+			// mid-build); skip the post-run store read/stats update in that case.
+			if (!cancelled) {
+				// Update cached stats in plugin data using actual store count
+				const actualCount = await inst.store.count();
+				const data = getData();
+				data.updateEmbeddingIndexStats(inst.indexId, {
+					lastBuiltAt: Date.now(),
+					documentCount: actualCount,
+				});
+			}
 
 			const { indexed, skipped } = inst.progress;
-			const cancelled = inst.abortController?.signal.aborted;
 			const skippedText = skipped > 0 ? `, ${skipped} skipped` : "";
 			const noticeMessage = cancelled
 				? `Indexing cancelled (${indexed} notes indexed so far)`
@@ -1930,6 +1947,14 @@ export class VectorStoreService {
 	async deleteIndex(indexId: string): Promise<void> {
 		const inst = this.instances.get(indexId);
 		if (inst) {
+			// Abort any in-flight indexing run so it stops writing to the store
+			// we're about to clear, and flip progress off so listeners (e.g. the
+			// settings progress bar) hide immediately instead of lingering. Keep
+			// the abortController set (don't null it) so the loop's own
+			// `signal.aborted` checks fire and it breaks out on its next tick.
+			inst.abortController?.abort();
+			this.updateInstanceProgress(inst, { isIndexing: false, currentFile: null, etaMs: null });
+			inst.isIndexing = false;
 			await inst.store.clear();
 			await inst.store.close();
 			this.instances.delete(indexId);

--- a/src/vectorstore/batchSize.ts
+++ b/src/vectorstore/batchSize.ts
@@ -6,8 +6,9 @@ export function getDefaultEmbeddingBatchSize(providerId: string): number {
 		case "openai":
 		case "openrouter":
 			return 100;
+		case "omlx":
 		case "ollama":
-			return 1;
+			return 10;
 		default:
 			return 50;
 	}

--- a/src/vectorstore/hnswWorker.ts
+++ b/src/vectorstore/hnswWorker.ts
@@ -126,6 +126,10 @@ globalThis.onmessage = async (e: MessageEvent<HNSWWorkerRequest>) => {
 				result = await requireStore().count();
 				break;
 			}
+			case "countNotes": {
+				result = await requireStore().countNotes();
+				break;
+			}
 			case "search": {
 				const [queryVector, topK, threshold] = args as [Float32Array | number[], number, number | undefined];
 				const qv = queryVector instanceof Float32Array ? queryVector : toFloat32Array(queryVector);

--- a/src/vectorstore/index.ts
+++ b/src/vectorstore/index.ts
@@ -12,6 +12,7 @@ export {
 	isVectorStoreInitialized,
 	waitForVectorStore,
 	waitForVectorStoreIndex,
+	formatEta,
 } from "./VectorStoreService";
 
 export type {

--- a/src/vectorstore/types.ts
+++ b/src/vectorstore/types.ts
@@ -182,6 +182,8 @@ export interface IndexingProgress {
 	currentFile: string | null;
 	/** Progress percentage (0-100) */
 	percentage: number;
+	/** Estimated milliseconds remaining, or null when not yet known */
+	etaMs: number | null;
 }
 
 /** Reasons a file can be skipped during indexing */

--- a/src/vectorstore/types.ts
+++ b/src/vectorstore/types.ts
@@ -330,9 +330,16 @@ export interface VectorStore {
 	clear(): Promise<void>;
 
 	/**
-	 * Get the number of documents in the store.
+	 * Get the number of documents (chunks) in the store.
 	 */
 	count(): Promise<number>;
+
+	/**
+	 * Get the number of distinct notes (unique paths) in the store. A note is
+	 * split into multiple chunk documents, so this is <= count() and is the
+	 * user-facing "notes indexed" figure.
+	 */
+	countNotes(): Promise<number>;
 
 	/**
 	 * Search for similar vectors.

--- a/test/vectorstore/VectorStoreService.test.ts
+++ b/test/vectorstore/VectorStoreService.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { summarizeValidationProgressCounts } from "../../src/vectorstore/VectorStoreService";
+import { formatEta, summarizeValidationProgressCounts } from "../../src/vectorstore/VectorStoreService";
 import { getDefaultEmbeddingBatchSize, normalizeEmbeddingBatchSize } from "../../src/vectorstore/batchSize";
 
 describe("embedding batch size helpers", () => {
     it("returns provider-specific defaults", () => {
-        expect(getDefaultEmbeddingBatchSize("ollama")).toBe(1);
+        expect(getDefaultEmbeddingBatchSize("ollama")).toBe(10);
+        expect(getDefaultEmbeddingBatchSize("omlx")).toBe(10);
         expect(getDefaultEmbeddingBatchSize("openai")).toBe(100);
         expect(getDefaultEmbeddingBatchSize("custom-provider")).toBe(50);
     });
@@ -42,5 +43,23 @@ describe("summarizeValidationProgressCounts", () => {
             startingIndexedCount: 2000,
             totalCount: 2900,
         });
+    });
+});
+
+describe("formatEta", () => {
+    it("formats sub-minute durations in seconds", () => {
+        expect(formatEta(5_000)).toBe("5s");
+        expect(formatEta(59_000)).toBe("59s");
+    });
+
+    it("rounds up so in-flight work never reads as 0s", () => {
+        expect(formatEta(200)).toBe("1s");
+        expect(formatEta(0)).toBe("1s");
+    });
+
+    it("formats minutes and hours", () => {
+        expect(formatEta(90_000)).toBe("2m");
+        expect(formatEta(60 * 60_000)).toBe("1h");
+        expect(formatEta(72 * 60_000)).toBe("1h 12m");
     });
 });


### PR DESCRIPTION
Resolves #147 

## Summary

- **Indexing ETA**: live `(~Xm left)` estimate shown in the settings progress bar and the indexing notice, computed from the current run's file-processing rate. Hidden until the first file completes to avoid noisy early guesses; disappears when indexing finishes.
- **Index list UI**: "N notes indexed" moved into the single meta line alongside provider name and date. Removed the separate `desc` line and the "Used by X only" text — the Search/Graph badges already convey that.
- **Batch size defaults**: local providers (Ollama, oMLX) → 10; everything else → 50; OpenAI/OpenRouter unchanged at 100.

## Test plan

- [ ] Start a full index rebuild on a large vault and confirm the ETA appears after the first file, updates as files complete, and disappears when done
- [ ] Cancel mid-index and confirm the ETA disappears cleanly
- [ ] Check the index list shows a single meta line: `Provider · Date · N notes indexed`
- [ ] Confirm Ollama/oMLX default to batch 10 in the Add Index modal
- [ ] `bun run test` — all 762 tests pass

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._