### PR TITLE
fix: resolve minor UI/UX issues (#344)

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -1587,7 +1587,7 @@ export class AgentManager {
 				leaf = location === "left" ? workspace.getLeftLeaf(false) : workspace.getRightLeaf(false);
 			}
 		} else {
-			leaf = workspace.getLeaf(false);
+			leaf = workspace.getLeaf("tab");
 		}
 		if (!leaf) return;
 		await leaf.openFile(file);

--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -1004,15 +1004,15 @@ async function toggleVisibleNoteAttachment(note: VisibleNote, currentlyAttached:
     }
   }}
 >
-  {#if models.hasUnavailableProviders}
+  {#if selectedChatModel && models.unavailableProviders.includes(selectedChatModel.provider)}
     <button
-      class="flex flex-row items-center gap-1.5 px-2 py-1 rounded-md bg-[--background-modifier-error] text-[--text-on-accent] text-xs cursor-pointer border-none"
+      class="flex flex-row items-center gap-1 text-xs cursor-pointer border-none bg-transparent p-0"
+      style="color: var(--text-error);"
       onclick={models.refetchProviders}
       title="Click to retry connection"
     >
       <div class="h-icon-xs" use:icon={"alert-triangle"} style="--icon-size: var(--icon-xs)"></div>
-      <span>Cannot connect to: {models.unavailableProviders.join(", ")}</span>
-      <div class="h-icon-xs" use:icon={"refresh-cw"} style="--icon-size: var(--icon-xs)"></div>
+      <span>Cannot connect to {selectedChatModel.provider} — click to retry</span>
     </button>
   {/if}
   <PendingChangesBar {threadPath} />

--- a/src/components/modal/AgentEditorModal.svelte
+++ b/src/components/modal/AgentEditorModal.svelte
@@ -70,8 +70,6 @@ const POPULAR_AGENT_ICONS = [
 	"workflow",
 ] as const;
 
-const AGENT_PICTOGRAM_OPTIONS = ["🤖", "🧠", "📚", "💡", "🧭", "🛠️"] as const;
-
 const BUILT_IN_AGENT_ICONS = getIconIds()
 	.slice()
 	.sort((left, right) => left.localeCompare(right));
@@ -91,7 +89,9 @@ function updateAgentName(name: string) {
 }
 
 function updateAgentIcon(icon: string) {
-	const nextIcon = icon.trim() || DEFAULT_AGENT_ICON;
+	const trimmed = icon.trim();
+	const isValid = trimmed.length > 0 && BUILT_IN_AGENT_ICONS.includes(trimmed);
+	const nextIcon = isValid ? trimmed : DEFAULT_AGENT_ICON;
 	pluginData.updateAgent(agentId, { icon: nextIcon });
 }
 
@@ -741,22 +741,6 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
                   onchange={(value: string) => (agentIconQuery = value)}
                 />
 
-                <div class="agent-icon-pictograms">
-                  {#each AGENT_PICTOGRAM_OPTIONS as pictogram}
-                    <button
-                      type="button"
-                      class="agent-icon-chip"
-                      class:selected={selectedAgentIcon === pictogram}
-                      onclick={() => {
-                        updateAgentIcon(pictogram);
-                        isAgentIconPickerOpen = false;
-                      }}
-                    >
-                      <span class="agent-icon-chip-glyph">{pictogram}</span>
-                    </button>
-                  {/each}
-                </div>
-
                 <div class="agent-icon-results-header">
                   <span>{agentIconQuery.trim() ? `Built-in icons (${matchingAgentIconCount})` : "Popular icons"}</span>
                 </div>
@@ -782,7 +766,7 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
                     {/each}
                   {:else}
                     <div class="agent-icon-empty-state">
-                      No built-in icons match this search. Use the text field for a custom icon ID or emoji.
+                      No built-in icons match this search.
                     </div>
                   {/if}
                 </div>
@@ -798,7 +782,7 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
                 onblur={(value: string) => updateAgentName(value)}
               />
               <div class="agent-overview-name-hint">
-                Search built-in Obsidian icons or type any icon ID or emoji directly.
+                Search built-in Obsidian (Lucide) icons.
                 <button
                   type="button"
                   class="agent-icon-inline-edit"
@@ -1345,40 +1329,16 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
     width: 100%;
   }
 
-  .agent-icon-pictograms {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-  }
-
-  .agent-icon-chip,
   .agent-icon-option {
     border: 1px solid var(--background-modifier-border);
     background: var(--background-primary);
     color: var(--text-normal);
   }
 
-  .agent-icon-chip {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 34px;
-    height: 34px;
-    padding: 0 8px;
-    border-radius: 10px;
-  }
-
-  .agent-icon-chip-glyph {
-    font-size: 1rem;
-    line-height: 1;
-  }
-
-  .agent-icon-chip:hover,
   .agent-icon-option:hover {
     background: var(--background-modifier-hover);
   }
 
-  .agent-icon-chip.selected,
   .agent-icon-option.selected {
     border-color: color-mix(in srgb, var(--interactive-accent) 55%, var(--background-modifier-border));
     background: color-mix(in srgb, var(--interactive-accent) 14%, var(--background-primary));

--- a/src/components/modal/SearchModal.ts
+++ b/src/components/modal/SearchModal.ts
@@ -147,6 +147,10 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 	private isSearching = false;
 	private isClosed = false;
 	private semanticEnabled = false;
+	/** When Tab arms a one-shot semantic search, this holds the query it was
+	 * armed for. Semantic stays on (results visible) until the query text
+	 * changes, at which point it auto-reverts to lexical. null = not armed. */
+	private semanticOneShotQuery: string | null = null;
 	private requireAllTags = false;
 	private glowAnimationId: number | null = null;
 	private borderEl: HTMLElement | null = null;
@@ -410,6 +414,9 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 		}
 
 		this.semanticEnabled = !this.semanticEnabled;
+		// Arm one-shot only when turning semantic ON, keyed to the current query
+		// so it reverts to lexical once the user changes what they're searching.
+		this.semanticOneShotQuery = this.semanticEnabled ? this.currentQuery : null;
 		this.updateInstructions();
 		this.syncGlowAnimation();
 
@@ -949,6 +956,8 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 		this.lastRequestedSearchKey = "";
 		this.activeFilters = [];
 		this.hasPrimedOpenResults = false;
+		this.semanticEnabled = false;
+		this.semanticOneShotQuery = null;
 
 		this.searchResults = this.getModalRecentNotes();
 		this.hasPrimedOpenResults = true;
@@ -1794,6 +1803,15 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 
 	getSuggestions(query: string): SearchSuggestion[] | Promise<SearchSuggestion[]> {
 		this.currentQuery = query;
+
+		// One-shot semantic (armed by Tab) reverts to lexical as soon as the
+		// query text changes — the semantic results for the armed query stay
+		// visible, but the next search the user types runs lexically.
+		if (this.semanticOneShotQuery !== null && query !== this.semanticOneShotQuery) {
+			this.semanticOneShotQuery = null;
+			this.semanticEnabled = false;
+			this.updateInstructions();
+		}
 
 		// Check for autocomplete mode (typing # or folder/)
 		const autocompleteSuggestions = this.getAutocompleteSuggestions(query);

--- a/src/components/settings/SettingContainer.svelte
+++ b/src/components/settings/SettingContainer.svelte
@@ -35,7 +35,7 @@ const isRowDisabled = $derived(disabled || isDisabled);
     : ''} {compact ? 'setting-item--compact' : ''} {className}"
 >
   <div class="setting-item-info">
-    <div class="setting-item-name" title={compact && desc ? desc : ""}>
+    <div class="setting-item-name" aria-label={compact && desc ? desc : undefined}>
       {#if namePrefix}
         <span class="setting-item-name-prefix">{@render namePrefix()}</span>
       {/if}

--- a/src/components/ui/Button.svelte
+++ b/src/components/ui/Button.svelte
@@ -95,7 +95,6 @@ function handleClick(event: MouseEvent) {
   onclick={handleClick}
   aria-label={effectiveAriaLabel}
   data-testid={dataTestId}
-  title={tooltip}
 >
   {#if iconId !== ""}
     <span class="s2b-button-icon" class:s2b-button-icon-only={isIconOnly} use:icon={iconId}></span>

--- a/src/views/onboarding/Onboarding.svelte
+++ b/src/views/onboarding/Onboarding.svelte
@@ -226,7 +226,21 @@ async function exploreGraph() {
 		</div>
 	</section>
 
-	<footer class="s2b-onboarding-footer" class:s2b-fade-in={playIntro} style="--s2b-delay: 2820ms">
+	<!-- Privacy note -->
+	<div class="s2b-onboarding-privacy" class:s2b-fade-in={playIntro} style="--s2b-delay: 2800ms">
+		<span class="s2b-onboarding-privacy-icon" use:icon={"shield"} aria-hidden="true"></span>
+		<div>
+			<div class="s2b-onboarding-privacy-title">Note access is private by default</div>
+			<div class="s2b-onboarding-privacy-desc">
+				By default your notes are <strong>not</strong> shared with AI providers. You can unblock access
+				two ways: mark a specific provider as <strong>trusted</strong> in its settings (that provider
+				only), or switch to <strong>public by default</strong> in <strong>Settings → Privacy</strong> to
+				allow all providers.
+			</div>
+		</div>
+	</div>
+
+	<footer class="s2b-onboarding-footer" class:s2b-fade-in={playIntro} style="--s2b-delay: 2920ms">
 		<Button buttonText="Skip for now" onClick={finish} />
 		<div class="s2b-onboarding-footer-primary">
 			<Button buttonText="Explore the graph" onClick={exploreGraph} />
@@ -478,6 +492,37 @@ async function exploreGraph() {
 	}
 
 	.s2b-onboarding-step-desc {
+		color: var(--text-muted);
+		font-size: var(--font-ui-small);
+	}
+
+	.s2b-onboarding-privacy {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.75rem;
+		padding: 0.75rem;
+		border-radius: var(--radius-m);
+		background: color-mix(in srgb, var(--color-blue) 10%, var(--background-secondary));
+		border: 1px solid color-mix(in srgb, var(--color-blue) 25%, transparent);
+	}
+
+	.s2b-onboarding-privacy-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 20px;
+		height: 20px;
+		color: var(--color-blue);
+		flex-shrink: 0;
+		margin-top: 2px;
+	}
+
+	.s2b-onboarding-privacy-title {
+		font-weight: var(--font-semibold);
+		margin-bottom: 0.25rem;
+	}
+
+	.s2b-onboarding-privacy-desc {
 		color: var(--text-muted);
 		font-size: var(--font-ui-small);
 	}

--- a/src/views/settings/GraphSettings.svelte
+++ b/src/views/settings/GraphSettings.svelte
@@ -1,20 +1,11 @@
 <script lang="ts">
-import { ModelSelectionModal } from "../../components/modal/ModelSelectionModal";
 import EmbeddingIndexSection from "../../components/settings/EmbeddingIndexSection.svelte";
-import ModelSettingControl from "../../components/settings/ModelSettingControl.svelte";
 import SettingGroup from "../../components/settings/SettingGroup.svelte";
 import SettingItem from "../../components/settings/SettingItem.svelte";
 import RangeSlider from "../../components/ui/RangeSlider.svelte";
-import Toggle from "../../components/ui/Toggle.svelte";
-import GenericAIIcon from "../../components/ui/logos/GenericAIIcon.svelte";
-import { useAvailableModels } from "../../hooks/useAvailableModels.svelte";
-import { getProviderDefinition } from "../../providers/index";
 import { getData } from "../../stores/dataStore.svelte";
-import { getPlugin } from "../../stores/state.svelte";
 
 const pluginData = getData();
-const plugin = getPlugin();
-const availableModels = useAvailableModels();
 
 // Helper to update a single graph setting field
 function updateSetting<K extends keyof typeof pluginData.smartGraphSettings>(
@@ -23,82 +14,10 @@ function updateSetting<K extends keyof typeof pluginData.smartGraphSettings>(
 ) {
 	pluginData.smartGraphSettings = { ...pluginData.smartGraphSettings, [key]: value };
 }
-
-// Chat model display info
-const currentModelDisplay = $derived.by(() => {
-	const model = pluginData.smartGraphSettings.graphChatModel;
-	if (!model) return null;
-	const providerDef = getProviderDefinition(model.provider, pluginData.getAllProviderMeta());
-	return {
-		model: model.model,
-		providerName: providerDef?.displayName ?? model.provider,
-		logo: providerDef && "logo" in providerDef && providerDef.logo ? providerDef.logo : GenericAIIcon,
-	};
-});
-
-function openModelSelectionModal() {
-	const current = pluginData.smartGraphSettings.graphChatModel;
-	const currentSelection = current ? { provider: current.provider, model: current.model } : null;
-
-	const modal = new ModelSelectionModal(plugin, "chat", currentSelection, (selected) => {
-		if (selected) {
-			updateSetting("graphChatModel", {
-				provider: selected.provider,
-				model: selected.model,
-				modelConfig: {},
-			});
-		}
-	});
-	modal.open();
-}
-
-function clearModel() {
-	updateSetting("graphChatModel", null);
-}
 </script>
 
 <!-- Embedding Index for Graph -->
 <EmbeddingIndexSection purpose="graph" />
-
-<!-- LLM Model -->
-<SettingGroup heading="LLM Model">
-  <SettingItem
-    name="Chat Model"
-    desc="Model used for LLM-powered graph features like cluster labeling."
-  >
-    <ModelSettingControl
-      available={availableModels.hasProviders && availableModels.hasModels}
-      loading={availableModels.hasProviders && availableModels.isLoadingModels}
-      configureLabel={!availableModels.hasProviders ? "Configure Provider" : "Configure Models"}
-      onConfigure={availableModels.openSettings}
-      placeholder="Select model"
-      selectedLabel={currentModelDisplay?.model ?? null}
-      selectedLogo={currentModelDisplay?.logo ?? null}
-      onSelect={openModelSelectionModal}
-      secondaryLabel={currentModelDisplay ? "Clear" : undefined}
-      onSecondary={currentModelDisplay ? clearModel : undefined}
-    />
-  </SettingItem>
-
-  <SettingItem
-    name="Auto Label Clusters"
-    desc="Automatically generate cluster labels using the selected model after each clustering."
-  >
-    <Toggle
-      checked={pluginData.smartGraphSettings.autoLabelClusters}
-      onchange={(v) => updateSetting("autoLabelClusters", v)}
-    />
-  </SettingItem>
-</SettingGroup>
-
-<SettingGroup heading="Display">
-  <SettingItem name="Direction Arrows" desc="Show arrows for directed wiki links in graph views.">
-    <Toggle
-      checked={pluginData.smartGraphSettings.directedWikiEdges}
-      onchange={(v) => updateSetting("directedWikiEdges", v)}
-    />
-  </SettingItem>
-</SettingGroup>
 
 <SettingGroup heading="Outline View">
   <SettingItem


### PR DESCRIPTION
Resolves several items from #344.

## Changes

- **Double hover popovers** — Removed `title=` from `Button` (its `aria-label` already drives Obsidian's native tooltip) and switched `SettingContainer`'s compact-mode tooltip from a raw browser `title=` to `aria-label`, so only the native Obsidian popover shows.
- **Semantic search one-shot** — Pressing Tab now arms a one-shot semantic search keyed to the current query. The augmented results stay on screen; semantic reverts to lexical only when the query text changes. Decoupled from the persisted `searchAlgorithm` setting, which was causing the modal to mutate the agent `search_notes` default and write settings to disk on every search.
- **Graph settings cleanup** — Removed the *LLM Model* and *Display* sections (direction arrows already live in the graph panel); dropped the now-unused imports/derived state.
- **Onboarding privacy note** — Added a callout explaining that note access is private by default, and the two ways to grant access: mark a specific provider as trusted, or switch to public-by-default in Settings → Privacy.
- **New chat in a new tab** — `openInChatLeaf` now uses `getLeaf("tab")` so New Chat opens in a fresh tab; sidebar mode (`left`/`right`) is unchanged.
- **Agent icon: Lucide-only** — Removed the emoji pictogram options and free-text fallback; `updateAgentIcon` now validates against `getIconIds()` and falls back to the default for anything unrecognized.
- **Unavailable-provider banner** — Now shows only when the *currently selected* chat model's provider is unreachable (not any unrelated configured provider), and is restyled from a solid error-red container to plain error-colored text.

## Testing

- `bun run check` — clean (only 4 pre-existing `GraphCanvas.svelte` errors, unrelated to this change)
- `bun run format` — clean

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._