### PR TITLE
feat: schema versioning and migration framework across persistence surfaces

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -10,6 +10,7 @@ import { CAPABILITIES, VAULT_TOOL_IDS, WEB_TOOL_IDS, type BuiltInToolId, type Ag
 import { VIEW_TYPE_CHAT } from "../views/chat/Chat";
 import { lookupModelInfo } from "../providers/modelsDevApi";
 import { fetchOllamaModelsInfo } from "../providers/ollamaModels";
+import { SystemPromptModal } from "../components/modal/SystemPromptModal";
 import {
 	extractCapabilities as extractOpenRouterCapabilities,
 	fetchOpenRouterModels,
@@ -518,6 +519,24 @@ export class AgentManager {
 		this.mcpToolsByAgent.clear();
 		this.mcpToolsInflight.clear();
 		this.agent?.invalidateAllRunnables();
+	}
+
+	openSystemPromptDiff(agentName: string): void {
+		const pluginData = getData();
+		const agent = Object.values(pluginData.agents).find((a) => a.name === agentName);
+		if (!agent) return;
+		new SystemPromptModal(
+			this.plugin,
+			{
+				getPrompt: () => agent.systemPrompt,
+				setPrompt: (prompt: string) => {
+					pluginData.updateAgent(agent.id, { systemPrompt: prompt });
+					this.invalidateSystemPromptCaches();
+				},
+				defaultPrompt: BASE_SYSTEM_PROMPT,
+			},
+			{ title: `System Prompt — ${agent.name}`, showDiff: true },
+		).open();
 	}
 
 	/**
@@ -1311,7 +1330,7 @@ export class AgentManager {
 
 	async *streamQuery(
 		query: string,
-		threadId,
+		threadId: string,
 		agentId: string,
 		checkpointId?: string,
 		signal?: AbortSignal,

--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -1311,7 +1311,7 @@ export class AgentManager {
 
 	async *streamQuery(
 		query: string,
-		threadId = "default-thread",
+		threadId,
 		agentId: string,
 		checkpointId?: string,
 		signal?: AbortSignal,

--- a/src/agent/ObsidianChatManager.ts
+++ b/src/agent/ObsidianChatManager.ts
@@ -63,6 +63,9 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 	private dirtyThreadVersions: Map<string, number> = new Map();
 	private persistedThreadVersions: Map<string, number> = new Map();
 	private inFlightThreadSaves: Map<string, Promise<void>> = new Map();
+	/** Thread IDs loaded from a file whose version exceeds THREAD_DATA_VERSION. We must
+	 *  not overwrite them — doing so would downgrade a newer-format file to an older schema. */
+	private newerVersionThreadIds: Set<string> = new Set();
 
 	constructor(plugin: SecondBrainPlugin) {
 		super();
@@ -158,6 +161,7 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 			Logger.warn(
 				`[ChatManager] Thread file version ${parsed.version} is newer than supported ${THREAD_DATA_VERSION}. Some data may not display correctly.`,
 			);
+			this.newerVersionThreadIds.add(parsed.threadId);
 		}
 		return parsed;
 	}
@@ -492,6 +496,15 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 
 		const data = this.storage.get(threadId);
 		if (!data) return;
+
+		// Never overwrite a file that was written by a newer plugin version — doing so
+		// would downgrade its schema and corrupt data the older plugin can't interpret.
+		if (this.newerVersionThreadIds.has(threadId)) {
+			Logger.warn(
+				`[ChatManager] Skipping save of thread ${threadId} — file was created by a newer plugin version.`,
+			);
+			return;
+		}
 
 		let safePath: string;
 		try {

--- a/src/agent/ObsidianChatManager.ts
+++ b/src/agent/ObsidianChatManager.ts
@@ -18,6 +18,9 @@ import { Logger } from "../utils/logging";
 import { toBase64, toBase64DataUri } from "../utils/attachments";
 import type { ChatAttachment } from "../types/shared";
 
+/** Bump when the ThreadData/CheckpointEntry schema changes. Absent in pre-versioning files → treated as 0. */
+const THREAD_DATA_VERSION = 1;
+
 interface CheckpointEntry {
 	checkpoint: Checkpoint;
 	metadata: CheckpointMetadata;
@@ -25,6 +28,8 @@ interface CheckpointEntry {
 }
 
 interface ThreadData {
+	/** Schema version written on save; absent (0) on files predating versioning. */
+	version?: number;
 	// Metadata (ThreadSnapshot)
 	threadId: string;
 	title?: string;
@@ -148,7 +153,13 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 		});
 		// Yield after decompression so JSON.parse doesn't block the same frame.
 		await new Promise<void>((resolve) => setTimeout(resolve, 0));
-		return JSON.parse(decompressed) as ThreadData;
+		const parsed = JSON.parse(decompressed) as ThreadData;
+		if ((parsed.version ?? 0) > THREAD_DATA_VERSION) {
+			Logger.warn(
+				`[ChatManager] Thread file version ${parsed.version} is newer than supported ${THREAD_DATA_VERSION}. Some data may not display correctly.`,
+			);
+		}
+		return parsed;
 	}
 
 	private stripBase64FromChannelValues(channelValues: Record<string, unknown> | undefined): void {
@@ -496,7 +507,7 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 		let savePromise: Promise<void> | null = null;
 		savePromise = (async () => {
 			try {
-				const compressed = gzipSync(JSON.stringify(data));
+				const compressed = gzipSync(JSON.stringify({ ...data, version: THREAD_DATA_VERSION }));
 				await this.adapter.writeBinary(
 					safePath,
 					compressed.buffer.slice(

--- a/src/agent/ObsidianChatManager.ts
+++ b/src/agent/ObsidianChatManager.ts
@@ -96,6 +96,8 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 	 * Cleans up in-memory caches so stale threads don't appear in the UI.
 	 */
 	private onChatFileDeleted(filePath: string): void {
+		const data = this.storage.get(filePath);
+		if (data) this.newerVersionThreadIds.delete(data.threadId);
 		this.storage.delete(filePath);
 		this.threadIndex.delete(filePath);
 		this.dirtyThreadVersions.delete(filePath);
@@ -116,6 +118,10 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 	private rekeyThread(oldPath: string, newPath: string): void {
 		const data = this.storage.get(oldPath);
 		if (data) {
+			if (this.newerVersionThreadIds.has(data.threadId)) {
+				this.newerVersionThreadIds.delete(data.threadId);
+				this.newerVersionThreadIds.add(newPath);
+			}
 			data.threadId = newPath;
 			this.storage.delete(oldPath);
 			this.storage.set(newPath, data);

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -93,7 +93,7 @@ export const DEFAULT_VAULT_CAPABILITY_GUIDANCE = `## Finding Notes
  * fetch_url / web_search carries the operational detail. User-editable via the
  * capability pencil; `capabilityPrompts.web` overrides it.
  */
-export const DEFAULT_WEB_CAPABILITY_GUIDANCE = `Prefer the vault first; reach for web tools when the user references a link or when the needed information cannot be in the vault. Only the query or URL you pass is sent to the configured web service — never vault contents.`;
+export const DEFAULT_WEB_CAPABILITY_GUIDANCE = "Prefer the vault first; reach for web tools when the user references a link or when the needed information cannot be in the vault. Only the query or URL you pass is sent to the configured web service — never vault contents.";
 
 /**
  * Default guidance for a built-in capability, used to seed `capabilityPrompts[id]` on

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -108,3 +108,54 @@ export function buildDefaultCapabilityGuidance(id: CapabilityId): string {
 			return DEFAULT_WEB_CAPABILITY_GUIDANCE;
 	}
 }
+
+/** Increment when BASE_SYSTEM_PROMPT changes in a way that affects agent behaviour. */
+export const BASE_SYSTEM_PROMPT_VERSION = 1;
+
+/**
+ * Maps each historical version number to the exact prompt string shipped at that version.
+ * Lets normalizeAgent() detect "still on old default" vs "user customized" without storing
+ * a hash. Keep all entries forever — never remove old versions.
+ */
+export const HISTORICAL_SYSTEM_PROMPTS: ReadonlyMap<number, string> = new Map([[1, BASE_SYSTEM_PROMPT]]);
+
+/**
+ * All known-default strings for each capability, across all plugin versions.
+ * If a stored capabilityPrompts[id] value is in this set it is treated as
+ * "user hasn't customized it" and the key is cleared so the live default is used.
+ * Append new defaults here when guidance text changes; never remove old entries.
+ */
+export const HISTORICAL_CAPABILITY_GUIDANCE: ReadonlyMap<CapabilityId, ReadonlySet<string>> = new Map([
+	["vault", new Set([DEFAULT_VAULT_CAPABILITY_GUIDANCE])],
+	["web", new Set([DEFAULT_WEB_CAPABILITY_GUIDANCE])],
+]);
+
+/**
+ * All known-default promptGuidance strings per tool, across all plugin versions.
+ * Same semantics as HISTORICAL_CAPABILITY_GUIDANCE — stored value in set ⇒ treat as absent.
+ * read_content is intentionally omitted: its guidance is dynamic (varies by processor config)
+ * and already handled by READ_CONTENT_GUIDANCE_DEFAULTS.
+ */
+export const HISTORICAL_TOOL_GUIDANCE: ReadonlyMap<
+	import("../types/plugin").BuiltInToolId,
+	ReadonlySet<string>
+> = new Map([
+	[
+		"execute_javascript",
+		new Set([
+			"Use this for calculations, reshaping JSON, filtering arrays, parsing structured text, or other logic-heavy transformations. The code runs in an isolated worker without Obsidian APIs, so do not use it for note edits or vault access.",
+		]),
+	],
+	[
+		"fetch_url",
+		new Set([
+			"Use this only for URLs the user provided or for clearly public references. The tool sends the URL to the configured network — it does not send vault contents. Prefer searching the vault first; reach for fetch_url when the user explicitly references a link or when needed information cannot be in the vault.",
+		]),
+	],
+	[
+		"web_search",
+		new Set([
+			"Use web_search for questions about external facts, current events, documentation, or topics the vault is unlikely to contain. Prefer search_notes for vault-internal queries. When results look promising, follow up with fetch_url to read the full page. Cite sources in your response.",
+		]),
+	],
+]);

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -93,7 +93,8 @@ export const DEFAULT_VAULT_CAPABILITY_GUIDANCE = `## Finding Notes
  * fetch_url / web_search carries the operational detail. User-editable via the
  * capability pencil; `capabilityPrompts.web` overrides it.
  */
-export const DEFAULT_WEB_CAPABILITY_GUIDANCE = "Prefer the vault first; reach for web tools when the user references a link or when the needed information cannot be in the vault. Only the query or URL you pass is sent to the configured web service — never vault contents.";
+export const DEFAULT_WEB_CAPABILITY_GUIDANCE =
+	"Prefer the vault first; reach for web tools when the user references a link or when the needed information cannot be in the vault. Only the query or URL you pass is sent to the configured web service — never vault contents.";
 
 /**
  * Default guidance for a built-in capability, used to seed `capabilityPrompts[id]` on

--- a/src/components/modal/GuidanceEditor.svelte
+++ b/src/components/modal/GuidanceEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onDestroy, onMount } from "svelte";
+import { diffWords } from "diff";
 import { EmbeddableMarkdownEditor } from "../../lib/editor";
 import type SecondBrainPlugin from "../../main";
 
@@ -18,11 +19,23 @@ const { plugin, value, defaultValue, placeholder = "", onCommit }: Props = $prop
 
 let editorContainer: HTMLDivElement | undefined = $state();
 let editor: EmbeddableMarkdownEditor | undefined = $state();
-// The value shown/edited: stored value if set, else the default. Seeds the initial
-// editor state only; callers remount (via {#key}) when the effective default changes.
 // svelte-ignore state_referenced_locally
 let current = $state(value?.trim() ? value : defaultValue);
 const isAtDefault = $derived(current === defaultValue);
+let showDiff = $state(false);
+
+function renderDiffSide(oldText: string, newText: string, side: "old" | "new"): string {
+	const parts = diffWords(oldText, newText);
+	return parts
+		.filter((p) => (side === "old" ? !p.added : !p.removed))
+		.map((p) => {
+			const escaped = p.value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+			if (side === "old" && p.removed) return `<mark class="s2b-prompt-diff-removed">${escaped}</mark>`;
+			if (side === "new" && p.added) return `<mark class="s2b-prompt-diff-added">${escaped}</mark>`;
+			return escaped;
+		})
+		.join("");
+}
 
 onMount(() => {
 	if (!editorContainer) return;
@@ -46,14 +59,31 @@ function handleReset() {
 	current = defaultValue;
 	editor?.setValue(defaultValue);
 	onCommit(defaultValue);
+	showDiff = false;
 }
 </script>
 
 <div class="guidance-editor">
-  <div bind:this={editorContainer} class="guidance-editor-container"></div>
+  {#if showDiff}
+    <div class="guidance-diff-container">
+      <div class="guidance-diff-pane">
+        <div class="guidance-diff-pane-label">Yours</div>
+        <pre class="guidance-diff-text">{@html renderDiffSide(current, defaultValue, "old")}</pre>
+      </div>
+      <div class="guidance-diff-pane">
+        <div class="guidance-diff-pane-label">Default</div>
+        <pre class="guidance-diff-text">{@html renderDiffSide(current, defaultValue, "new")}</pre>
+      </div>
+    </div>
+  {:else}
+    <div bind:this={editorContainer} class="guidance-editor-container"></div>
+  {/if}
   {#if !isAtDefault}
-    <div class="guidance-editor-reset">
+    <div class="guidance-editor-footer">
       <button type="button" class="guidance-reset-link" onclick={handleReset}>Reset to default</button>
+      <button type="button" class="guidance-diff-link" onclick={() => (showDiff = !showDiff)}>
+        {showDiff ? "Back to editor" : "Diff with default"}
+      </button>
     </div>
   {/if}
 </div>
@@ -103,12 +133,69 @@ function handleReset() {
     color: var(--text-muted);
   }
 
-  .guidance-editor-reset {
+  /* ── Diff view ── */
+  .guidance-diff-container {
     display: flex;
-    justify-content: flex-end;
+    gap: 10px;
+    min-height: 160px;
+    max-height: 320px;
+    overflow: hidden;
   }
 
-  .guidance-reset-link {
+  .guidance-diff-pane {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow-y: auto;
+    background: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 12px;
+    padding: 10px 12px;
+  }
+
+  .guidance-diff-pane-label {
+    font-size: var(--font-ui-smaller);
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+    flex-shrink: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .guidance-diff-text {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: var(--font-text);
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--text-normal);
+    user-select: text;
+  }
+
+  :global(mark.s2b-prompt-diff-removed) {
+    background: color-mix(in srgb, var(--color-red) 35%, transparent);
+    border-radius: 2px;
+    color: inherit;
+  }
+
+  :global(mark.s2b-prompt-diff-added) {
+    background: color-mix(in srgb, var(--color-green) 35%, transparent);
+    border-radius: 2px;
+    color: inherit;
+  }
+
+  /* ── Footer row ── */
+  .guidance-editor-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+  }
+
+  .guidance-reset-link,
+  .guidance-diff-link {
     border: 0;
     background: transparent;
     color: var(--text-accent);
@@ -117,7 +204,8 @@ function handleReset() {
     font-size: var(--font-ui-smaller);
   }
 
-  .guidance-reset-link:hover {
+  .guidance-reset-link:hover,
+  .guidance-diff-link:hover {
     text-decoration: underline;
   }
 </style>

--- a/src/components/modal/GuidanceEditor.svelte
+++ b/src/components/modal/GuidanceEditor.svelte
@@ -75,9 +75,8 @@ function handleReset() {
         <pre class="guidance-diff-text">{@html renderDiffSide(current, defaultValue, "new")}</pre>
       </div>
     </div>
-  {:else}
-    <div bind:this={editorContainer} class="guidance-editor-container"></div>
   {/if}
+  <div bind:this={editorContainer} class="guidance-editor-container" class:hidden={showDiff}></div>
   {#if !isAtDefault}
     <div class="guidance-editor-footer">
       <button type="button" class="guidance-reset-link" onclick={handleReset}>Reset to default</button>
@@ -100,6 +99,10 @@ function handleReset() {
     max-height: 320px;
     overflow-y: auto;
     border-radius: 12px;
+  }
+
+  .guidance-editor-container.hidden {
+    display: none;
   }
 
   .guidance-editor-container :global(.cm-editor) {

--- a/src/components/modal/SkillModal.svelte
+++ b/src/components/modal/SkillModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onDestroy, onMount } from "svelte";
+import { diffWords } from "diff";
 import { getBundledSkill, parseFrontmatter } from "../../skills";
 import { EmbeddableMarkdownEditor } from "../../lib/editor";
 import type SecondBrainPlugin from "../../main";
@@ -71,6 +72,22 @@ let hasParsedBundledDefault = $state(false);
 const isDirty = $derived(
 	editName !== initialName || editDescription !== initialDescription || promptValue !== initialPrompt,
 );
+
+let showInstructionsDiff = $state(false);
+const canShowInstructionsDiff = $derived(hasParsedBundledDefault && promptValue !== bundledDefaultPrompt);
+
+function renderDiffSide(oldText: string, newText: string, side: "old" | "new"): string {
+	const parts = diffWords(oldText, newText);
+	return parts
+		.filter((p) => (side === "old" ? !p.added : !p.removed))
+		.map((p) => {
+			const escaped = p.value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+			if (side === "old" && p.removed) return `<mark class="s2b-prompt-diff-removed">${escaped}</mark>`;
+			if (side === "new" && p.added) return `<mark class="s2b-prompt-diff-added">${escaped}</mark>`;
+			return escaped;
+		})
+		.join("");
+}
 
 const isAtBundledDefault = $derived(
 	hasParsedBundledDefault &&
@@ -188,6 +205,7 @@ async function handleResetToDefault() {
 	editDescription = bundledDefaultDescription;
 	promptValue = bundledDefaultPrompt;
 	editor?.setValue(bundledDefaultPrompt);
+	showInstructionsDiff = false;
 }
 </script>
 
@@ -223,7 +241,19 @@ async function handleResetToDefault() {
 
   <div class="skill-field flex-1">
     <div class="skill-label">Instructions</div>
-    <div bind:this={editorContainer} class="skill-editor-container"></div>
+    {#if showInstructionsDiff}
+      <div class="skill-diff-container">
+        <div class="skill-diff-pane">
+          <div class="skill-diff-pane-label">Yours</div>
+          <pre class="skill-diff-text">{@html renderDiffSide(promptValue, bundledDefaultPrompt, "old")}</pre>
+        </div>
+        <div class="skill-diff-pane">
+          <div class="skill-diff-pane-label">Bundled default</div>
+          <pre class="skill-diff-text">{@html renderDiffSide(promptValue, bundledDefaultPrompt, "new")}</pre>
+        </div>
+      </div>
+    {/if}
+    <div bind:this={editorContainer} class="skill-editor-container" class:hidden={showInstructionsDiff}></div>
   </div>
 
   {#if validationError}
@@ -235,6 +265,12 @@ async function handleResetToDefault() {
     <div class="flex-1"></div>
     {#if showResetToDefault}
       <Button buttonText="Reset to Default" onClick={handleResetToDefault} />
+    {/if}
+    {#if canShowInstructionsDiff}
+      <Button
+        buttonText={showInstructionsDiff ? "Back to editor" : "Diff with default"}
+        onClick={() => (showInstructionsDiff = !showInstructionsDiff)}
+      />
     {/if}
     {#if isDirty}
       <Button
@@ -297,6 +333,52 @@ async function handleResetToDefault() {
     min-height: 0;
     overflow-y: auto;
     border-radius: 12px;
+  }
+
+  .skill-editor-container.hidden {
+    display: none;
+  }
+
+  /* ── Instructions diff ── */
+  .skill-diff-container {
+    display: flex;
+    gap: 12px;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .skill-diff-pane {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow-y: auto;
+    background: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 12px;
+    padding: 12px 14px;
+  }
+
+  .skill-diff-pane-label {
+    font-size: var(--font-ui-smaller);
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-bottom: 8px;
+    flex-shrink: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .skill-diff-text {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: var(--font-text);
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--text-normal);
+    user-select: text;
   }
 
   .skill-editor-container :global(.cm-editor) {

--- a/src/components/modal/SystemPromptModal.svelte
+++ b/src/components/modal/SystemPromptModal.svelte
@@ -121,8 +121,13 @@ function handleUseNewDefault() {
         <pre class="system-prompt-preview">{promptValue}</pre>
       {/if}
     </div>
-  {:else}
-    <div bind:this={editorContainer} class="system-prompt-editor-container">
+  {/if}
+  {#if !readOnly}
+    <div
+      bind:this={editorContainer}
+      class="system-prompt-editor-container"
+      class:hidden={viewMode === "diff"}
+    >
       {#if isLoading}
         <div class="system-prompt-loading">Loading prompt…</div>
       {/if}
@@ -221,7 +226,11 @@ function handleUseNewDefault() {
     color: inherit;
   }
 
-  /* ── Editor / preview (unchanged from before) ── */
+  /* ── Editor / preview ── */
+  .hidden {
+    display: none;
+  }
+
   .system-prompt-editor-container {
     flex: 1 1 auto;
     min-height: 0;

--- a/src/components/modal/SystemPromptModal.svelte
+++ b/src/components/modal/SystemPromptModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onDestroy, onMount } from "svelte";
+import { diffWords } from "diff";
 import { BASE_SYSTEM_PROMPT } from "../../agent/prompts";
 import { EmbeddableMarkdownEditor } from "../../lib/editor";
 import type SecondBrainPlugin from "../../main";
@@ -12,26 +13,50 @@ interface Props {
 	accessors: SystemPromptAccessors;
 	description: string;
 	readOnly: boolean;
+	showDiff?: boolean;
 }
 
-const { modal, plugin, accessors, description, readOnly }: Props = $props();
+const { modal, plugin, accessors, description, readOnly, showDiff = false }: Props = $props();
+
+type ViewMode = "edit" | "diff";
 
 let editorContainer: HTMLDivElement | undefined = $state();
 let editor: EmbeddableMarkdownEditor | undefined = $state();
 let initialPromptValue = $state("");
 let promptValue = $state("");
 let isLoading = $state(true);
+let viewMode: ViewMode = $state<ViewMode>("edit");
+
+// Initialise to diff tab when the modal was opened with showDiff=true.
+// Use $effect (run once on mount) rather than reading showDiff directly in
+// $state() to avoid the "captures initial value only" Svelte warning.
+$effect(() => {
+	if (showDiff) viewMode = "diff";
+});
+
 const defaultPrompt = $derived(accessors.defaultPrompt ?? BASE_SYSTEM_PROMPT);
 const isDirty = $derived(promptValue !== initialPromptValue);
 const isAtDefault = $derived(promptValue === defaultPrompt);
-const showResetToDefault = $derived(!isAtDefault);
+const canShowDiff = $derived(!readOnly && !isAtDefault);
+
+function renderDiffSide(oldText: string, newText: string, side: "old" | "new"): string {
+	const parts = diffWords(oldText, newText);
+	return parts
+		.filter((p) => (side === "old" ? !p.added : !p.removed))
+		.map((p) => {
+			const escaped = p.value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+			if (side === "old" && p.removed) return `<mark class="s2b-prompt-diff-removed">${escaped}</mark>`;
+			if (side === "new" && p.added) return `<mark class="s2b-prompt-diff-added">${escaped}</mark>`;
+			return escaped;
+		})
+		.join("");
+}
 
 onMount(() => {
 	if (readOnly) {
 		void loadPrompt();
 		return;
 	}
-
 	void initializeEditor();
 });
 
@@ -69,11 +94,37 @@ function handleResetToDefault() {
 	promptValue = defaultPrompt;
 	editor?.setValue(defaultPrompt);
 }
+
+function handleUseNewDefault() {
+	handleResetToDefault();
+	viewMode = "edit";
+}
 </script>
 
 <div class="system-prompt-modal-content">
   <p class="system-prompt-description">{description}</p>
-  {#if readOnly}
+
+  {#if canShowDiff}
+    <div class="prompt-view-tabs">
+      <button class="prompt-tab" class:active={viewMode === "edit"} onclick={() => (viewMode = "edit")}>Edit</button>
+      <button class="prompt-tab" class:active={viewMode === "diff"} onclick={() => (viewMode = "diff")}
+        >Diff with default</button
+      >
+    </div>
+  {/if}
+
+  {#if viewMode === "diff" && canShowDiff}
+    <div class="prompt-diff-container">
+      <div class="prompt-diff-pane">
+        <div class="prompt-diff-pane-label">Yours</div>
+        <pre class="prompt-diff-text">{@html renderDiffSide(promptValue, defaultPrompt, "old")}</pre>
+      </div>
+      <div class="prompt-diff-pane">
+        <div class="prompt-diff-pane-label">New default</div>
+        <pre class="prompt-diff-text">{@html renderDiffSide(promptValue, defaultPrompt, "new")}</pre>
+      </div>
+    </div>
+  {:else if readOnly}
     <div class="system-prompt-preview-container">
       {#if isLoading}
         <div class="system-prompt-loading">Loading prompt…</div>
@@ -88,17 +139,23 @@ function handleResetToDefault() {
       {/if}
     </div>
   {/if}
+
   <div class="system-prompt-actions">
     <Button buttonText={readOnly ? "Close" : "Cancel"} onClick={() => modal.close()} />
     <div class="flex-1"></div>
-    {#if !readOnly && accessors.viewFinalPrompt}
-      <Button buttonText="View Final" onClick={accessors.viewFinalPrompt} />
-    {/if}
-    {#if !readOnly && showResetToDefault}
-      <Button buttonText="Reset to Default" onClick={handleResetToDefault} />
-    {/if}
-    {#if !readOnly && isDirty}
-      <Button buttonText="Save" cta={true} onClick={handleSave} />
+    {#if viewMode === "diff" && canShowDiff}
+      <Button buttonText="Keep mine" onClick={() => (viewMode = "edit")} />
+      <Button buttonText="Use new default" cta={true} onClick={handleUseNewDefault} />
+    {:else}
+      {#if !readOnly && accessors.viewFinalPrompt}
+        <Button buttonText="View Final" onClick={accessors.viewFinalPrompt} />
+      {/if}
+      {#if !readOnly && !isAtDefault}
+        <Button buttonText="Reset to Default" onClick={handleResetToDefault} />
+      {/if}
+      {#if !readOnly && isDirty}
+        <Button buttonText="Save" cta={true} onClick={handleSave} />
+      {/if}
     {/if}
   </div>
 </div>
@@ -108,7 +165,7 @@ function handleResetToDefault() {
     display: flex;
     flex-direction: column;
     flex: 1;
-    min-height: 0; /* Required for nested flex to shrink properly */
+    min-height: 0;
   }
 
   .system-prompt-description {
@@ -118,9 +175,93 @@ function handleResetToDefault() {
     font-size: var(--font-ui-small);
   }
 
+  /* ── Tab toggle ── */
+  .prompt-view-tabs {
+    display: flex;
+    gap: 2px;
+    flex-shrink: 0;
+    margin-bottom: 10px;
+    border-bottom: 1px solid var(--background-modifier-border);
+  }
+
+  .prompt-tab {
+    padding: 4px 12px 8px;
+    font-size: var(--font-ui-small);
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    color: var(--text-muted);
+    margin-bottom: -1px;
+  }
+
+  .prompt-tab:hover {
+    color: var(--text-normal);
+  }
+
+  .prompt-tab.active {
+    color: var(--text-normal);
+    border-bottom-color: var(--interactive-accent);
+  }
+
+  /* ── Two-pane diff ── */
+  .prompt-diff-container {
+    display: flex;
+    gap: 12px;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .prompt-diff-pane {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow-y: auto;
+    background: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 12px;
+    padding: 12px 14px;
+  }
+
+  .prompt-diff-pane-label {
+    font-size: var(--font-ui-smaller);
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-bottom: 8px;
+    flex-shrink: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .prompt-diff-text {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: var(--font-monospace);
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--text-normal);
+    user-select: text;
+  }
+
+  :global(mark.s2b-prompt-diff-removed) {
+    background: color-mix(in srgb, var(--color-red) 35%, transparent);
+    border-radius: 2px;
+    color: inherit;
+  }
+
+  :global(mark.s2b-prompt-diff-added) {
+    background: color-mix(in srgb, var(--color-green) 35%, transparent);
+    border-radius: 2px;
+    color: inherit;
+  }
+
+  /* ── Editor / preview (unchanged from before) ── */
   .system-prompt-editor-container {
     flex: 1 1 auto;
-    min-height: 0; /* Required for flex child to shrink below content */
+    min-height: 0;
     overflow-y: auto;
     border-radius: 12px;
   }

--- a/src/components/modal/SystemPromptModal.svelte
+++ b/src/components/modal/SystemPromptModal.svelte
@@ -27,9 +27,7 @@ let promptValue = $state("");
 let isLoading = $state(true);
 let viewMode: ViewMode = $state<ViewMode>("edit");
 
-// Initialise to diff tab when the modal was opened with showDiff=true.
-// Use $effect (run once on mount) rather than reading showDiff directly in
-// $state() to avoid the "captures initial value only" Svelte warning.
+// Initialise to diff when the modal was opened with showDiff=true.
 $effect(() => {
 	if (showDiff) viewMode = "diff";
 });
@@ -104,15 +102,6 @@ function handleUseNewDefault() {
 <div class="system-prompt-modal-content">
   <p class="system-prompt-description">{description}</p>
 
-  {#if canShowDiff}
-    <div class="prompt-view-tabs">
-      <button class="prompt-tab" class:active={viewMode === "edit"} onclick={() => (viewMode = "edit")}>Edit</button>
-      <button class="prompt-tab" class:active={viewMode === "diff"} onclick={() => (viewMode = "diff")}
-        >Diff with default</button
-      >
-    </div>
-  {/if}
-
   {#if viewMode === "diff" && canShowDiff}
     <div class="prompt-diff-container">
       <div class="prompt-diff-pane">
@@ -144,7 +133,7 @@ function handleUseNewDefault() {
     <Button buttonText={readOnly ? "Close" : "Cancel"} onClick={() => modal.close()} />
     <div class="flex-1"></div>
     {#if viewMode === "diff" && canShowDiff}
-      <Button buttonText="Keep mine" onClick={() => (viewMode = "edit")} />
+      <Button buttonText="Back to editor" onClick={() => (viewMode = "edit")} />
       <Button buttonText="Use new default" cta={true} onClick={handleUseNewDefault} />
     {:else}
       {#if !readOnly && accessors.viewFinalPrompt}
@@ -152,6 +141,9 @@ function handleUseNewDefault() {
       {/if}
       {#if !readOnly && !isAtDefault}
         <Button buttonText="Reset to Default" onClick={handleResetToDefault} />
+      {/if}
+      {#if canShowDiff}
+        <Button buttonText="Diff with default" onClick={() => (viewMode = "diff")} />
       {/if}
       {#if !readOnly && isDirty}
         <Button buttonText="Save" cta={true} onClick={handleSave} />
@@ -173,35 +165,6 @@ function handleUseNewDefault() {
     margin: 0 0 12px 0;
     color: var(--text-muted);
     font-size: var(--font-ui-small);
-  }
-
-  /* ── Tab toggle ── */
-  .prompt-view-tabs {
-    display: flex;
-    gap: 2px;
-    flex-shrink: 0;
-    margin-bottom: 10px;
-    border-bottom: 1px solid var(--background-modifier-border);
-  }
-
-  .prompt-tab {
-    padding: 4px 12px 8px;
-    font-size: var(--font-ui-small);
-    background: none;
-    border: none;
-    border-bottom: 2px solid transparent;
-    cursor: pointer;
-    color: var(--text-muted);
-    margin-bottom: -1px;
-  }
-
-  .prompt-tab:hover {
-    color: var(--text-normal);
-  }
-
-  .prompt-tab.active {
-    color: var(--text-normal);
-    border-bottom-color: var(--interactive-accent);
   }
 
   /* ── Two-pane diff ── */

--- a/src/components/modal/SystemPromptModal.ts
+++ b/src/components/modal/SystemPromptModal.ts
@@ -27,11 +27,12 @@ export class SystemPromptModal extends Modal {
 	private readonly titleText: string;
 	private readonly descriptionText: string;
 	private readonly readOnly: boolean;
+	private readonly showDiff: boolean;
 
 	constructor(
 		plugin: SecondBrainPlugin,
 		accessors: SystemPromptAccessors,
-		options?: { title?: string; description?: string; readOnly?: boolean },
+		options?: { title?: string; description?: string; readOnly?: boolean; showDiff?: boolean },
 	) {
 		super(plugin.app);
 		this.plugin = plugin;
@@ -39,6 +40,7 @@ export class SystemPromptModal extends Modal {
 		this.titleText = options?.title ?? "System Prompt";
 		this.descriptionText = options?.description ?? "Customize the system instructions used for every chat.";
 		this.readOnly = options?.readOnly ?? false;
+		this.showDiff = options?.showDiff ?? false;
 		this.setTitle(this.titleText);
 	}
 
@@ -58,6 +60,7 @@ export class SystemPromptModal extends Modal {
 				accessors: this.accessors,
 				description: this.descriptionText,
 				readOnly: this.readOnly,
+				showDiff: this.showDiff,
 			},
 		});
 	}

--- a/src/components/modal/ToolConfigForm.svelte
+++ b/src/components/modal/ToolConfigForm.svelte
@@ -115,6 +115,7 @@ let allowMove = $state(
 );
 let diffViewMode = $state<DiffViewMode>(pluginData.diffViewMode);
 let showGuidanceDiff = $state(false);
+let showDescriptionDiff = $state(false);
 
 function renderDiffSide(oldText: string, newText: string, side: "old" | "new"): string {
 	const parts = diffWords(oldText, newText);
@@ -512,16 +513,36 @@ function openProcessorSelectionModal(currentProcessor: ChatModel | null, onSelec
     desc="Describe what the tool does. The AI uses this to decide when to use the tool."
     for="tool-config-description"
   >
-    <TextArea
-      id="tool-config-description"
-      class="w-full h-24"
-      value={description}
-      placeholder={defaultConfig.description}
-      onblur={(v) => {
-        description = v;
-        commit();
-      }}
-    />
+    {#if showDescriptionDiff}
+      <div class="tool-guidance-diff-container">
+        <div class="tool-guidance-diff-pane">
+          <div class="tool-guidance-diff-pane-label">Yours</div>
+          <pre class="tool-guidance-diff-text">{@html renderDiffSide(description, defaultConfig.description, "old")}</pre>
+        </div>
+        <div class="tool-guidance-diff-pane">
+          <div class="tool-guidance-diff-pane-label">Default</div>
+          <pre class="tool-guidance-diff-text">{@html renderDiffSide(description, defaultConfig.description, "new")}</pre>
+        </div>
+      </div>
+    {:else}
+      <TextArea
+        id="tool-config-description"
+        class="w-full h-24"
+        value={description}
+        placeholder={defaultConfig.description}
+        onblur={(v) => {
+          description = v;
+          commit();
+        }}
+      />
+    {/if}
+    {#if description !== defaultConfig.description && !READ_CONTENT_DESC_DEFAULTS.has(description)}
+      <div class="tool-guidance-diff-footer">
+        <button type="button" class="tool-guidance-link" onclick={() => (showDescriptionDiff = !showDescriptionDiff)}>
+          {showDescriptionDiff ? "Back to editor" : "Diff with default"}
+        </button>
+      </div>
+    {/if}
   </ModalField>
 
   <ModalField

--- a/src/components/modal/ToolConfigForm.svelte
+++ b/src/components/modal/ToolConfigForm.svelte
@@ -10,6 +10,7 @@ import {
 import type { BuiltInToolId, DiffViewMode, SearchAlgorithm, ToolConfig } from "../../types/plugin";
 import type { ChatModel } from "../../stores/chatStore.svelte";
 import type SecondBrainPlugin from "../../main";
+import { diffWords } from "diff";
 import { ModelSelectionModal, type SelectedModel } from "./ModelSelectionModal";
 import { NATIVE_PDF_PROVIDERS } from "../../agent/Agent";
 import SecretSelect from "../settings/SecretSelect.svelte";
@@ -113,6 +114,20 @@ let allowMove = $state(
 		true,
 );
 let diffViewMode = $state<DiffViewMode>(pluginData.diffViewMode);
+let showGuidanceDiff = $state(false);
+
+function renderDiffSide(oldText: string, newText: string, side: "old" | "new"): string {
+	const parts = diffWords(oldText, newText);
+	return parts
+		.filter((p) => (side === "old" ? !p.added : !p.removed))
+		.map((p) => {
+			const escaped = p.value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+			if (side === "old" && p.removed) return `<mark class="s2b-prompt-diff-removed">${escaped}</mark>`;
+			if (side === "new" && p.added) return `<mark class="s2b-prompt-diff-added">${escaped}</mark>`;
+			return escaped;
+		})
+		.join("");
+}
 
 const diffViewModeOptions = [
 	{ display: "Two Pane (rendered markdown)", value: "two-pane" as const },
@@ -514,16 +529,37 @@ function openProcessorSelectionModal(currentProcessor: ChatModel | null, onSelec
     desc="Optional vault-specific guidance injected into the assembled system prompt when this tool is enabled."
     for="tool-config-prompt-guidance"
   >
-    <TextArea
-      id="tool-config-prompt-guidance"
-      class="w-full h-24"
-      value={promptGuidance}
-      placeholder="Optional guidance for how the agent should use this tool..."
-      onblur={(v) => {
-        promptGuidance = v;
-        commit();
-      }}
-    />
+    {#if showGuidanceDiff}
+      {@const defaultGuidance = defaultConfig.promptGuidance ?? ""}
+      <div class="tool-guidance-diff-container">
+        <div class="tool-guidance-diff-pane">
+          <div class="tool-guidance-diff-pane-label">Yours</div>
+          <pre class="tool-guidance-diff-text">{@html renderDiffSide(promptGuidance, defaultGuidance, "old")}</pre>
+        </div>
+        <div class="tool-guidance-diff-pane">
+          <div class="tool-guidance-diff-pane-label">Default</div>
+          <pre class="tool-guidance-diff-text">{@html renderDiffSide(promptGuidance, defaultGuidance, "new")}</pre>
+        </div>
+      </div>
+    {:else}
+      <TextArea
+        id="tool-config-prompt-guidance"
+        class="w-full h-24"
+        value={promptGuidance}
+        placeholder="Optional guidance for how the agent should use this tool..."
+        onblur={(v) => {
+          promptGuidance = v;
+          commit();
+        }}
+      />
+    {/if}
+    {#if promptGuidance !== (defaultConfig.promptGuidance ?? "") && !READ_CONTENT_GUIDANCE_DEFAULTS.has(promptGuidance)}
+      <div class="tool-guidance-diff-footer">
+        <button type="button" class="tool-guidance-link" onclick={() => (showGuidanceDiff = !showGuidanceDiff)}>
+          {showGuidanceDiff ? "Back to editor" : "Diff with default"}
+        </button>
+      </div>
+    {/if}
   </ModalField>
 
   {#if capturedToolId === "search_notes"}
@@ -856,5 +892,66 @@ function openProcessorSelectionModal(currentProcessor: ChatModel | null, onSelec
     align-items: center;
     gap: 8px;
     margin-top: 6px;
+  }
+
+  /* ── Prompt guidance diff ── */
+  .tool-guidance-diff-container {
+    display: flex;
+    gap: 10px;
+    min-height: 96px;
+    max-height: 240px;
+    overflow: hidden;
+  }
+
+  .tool-guidance-diff-pane {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    overflow-y: auto;
+    background: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 8px;
+    padding: 8px 10px;
+  }
+
+  .tool-guidance-diff-pane-label {
+    font-size: var(--font-ui-smaller);
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-bottom: 4px;
+    flex-shrink: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .tool-guidance-diff-text {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: var(--font-text);
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--text-normal);
+    user-select: text;
+  }
+
+  .tool-guidance-diff-footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 4px;
+  }
+
+  .tool-guidance-link {
+    border: 0;
+    background: transparent;
+    color: var(--text-accent);
+    cursor: pointer;
+    padding: 0;
+    font-size: var(--font-ui-smaller);
+  }
+
+  .tool-guidance-link:hover {
+    text-decoration: underline;
   }
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -522,14 +522,23 @@ export default class SecondBrainPlugin extends Plugin {
 			}
 
 			// Notify about agents whose system prompt was customized and could not be
-			// auto-updated to the latest default (user needs to review manually).
+			// auto-updated to the latest default — show a persistent notice with a
+			// "Review diff" link that opens the modal directly on the diff tab.
 			const stale = this.pluginData.stalePromptAgentNames;
 			if (stale.length > 0) {
-				const names = stale.join(", ");
-				new Notice(
-					`Smart Second Brain: the default system prompt was updated, but ${stale.length === 1 ? `agent "${names}" has` : `agents ${names} have`} a customized prompt that was left unchanged. Review it in Settings → Agents.`,
-					0,
-				);
+				for (const agentName of stale) {
+					const notice = new Notice("", 0);
+					notice.noticeEl.empty();
+					notice.noticeEl.appendText(
+						`Smart Second Brain: the default system prompt was updated. Agent "${agentName}" has a customized prompt that was not auto-updated. `,
+					);
+					const link = notice.noticeEl.createEl("a", { text: "Review diff", href: "#" });
+					link.addEventListener("click", (e) => {
+						e.preventDefault();
+						notice.hide();
+						this.agentManager.openSystemPromptDiff(agentName);
+					});
+				}
 			}
 
 			// Start search/vector store initialization (non-blocking, fire-and-forget)

--- a/src/main.ts
+++ b/src/main.ts
@@ -521,6 +521,17 @@ export default class SecondBrainPlugin extends Plugin {
 				void this.activateOnboardingView();
 			}
 
+			// Notify about agents whose system prompt was customized and could not be
+			// auto-updated to the latest default (user needs to review manually).
+			const stale = this.pluginData.stalePromptAgentNames;
+			if (stale.length > 0) {
+				const names = stale.join(", ");
+				new Notice(
+					`Smart Second Brain: the default system prompt was updated, but ${stale.length === 1 ? `agent "${names}" has` : `agents ${names} have`} a customized prompt that was left unchanged. Review it in Settings → Agents.`,
+					0,
+				);
+			}
+
 			// Start search/vector store initialization (non-blocking, fire-and-forget)
 			this.lexicalSearchService = StartupProfiler.measureSync("lexical:startInit", () =>
 				LexicalSearchService.startInitialize(this),

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -1,5 +1,11 @@
 import { normalizePath } from "obsidian";
-import { BASE_SYSTEM_PROMPT } from "../agent/prompts";
+import {
+	BASE_SYSTEM_PROMPT,
+	BASE_SYSTEM_PROMPT_VERSION,
+	HISTORICAL_CAPABILITY_GUIDANCE,
+	HISTORICAL_SYSTEM_PROMPTS,
+	HISTORICAL_TOOL_GUIDANCE,
+} from "../agent/prompts";
 import {
 	createEmptySpaceFilter,
 	matchesSpaceMembershipDraftPath,
@@ -365,6 +371,7 @@ export function createDefaultAgentConfig(id?: string, name?: string): AgentConfi
 		summarizationModel: null,
 		titleModel: null,
 		systemPrompt: BASE_SYSTEM_PROMPT,
+		systemPromptVersion: BASE_SYSTEM_PROMPT_VERSION,
 		skills: {},
 		toolsConfig: structuredClone(DEFAULT_TOOLS_CONFIG),
 		mcpServers: {},
@@ -386,6 +393,7 @@ function createDefaultAgent(): AgentConfig {
 		summarizationModel: null,
 		titleModel: null,
 		systemPrompt: BASE_SYSTEM_PROMPT,
+		systemPromptVersion: BASE_SYSTEM_PROMPT_VERSION,
 		skills: {},
 		toolsConfig: structuredClone(DEFAULT_TOOLS_CONFIG),
 		mcpServers: {},
@@ -400,7 +408,7 @@ function createDefaultAgent(): AgentConfig {
 // ---------------------------------------------------------------------------
 
 /** Increment this when making any breaking change to PluginData. Add a corresponding entry to MIGRATIONS. */
-const CURRENT_SCHEMA_VERSION = 1;
+const CURRENT_SCHEMA_VERSION = 2;
 
 type Migration = (data: PluginData) => void;
 
@@ -410,6 +418,9 @@ type Migration = (data: PluginData) => void;
  */
 const MIGRATIONS: Migration[] = [
 	// v0 → v1: first versioned release — no structural changes needed
+	(_data) => {},
+	// v1 → v2: prompt auto-migration added — logic lives in normalizeAgent() which
+	//           runs on every load; the version bump marks that the tracking fields exist
 	(_data) => {},
 ];
 
@@ -2020,7 +2031,42 @@ function normalizeAgent(agent: AgentConfig): void {
 	agent.skills ??= {};
 	agent.mcpServers ??= {};
 	agent.pluginExecTools ??= {};
+
+	// --- Prompt auto-migration ---
+
+	// 1. System prompt: silently update to current default if the stored prompt still
+	//    matches an old default verbatim; leave custom prompts untouched.
+	const storedPromptVersion = agent.systemPromptVersion ?? 0;
+	if (storedPromptVersion < BASE_SYSTEM_PROMPT_VERSION) {
+		const historicalDefault = HISTORICAL_SYSTEM_PROMPTS.get(storedPromptVersion);
+		if (!historicalDefault || agent.systemPrompt === historicalDefault) {
+			agent.systemPrompt = BASE_SYSTEM_PROMPT;
+		}
+		agent.systemPromptVersion = BASE_SYSTEM_PROMPT_VERSION;
+	}
 	agent.systemPrompt ??= BASE_SYSTEM_PROMPT;
+	agent.systemPromptVersion ??= BASE_SYSTEM_PROMPT_VERSION;
+
+	// 2. Capability prompts: if the stored value is a verbatim historical default,
+	//    delete the key so the live default is used going forward.
+	if (agent.capabilityPrompts) {
+		for (const [capId, historicalSet] of HISTORICAL_CAPABILITY_GUIDANCE) {
+			const stored = agent.capabilityPrompts[capId];
+			if (stored !== undefined && historicalSet.has(stored)) {
+				delete agent.capabilityPrompts[capId];
+			}
+		}
+	}
+
+	// 3. Per-tool promptGuidance: same pattern. read_content is handled separately
+	//    by READ_CONTENT_GUIDANCE_DEFAULTS elsewhere; skip it here.
+	for (const [toolId, historicalSet] of HISTORICAL_TOOL_GUIDANCE) {
+		const toolCfg = agent.toolsConfig[toolId];
+		if (toolCfg?.promptGuidance !== undefined && historicalSet.has(toolCfg.promptGuidance)) {
+			delete toolCfg.promptGuidance;
+		}
+	}
+
 	agent.summarizationModel ??= null;
 	agent.titleModel ??= null;
 }

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -2078,7 +2078,7 @@ function normalizeAgent(agent: AgentConfig): boolean {
 	for (const [toolId, historicalSet] of HISTORICAL_TOOL_GUIDANCE) {
 		const toolCfg = agent.toolsConfig[toolId];
 		if (toolCfg?.promptGuidance !== undefined && historicalSet.has(toolCfg.promptGuidance)) {
-			delete toolCfg.promptGuidance;
+			toolCfg.promptGuidance = undefined;
 		}
 	}
 

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -502,9 +502,17 @@ export class PluginDataStore {
 	#data: PluginData;
 	private readonly _plugin: SecondBrainPlugin;
 
-	constructor(plugin: SecondBrainPlugin, initialData: PluginData) {
+	/**
+	 * Agent names whose system prompt was customized and could not be auto-updated
+	 * to the latest default. Populated once at startup; read by main.ts to surface
+	 * a one-time Notice after the workspace is ready.
+	 */
+	readonly stalePromptAgentNames: readonly string[];
+
+	constructor(plugin: SecondBrainPlugin, initialData: PluginData, stalePromptAgentNames: string[] = []) {
 		this._plugin = plugin;
 		this.#data = $state(initialData);
+		this.stalePromptAgentNames = stalePromptAgentNames;
 	}
 
 	/**
@@ -2014,7 +2022,7 @@ export class PluginDataStore {
 
 let _pluginDataStore: PluginDataStore | null = null;
 
-function normalizeAgent(agent: AgentConfig): void {
+function normalizeAgent(agent: AgentConfig): boolean {
 	// Ensure toolsConfig exists and has all tools
 	if (agent.toolsConfig) {
 		agent.toolsConfig = { ...structuredClone(DEFAULT_TOOLS_CONFIG), ...agent.toolsConfig };
@@ -2039,11 +2047,15 @@ function normalizeAgent(agent: AgentConfig): void {
 
 	// 1. System prompt: silently update to current default if the stored prompt still
 	//    matches an old default verbatim; leave custom prompts untouched.
+	//    Returns true when a custom prompt is stale (so callers can notify the user).
+	let hasStaleCustomPrompt = false;
 	const storedPromptVersion = agent.systemPromptVersion ?? 0;
 	if (storedPromptVersion < BASE_SYSTEM_PROMPT_VERSION) {
 		const historicalDefault = HISTORICAL_SYSTEM_PROMPTS.get(storedPromptVersion);
 		if (!historicalDefault || agent.systemPrompt === historicalDefault) {
 			agent.systemPrompt = BASE_SYSTEM_PROMPT;
+		} else {
+			hasStaleCustomPrompt = true;
 		}
 		agent.systemPromptVersion = BASE_SYSTEM_PROMPT_VERSION;
 	}
@@ -2072,14 +2084,19 @@ function normalizeAgent(agent: AgentConfig): void {
 
 	agent.summarizationModel ??= null;
 	agent.titleModel ??= null;
+	return hasStaleCustomPrompt;
 }
 
-function normalizeAgents(mergedData: PluginData): void {
+function normalizeAgents(mergedData: PluginData): string[] {
 	if (!mergedData.agents[DEFAULT_AGENT_ID]) {
 		mergedData.agents[DEFAULT_AGENT_ID] = createDefaultAgent();
 	}
+	const staleAgentNames: string[] = [];
 	for (const agentId of Object.keys(mergedData.agents)) {
-		normalizeAgent(mergedData.agents[agentId]);
+		const agent = mergedData.agents[agentId];
+		if (normalizeAgent(agent)) {
+			staleAgentNames.push(agent.name);
+		}
 	}
 	// Ensure defaultAgentId is valid
 	if (mergedData.defaultAgentId !== null && !mergedData.agents[mergedData.defaultAgentId]) {
@@ -2088,6 +2105,7 @@ function normalizeAgents(mergedData: PluginData): void {
 	if (!mergedData.selectedAgentId || !mergedData.agents[mergedData.selectedAgentId]) {
 		mergedData.selectedAgentId = mergedData.defaultAgentId ?? DEFAULT_AGENT_ID;
 	}
+	return staleAgentNames;
 }
 
 export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataStore> {
@@ -2102,12 +2120,13 @@ export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataS
 
 	runMigrations(mergedData);
 
+	let stalePromptAgentNames: string[] = [];
 	if (!rawData?.agents || Object.keys(rawData.agents).length === 0) {
 		mergedData.agents = { [DEFAULT_AGENT_ID]: createDefaultAgent() };
 		mergedData.defaultAgentId = DEFAULT_AGENT_ID;
 		mergedData.selectedAgentId = DEFAULT_AGENT_ID;
 	} else {
-		normalizeAgents(mergedData);
+		stalePromptAgentNames = normalizeAgents(mergedData);
 	}
 
 	// Resolve vault slug once on first load; persisted so vault renames don't orphan indexes
@@ -2115,7 +2134,7 @@ export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataS
 		mergedData.vaultSlug = await resolveVaultSlug(plugin.app.vault.getName());
 	}
 
-	_pluginDataStore = new PluginDataStore(plugin, mergedData);
+	_pluginDataStore = new PluginDataStore(plugin, mergedData, stalePromptAgentNames);
 
 	return _pluginDataStore;
 }

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -426,6 +426,9 @@ const MIGRATIONS: Migration[] = [
 
 function runMigrations(data: PluginData): void {
 	const from = data.schemaVersion ?? 0;
+	// If data was written by a newer plugin, leave schemaVersion untouched so the
+	// correct migrations run again when the user upgrades back to the newer version.
+	if (from > CURRENT_SCHEMA_VERSION) return;
 	for (let v = from; v < CURRENT_SCHEMA_VERSION; v++) {
 		MIGRATIONS[v]?.(data);
 	}

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -2120,8 +2120,20 @@ export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataS
 
 	runMigrations(mergedData);
 
+	// If the data was written by a newer plugin, skip normalizeAgents() too — it
+	// would rewrite prompt fields using this plugin's older defaults and those
+	// mutations would be persisted on the next save, corrupting the newer state.
+	const fromNewerPlugin = (rawData?.schemaVersion ?? 0) > CURRENT_SCHEMA_VERSION;
+
 	let stalePromptAgentNames: string[] = [];
-	if (!rawData?.agents || Object.keys(rawData.agents).length === 0) {
+	if (fromNewerPlugin) {
+		// Leave agents untouched; just ensure the bare minimum so the UI doesn't crash.
+		if (!mergedData.agents || Object.keys(mergedData.agents).length === 0) {
+			mergedData.agents = { [DEFAULT_AGENT_ID]: createDefaultAgent() };
+			mergedData.defaultAgentId = DEFAULT_AGENT_ID;
+			mergedData.selectedAgentId = DEFAULT_AGENT_ID;
+		}
+	} else if (!rawData?.agents || Object.keys(rawData.agents).length === 0) {
 		mergedData.agents = { [DEFAULT_AGENT_ID]: createDefaultAgent() };
 		mergedData.defaultAgentId = DEFAULT_AGENT_ID;
 		mergedData.selectedAgentId = DEFAULT_AGENT_ID;

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -395,7 +395,36 @@ function createDefaultAgent(): AgentConfig {
 	};
 }
 
+// ---------------------------------------------------------------------------
+// Settings schema versioning
+// ---------------------------------------------------------------------------
+
+/** Increment this when making any breaking change to PluginData. Add a corresponding entry to MIGRATIONS. */
+const CURRENT_SCHEMA_VERSION = 1;
+
+type Migration = (data: PluginData) => void;
+
+/**
+ * One entry per version step. MIGRATIONS[v] upgrades data from version v → v+1.
+ * Keep entries in order; never remove them.
+ */
+const MIGRATIONS: Migration[] = [
+	// v0 → v1: first versioned release — no structural changes needed
+	(_data) => {},
+];
+
+function runMigrations(data: PluginData): void {
+	const from = data.schemaVersion ?? 0;
+	for (let v = from; v < CURRENT_SCHEMA_VERSION; v++) {
+		MIGRATIONS[v]?.(data);
+	}
+	data.schemaVersion = CURRENT_SCHEMA_VERSION;
+}
+
+// ---------------------------------------------------------------------------
+
 export const DEFAULT_SETTINGS: PluginData = {
+	schemaVersion: CURRENT_SCHEMA_VERSION,
 	// Configured provider instances keyed by opaque provider instance ID
 	providerConfig: {},
 	// Persisted metadata for configured provider instances
@@ -2021,6 +2050,8 @@ export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataS
 		...DEFAULT_SETTINGS,
 		...rawData,
 	};
+
+	runMigrations(mergedData);
 
 	if (!rawData?.agents || Object.keys(rawData.agents).length === 0) {
 		mergedData.agents = { [DEFAULT_AGENT_ID]: createDefaultAgent() };

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -473,6 +473,9 @@ export type ChatOpenLocation = "tab" | "left" | "right";
 export type PrivacyMode = "private-by-default" | "public-by-default";
 
 export interface PluginData {
+	/** Incremented whenever a breaking schema change is made; drives runMigrations(). Absent on pre-versioning data ⇒ treated as 0. */
+	schemaVersion: number;
+
 	/** All configured provider instances keyed by opaque provider instance ID */
 	providerConfig: Record<string, StoredProviderState>;
 	/** Persisted metadata for configured provider instances */

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -417,6 +417,12 @@ export interface AgentConfig {
 	titleModel: import("../stores/chatStore.svelte").ChatModel | null;
 	/** Base system prompt for this agent */
 	systemPrompt: string;
+	/**
+	 * Which version of BASE_SYSTEM_PROMPT this agent's systemPrompt was copied from.
+	 * Absent = pre-versioning (treated as 0). normalizeAgent() uses this to detect
+	 * whether the stored prompt is still an unmodified default and can be auto-updated.
+	 */
+	systemPromptVersion?: number;
 	/** Skill enable states for this agent (skill name -> state) */
 	skills: Record<string, AgentSkillState>;
 	/** Configuration for built-in tools */

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -1910,9 +1910,15 @@ export class VectorStoreService {
 			const raw = fs.readFileSync(filePaths[0]);
 			const decoded = decode(new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength)) as SerializedIndex;
 
-			if (decoded.version !== INDEX_VERSION) {
+			if (decoded.version < INDEX_VERSION) {
 				new Notice(
-					`Export file version mismatch (expected ${INDEX_VERSION}, got ${decoded.version}). Re-index instead.`,
+					`Export file schema v${decoded.version} is outdated (current: v${INDEX_VERSION}). Re-index to regenerate a compatible export.`,
+				);
+				return null;
+			}
+			if (decoded.version > INDEX_VERSION) {
+				new Notice(
+					`Export file was created with a newer plugin version (schema v${decoded.version}). Update the plugin to import it.`,
 				);
 				return null;
 			}

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -1910,6 +1910,12 @@ export class VectorStoreService {
 			const raw = fs.readFileSync(filePaths[0]);
 			const decoded = decode(new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength)) as SerializedIndex;
 
+			if (typeof decoded.version !== "number" || !Number.isInteger(decoded.version)) {
+				new Notice(
+					"Export file has an invalid or missing version field. Re-index to regenerate a compatible export.",
+				);
+				return null;
+			}
 			if (decoded.version < INDEX_VERSION) {
 				new Notice(
 					`Export file schema v${decoded.version} is outdated (current: v${INDEX_VERSION}). Re-index to regenerate a compatible export.`,


### PR DESCRIPTION
Resolves #335 

## Summary

### Migration hardening (original scope)

- **`PluginData` migration framework** — adds `schemaVersion: number` to the settings type and a `runMigrations()` runner in `createData()`. Existing users without the field start at v0 and run through the migration array on next load. Future breaking renames/removals need only a new `MIGRATIONS[]` entry and a `CURRENT_SCHEMA_VERSION` bump — no user action required.

- **`.chat` file versioning** — adds `THREAD_DATA_VERSION` and an optional `version` field to `ThreadData`. Every save now stamps the current version; reads warn (but don't crash) if a file was written by a newer plugin. Pre-versioning files (no `version` field) continue to load unchanged.

- **Vector index export version check** — replaces the single `!==` equality check with two directional guards: `< INDEX_VERSION` (outdated export → re-index) and `> INDEX_VERSION` (file from a newer plugin → update plugin). Each guard shows a specific user-facing notice instead of a generic "mismatch" message.

### Prompt auto-migration (closes #335)

When the plugin ships updated default prompts, users previously had to manually update all agents. Now:

- **`systemPrompt`** — `systemPromptVersion` tracks which version of `BASE_SYSTEM_PROMPT` an agent was seeded with. On load, `normalizeAgent()` silently replaces the stored prompt with the current default if it still matches the old verbatim default. Custom prompts are untouched.

- **`capabilityPrompts`** — `HISTORICAL_CAPABILITY_GUIDANCE` maps each capability to the set of all default strings ever shipped. If a stored value is in the set (i.e. user saved without editing), the key is deleted so the live default is picked up automatically.

- **`promptGuidance` on tools** — same pattern via `HISTORICAL_TOOL_GUIDANCE` for `execute_javascript`, `fetch_url`, and `web_search`. (`read_content` was already handled by the existing `READ_CONTENT_GUIDANCE_DEFAULTS` set.)

Adding new default text in the future only requires: update the constant, append the old string to the historical set, bump `BASE_SYSTEM_PROMPT_VERSION` if needed.

## Test plan

- [ ] `bun run check` — no new type errors
- [ ] `bun run format` — no formatting changes
- [ ] Load test vault → plugin initialises without errors, `dev:errors` empty
- [ ] Simulate old settings: remove `schemaVersion` from `data.json`, reload → resolves to `2`
- [ ] Simulate unmodified system prompt (no `systemPromptVersion`): prompt matches current default → auto-updated, version stamped
- [ ] Simulate customized system prompt: differs from default → left untouched, version stamped
- [ ] Simulate capability prompt set to verbatim default → key absent after load
- [ ] Simulate custom capability prompt → preserved after load
- [ ] Open a `.chat` file written before this change → loads correctly
- [ ] Import a vector export with mismatched version → correct directional notice shown

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._