### PR TITLE
feat: new-chat recommendations surface (#334, #355, #356)

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -529,16 +529,16 @@ export class AgentManager {
 		this.agent?.invalidateAllRunnables();
 	}
 
-	openSystemPromptDiff(agentName: string): void {
+	openSystemPromptDiff(agentId: string): void {
 		const pluginData = getData();
-		const agent = Object.values(pluginData.agents).find((a) => a.name === agentName);
+		const agent = pluginData.agents[agentId];
 		if (!agent) return;
 		new SystemPromptModal(
 			this.plugin,
 			{
-				getPrompt: () => agent.systemPrompt,
+				getPrompt: () => pluginData.agents[agentId]?.systemPrompt ?? BASE_SYSTEM_PROMPT,
 				setPrompt: (prompt: string) => {
-					pluginData.updateAgent(agent.id, { systemPrompt: prompt });
+					pluginData.updateAgent(agentId, { systemPrompt: prompt });
 					this.invalidateSystemPromptCaches();
 				},
 				defaultPrompt: BASE_SYSTEM_PROMPT,

--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -6,11 +6,19 @@ import { invalidateProviderState } from "../lib/query";
 import type SecondBrainPlugin from "../main";
 import type { ChatModel } from "../stores/chatStore.svelte";
 import { READ_CONTENT_GUIDANCE_DEFAULTS, getData, getReadContentGuidance } from "../stores/dataStore.svelte";
-import { CAPABILITIES, VAULT_TOOL_IDS, WEB_TOOL_IDS, type BuiltInToolId, type AgentConfig } from "../types/plugin";
+import {
+	CAPABILITIES,
+	VAULT_TOOL_IDS,
+	WEB_TOOL_IDS,
+	type BuiltInToolId,
+	type CapabilityId,
+	type AgentConfig,
+} from "../types/plugin";
 import { VIEW_TYPE_CHAT } from "../views/chat/Chat";
 import { lookupModelInfo } from "../providers/modelsDevApi";
 import { fetchOllamaModelsInfo } from "../providers/ollamaModels";
 import { SystemPromptModal } from "../components/modal/SystemPromptModal";
+import { CapabilitySettingsModal } from "../components/modal/CapabilitySettingsModal";
 import {
 	extractCapabilities as extractOpenRouterCapabilities,
 	fetchOpenRouterModels,
@@ -537,6 +545,31 @@ export class AgentManager {
 			},
 			{ title: `System Prompt — ${agent.name}`, showDiff: true },
 		).open();
+	}
+
+	/**
+	 * Opens the per-capability settings modal so the user can review the capability's
+	 * guidance against the current default (GuidanceEditor has a built-in "Diff with
+	 * default" toggle). Used by the "updated guidance" notice's Review action for a
+	 * `kind: "capability"` stale record.
+	 */
+	openCapabilityGuidanceDiff(agentId: string, capId: CapabilityId): void {
+		const pluginData = getData();
+		if (!pluginData.agents[agentId] || !CAPABILITIES.some((c) => c.id === capId)) return;
+		new CapabilitySettingsModal(this.plugin, capId, agentId, {
+			onChange: () => this.invalidateAgentRunnable(agentId),
+		}).open();
+	}
+
+	/**
+	 * Opens the settings modal for the capability that owns `toolId`, where the tool's
+	 * own guidance (with its "Diff with default" toggle) lives. Used by the "updated
+	 * guidance" notice's Review action for a `kind: "tool"` stale record.
+	 */
+	openToolGuidanceDiff(agentId: string, toolId: BuiltInToolId): void {
+		const cap = CAPABILITIES.find((c) => c.toolIds.includes(toolId));
+		if (!cap) return;
+		this.openCapabilityGuidanceDiff(agentId, cap.id);
 	}
 
 	/**

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -160,3 +160,27 @@ export const HISTORICAL_TOOL_GUIDANCE: ReadonlyMap<
 		]),
 	],
 ]);
+
+/**
+ * Current default version per capability. Bump the entry for a capability
+ * whenever its default guidance text changes (and append the new default to
+ * HISTORICAL_CAPABILITY_GUIDANCE). Agents stamp the version their customized
+ * guidance was written against (capabilityPromptsVersion) so normalizeAgent()
+ * can flag "the default moved since you customized this" — see issue #356.
+ * Capabilities absent here are treated as version 1.
+ */
+export const CAPABILITY_GUIDANCE_VERSION: ReadonlyMap<CapabilityId, number> = new Map([
+	["vault", 1],
+	["web", 1],
+]);
+
+/**
+ * Current default version per built-in tool guidance. Same contract as
+ * CAPABILITY_GUIDANCE_VERSION. Tools absent here are treated as version 1.
+ * read_content is intentionally omitted (dynamic guidance).
+ */
+export const TOOL_GUIDANCE_VERSION: ReadonlyMap<import("../types/plugin").BuiltInToolId, number> = new Map([
+	["execute_javascript", 1],
+	["fetch_url", 1],
+	["web_search", 1],
+]);

--- a/src/components/chat/ChatRecommendations.svelte
+++ b/src/components/chat/ChatRecommendations.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+import { getData } from "../../stores/dataStore.svelte";
+import type { SessionRegistry } from "../../stores/chatStore.svelte";
+import { useAvailableModels } from "../../hooks/useAvailableModels.svelte";
+import { icon } from "../../utils/utils";
+import { DISMISS_ALL_ID, filterSuggestions, type SuggestedQuery } from "./chatRecommendations";
+
+interface Props {
+	registry: SessionRegistry;
+}
+
+let { registry }: Props = $props();
+
+const data = getData();
+const models = useAvailableModels();
+
+/** True when the given embed index is assigned and actually populated. */
+function indexPopulated(indexId: string | null): boolean {
+	if (!indexId) return false;
+	return (data.getEmbeddingIndex(indexId)?.documentCount ?? 0) > 0;
+}
+
+const ctx = $derived({
+	hasChat: models.hasModels,
+	hasSearch: indexPopulated(data.searchEmbedIndex),
+	hasGraph: indexPopulated(data.graphEmbedIndex),
+});
+
+const visible = $derived(filterSuggestions(ctx, data.dismissedRecommendations));
+
+function useSuggestion(s: SuggestedQuery): void {
+	// Prefill only — the input effect mirrors this into the editor and focuses.
+	registry.pendingInput = s.query ?? s.label;
+}
+
+function dismiss(id: string): void {
+	data.dismissRecommendation(id);
+}
+</script>
+
+{#if visible.length > 0}
+  <div class="chat-recommendations flex flex-col items-center gap-3">
+    <div class="recommendations-header flex items-center gap-2">
+      <p class="text-sm opacity-70">Try asking…</p>
+      <button
+        type="button"
+        class="dismiss-all clickable-icon"
+        aria-label="Dismiss suggestions"
+        title="Dismiss suggestions"
+        onclick={() => dismiss(DISMISS_ALL_ID)}
+      >
+        <span use:icon={"x"} style="--icon-size: 14px"></span>
+      </button>
+    </div>
+    <div class="recommendation-chips flex flex-row flex-wrap justify-center gap-1.5">
+      {#each visible as s (s.id)}
+        <div class="recommendation-chip-wrap inline-flex items-center">
+          <button
+            type="button"
+            class="recommendation-chip s2b-pill s2b-pill--interactive"
+            title={s.query ?? s.label}
+            onclick={() => useSuggestion(s)}
+          >
+            <span class="chip-icon" use:icon={s.icon} style="--icon-size: 12px"></span>
+            <span>{s.label}</span>
+          </button>
+          <button
+            type="button"
+            class="dismiss-chip clickable-icon"
+            aria-label={`Dismiss "${s.label}"`}
+            title="Dismiss this suggestion"
+            onclick={() => dismiss(s.id)}
+          >
+            <span use:icon={"x"} style="--icon-size: 11px"></span>
+          </button>
+        </div>
+      {/each}
+    </div>
+  </div>
+{:else}
+  <!-- Fallback so the empty chat view is never completely blank (all dismissed / no capability). -->
+  <div class="flex flex-col items-center">
+    <p class="text-lg mb-1">Start a new conversation</p>
+    <p class="text-sm opacity-70">Ask me anything about your notes.</p>
+  </div>
+{/if}
+
+<style>
+  .recommendation-chip {
+    --s2b-pill-bg: var(--background-secondary);
+    --s2b-pill-border: var(--background-modifier-border);
+    --s2b-pill-color: var(--text-normal);
+    --s2b-pill-bg-hover: var(--background-modifier-hover);
+    --s2b-pill-border-hover: var(--background-modifier-border-hover);
+  }
+
+  .chip-icon {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    opacity: 0.9;
+  }
+
+  .dismiss-chip {
+    opacity: 0;
+    margin-left: -0.35rem;
+    color: var(--text-muted);
+    transition: opacity 120ms ease;
+  }
+
+  .recommendation-chip-wrap:hover .dismiss-chip,
+  .dismiss-chip:focus-visible {
+    opacity: 1;
+  }
+
+  .dismiss-all {
+    color: var(--text-muted);
+    opacity: 0.6;
+  }
+
+  .dismiss-all:hover {
+    opacity: 1;
+  }
+</style>

--- a/src/components/chat/ChatRecommendations.svelte
+++ b/src/components/chat/ChatRecommendations.svelte
@@ -1,9 +1,20 @@
 <script lang="ts">
+import { Notice } from "obsidian";
 import { getData } from "../../stores/dataStore.svelte";
+import { getPlugin } from "../../stores/state.svelte";
 import type { SessionRegistry } from "../../stores/chatStore.svelte";
 import { useAvailableModels } from "../../hooks/useAvailableModels.svelte";
+import { getPluginIcon, toExecToolId } from "../../agent/integrations/pluginIntegrations";
 import { icon } from "../../utils/utils";
-import { DISMISS_ALL_ID, filterSuggestions, type SuggestedQuery } from "./chatRecommendations";
+import Button from "../ui/Button.svelte";
+import {
+	DISMISS_ALL_ID,
+	filterPluginNudges,
+	filterSuggestions,
+	type PluginNudge,
+	pluginNudgeId,
+	type SuggestedQuery,
+} from "./chatRecommendations";
 
 interface Props {
 	registry: SessionRegistry;
@@ -12,7 +23,30 @@ interface Props {
 let { registry }: Props = $props();
 
 const data = getData();
+const plugin = getPlugin();
 const models = useAvailableModels();
+
+// resolvePluginIntegrations() reads live app.plugins state, which is not a Svelte
+// signal. Bump this on the plugin manager's "changed" event and on window focus
+// (returning from Obsidian's plugin settings) so newly installed/enabled plugins
+// surface without a full reload — mirrors AgentEditorModal.svelte.
+let pluginRefresh = $state(0);
+
+$effect(() => {
+	const refresh = () => {
+		pluginRefresh++;
+	};
+	// @ts-ignore - app.plugins is not in the official Obsidian types
+	const pluginManager = plugin.app.plugins as
+		| { on?: (name: string, cb: () => void) => unknown; offref?: (ref: unknown) => void }
+		| undefined;
+	const changeRef = pluginManager?.on?.("changed", refresh);
+	window.addEventListener("focus", refresh);
+	return () => {
+		if (changeRef) pluginManager?.offref?.(changeRef);
+		window.removeEventListener("focus", refresh);
+	};
+});
 
 /** True when the given embed index is assigned and actually populated. */
 function indexPopulated(indexId: string | null): boolean {
@@ -26,11 +60,54 @@ const ctx = $derived({
 	hasGraph: indexPopulated(data.graphEmbedIndex),
 });
 
-const visible = $derived(filterSuggestions(ctx, data.dismissedRecommendations));
+const suggestions = $derived(filterSuggestions(ctx, data.dismissedRecommendations));
+
+// Installed+enabled plugins whose S2B integration isn't switched on for the
+// selected agent yet. Not dismissed = eligible to nudge.
+const pluginNudges = $derived.by<PluginNudge[]>(() => {
+	// Depend on the live-plugin refresh signal so this recomputes on install/enable.
+	const _refresh = pluginRefresh;
+	const integrations = plugin.agentManager?.resolvePluginIntegrations() ?? [];
+	const agent = data.getSelectedAgent();
+	const candidates: PluginNudge[] = [];
+	for (const integ of integrations) {
+		// A skill-backed integration is only actually bound to the agent when its
+		// skill state is explicitly enabled (absent = off), matching the runtime
+		// AgentManager.getEnabledPluginIds() semantics — not the editor's display
+		// default. Exec-only integrations (no skill) are on when their exec tool is.
+		const enabled = integ.skillId
+			? (agent.skills[integ.skillId]?.enabled ?? false)
+			: (agent.pluginExecTools?.[toExecToolId(integ.pluginId)] ?? false);
+		if (enabled) continue;
+		candidates.push({
+			id: pluginNudgeId(integ.pluginId),
+			pluginId: integ.pluginId,
+			displayName: integ.displayName,
+			icon: getPluginIcon(integ.pluginId),
+			skillId: integ.skillId,
+		});
+	}
+	return filterPluginNudges(candidates, data.dismissedRecommendations);
+});
+
+const hasContent = $derived(pluginNudges.length > 0 || suggestions.length > 0);
 
 function useSuggestion(s: SuggestedQuery): void {
 	// Prefill only — the input effect mirrors this into the editor and focuses.
 	registry.pendingInput = s.query ?? s.label;
+}
+
+function enablePlugin(nudge: PluginNudge): void {
+	const agent = data.getSelectedAgent();
+	// Mirror AgentEditorModal.toggleSkill/toggleAutoIntegration: enable the
+	// documenting skill when present, and grant the exec tool so the agent can
+	// script against the plugin's api.
+	if (nudge.skillId) {
+		data.setAgentSkillEnabled(agent.id, nudge.skillId, true);
+	}
+	data.setAgentPluginExecEnabled(agent.id, toExecToolId(nudge.pluginId), true);
+	new Notice(`Enabled ${nudge.displayName} for ${agent.name}.`);
+	// pluginNudges recomputes off the persisted agent state and drops this entry.
 }
 
 function dismiss(id: string): void {
@@ -38,44 +115,73 @@ function dismiss(id: string): void {
 }
 </script>
 
-{#if visible.length > 0}
-  <div class="chat-recommendations flex flex-col items-center gap-3">
-    <div class="recommendations-header flex items-center gap-2">
-      <p class="text-sm opacity-70">Try asking…</p>
-      <button
-        type="button"
-        class="dismiss-all clickable-icon"
-        aria-label="Dismiss suggestions"
-        title="Dismiss suggestions"
-        onclick={() => dismiss(DISMISS_ALL_ID)}
-      >
-        <span use:icon={"x"} style="--icon-size: 14px"></span>
-      </button>
-    </div>
-    <div class="recommendation-chips flex flex-row flex-wrap justify-center gap-1.5">
-      {#each visible as s (s.id)}
-        <div class="recommendation-chip-wrap inline-flex items-center">
-          <button
-            type="button"
-            class="recommendation-chip s2b-pill s2b-pill--interactive"
-            title={s.query ?? s.label}
-            onclick={() => useSuggestion(s)}
-          >
-            <span class="chip-icon" use:icon={s.icon} style="--icon-size: 12px"></span>
-            <span>{s.label}</span>
-          </button>
-          <button
-            type="button"
-            class="dismiss-chip clickable-icon"
-            aria-label={`Dismiss "${s.label}"`}
-            title="Dismiss this suggestion"
-            onclick={() => dismiss(s.id)}
-          >
-            <span use:icon={"x"} style="--icon-size: 11px"></span>
-          </button>
+{#if hasContent}
+  <div class="chat-recommendations flex flex-col items-center gap-5">
+    {#if pluginNudges.length > 0}
+      <div class="recommendation-group flex flex-col items-center gap-2">
+        <p class="text-sm opacity-70">Enable capabilities for your plugins</p>
+        <div class="plugin-nudges flex flex-col gap-1.5 w-full">
+          {#each pluginNudges as nudge (nudge.id)}
+            <div class="plugin-nudge flex items-center gap-2">
+              <span class="chip-icon" use:icon={nudge.icon} style="--icon-size: 14px"></span>
+              <span class="plugin-nudge-name flex-1">{nudge.displayName}</span>
+              <Button buttonText="Enable" cta onClick={() => enablePlugin(nudge)} />
+              <button
+                type="button"
+                class="dismiss-chip clickable-icon"
+                aria-label={`Dismiss ${nudge.displayName} suggestion`}
+                title="Dismiss this suggestion"
+                onclick={() => dismiss(nudge.id)}
+              >
+                <span use:icon={"x"} style="--icon-size: 12px"></span>
+              </button>
+            </div>
+          {/each}
         </div>
-      {/each}
-    </div>
+      </div>
+    {/if}
+
+    {#if suggestions.length > 0}
+      <div class="recommendation-group flex flex-col items-center gap-2">
+        <div class="recommendations-header flex items-center gap-2">
+          <p class="text-sm opacity-70">Try asking…</p>
+        </div>
+        <div class="recommendation-chips flex flex-row flex-wrap justify-center gap-1.5">
+          {#each suggestions as s (s.id)}
+            <div class="recommendation-chip-wrap inline-flex items-center">
+              <button
+                type="button"
+                class="recommendation-chip s2b-pill s2b-pill--interactive"
+                title={s.query ?? s.label}
+                onclick={() => useSuggestion(s)}
+              >
+                <span class="chip-icon" use:icon={s.icon} style="--icon-size: 12px"></span>
+                <span>{s.label}</span>
+              </button>
+              <button
+                type="button"
+                class="dismiss-chip clickable-icon"
+                aria-label={`Dismiss "${s.label}"`}
+                title="Dismiss this suggestion"
+                onclick={() => dismiss(s.id)}
+              >
+                <span use:icon={"x"} style="--icon-size: 11px"></span>
+              </button>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    <button
+      type="button"
+      class="dismiss-all clickable-icon"
+      aria-label="Dismiss all suggestions"
+      title="Dismiss all suggestions"
+      onclick={() => dismiss(DISMISS_ALL_ID)}
+    >
+      <span use:icon={"x"} style="--icon-size: 14px"></span>
+    </button>
   </div>
 {:else}
   <!-- Fallback so the empty chat view is never completely blank (all dismissed / no capability). -->
@@ -86,6 +192,22 @@ function dismiss(id: string): void {
 {/if}
 
 <style>
+  .recommendation-group {
+    max-width: 28rem;
+  }
+
+  .plugin-nudge {
+    padding: 0.35rem 0.5rem;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m);
+    background: var(--background-secondary);
+  }
+
+  .plugin-nudge-name {
+    font-size: var(--font-ui-small);
+    color: var(--text-normal);
+  }
+
   .recommendation-chip {
     --s2b-pill-bg: var(--background-secondary);
     --s2b-pill-border: var(--background-modifier-border);
@@ -109,6 +231,7 @@ function dismiss(id: string): void {
   }
 
   .recommendation-chip-wrap:hover .dismiss-chip,
+  .plugin-nudge:hover .dismiss-chip,
   .dismiss-chip:focus-visible {
     opacity: 1;
   }

--- a/src/components/chat/ChatRecommendations.svelte
+++ b/src/components/chat/ChatRecommendations.svelte
@@ -128,7 +128,7 @@ function reviewNotice(notice: UpdateNotice): void {
 	if (!mgr) return;
 	switch (notice.kind) {
 		case "system-prompt":
-			mgr.openSystemPromptDiff(notice.agentName);
+			mgr.openSystemPromptDiff(notice.agentId);
 			break;
 		case "capability":
 			if (notice.targetId) mgr.openCapabilityGuidanceDiff(notice.agentId, notice.targetId as CapabilityId);

--- a/src/components/chat/ChatRecommendations.svelte
+++ b/src/components/chat/ChatRecommendations.svelte
@@ -3,6 +3,7 @@ import { Notice } from "obsidian";
 import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
 import type { SessionRegistry } from "../../stores/chatStore.svelte";
+import type { BuiltInToolId, CapabilityId } from "../../types/plugin";
 import { useAvailableModels } from "../../hooks/useAvailableModels.svelte";
 import { getPluginIcon, toExecToolId } from "../../agent/integrations/pluginIntegrations";
 import { icon } from "../../utils/utils";
@@ -11,9 +12,11 @@ import {
 	DISMISS_ALL_ID,
 	filterPluginNudges,
 	filterSuggestions,
+	filterUpdateNotices,
 	type PluginNudge,
 	pluginNudgeId,
 	type SuggestedQuery,
+	type UpdateNotice,
 } from "./chatRecommendations";
 
 interface Props {
@@ -90,7 +93,12 @@ const pluginNudges = $derived.by<PluginNudge[]>(() => {
 	return filterPluginNudges(candidates, data.dismissedRecommendations);
 });
 
-const hasContent = $derived(pluginNudges.length > 0 || suggestions.length > 0);
+// "Updated default" notices: agents whose customized prompt/guidance couldn't be
+// auto-migrated after a default changed upstream (issue #356). staleGuidance is
+// computed once at startup, so this is a plain read (not reactive to live edits).
+const updateNotices = $derived<UpdateNotice[]>(filterUpdateNotices(data.staleGuidance, data.dismissedRecommendations));
+
+const hasContent = $derived(updateNotices.length > 0 || pluginNudges.length > 0 || suggestions.length > 0);
 
 function useSuggestion(s: SuggestedQuery): void {
 	// Prefill only — the input effect mirrors this into the editor and focuses.
@@ -113,10 +121,54 @@ function enablePlugin(nudge: PluginNudge): void {
 function dismiss(id: string): void {
 	data.dismissRecommendation(id);
 }
+
+// Opens the right diff surface for a stale-guidance notice's Review action.
+function reviewNotice(notice: UpdateNotice): void {
+	const mgr = plugin.agentManager;
+	if (!mgr) return;
+	switch (notice.kind) {
+		case "system-prompt":
+			mgr.openSystemPromptDiff(notice.agentName);
+			break;
+		case "capability":
+			if (notice.targetId) mgr.openCapabilityGuidanceDiff(notice.agentId, notice.targetId as CapabilityId);
+			break;
+		case "tool":
+			if (notice.targetId) mgr.openToolGuidanceDiff(notice.agentId, notice.targetId as BuiltInToolId);
+			break;
+	}
+}
 </script>
 
 {#if hasContent}
   <div class="chat-recommendations flex flex-col items-center gap-5">
+    {#if updateNotices.length > 0}
+      <div class="recommendation-group flex flex-col items-center gap-2">
+        <p class="text-sm opacity-70">A default was updated</p>
+        <div class="update-notices flex flex-col gap-1.5 w-full">
+          {#each updateNotices as notice (notice.id)}
+            <div class="update-notice flex items-center gap-2">
+              <span class="chip-icon" use:icon={"refresh-cw"} style="--icon-size: 14px"></span>
+              <span class="update-notice-text flex-1">
+                The default {notice.label} changed. <strong>{notice.agentName}</strong>'s customized version
+                was kept — review the diff to update it.
+              </span>
+              <Button buttonText="Review" onClick={() => reviewNotice(notice)} />
+              <button
+                type="button"
+                class="dismiss-chip clickable-icon"
+                aria-label={`Dismiss ${notice.label} update notice`}
+                title="Dismiss this notice"
+                onclick={() => dismiss(notice.id)}
+              >
+                <span use:icon={"x"} style="--icon-size: 12px"></span>
+              </button>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
     {#if pluginNudges.length > 0}
       <div class="recommendation-group flex flex-col items-center gap-2">
         <p class="text-sm opacity-70">Enable capabilities for your plugins</p>
@@ -203,6 +255,18 @@ function dismiss(id: string): void {
     background: var(--background-secondary);
   }
 
+  .update-notice {
+    padding: 0.35rem 0.5rem;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m);
+    background: var(--background-secondary);
+  }
+
+  .update-notice-text {
+    font-size: var(--font-ui-small);
+    color: var(--text-muted);
+  }
+
   .plugin-nudge-name {
     font-size: var(--font-ui-small);
     color: var(--text-normal);
@@ -232,6 +296,7 @@ function dismiss(id: string): void {
 
   .recommendation-chip-wrap:hover .dismiss-chip,
   .plugin-nudge:hover .dismiss-chip,
+  .update-notice:hover .dismiss-chip,
   .dismiss-chip:focus-visible {
     opacity: 1;
   }

--- a/src/components/chat/MessageContainer.svelte
+++ b/src/components/chat/MessageContainer.svelte
@@ -21,6 +21,7 @@ import CollapsibleUserBubble from "./CollapsibleUserBubble.svelte";
 import UserAttachmentFiles from "./UserAttachmentFiles.svelte";
 import UserAttachmentImages from "./UserAttachmentImages.svelte";
 import ToolCallsSection from "./ToolCallsSection.svelte";
+import ChatRecommendations from "./ChatRecommendations.svelte";
 import { icon } from "../../utils/utils";
 
 interface Props {
@@ -310,8 +311,7 @@ $effect(() => {
       {:else if !messages || messages.length === 0}
         <!-- Empty state -->
         <div class="flex flex-col items-center justify-center h-full">
-          <p class="text-lg mb-1">Start a new conversation</p>
-          <p class="text-sm opacity-70">Ask me anything about your notes.</p>
+          <ChatRecommendations {registry} />
         </div>
       {:else}
         {#each messages as messagePair, index (messagePair.id)}

--- a/src/components/chat/chatRecommendations.ts
+++ b/src/components/chat/chatRecommendations.ts
@@ -1,0 +1,103 @@
+/**
+ * Static catalog of new-chat recommendations and the pure gating logic used to
+ * decide which ones to show. Kept free of Svelte/Obsidian imports so it can be
+ * unit-tested in isolation and reused by future recommendation types
+ * (plugin-capability nudges, updated-prompt notices — see issue #334).
+ */
+
+/** Capability a suggestion depends on. `undefined` ⇒ always available. */
+export type SuggestionRequirement = "chat" | "search" | "graph";
+
+export interface SuggestedQuery {
+	/** Stable id, used as the dismissal key. */
+	id: string;
+	/** Lucide icon id rendered on the chip. */
+	icon: string;
+	/** Chip text; also the query prefilled into the input unless `query` is set. */
+	label: string;
+	/** Prefilled query text, when it should differ from the visible label. */
+	query?: string;
+	/** Capability gate; the suggestion is hidden unless the capability is available. */
+	requires?: SuggestionRequirement;
+}
+
+/** Well-known id used to dismiss the entire recommendations block at once. */
+export const DISMISS_ALL_ID = "suggested-queries";
+
+/** Snapshot of which capabilities are currently available in the vault. */
+export interface RecommendationContext {
+	hasChat: boolean;
+	hasSearch: boolean;
+	hasGraph: boolean;
+}
+
+/**
+ * Curated first-query suggestions. `requires` gates each on a capability so we
+ * never suggest something the user can't run (e.g. a vault-search prompt with
+ * no populated index).
+ */
+export const SUGGESTED_QUERIES: SuggestedQuery[] = [
+	{
+		id: "help-overview",
+		icon: "sparkles",
+		label: "What can you help me with?",
+	},
+	{
+		id: "summarize-recent",
+		icon: "clock",
+		label: "Summarize my recent notes",
+		requires: "search",
+	},
+	{
+		id: "find-notes",
+		icon: "search",
+		label: "Find notes about a topic",
+		query: "Find my notes about ",
+		requires: "search",
+	},
+	{
+		id: "vault-themes",
+		icon: "git-fork",
+		label: "What are the main themes in my vault?",
+		requires: "graph",
+	},
+	{
+		id: "connect-ideas",
+		icon: "network",
+		label: "Connect ideas across my notes",
+		requires: "graph",
+	},
+	{
+		id: "brainstorm",
+		icon: "lightbulb",
+		label: "Help me brainstorm ideas",
+		requires: "chat",
+	},
+];
+
+function requirementMet(requires: SuggestionRequirement | undefined, ctx: RecommendationContext): boolean {
+	switch (requires) {
+		case "chat":
+			return ctx.hasChat;
+		case "search":
+			return ctx.hasSearch;
+		case "graph":
+			return ctx.hasGraph;
+		default:
+			return true;
+	}
+}
+
+/**
+ * Returns the suggestions to display: those whose capability gate is met and
+ * that the user hasn't dismissed. If the whole block was dismissed
+ * ({@link DISMISS_ALL_ID}) the result is empty.
+ */
+export function filterSuggestions(
+	ctx: RecommendationContext,
+	dismissed: readonly string[],
+	catalog: readonly SuggestedQuery[] = SUGGESTED_QUERIES,
+): SuggestedQuery[] {
+	if (dismissed.includes(DISMISS_ALL_ID)) return [];
+	return catalog.filter((s) => requirementMet(s.requires, ctx) && !dismissed.includes(s.id));
+}

--- a/src/components/chat/chatRecommendations.ts
+++ b/src/components/chat/chatRecommendations.ts
@@ -101,3 +101,32 @@ export function filterSuggestions(
 	if (dismissed.includes(DISMISS_ALL_ID)) return [];
 	return catalog.filter((s) => requirementMet(s.requires, ctx) && !dismissed.includes(s.id));
 }
+
+/**
+ * A nudge to enable an S2B agent capability for an installed Obsidian plugin
+ * whose integration isn't switched on for the selected agent yet (issue #355).
+ */
+export interface PluginNudge {
+	/** Dismissal key, of the form `plugin:<pluginId>`. */
+	id: string;
+	pluginId: string;
+	displayName: string;
+	/** Lucide icon id (matching the plugin's own glyph where known). */
+	icon: string;
+	/** Bundled skill id documenting the plugin, when the integration has one. */
+	skillId?: string;
+}
+
+/** Dismissal key for a plugin nudge. Keep in sync with {@link PluginNudge.id}. */
+export const pluginNudgeId = (pluginId: string): string => `plugin:${pluginId}`;
+
+/**
+ * Filters plugin nudges down to those the user hasn't dismissed. The candidate
+ * list is expected to already be narrowed to installed-but-not-enabled
+ * integrations by the caller (which reads live `app.plugins` / agent state).
+ * Respects {@link DISMISS_ALL_ID} so "Dismiss all" hides plugin nudges too.
+ */
+export function filterPluginNudges(candidates: readonly PluginNudge[], dismissed: readonly string[]): PluginNudge[] {
+	if (dismissed.includes(DISMISS_ALL_ID)) return [];
+	return candidates.filter((n) => !dismissed.includes(n.id));
+}

--- a/src/components/chat/chatRecommendations.ts
+++ b/src/components/chat/chatRecommendations.ts
@@ -130,3 +130,64 @@ export function filterPluginNudges(candidates: readonly PluginNudge[], dismissed
 	if (dismissed.includes(DISMISS_ALL_ID)) return [];
 	return candidates.filter((n) => !dismissed.includes(n.id));
 }
+
+/**
+ * The kind of guidance surface a stale-guidance notice refers to. Mirrors
+ * `StaleGuidance.kind` from types/plugin — duplicated here to keep this module
+ * free of the plugin-types import (it stays pure/unit-testable).
+ */
+export type UpdateNoticeKind = "system-prompt" | "capability" | "tool";
+
+/**
+ * A notice that a built-in prompt/guidance default changed upstream while the
+ * user had a customization of the same surface, so it couldn't be auto-updated
+ * (issue #356). Sourced from the store's `staleGuidance` records.
+ */
+export interface UpdateNotice {
+	/** Dismissal key, of the form `update:<agentId>:<kind>[:<targetId>]`. */
+	id: string;
+	agentId: string;
+	agentName: string;
+	kind: UpdateNoticeKind;
+	/** CapabilityId / BuiltInToolId for capability|tool kinds; undefined for system-prompt. */
+	targetId?: string;
+	/** Human label for the surface, e.g. "Vault guidance", "web_search guidance". */
+	label: string;
+}
+
+/** Minimal shape of a store `StaleGuidance` record consumed by {@link toUpdateNotice}. */
+export interface StaleGuidanceLike {
+	agentId: string;
+	agentName: string;
+	kind: UpdateNoticeKind;
+	targetId?: string;
+	label: string;
+}
+
+/** Dismissal key for an update notice. Keep in sync with {@link UpdateNotice.id}. */
+export const updateNoticeId = (agentId: string, kind: UpdateNoticeKind, targetId?: string): string =>
+	`update:${agentId}:${kind}${targetId ? `:${targetId}` : ""}`;
+
+/** Maps a store stale-guidance record to a dismissable notice. */
+export function toUpdateNotice(record: StaleGuidanceLike): UpdateNotice {
+	return {
+		id: updateNoticeId(record.agentId, record.kind, record.targetId),
+		agentId: record.agentId,
+		agentName: record.agentName,
+		kind: record.kind,
+		targetId: record.targetId,
+		label: record.label,
+	};
+}
+
+/**
+ * Maps stale-guidance records to notices and drops the dismissed ones. Respects
+ * {@link DISMISS_ALL_ID} so "Dismiss all" hides update notices too.
+ */
+export function filterUpdateNotices(
+	records: readonly StaleGuidanceLike[],
+	dismissed: readonly string[],
+): UpdateNotice[] {
+	if (dismissed.includes(DISMISS_ALL_ID)) return [];
+	return records.map(toUpdateNotice).filter((n) => !dismissed.includes(n.id));
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -521,25 +521,10 @@ export default class SecondBrainPlugin extends Plugin {
 				void this.activateOnboardingView();
 			}
 
-			// Notify about agents whose system prompt was customized and could not be
-			// auto-updated to the latest default — show a persistent notice with a
-			// "Review diff" link that opens the modal directly on the diff tab.
-			const stale = this.pluginData.stalePromptAgentNames;
-			if (stale.length > 0) {
-				for (const agentName of stale) {
-					const notice = new Notice("", 0);
-					notice.noticeEl.empty();
-					notice.noticeEl.appendText(
-						`Smart Second Brain: the default system prompt was updated. Agent "${agentName}" has a customized prompt that was not auto-updated. `,
-					);
-					const link = notice.noticeEl.createEl("a", { text: "Review diff", href: "#" });
-					link.addEventListener("click", (e) => {
-						e.preventDefault();
-						notice.hide();
-						this.agentManager.openSystemPromptDiff(agentName);
-					});
-				}
-			}
+			// Agents whose customized prompt/guidance couldn't be auto-updated after a
+			// default changed are surfaced in the new-chat recommendations view
+			// (ChatRecommendations.svelte reads pluginData.staleGuidance), so no startup
+			// Notice here — that would double-notify.
 
 			// Start search/vector store initialization (non-blocking, fire-and-forget)
 			this.lexicalSearchService = StartupProfiler.measureSync("lexical:startInit", () =>

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -529,16 +529,18 @@ export class PluginDataStore {
 
 	/**
 	 * Guidance surfaces (base system prompt, per-capability guidance, per-tool
-	 * guidance) that a user had customized against an older default which has since
-	 * changed, so they couldn't be auto-updated. Populated once at startup; read by
-	 * the new-chat recommendations surface (and main.ts fallback) to notify the user.
+	 * guidance) whose built-in default changed while the user had a customization
+	 * stamped against an older version, so it couldn't be auto-updated. Derived
+	 * reactively from live agent state — the moment the user re-aligns a prompt (which
+	 * re-stamps its version to current), the corresponding notice disappears (#356).
 	 */
-	readonly staleGuidance: readonly StaleGuidance[];
+	get staleGuidance(): readonly StaleGuidance[] {
+		return computeStaleGuidance(this.#data.agents);
+	}
 
-	constructor(plugin: SecondBrainPlugin, initialData: PluginData, staleGuidance: StaleGuidance[] = []) {
+	constructor(plugin: SecondBrainPlugin, initialData: PluginData) {
 		this._plugin = plugin;
 		this.#data = $state(initialData);
-		this.staleGuidance = staleGuidance;
 	}
 
 	/**
@@ -924,16 +926,25 @@ export class PluginDataStore {
 			throw new Error(`Agent with ID "${agentId}" not found`);
 		}
 
-		// When capability guidance is (re)written, stamp each present capability with
-		// the current default version so normalizeAgent() can detect a later default
-		// change vs. a customization written against the current default (issue #356).
+		// Stamp guidance/prompt version to the current default whenever the user
+		// actually CHANGES the corresponding value, so detectStaleGuidance() stops
+		// reporting it (issue #356). Only changed entries are stamped — the modal
+		// submits the whole capabilityPrompts map, so blindly stamping every key would
+		// erase a sibling capability's older (stale) stamp (greptile P1).
 		let stampedUpdates = updates;
 		if (updates.capabilityPrompts) {
 			const version: Partial<Record<CapabilityId, number>> = { ...agent.capabilityPromptsVersion };
 			for (const capId of Object.keys(updates.capabilityPrompts) as CapabilityId[]) {
-				version[capId] = CAPABILITY_GUIDANCE_VERSION.get(capId) ?? 1;
+				if (updates.capabilityPrompts[capId] !== agent.capabilityPrompts?.[capId]) {
+					version[capId] = CAPABILITY_GUIDANCE_VERSION.get(capId) ?? 1;
+				}
 			}
-			stampedUpdates = { ...updates, capabilityPromptsVersion: version };
+			stampedUpdates = { ...stampedUpdates, capabilityPromptsVersion: version };
+		}
+		// A changed system prompt is re-aligned to the current default version, so a
+		// prior stale-prompt notice closes once the user edits it via the diff modal.
+		if (updates.systemPrompt !== undefined && updates.systemPrompt !== agent.systemPrompt) {
+			stampedUpdates = { ...stampedUpdates, systemPromptVersion: BASE_SYSTEM_PROMPT_VERSION };
 		}
 
 		this.#data.agents = {
@@ -1050,10 +1061,14 @@ export class PluginDataStore {
 				...agent.toolsConfig[toolId],
 				...config,
 			};
-			// Stamp the guidance version whenever promptGuidance is (re)written, so
-			// normalizeAgent() can later tell a stale-default customization from a
-			// current one (issue #356). read_content has dynamic guidance — skip it.
-			if (config.promptGuidance !== undefined && toolId !== "read_content") {
+			// Stamp the guidance version to current whenever promptGuidance actually
+			// CHANGES, so detectStaleGuidance() stops reporting a re-aligned value
+			// (issue #356). read_content has dynamic guidance — skip it.
+			if (
+				config.promptGuidance !== undefined &&
+				config.promptGuidance !== agent.toolsConfig[toolId].promptGuidance &&
+				toolId !== "read_content"
+			) {
 				next.promptGuidanceVersion = TOOL_GUIDANCE_VERSION.get(toolId) ?? 1;
 			}
 			agent.toolsConfig[toolId] = next;
@@ -2088,11 +2103,83 @@ const CAPABILITY_GUIDANCE_LABEL: Record<CapabilityId, string> = {
 };
 
 /**
- * Normalizes an agent in place and collects any built-in prompt/guidance that
- * changed upstream while the user had a customization (so it couldn't be
- * auto-migrated). Returns the stale records for that agent (empty when clean).
+ * Pure staleness detection for one agent (NO mutation). Reads the agent's current
+ * prompt/guidance values + version stamps and returns records for any built-in
+ * default that moved past the version the user's customization was stamped against.
+ * Kept separate from normalizeAgent() so the store can recompute it reactively —
+ * the moment a user re-aligns a prompt (which re-stamps the version), the matching
+ * notice disappears (issue #356). Verbatim-old-default values are treated as
+ * not-stale here because normalizeAgent() clears them to the live default on load.
  */
-function normalizeAgent(agent: AgentConfig): StaleGuidance[] {
+function detectStaleGuidance(agent: AgentConfig): StaleGuidance[] {
+	const stale: StaleGuidance[] = [];
+
+	// 1. System prompt: stale when it's a customization (not the current default and
+	//    not a verbatim historical default) whose stamped version predates the current.
+	const promptVersion = agent.systemPromptVersion ?? 0;
+	if (
+		promptVersion < BASE_SYSTEM_PROMPT_VERSION &&
+		agent.systemPrompt !== undefined &&
+		agent.systemPrompt !== BASE_SYSTEM_PROMPT &&
+		HISTORICAL_SYSTEM_PROMPTS.get(promptVersion) !== agent.systemPrompt
+	) {
+		stale.push({ agentId: agent.id, agentName: agent.name, kind: "system-prompt", label: "system prompt" });
+	}
+
+	// 2. Capability guidance: stale when customized (not a verbatim historical default)
+	//    and stamped against an older version than the one currently shipped.
+	if (agent.capabilityPrompts) {
+		for (const [capId, historicalSet] of HISTORICAL_CAPABILITY_GUIDANCE) {
+			const stored = agent.capabilityPrompts[capId];
+			if (stored === undefined || historicalSet.has(stored)) continue;
+			const storedVersion =
+				agent.capabilityPromptsVersion?.[capId] ?? CAPABILITY_GUIDANCE_VERSION.get(capId) ?? 1;
+			if (storedVersion < (CAPABILITY_GUIDANCE_VERSION.get(capId) ?? 1)) {
+				stale.push({
+					agentId: agent.id,
+					agentName: agent.name,
+					kind: "capability",
+					targetId: capId,
+					label: CAPABILITY_GUIDANCE_LABEL[capId],
+				});
+			}
+		}
+	}
+
+	// 3. Per-tool guidance: same pattern. read_content is dynamic — handled elsewhere.
+	for (const [toolId, historicalSet] of HISTORICAL_TOOL_GUIDANCE) {
+		const toolCfg = agent.toolsConfig?.[toolId];
+		if (toolCfg?.promptGuidance === undefined || historicalSet.has(toolCfg.promptGuidance)) continue;
+		const storedVersion = toolCfg.promptGuidanceVersion ?? TOOL_GUIDANCE_VERSION.get(toolId) ?? 1;
+		if (storedVersion < (TOOL_GUIDANCE_VERSION.get(toolId) ?? 1)) {
+			stale.push({
+				agentId: agent.id,
+				agentName: agent.name,
+				kind: "tool",
+				targetId: toolId,
+				label: `${toolId} guidance`,
+			});
+		}
+	}
+
+	return stale;
+}
+
+/** Aggregates {@link detectStaleGuidance} across all agents (pure, no mutation). */
+function computeStaleGuidance(agents: AgentsConfig): StaleGuidance[] {
+	const stale: StaleGuidance[] = [];
+	for (const agent of Object.values(agents)) stale.push(...detectStaleGuidance(agent));
+	return stale;
+}
+
+/**
+ * Normalizes an agent in place: fills defaults, and auto-migrates prompt/guidance
+ * that still matches an OLD default verbatim up to the current default. Crucially it
+ * does NOT advance the version stamp of a *customized* stale value — that stamp is
+ * the durable signal detectStaleGuidance() reads, so bumping it here would silently
+ * consume the "review this" state before the user ever saw it (issue #356).
+ */
+function normalizeAgent(agent: AgentConfig): void {
 	// Ensure toolsConfig exists and has all tools
 	if (agent.toolsConfig) {
 		agent.toolsConfig = { ...structuredClone(DEFAULT_TOOLS_CONFIG), ...agent.toolsConfig };
@@ -2113,29 +2200,28 @@ function normalizeAgent(agent: AgentConfig): StaleGuidance[] {
 	agent.mcpServers ??= {};
 	agent.pluginExecTools ??= {};
 
-	const stale: StaleGuidance[] = [];
+	// --- Prompt auto-migration (mutations only; staleness is detected separately) ---
 
-	// --- Prompt auto-migration ---
-
-	// 1. System prompt: silently update to current default if the stored prompt still
-	//    matches an old default verbatim; leave custom prompts untouched and flag them
-	//    stale (so callers can notify the user).
+	// 1. System prompt: if the stored prompt still matches an old default verbatim,
+	//    silently upgrade it to the current default and advance the version stamp. A
+	//    *customized* stale prompt is left fully untouched — including its old version
+	//    stamp — so detectStaleGuidance() keeps reporting it until the user re-aligns
+	//    it (bumping the stamp here would consume that signal before it's seen).
 	const storedPromptVersion = agent.systemPromptVersion ?? 0;
 	if (storedPromptVersion < BASE_SYSTEM_PROMPT_VERSION) {
 		const historicalDefault = HISTORICAL_SYSTEM_PROMPTS.get(storedPromptVersion);
-		if (!historicalDefault || agent.systemPrompt === historicalDefault) {
+		if (agent.systemPrompt === undefined || !historicalDefault || agent.systemPrompt === historicalDefault) {
 			agent.systemPrompt = BASE_SYSTEM_PROMPT;
-		} else {
-			stale.push({ agentId: agent.id, agentName: agent.name, kind: "system-prompt", label: "system prompt" });
+			agent.systemPromptVersion = BASE_SYSTEM_PROMPT_VERSION;
 		}
-		agent.systemPromptVersion = BASE_SYSTEM_PROMPT_VERSION;
+		// else: customized old-version prompt — leave prompt AND version as-is (stale).
 	}
 	agent.systemPrompt ??= BASE_SYSTEM_PROMPT;
 	agent.systemPromptVersion ??= BASE_SYSTEM_PROMPT_VERSION;
 
 	// 2. Capability prompts: if the stored value is a verbatim historical default,
-	//    delete the key so the live default is used going forward. If it's a
-	//    customization stamped against an older version, flag it stale.
+	//    delete the key so the live default is used going forward. Customized values
+	//    are left untouched (their staleness is reported by detectStaleGuidance).
 	if (agent.capabilityPrompts) {
 		for (const [capId, historicalSet] of HISTORICAL_CAPABILITY_GUIDANCE) {
 			const stored = agent.capabilityPrompts[capId];
@@ -2143,21 +2229,6 @@ function normalizeAgent(agent: AgentConfig): StaleGuidance[] {
 			if (historicalSet.has(stored)) {
 				delete agent.capabilityPrompts[capId];
 				if (agent.capabilityPromptsVersion) delete agent.capabilityPromptsVersion[capId];
-				continue;
-			}
-			// Customized value: flag stale only when it was stamped against an older
-			// default version than the one currently shipped (absent stamp = treated
-			// as current — pre-versioning data is seeded by the v2→v3 migration).
-			const storedVersion =
-				agent.capabilityPromptsVersion?.[capId] ?? CAPABILITY_GUIDANCE_VERSION.get(capId) ?? 1;
-			if (storedVersion < (CAPABILITY_GUIDANCE_VERSION.get(capId) ?? 1)) {
-				stale.push({
-					agentId: agent.id,
-					agentName: agent.name,
-					kind: "capability",
-					targetId: capId,
-					label: CAPABILITY_GUIDANCE_LABEL[capId],
-				});
 			}
 		}
 	}
@@ -2170,33 +2241,19 @@ function normalizeAgent(agent: AgentConfig): StaleGuidance[] {
 		if (historicalSet.has(toolCfg.promptGuidance)) {
 			toolCfg.promptGuidance = undefined;
 			toolCfg.promptGuidanceVersion = undefined;
-			continue;
-		}
-		const storedVersion = toolCfg.promptGuidanceVersion ?? TOOL_GUIDANCE_VERSION.get(toolId) ?? 1;
-		if (storedVersion < (TOOL_GUIDANCE_VERSION.get(toolId) ?? 1)) {
-			stale.push({
-				agentId: agent.id,
-				agentName: agent.name,
-				kind: "tool",
-				targetId: toolId,
-				label: `${toolId} guidance`,
-			});
 		}
 	}
 
 	agent.summarizationModel ??= null;
 	agent.titleModel ??= null;
-	return stale;
 }
 
-function normalizeAgents(mergedData: PluginData): StaleGuidance[] {
+function normalizeAgents(mergedData: PluginData): void {
 	if (!mergedData.agents[DEFAULT_AGENT_ID]) {
 		mergedData.agents[DEFAULT_AGENT_ID] = createDefaultAgent();
 	}
-	const stale: StaleGuidance[] = [];
 	for (const agentId of Object.keys(mergedData.agents)) {
-		const agent = mergedData.agents[agentId];
-		stale.push(...normalizeAgent(agent));
+		normalizeAgent(mergedData.agents[agentId]);
 	}
 	// Ensure defaultAgentId is valid
 	if (mergedData.defaultAgentId !== null && !mergedData.agents[mergedData.defaultAgentId]) {
@@ -2205,7 +2262,6 @@ function normalizeAgents(mergedData: PluginData): StaleGuidance[] {
 	if (!mergedData.selectedAgentId || !mergedData.agents[mergedData.selectedAgentId]) {
 		mergedData.selectedAgentId = mergedData.defaultAgentId ?? DEFAULT_AGENT_ID;
 	}
-	return stale;
 }
 
 export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataStore> {
@@ -2225,7 +2281,6 @@ export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataS
 	// mutations would be persisted on the next save, corrupting the newer state.
 	const fromNewerPlugin = (rawData?.schemaVersion ?? 0) > CURRENT_SCHEMA_VERSION;
 
-	let staleGuidance: StaleGuidance[] = [];
 	if (fromNewerPlugin) {
 		// Leave agents untouched; just ensure the bare minimum so the UI doesn't crash.
 		if (!mergedData.agents || Object.keys(mergedData.agents).length === 0) {
@@ -2238,7 +2293,7 @@ export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataS
 		mergedData.defaultAgentId = DEFAULT_AGENT_ID;
 		mergedData.selectedAgentId = DEFAULT_AGENT_ID;
 	} else {
-		staleGuidance = normalizeAgents(mergedData);
+		normalizeAgents(mergedData);
 	}
 
 	// Resolve vault slug once on first load; persisted so vault renames don't orphan indexes
@@ -2246,7 +2301,7 @@ export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataS
 		mergedData.vaultSlug = await resolveVaultSlug(plugin.app.vault.getName());
 	}
 
-	_pluginDataStore = new PluginDataStore(plugin, mergedData, staleGuidance);
+	_pluginDataStore = new PluginDataStore(plugin, mergedData);
 
 	return _pluginDataStore;
 }

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -465,6 +465,7 @@ export const DEFAULT_SETTINGS: PluginData = {
 	lastActiveChatId: null,
 	onboardingComplete: false,
 	onboardingSplashSeen: false,
+	dismissedRecommendations: [],
 
 	// Debugging & telemetry
 	enableLangSmith: false,
@@ -1228,6 +1229,20 @@ export class PluginDataStore {
 	set onboardingSplashSeen(val: boolean) {
 		this.#data.onboardingSplashSeen = val;
 		this.saveSettings();
+	}
+
+	get dismissedRecommendations() {
+		return this.#data.dismissedRecommendations;
+	}
+	isRecommendationDismissed(id: string) {
+		return this.#data.dismissedRecommendations.includes(id);
+	}
+	dismissRecommendation(id: string) {
+		if (!this.#data.dismissedRecommendations.includes(id)) {
+			// Reassign (not push) so $state reactivity fires.
+			this.#data.dismissedRecommendations = [...this.#data.dismissedRecommendations, id];
+			this.saveSettings();
+		}
 	}
 
 	get searchAlgorithm() {

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -2,9 +2,11 @@ import { normalizePath } from "obsidian";
 import {
 	BASE_SYSTEM_PROMPT,
 	BASE_SYSTEM_PROMPT_VERSION,
+	CAPABILITY_GUIDANCE_VERSION,
 	HISTORICAL_CAPABILITY_GUIDANCE,
 	HISTORICAL_SYSTEM_PROMPTS,
 	HISTORICAL_TOOL_GUIDANCE,
+	TOOL_GUIDANCE_VERSION,
 } from "../agent/prompts";
 import {
 	createEmptySpaceFilter,
@@ -20,6 +22,7 @@ import type {
 	AgentSkillState,
 	AgentsConfig,
 	BuiltInToolId,
+	CapabilityId,
 	DefaultEmbedModel,
 	ChatOpenLocation,
 	DiffViewMode,
@@ -31,6 +34,7 @@ import type {
 	PrivacyMode,
 	RecentNoteEntry,
 	SearchAlgorithm,
+	StaleGuidance,
 	ToolConfig,
 	ToolsConfig,
 } from "../types/plugin";
@@ -408,7 +412,7 @@ function createDefaultAgent(): AgentConfig {
 // ---------------------------------------------------------------------------
 
 /** Increment this when making any breaking change to PluginData. Add a corresponding entry to MIGRATIONS. */
-const CURRENT_SCHEMA_VERSION = 2;
+const CURRENT_SCHEMA_VERSION = 3;
 
 type Migration = (data: PluginData) => void;
 
@@ -422,6 +426,26 @@ const MIGRATIONS: Migration[] = [
 	// v1 → v2: prompt auto-migration added — logic lives in normalizeAgent() which
 	//           runs on every load; the version bump marks that the tracking fields exist
 	(_data) => {},
+	// v2 → v3: per-capability / per-tool guidance version stamps added (issue #356).
+	//          Seed every EXISTING customized guidance value to the current version so
+	//          pre-existing customizations aren't retroactively flagged as "the default
+	//          changed" — staleness detection only applies to changes made from here on.
+	(data) => {
+		for (const agent of Object.values(data.agents ?? {})) {
+			if (agent.capabilityPrompts) {
+				const version: Partial<Record<CapabilityId, number>> = { ...agent.capabilityPromptsVersion };
+				for (const capId of Object.keys(agent.capabilityPrompts) as CapabilityId[]) {
+					version[capId] ??= CAPABILITY_GUIDANCE_VERSION.get(capId) ?? 1;
+				}
+				agent.capabilityPromptsVersion = version;
+			}
+			for (const [toolId, toolCfg] of Object.entries(agent.toolsConfig ?? {})) {
+				if (toolCfg?.promptGuidance !== undefined && toolCfg.promptGuidanceVersion === undefined) {
+					toolCfg.promptGuidanceVersion = TOOL_GUIDANCE_VERSION.get(toolId as BuiltInToolId) ?? 1;
+				}
+			}
+		}
+	},
 ];
 
 function runMigrations(data: PluginData): void {
@@ -504,16 +528,17 @@ export class PluginDataStore {
 	private readonly _plugin: SecondBrainPlugin;
 
 	/**
-	 * Agent names whose system prompt was customized and could not be auto-updated
-	 * to the latest default. Populated once at startup; read by main.ts to surface
-	 * a one-time Notice after the workspace is ready.
+	 * Guidance surfaces (base system prompt, per-capability guidance, per-tool
+	 * guidance) that a user had customized against an older default which has since
+	 * changed, so they couldn't be auto-updated. Populated once at startup; read by
+	 * the new-chat recommendations surface (and main.ts fallback) to notify the user.
 	 */
-	readonly stalePromptAgentNames: readonly string[];
+	readonly staleGuidance: readonly StaleGuidance[];
 
-	constructor(plugin: SecondBrainPlugin, initialData: PluginData, stalePromptAgentNames: string[] = []) {
+	constructor(plugin: SecondBrainPlugin, initialData: PluginData, staleGuidance: StaleGuidance[] = []) {
 		this._plugin = plugin;
 		this.#data = $state(initialData);
-		this.stalePromptAgentNames = stalePromptAgentNames;
+		this.staleGuidance = staleGuidance;
 	}
 
 	/**
@@ -899,11 +924,23 @@ export class PluginDataStore {
 			throw new Error(`Agent with ID "${agentId}" not found`);
 		}
 
+		// When capability guidance is (re)written, stamp each present capability with
+		// the current default version so normalizeAgent() can detect a later default
+		// change vs. a customization written against the current default (issue #356).
+		let stampedUpdates = updates;
+		if (updates.capabilityPrompts) {
+			const version: Partial<Record<CapabilityId, number>> = { ...agent.capabilityPromptsVersion };
+			for (const capId of Object.keys(updates.capabilityPrompts) as CapabilityId[]) {
+				version[capId] = CAPABILITY_GUIDANCE_VERSION.get(capId) ?? 1;
+			}
+			stampedUpdates = { ...updates, capabilityPromptsVersion: version };
+		}
+
 		this.#data.agents = {
 			...this.#data.agents,
 			[agentId]: {
 				...agent,
-				...updates,
+				...stampedUpdates,
 			},
 		};
 		this.saveSettings();
@@ -1009,10 +1046,17 @@ export class PluginDataStore {
 	updateAgentToolConfig(agentId: string, toolId: BuiltInToolId, config: Partial<ToolConfig>): void {
 		const agent = this.#data.agents[agentId];
 		if (agent?.toolsConfig[toolId]) {
-			agent.toolsConfig[toolId] = {
+			const next: ToolConfig = {
 				...agent.toolsConfig[toolId],
 				...config,
 			};
+			// Stamp the guidance version whenever promptGuidance is (re)written, so
+			// normalizeAgent() can later tell a stale-default customization from a
+			// current one (issue #356). read_content has dynamic guidance — skip it.
+			if (config.promptGuidance !== undefined && toolId !== "read_content") {
+				next.promptGuidanceVersion = TOOL_GUIDANCE_VERSION.get(toolId) ?? 1;
+			}
+			agent.toolsConfig[toolId] = next;
 			this.saveSettings();
 		}
 	}
@@ -2037,7 +2081,18 @@ export class PluginDataStore {
 
 let _pluginDataStore: PluginDataStore | null = null;
 
-function normalizeAgent(agent: AgentConfig): boolean {
+/** Human label for a capability's guidance, shown in the "updated" notice. */
+const CAPABILITY_GUIDANCE_LABEL: Record<CapabilityId, string> = {
+	vault: "Vault guidance",
+	web: "Web guidance",
+};
+
+/**
+ * Normalizes an agent in place and collects any built-in prompt/guidance that
+ * changed upstream while the user had a customization (so it couldn't be
+ * auto-migrated). Returns the stale records for that agent (empty when clean).
+ */
+function normalizeAgent(agent: AgentConfig): StaleGuidance[] {
 	// Ensure toolsConfig exists and has all tools
 	if (agent.toolsConfig) {
 		agent.toolsConfig = { ...structuredClone(DEFAULT_TOOLS_CONFIG), ...agent.toolsConfig };
@@ -2058,19 +2113,20 @@ function normalizeAgent(agent: AgentConfig): boolean {
 	agent.mcpServers ??= {};
 	agent.pluginExecTools ??= {};
 
+	const stale: StaleGuidance[] = [];
+
 	// --- Prompt auto-migration ---
 
 	// 1. System prompt: silently update to current default if the stored prompt still
-	//    matches an old default verbatim; leave custom prompts untouched.
-	//    Returns true when a custom prompt is stale (so callers can notify the user).
-	let hasStaleCustomPrompt = false;
+	//    matches an old default verbatim; leave custom prompts untouched and flag them
+	//    stale (so callers can notify the user).
 	const storedPromptVersion = agent.systemPromptVersion ?? 0;
 	if (storedPromptVersion < BASE_SYSTEM_PROMPT_VERSION) {
 		const historicalDefault = HISTORICAL_SYSTEM_PROMPTS.get(storedPromptVersion);
 		if (!historicalDefault || agent.systemPrompt === historicalDefault) {
 			agent.systemPrompt = BASE_SYSTEM_PROMPT;
 		} else {
-			hasStaleCustomPrompt = true;
+			stale.push({ agentId: agent.id, agentName: agent.name, kind: "system-prompt", label: "system prompt" });
 		}
 		agent.systemPromptVersion = BASE_SYSTEM_PROMPT_VERSION;
 	}
@@ -2078,12 +2134,30 @@ function normalizeAgent(agent: AgentConfig): boolean {
 	agent.systemPromptVersion ??= BASE_SYSTEM_PROMPT_VERSION;
 
 	// 2. Capability prompts: if the stored value is a verbatim historical default,
-	//    delete the key so the live default is used going forward.
+	//    delete the key so the live default is used going forward. If it's a
+	//    customization stamped against an older version, flag it stale.
 	if (agent.capabilityPrompts) {
 		for (const [capId, historicalSet] of HISTORICAL_CAPABILITY_GUIDANCE) {
 			const stored = agent.capabilityPrompts[capId];
-			if (stored !== undefined && historicalSet.has(stored)) {
+			if (stored === undefined) continue;
+			if (historicalSet.has(stored)) {
 				delete agent.capabilityPrompts[capId];
+				if (agent.capabilityPromptsVersion) delete agent.capabilityPromptsVersion[capId];
+				continue;
+			}
+			// Customized value: flag stale only when it was stamped against an older
+			// default version than the one currently shipped (absent stamp = treated
+			// as current — pre-versioning data is seeded by the v2→v3 migration).
+			const storedVersion =
+				agent.capabilityPromptsVersion?.[capId] ?? CAPABILITY_GUIDANCE_VERSION.get(capId) ?? 1;
+			if (storedVersion < (CAPABILITY_GUIDANCE_VERSION.get(capId) ?? 1)) {
+				stale.push({
+					agentId: agent.id,
+					agentName: agent.name,
+					kind: "capability",
+					targetId: capId,
+					label: CAPABILITY_GUIDANCE_LABEL[capId],
+				});
 			}
 		}
 	}
@@ -2092,26 +2166,37 @@ function normalizeAgent(agent: AgentConfig): boolean {
 	//    by READ_CONTENT_GUIDANCE_DEFAULTS elsewhere; skip it here.
 	for (const [toolId, historicalSet] of HISTORICAL_TOOL_GUIDANCE) {
 		const toolCfg = agent.toolsConfig[toolId];
-		if (toolCfg?.promptGuidance !== undefined && historicalSet.has(toolCfg.promptGuidance)) {
+		if (toolCfg?.promptGuidance === undefined) continue;
+		if (historicalSet.has(toolCfg.promptGuidance)) {
 			toolCfg.promptGuidance = undefined;
+			toolCfg.promptGuidanceVersion = undefined;
+			continue;
+		}
+		const storedVersion = toolCfg.promptGuidanceVersion ?? TOOL_GUIDANCE_VERSION.get(toolId) ?? 1;
+		if (storedVersion < (TOOL_GUIDANCE_VERSION.get(toolId) ?? 1)) {
+			stale.push({
+				agentId: agent.id,
+				agentName: agent.name,
+				kind: "tool",
+				targetId: toolId,
+				label: `${toolId} guidance`,
+			});
 		}
 	}
 
 	agent.summarizationModel ??= null;
 	agent.titleModel ??= null;
-	return hasStaleCustomPrompt;
+	return stale;
 }
 
-function normalizeAgents(mergedData: PluginData): string[] {
+function normalizeAgents(mergedData: PluginData): StaleGuidance[] {
 	if (!mergedData.agents[DEFAULT_AGENT_ID]) {
 		mergedData.agents[DEFAULT_AGENT_ID] = createDefaultAgent();
 	}
-	const staleAgentNames: string[] = [];
+	const stale: StaleGuidance[] = [];
 	for (const agentId of Object.keys(mergedData.agents)) {
 		const agent = mergedData.agents[agentId];
-		if (normalizeAgent(agent)) {
-			staleAgentNames.push(agent.name);
-		}
+		stale.push(...normalizeAgent(agent));
 	}
 	// Ensure defaultAgentId is valid
 	if (mergedData.defaultAgentId !== null && !mergedData.agents[mergedData.defaultAgentId]) {
@@ -2120,7 +2205,7 @@ function normalizeAgents(mergedData: PluginData): string[] {
 	if (!mergedData.selectedAgentId || !mergedData.agents[mergedData.selectedAgentId]) {
 		mergedData.selectedAgentId = mergedData.defaultAgentId ?? DEFAULT_AGENT_ID;
 	}
-	return staleAgentNames;
+	return stale;
 }
 
 export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataStore> {
@@ -2140,7 +2225,7 @@ export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataS
 	// mutations would be persisted on the next save, corrupting the newer state.
 	const fromNewerPlugin = (rawData?.schemaVersion ?? 0) > CURRENT_SCHEMA_VERSION;
 
-	let stalePromptAgentNames: string[] = [];
+	let staleGuidance: StaleGuidance[] = [];
 	if (fromNewerPlugin) {
 		// Leave agents untouched; just ensure the bare minimum so the UI doesn't crash.
 		if (!mergedData.agents || Object.keys(mergedData.agents).length === 0) {
@@ -2153,7 +2238,7 @@ export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataS
 		mergedData.defaultAgentId = DEFAULT_AGENT_ID;
 		mergedData.selectedAgentId = DEFAULT_AGENT_ID;
 	} else {
-		stalePromptAgentNames = normalizeAgents(mergedData);
+		staleGuidance = normalizeAgents(mergedData);
 	}
 
 	// Resolve vault slug once on first load; persisted so vault renames don't orphan indexes
@@ -2161,7 +2246,7 @@ export async function createData(plugin: SecondBrainPlugin): Promise<PluginDataS
 		mergedData.vaultSlug = await resolveVaultSlug(plugin.app.vault.getName());
 	}
 
-	_pluginDataStore = new PluginDataStore(plugin, mergedData, stalePromptAgentNames);
+	_pluginDataStore = new PluginDataStore(plugin, mergedData, staleGuidance);
 
 	return _pluginDataStore;
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -142,6 +142,22 @@ export const VAULT_TOOL_IDS = BUILT_IN_TOOL_IDS.filter(
 export type CapabilityId = "vault" | "web";
 
 /**
+ * A built-in prompt or guidance default that changed in a plugin update while the
+ * user had a customized version, so it couldn't be auto-migrated. Surfaced as a
+ * dismissable "updated" notice in the new-chat recommendations surface (issue #356).
+ */
+export interface StaleGuidance {
+	agentId: string;
+	agentName: string;
+	/** Which surface is stale. */
+	kind: "system-prompt" | "capability" | "tool";
+	/** CapabilityId (kind "capability") or BuiltInToolId (kind "tool"); absent for the base prompt. */
+	targetId?: string;
+	/** Human-readable label for the notice, e.g. "system prompt", "Vault guidance", "web_search guidance". */
+	label: string;
+}
+
+/**
  * Definition of a built-in capability. Single source of truth shared by the editor UI
  * (which renders one card per capability) and `AgentManager.assembleSystemPrompt` (which
  * renders one `#` section per capability with its tools nested as `##` subheaders) so the
@@ -268,6 +284,12 @@ export interface ToolConfig {
 	description: string;
 	/** Optional prompt-only guidance injected into the assembled system prompt when this tool is enabled */
 	promptGuidance?: string;
+	/**
+	 * Which TOOL_GUIDANCE_VERSION `promptGuidance` was written against, stamped at
+	 * save time. Enables the same stale-default detection as capabilityPromptsVersion
+	 * (issue #356). Absent = pre-versioning (treated as current on first load).
+	 */
+	promptGuidanceVersion?: number;
 	/** Tool-specific settings */
 	settings?: ToolSpecificSettings;
 }
@@ -465,6 +487,13 @@ export interface AgentConfig {
 	 * pencil-edit; absent falls back to `buildDefaultCapabilityGuidance(id)`.
 	 */
 	capabilityPrompts?: Partial<Record<CapabilityId, string>>;
+	/**
+	 * Which CAPABILITY_GUIDANCE_VERSION each customized `capabilityPrompts` entry
+	 * was written against, stamped at save time. Lets normalizeAgent() detect when
+	 * the shipped default has moved since the user customized it (issue #356).
+	 * Absent for a capability = pre-versioning (treated as current on first load).
+	 */
+	capabilityPromptsVersion?: Partial<Record<CapabilityId, number>>;
 }
 
 /**

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -524,6 +524,8 @@ export interface PluginData {
 	onboardingComplete: boolean;
 	/** Whether the onboarding splash intro animation has already played (so it plays only once). */
 	onboardingSplashSeen: boolean;
+	/** IDs of new-chat recommendations the user has dismissed. Includes the well-known block id to dismiss the whole surface. */
+	dismissedRecommendations: string[];
 
 	// ============================================================================
 	// Web Search

--- a/test/components/chatRecommendations.test.ts
+++ b/test/components/chatRecommendations.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
 	DISMISS_ALL_ID,
+	filterPluginNudges,
 	filterSuggestions,
+	type PluginNudge,
+	pluginNudgeId,
 	type RecommendationContext,
 	type SuggestedQuery,
 	SUGGESTED_QUERIES,
@@ -62,5 +65,33 @@ describe("SUGGESTED_QUERIES catalog", () => {
 
 	it("does not reuse the whole-block dismissal id for any suggestion", () => {
 		expect(SUGGESTED_QUERIES.some((s) => s.id === DISMISS_ALL_ID)).toBe(false);
+	});
+});
+
+describe("plugin nudges", () => {
+	const nudge = (pluginId: string): PluginNudge => ({
+		id: pluginNudgeId(pluginId),
+		pluginId,
+		displayName: pluginId,
+		icon: "puzzle",
+	});
+
+	it("builds a `plugin:<id>` dismissal key", () => {
+		expect(pluginNudgeId("dataview")).toBe("plugin:dataview");
+	});
+
+	it("keeps candidates that are not dismissed", () => {
+		const nudges = [nudge("dataview"), nudge("tasknotes")];
+		expect(filterPluginNudges(nudges, []).map((n) => n.pluginId)).toEqual(["dataview", "tasknotes"]);
+	});
+
+	it("drops a nudge whose id is dismissed", () => {
+		const nudges = [nudge("dataview"), nudge("tasknotes")];
+		const visible = filterPluginNudges(nudges, [pluginNudgeId("dataview")]);
+		expect(visible.map((n) => n.pluginId)).toEqual(["tasknotes"]);
+	});
+
+	it("returns nothing when the whole block is dismissed", () => {
+		expect(filterPluginNudges([nudge("dataview")], [DISMISS_ALL_ID])).toEqual([]);
 	});
 });

--- a/test/components/chatRecommendations.test.ts
+++ b/test/components/chatRecommendations.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+	DISMISS_ALL_ID,
+	filterSuggestions,
+	type RecommendationContext,
+	type SuggestedQuery,
+	SUGGESTED_QUERIES,
+} from "../../src/components/chat/chatRecommendations";
+
+const ALL: RecommendationContext = { hasChat: true, hasSearch: true, hasGraph: true };
+const NONE: RecommendationContext = { hasChat: false, hasSearch: false, hasGraph: false };
+
+const CATALOG: SuggestedQuery[] = [
+	{ id: "always", icon: "sparkles", label: "Always" },
+	{ id: "chat", icon: "lightbulb", label: "Chat", requires: "chat" },
+	{ id: "search", icon: "search", label: "Search", requires: "search" },
+	{ id: "graph", icon: "network", label: "Graph", requires: "graph" },
+];
+
+const ids = (list: SuggestedQuery[]) => list.map((s) => s.id);
+
+describe("filterSuggestions — capability gating", () => {
+	it("keeps ungated suggestions regardless of context", () => {
+		expect(ids(filterSuggestions(NONE, [], CATALOG))).toContain("always");
+	});
+
+	it("hides gated suggestions when the capability is unavailable", () => {
+		const visible = ids(filterSuggestions(NONE, [], CATALOG));
+		expect(visible).toEqual(["always"]);
+	});
+
+	it("shows gated suggestions when the capability is available", () => {
+		expect(ids(filterSuggestions(ALL, [], CATALOG))).toEqual(["always", "chat", "search", "graph"]);
+	});
+
+	it("gates each capability independently", () => {
+		const searchOnly: RecommendationContext = { hasChat: false, hasSearch: true, hasGraph: false };
+		expect(ids(filterSuggestions(searchOnly, [], CATALOG))).toEqual(["always", "search"]);
+	});
+});
+
+describe("filterSuggestions — dismissal", () => {
+	it("excludes a dismissed suggestion by id", () => {
+		expect(ids(filterSuggestions(ALL, ["search"], CATALOG))).not.toContain("search");
+	});
+
+	it("returns nothing when the whole block is dismissed", () => {
+		expect(filterSuggestions(ALL, [DISMISS_ALL_ID], CATALOG)).toEqual([]);
+	});
+
+	it("combines gating and per-item dismissal", () => {
+		const searchOnly: RecommendationContext = { hasChat: false, hasSearch: true, hasGraph: false };
+		expect(ids(filterSuggestions(searchOnly, ["always"], CATALOG))).toEqual(["search"]);
+	});
+});
+
+describe("SUGGESTED_QUERIES catalog", () => {
+	it("has unique ids", () => {
+		const seen = new Set(SUGGESTED_QUERIES.map((s) => s.id));
+		expect(seen.size).toBe(SUGGESTED_QUERIES.length);
+	});
+
+	it("does not reuse the whole-block dismissal id for any suggestion", () => {
+		expect(SUGGESTED_QUERIES.some((s) => s.id === DISMISS_ALL_ID)).toBe(false);
+	});
+});

--- a/test/components/chatRecommendations.test.ts
+++ b/test/components/chatRecommendations.test.ts
@@ -3,11 +3,14 @@ import {
 	DISMISS_ALL_ID,
 	filterPluginNudges,
 	filterSuggestions,
+	filterUpdateNotices,
 	type PluginNudge,
 	pluginNudgeId,
 	type RecommendationContext,
+	type StaleGuidanceLike,
 	type SuggestedQuery,
 	SUGGESTED_QUERIES,
+	updateNoticeId,
 } from "../../src/components/chat/chatRecommendations";
 
 const ALL: RecommendationContext = { hasChat: true, hasSearch: true, hasGraph: true };
@@ -93,5 +96,59 @@ describe("plugin nudges", () => {
 
 	it("returns nothing when the whole block is dismissed", () => {
 		expect(filterPluginNudges([nudge("dataview")], [DISMISS_ALL_ID])).toEqual([]);
+	});
+});
+
+describe("update notices", () => {
+	const sys: StaleGuidanceLike = {
+		agentId: "a1",
+		agentName: "Default",
+		kind: "system-prompt",
+		label: "system prompt",
+	};
+	const cap: StaleGuidanceLike = {
+		agentId: "a1",
+		agentName: "Default",
+		kind: "capability",
+		targetId: "vault",
+		label: "Vault guidance",
+	};
+	const tool: StaleGuidanceLike = {
+		agentId: "a2",
+		agentName: "Researcher",
+		kind: "tool",
+		targetId: "web_search",
+		label: "web_search guidance",
+	};
+
+	it("builds `update:<agentId>:<kind>` for system-prompt (no targetId)", () => {
+		expect(updateNoticeId("a1", "system-prompt")).toBe("update:a1:system-prompt");
+	});
+
+	it("builds `update:<agentId>:<kind>:<targetId>` when a targetId is present", () => {
+		expect(updateNoticeId("a1", "capability", "vault")).toBe("update:a1:capability:vault");
+	});
+
+	it("maps records to notices with matching ids", () => {
+		const notices = filterUpdateNotices([sys, cap, tool], []);
+		expect(notices.map((n) => n.id)).toEqual([
+			"update:a1:system-prompt",
+			"update:a1:capability:vault",
+			"update:a2:tool:web_search",
+		]);
+	});
+
+	it("drops a notice whose id is dismissed", () => {
+		const visible = filterUpdateNotices([sys, cap], [updateNoticeId("a1", "capability", "vault")]);
+		expect(visible.map((n) => n.id)).toEqual(["update:a1:system-prompt"]);
+	});
+
+	it("returns nothing when the whole block is dismissed", () => {
+		expect(filterUpdateNotices([sys, cap, tool], [DISMISS_ALL_ID])).toEqual([]);
+	});
+
+	it("carries agentName/label/targetId through to the notice", () => {
+		const [notice] = filterUpdateNotices([cap], []);
+		expect(notice).toMatchObject({ agentName: "Default", label: "Vault guidance", targetId: "vault" });
 	});
 });

--- a/test/stores/dataStore.test.ts
+++ b/test/stores/dataStore.test.ts
@@ -39,6 +39,7 @@ import {
 } from "../../src/stores/dataStore.svelte";
 import { compileSpaceMembershipDraft } from "../../src/lib/views";
 import type { StoredProviderState } from "../../src/stores/dataStore.svelte";
+import { CAPABILITY_GUIDANCE_VERSION, TOOL_GUIDANCE_VERSION } from "../../src/agent/prompts";
 
 /* --------------------------------------------------------------------------
  * Helpers
@@ -457,6 +458,113 @@ describe("createData", () => {
 
 		const store = await createData(plugin as never);
 		expect(store.getAgent(DEFAULT_AGENT_ID)?.summarizationModel).toBeNull();
+	});
+});
+
+/* --------------------------------------------------------------------------
+ * Stale-guidance detection (#356) — reactive, derived from live agent state
+ * ------------------------------------------------------------------------*/
+
+describe("PluginDataStore – staleGuidance", () => {
+	const CUSTOM_VAULT = "MY custom vault guidance that differs from every default";
+	const CUSTOM_WEB = "MY custom web guidance";
+	const CUSTOM_PROMPT = "MY custom system prompt, not any shipped default";
+
+	// An agent whose vault + web capability guidance are customized and stamped
+	// against version 0 (below the shipped version), i.e. the default moved after
+	// the user customized — so both should surface as stale.
+	function staleAgentData() {
+		return {
+			agents: {
+				[DEFAULT_AGENT_ID]: {
+					id: DEFAULT_AGENT_ID,
+					name: "Default Agent",
+					chatModel: null,
+					systemPrompt: "unused",
+					systemPromptVersion: 1,
+					skills: {},
+					toolsConfig: structuredClone(DEFAULT_TOOLS_CONFIG),
+					mcpServers: {},
+					capabilityPrompts: { vault: CUSTOM_VAULT, web: CUSTOM_WEB },
+					capabilityPromptsVersion: { vault: 0, web: 0 },
+				},
+			},
+			defaultAgentId: DEFAULT_AGENT_ID,
+			selectedAgentId: DEFAULT_AGENT_ID,
+		};
+	}
+
+	it("flags customized capability guidance stamped below the current version", () => {
+		const { store } = makeStore(staleAgentData() as never);
+		const kinds = store.staleGuidance.map((s) => `${s.kind}:${s.targetId}`).sort();
+		expect(kinds).toEqual(["capability:vault", "capability:web"]);
+	});
+
+	it("does NOT flag guidance stamped at the current version", () => {
+		const data = staleAgentData();
+		data.agents[DEFAULT_AGENT_ID].capabilityPromptsVersion = {
+			vault: CAPABILITY_GUIDANCE_VERSION.get("vault") ?? 1,
+			web: CAPABILITY_GUIDANCE_VERSION.get("web") ?? 1,
+		};
+		const { store } = makeStore(data as never);
+		expect(store.staleGuidance).toEqual([]);
+	});
+
+	it("clears a capability's notice reactively once it is re-aligned, WITHOUT touching a sibling (greptile P1)", () => {
+		const { store } = makeStore(staleAgentData() as never);
+		expect(store.staleGuidance).toHaveLength(2);
+
+		// Edit only vault; modal submits the full map (both keys present).
+		store.updateAgent(DEFAULT_AGENT_ID, {
+			capabilityPrompts: { vault: "freshly re-aligned vault guidance", web: CUSTOM_WEB },
+		});
+
+		const remaining = store.staleGuidance.map((s) => s.targetId);
+		// vault cleared (re-stamped current); web still stale (unchanged value → old stamp kept).
+		expect(remaining).toEqual(["web"]);
+		expect(store.getAgent(DEFAULT_AGENT_ID)?.capabilityPromptsVersion?.web).toBe(0);
+	});
+
+	it("flags a customized system prompt whose stamp predates the current, and clears it on edit", () => {
+		const { store } = makeStore({
+			agents: {
+				[DEFAULT_AGENT_ID]: {
+					id: DEFAULT_AGENT_ID,
+					name: "Default Agent",
+					chatModel: null,
+					systemPrompt: CUSTOM_PROMPT,
+					systemPromptVersion: 0,
+					skills: {},
+					toolsConfig: structuredClone(DEFAULT_TOOLS_CONFIG),
+					mcpServers: {},
+				},
+			},
+			defaultAgentId: DEFAULT_AGENT_ID,
+			selectedAgentId: DEFAULT_AGENT_ID,
+		} as never);
+		expect(store.staleGuidance.map((s) => s.kind)).toEqual(["system-prompt"]);
+
+		store.updateAgent(DEFAULT_AGENT_ID, { systemPrompt: "edited to align with the new default" });
+		expect(store.staleGuidance).toEqual([]);
+	});
+
+	it("flags customized tool guidance below version and clears it via updateAgentToolConfig", () => {
+		const data = staleAgentData();
+		delete (data.agents[DEFAULT_AGENT_ID] as Record<string, unknown>).capabilityPrompts;
+		delete (data.agents[DEFAULT_AGENT_ID] as Record<string, unknown>).capabilityPromptsVersion;
+		data.agents[DEFAULT_AGENT_ID].toolsConfig.web_search = {
+			...data.agents[DEFAULT_AGENT_ID].toolsConfig.web_search,
+			promptGuidance: "MY custom web_search guidance",
+			promptGuidanceVersion: 0,
+		} as never;
+		const { store } = makeStore(data as never);
+		expect(store.staleGuidance.map((s) => `${s.kind}:${s.targetId}`)).toEqual(["tool:web_search"]);
+
+		store.updateAgentToolConfig(DEFAULT_AGENT_ID, "web_search", { promptGuidance: "re-aligned web_search guidance" });
+		expect(store.staleGuidance).toEqual([]);
+		expect(store.getAgent(DEFAULT_AGENT_ID)?.toolsConfig.web_search?.promptGuidanceVersion).toBe(
+			TOOL_GUIDANCE_VERSION.get("web_search") ?? 1,
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

- **#334** — Replaces the blank empty-chat view with a dismissable recommendations surface: context-gated suggested first-query chips (requires chat/search/graph capability), dismiss per-chip or dismiss-all, click prefills the input.
- **#355** — Adds a \"Enable capabilities for your plugins\" section: nudges when an installed+enabled Obsidian plugin has an S2B integration not yet switched on for the selected agent. One-click enable; refreshes on plugin installs and window focus.
- **#356** — Adds an \"A default was updated\" section: notifies when a plugin update changed a built-in prompt/guidance default that the user had customized (so it couldn't be auto-migrated). Review action opens the matching diff modal (system-prompt, capability settings, or tool settings). Retire the startup Notice that previously handled this. Includes schema v2→v3 migration that seeds existing customizations to current version so only *future* default changes trigger notices.

## Details

- New `StaleGuidance` type + `staleGuidance` store field (replaces `stalePromptAgentNames`).
- `capabilityPromptsVersion` on `AgentConfig` + `promptGuidanceVersion` on `ToolConfig`, stamped at save time.
- `CAPABILITY_GUIDANCE_VERSION` / `TOOL_GUIDANCE_VERSION` constants in `prompts.ts` as the current-default source of truth.
- `normalizeAgent`/`normalizeAgents` extended to detect and return stale capability/tool guidance records.
- `AgentManager.openCapabilityGuidanceDiff` / `openToolGuidanceDiff` open `CapabilitySettingsModal` at the relevant capability.
- `UpdateNotice` model + `filterUpdateNotices` in the pure `chatRecommendations.ts` module.
- 19 unit tests for all three filter functions.

## Test plan

- [ ] Empty new-chat view shows suggested-query chips gated on available capabilities; click prefills input without submitting
- [ ] Per-chip dismiss (×) removes that chip; dismiss-all (bottom ×) removes the whole block; both persist across reload
- [ ] Install/enable an Obsidian plugin with an S2B integration → plugin nudge appears; clicking Enable wires it to the selected agent
- [ ] Customize an agent's capability/tool guidance, bump the matching `CAPABILITY_/TOOL_GUIDANCE_VERSION` entry, reload → "A default was updated" notice appears with working Review diff; dismiss persists; no duplicate startup Notice
- [ ] `bun run check` (4 pre-existing GraphCanvas errors only), `bun run format`, `bun run test` (781/781 pass)

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._