### PR TITLE
feat: denser, plain-language tool-call rendering in chat (#350)

### DIFF
--- a/src/components/chat/ToolCallsSection.svelte
+++ b/src/components/chat/ToolCallsSection.svelte
@@ -404,7 +404,6 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   <details class="tool-card tool-card-merged">
     <summary class="tool-card-header">
       <span class="tool-card-name" class:tool-card-name-failed={status === "failed"}>{foldOutcome(summary)}</span>
-      <span class="tool-card-merged-count">{group.calls.length}×</span>
     </summary>
 
     <!-- Each merged call keeps its own friendly result (and raw I/O in dev mode). -->
@@ -600,6 +599,14 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
           </details>
         {/each}
       </div>
+    {:else}
+      <!-- No nested sections (e.g. a heterogeneous array reduced to an item count):
+           show the full payload as the friendly result so its contents remain
+           visible without the developer raw-I/O toggle. -->
+      <MarkdownRenderer
+        content={formatRawToolOutput(model.json)}
+        class="tool-output-content markdown-preview-view !m-0 !p-0 text-[0.8rem] leading-[1.55] [&_pre]:my-0 [&_pre]:bg-[--background-primary] [&_pre]:p-2.5 [&_pre]:rounded"
+      />
     {/if}
   {:else if model.kind === "search_notes"}
     {@const visibleResults = getVisibleItems(model.payload.results, 6)}
@@ -1145,15 +1152,6 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   }
 
   /* ── Merged multi-call row ── */
-  /* Small "3×" count chip trailing the merged sentence. The label flex-grows and
-     ellipsizes, so the chip hugs the end of the (possibly truncated) sentence. */
-  .tool-card-merged-count {
-    flex: 0 0 auto;
-    color: var(--text-faint);
-    font-size: 0.72rem;
-    font-variant-numeric: tabular-nums;
-  }
-
   /* Expanded body of a merged row: one indented sub-entry per call, each with its
      own label and full input/output, under the same left rule as a single row. */
   .tool-card-merged-list {

--- a/src/components/chat/ToolCallsSection.svelte
+++ b/src/components/chat/ToolCallsSection.svelte
@@ -11,7 +11,7 @@ import {
 	type ToolCallGroup,
 	type UnifiedToolCall,
 } from "./toolTimelineModel";
-import { buildToolSummary, buildMergedToolSummary, type MergedCall } from "./toolSummaryModel";
+import { buildToolSummary, buildMergedToolSummary, type MergedCall, type ToolSummary } from "./toolSummaryModel";
 import MarkdownRenderer from "../ui/MarkdownRenderer.svelte";
 
 interface Props {
@@ -74,6 +74,16 @@ function getTaskSummary(input: Record<string, unknown> | null | undefined): stri
 /** Output render model for a tool call, or undefined if it hasn't produced output. */
 function toOutputModel(tool: UnifiedToolCall): ToolOutputRenderModel | undefined {
 	return tool.output !== undefined ? buildToolOutputRenderModel(tool.name, tool.output, tool.input) : undefined;
+}
+
+/**
+ * Folds a tool summary into one continuous sentence — the plain-language label
+ * with the outcome clause appended after a comma (e.g. "Read main.md, 512 lines").
+ * The outcome is already phrased to read as a natural continuation. When there is
+ * no outcome yet (still running, or nothing to report) just the label is shown.
+ */
+function foldOutcome(summary: ToolSummary): string {
+	return summary.summary ? `${summary.label}, ${summary.summary}` : summary.label;
 }
 
 /**
@@ -290,12 +300,16 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
       : undefined}
   {@const isSubAgentParent = tool.name === "task" && !!tool.subAgentName}
   {@const toolSummary = buildToolSummary(tool.name, tool.input, outputModel, tool.status)}
-  {@const headerLabel = tool.name === "task" ? toolDisplayName(tool) : toolSummary.label}
-  {@const headerSummary = tool.name === "task" ? getTaskSummary(tool.input) : toolSummary.summary}
+  {@const isTask = tool.name === "task"}
+  <!-- Regular tools fold the outcome into the sentence ("Read main.md, 512 lines");
+       task rows keep the subagent name as the label and the task description as a
+       separate faint subtitle rather than a comma-joined outcome clause. -->
+  {@const headerLabel = isTask ? toolDisplayName(tool) : foldOutcome(toolSummary)}
+  {@const headerSubtitle = isTask ? getTaskSummary(tool.input) : ""}
   {#if isExpandable(tool)}
     <details class="tool-card">
       <summary class="tool-card-header">
-        {@render toolCardHeader(headerLabel, headerSummary, tool.status, isSubAgentParent, tool.subAgentName)}
+        {@render toolCardHeader(headerLabel, headerSubtitle, tool.status, isSubAgentParent, tool.subAgentName)}
       </summary>
       <div class="tool-card-body">
         {@render toolBody(tool, outputModel)}
@@ -304,7 +318,7 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   {:else}
     <div class="tool-card tool-card-flat">
       <div class="tool-card-header">
-        {@render toolCardHeader(headerLabel, headerSummary, tool.status, isSubAgentParent, tool.subAgentName)}
+        {@render toolCardHeader(headerLabel, headerSubtitle, tool.status, isSubAgentParent, tool.subAgentName)}
       </div>
     </div>
   {/if}
@@ -312,7 +326,7 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
 
 {#snippet toolCardHeader(
   label: string,
-  summary: string,
+  subtitle: string,
   status: UnifiedToolCall["status"],
   isSubAgentParent: boolean,
   subAgentName: string | undefined,
@@ -323,8 +337,8 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   {:else if subAgentName}
     <span class="tool-card-subagent-badge">via {subAgentName}</span>
   {/if}
-  {#if summary}
-    <span class="tool-card-summary">{summary}</span>
+  {#if subtitle}
+    <span class="tool-card-summary">{subtitle}</span>
   {/if}
 {/snippet}
 
@@ -389,11 +403,8 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   {@const summary = buildMergedToolSummary(group.name, toMergedCalls(group), status)}
   <details class="tool-card tool-card-merged">
     <summary class="tool-card-header">
-      <span class="tool-card-name" class:tool-card-name-failed={status === "failed"}>{summary.label}</span>
+      <span class="tool-card-name" class:tool-card-name-failed={status === "failed"}>{foldOutcome(summary)}</span>
       <span class="tool-card-merged-count">{group.calls.length}×</span>
-      {#if summary.summary}
-        <span class="tool-card-summary">{summary.summary}</span>
-      {/if}
     </summary>
 
     <!-- Each merged call keeps its own friendly result (and raw I/O in dev mode). -->
@@ -403,10 +414,7 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
         <div class="tool-card-merged-item">
           <div class="tool-card-merged-item-label">
             <span class="tool-card-merged-item-index">{callIdx + 1}.</span>
-            <span class:tool-card-name-failed={call.status === "failed"}>{callSummary.label}</span>
-            {#if callSummary.summary}
-              <span class="tool-card-summary">{callSummary.summary}</span>
-            {/if}
+            <span class:tool-card-name-failed={call.status === "failed"}>{foldOutcome(callSummary)}</span>
           </div>
           <div class="tool-card-body tool-card-body-merged">
             {@render toolBody(call, toOutputModel(call))}
@@ -1137,10 +1145,10 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   }
 
   /* ── Merged multi-call row ── */
-  /* Small "3×" count chip after the merged sentence; grows to keep the summary
-     and chevron right-aligned like the single-row layout. */
+  /* Small "3×" count chip trailing the merged sentence. The label flex-grows and
+     ellipsizes, so the chip hugs the end of the (possibly truncated) sentence. */
   .tool-card-merged-count {
-    flex: 1 1 auto;
+    flex: 0 0 auto;
     color: var(--text-faint);
     font-size: 0.72rem;
     font-variant-numeric: tabular-nums;

--- a/src/components/chat/ToolCallsSection.svelte
+++ b/src/components/chat/ToolCallsSection.svelte
@@ -145,10 +145,6 @@ function getVisibleItems<T>(items: T[] | undefined, maxItems = 8): { visible: T[
 	};
 }
 
-function countLines(value: string): number {
-	return value.split(/\r?\n/).length;
-}
-
 function formatReadContentSource(sourceType: "file" | "pdf" | "excalidraw"): string {
 	if (sourceType === "pdf") return "PDF";
 	if (sourceType === "excalidraw") return "Excalidraw";
@@ -363,7 +359,7 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   {#if hasFriendlyResult(outputModel)}
     <div class="tool-io-section">
       <div class="tool-io-output">
-        {@render outputRenderer(outputModel!)}
+        {@render outputBody(outputModel!)}
       </div>
     </div>
   {:else if showRawIO && tool.status !== "running"}
@@ -796,10 +792,6 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   {/if}
 {/snippet}
 
-{#snippet outputRenderer(model: ToolOutputRenderModel)}
-  {@render outputBody(model)}
-{/snippet}
-
 {#if noTimelineWrap}
   <!-- Inline rendering: content streaming with no tool-call steps yet.
        Renders identical to the completed plain-MarkdownRenderer path so there
@@ -1144,9 +1136,9 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
     color: var(--color-red);
   }
 
-  /* Muted one-line result summary shown after the plain-language label
-     (e.g. "3 notes", "512 lines"). Hugs its content on the right; the label's
-     flex-grow keeps the chevron pinned to the edge. */
+  /* Faint task-description subtitle shown only on a subagent `task` row (the
+     "what it was asked to do"). Regular tools fold their outcome into the label
+     instead, so this never carries a result count. */
   .tool-card-summary {
     flex: 0 1 auto;
     min-width: 0;

--- a/src/components/chat/ToolCallsSection.svelte
+++ b/src/components/chat/ToolCallsSection.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
 import type { AssistantTimelineEvent, ToolCallState } from "../../stores/chatStore.svelte";
+import { getData } from "../../stores/dataStore.svelte";
 import { buildToolOutputRenderModel, type ToolOutputRenderModel } from "./toolOutputRenderModel";
 import {
 	buildStepsFromEvents,
 	buildStepsFromToolCalls,
+	groupStepTools,
 	toolDisplayName,
 	type TimelineStep,
+	type ToolCallGroup,
 	type UnifiedToolCall,
 } from "./toolTimelineModel";
+import { buildToolSummary, buildMergedToolSummary, type MergedCall } from "./toolSummaryModel";
 import MarkdownRenderer from "../ui/MarkdownRenderer.svelte";
 
 interface Props {
@@ -24,6 +28,13 @@ interface Props {
 const { toolCalls, assistantTimeline, collapsed, answerContent, isStreaming, isError, isProcessing, ontoggle }: Props =
 	$props();
 
+const pluginData = getData();
+
+// Raw tool input args + raw output blob are hidden by default; a tool row expands
+// to only the friendly structured result. Developers can flip this on (DEV-only
+// Developer settings) to also see the exact I/O for debugging.
+const showRawIO = $derived(pluginData.showToolIODetails);
+
 let hoveringFinalControl = $state(false);
 
 // Per-`task`-card expansion of the nested subagent sub-timeline, keyed by the
@@ -38,14 +49,6 @@ function toggleSubAgent(taskCallId: string) {
 
 /* ── Formatters ── */
 
-function formatToolName(name: string): string {
-	if (!name) return "Unknown Tool";
-	return name
-		.replace(/_/g, " ")
-		.replace(/([a-z])([A-Z])/g, "$1 $2")
-		.replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
 function formatValue(value: unknown): string {
 	if (value === null || value === undefined) return "null";
 	if (typeof value === "string") return value;
@@ -58,40 +61,56 @@ function formatToolInput(input: Record<string, unknown> | null | undefined): { k
 	return Object.entries(input).map(([key, value]) => ({ key, value }));
 }
 
-function hasToolInputValue(value: unknown): boolean {
-	if (value === null || value === undefined) return false;
-	if (typeof value === "string") return value.trim().length > 0;
-	if (Array.isArray(value)) return value.length > 0;
-	if (typeof value === "object") return Object.keys(value as Record<string, unknown>).length > 0;
-	return true;
+/**
+ * Muted one-line summary for a `task` (subagent) row: the subagent's task
+ * description, if one was passed. The label already carries the subagent name,
+ * so this adds the "what it was asked to do" without the removed argument pills.
+ */
+function getTaskSummary(input: Record<string, unknown> | null | undefined): string {
+	const description = input?.description;
+	return typeof description === "string" ? description.trim() : "";
 }
 
-function formatInlineValue(value: unknown): string {
-	if (typeof value === "string") return value;
-	if (typeof value === "number" || typeof value === "boolean") return String(value);
-	if (Array.isArray(value)) return `[${value.length} item${value.length === 1 ? "" : "s"}]`;
-	if (typeof value === "object" && value !== null) {
-		const keys = Object.keys(value as Record<string, unknown>);
-		if (keys.length === 1) return `{${keys[0]}}`;
-		return `{${keys.length} keys}`;
-	}
-	return formatValue(value);
+/** Output render model for a tool call, or undefined if it hasn't produced output. */
+function toOutputModel(tool: UnifiedToolCall): ToolOutputRenderModel | undefined {
+	return tool.output !== undefined ? buildToolOutputRenderModel(tool.name, tool.output, tool.input) : undefined;
 }
 
-function getToolInputPreview(
-	input: Record<string, unknown> | null | undefined,
-	maxItems = 2,
-): { visibleEntries: { key: string; value: string }[]; hiddenCount: number } {
-	const entries = formatToolInput(input).filter((entry) => hasToolInputValue(entry.value));
-	const visibleEntries = entries.slice(0, maxItems).map(({ key, value }) => ({
-		key,
-		value: formatInlineValue(value),
-	}));
+/**
+ * Whether a friendly, user-facing structured result exists for this output model.
+ * Everything except the empty/unknown fallback renders a meaningful result view;
+ * `empty` (and an absent model) has nothing worth an expand affordance.
+ */
+function hasFriendlyResult(model: ToolOutputRenderModel | undefined): boolean {
+	return !!model && model.kind !== "empty";
+}
 
-	return {
-		visibleEntries,
-		hiddenCount: Math.max(0, entries.length - visibleEntries.length),
-	};
+/**
+ * Whether a row should be expandable at all. Without raw-I/O mode, a row expands
+ * only when it has a friendly structured result; with raw-I/O mode on it also
+ * expands whenever there are input args or any output to show. Rows with nothing
+ * to reveal render as flat one-liners (no chevron, non-interactive).
+ */
+function isExpandable(tool: UnifiedToolCall): boolean {
+	const model = toOutputModel(tool);
+	if (hasFriendlyResult(model)) return true;
+	if (showRawIO && (formatToolInput(tool.input).length > 0 || tool.output !== undefined)) return true;
+	return false;
+}
+
+/** The merged calls (input + output model) for a group's summary builder. */
+function toMergedCalls(group: ToolCallGroup): MergedCall[] {
+	return group.calls.map((tool) => ({ input: tool.input, model: toOutputModel(tool) }));
+}
+
+/**
+ * A merged group's overall status: running if any call is still running, failed
+ * if any failed (and none running), else completed — mirroring the step-dot rule.
+ */
+function mergedGroupStatus(group: ToolCallGroup): "running" | "completed" | "failed" {
+	if (group.calls.some((c) => c.status === "running")) return "running";
+	if (group.calls.some((c) => c.status === "failed")) return "failed";
+	return "completed";
 }
 
 function formatRawToolOutput(rawText: string): string {
@@ -265,109 +284,80 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
       />
     </div>
   {/if}
-  {@const inputPreview = getToolInputPreview(tool.input)}
   {@const outputModel =
     tool.output !== undefined
       ? buildToolOutputRenderModel(tool.name, tool.output, tool.input)
       : undefined}
   {@const isSubAgentParent = tool.name === "task" && !!tool.subAgentName}
-  <details class="tool-card" class:tool-card-subagent={isSubAgentParent}>
-    <summary class="tool-card-header">
-      <span
-        class="tool-status-icon"
-        class:status-running={tool.status === "running"}
-        class:status-done={tool.status === "completed"}
-        class:status-failed={tool.status === "failed"}
-      >
-        {#if tool.status === "running"}
-          <span class="tool-spinner"></span>
-        {:else if tool.status === "completed"}
-          <svg viewBox="0 0 16 16" fill="none" class="tool-icon-svg">
-            <path
-              d="M3.5 8.5L6.5 11.5L12.5 4.5"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-        {:else}
-          <svg viewBox="0 0 16 16" fill="none" class="tool-icon-svg">
-            <path
-              d="M4 4L12 12M12 4L4 12"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-            />
-          </svg>
-        {/if}
-      </span>
-      <span class="tool-card-name">
-        {tool.name === "task" ? toolDisplayName(tool) : formatToolName(tool.name)}
-      </span>
-      {#if isSubAgentParent}
-        <span class="tool-card-subagent-badge">subagent</span>
-      {:else if tool.subAgentName}
-        <span class="tool-card-subagent-badge">via {tool.subAgentName}</span>
-      {/if}
-      {#if inputPreview.visibleEntries.length > 0}
-        <span class="tool-card-input-preview">
-          {#each inputPreview.visibleEntries as entry (entry.key)}
-            <span class="tool-card-input-chip">
-              <span class="tool-card-input-key">{entry.key}:</span>
-              <span class="tool-card-input-value">{entry.value}</span>
-            </span>
-          {/each}
-          {#if inputPreview.hiddenCount > 0}
-            <span class="tool-card-input-more">+{inputPreview.hiddenCount}</span>
-          {/if}
-        </span>
-      {/if}
-      <span class="tool-card-expand-hint">
-        <svg viewBox="0 0 16 16" fill="none" class="tool-expand-chevron">
-          <path
-            d="M6 4L10 8L6 12"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-      </span>
-    </summary>
-
-    <div class="tool-card-body">
-      {#if formatToolInput(tool.input).length > 0}
-        <div class="tool-io-section">
-          <div class="tool-io-label">Input</div>
-          <div class="tool-io-entries">
-            {#each formatToolInput(tool.input) as { key, value } (key)}
-              <div class="tool-io-entry">
-                <span class="tool-io-key">{key}</span>
-                <MarkdownRenderer content={formatValue(value)} class="tool-io-value [&_p]:m-0" />
-              </div>
-            {/each}
-          </div>
-        </div>
-      {/if}
-
-      {#if tool.output !== undefined}
-        <div class="tool-io-section">
-          <div class="tool-io-label">Output</div>
-          <div class="tool-io-output">
-            {#if outputModel}
-              {@render outputRenderer(outputModel)}
-            {/if}
-          </div>
-        </div>
-      {:else if tool.status !== "running"}
-        <div class="tool-io-section">
-          <div class="tool-io-label">Output</div>
-          <span class="tool-io-empty">(no output)</span>
-        </div>
-      {/if}
+  {@const toolSummary = buildToolSummary(tool.name, tool.input, outputModel, tool.status)}
+  {@const headerLabel = tool.name === "task" ? toolDisplayName(tool) : toolSummary.label}
+  {@const headerSummary = tool.name === "task" ? getTaskSummary(tool.input) : toolSummary.summary}
+  {#if isExpandable(tool)}
+    <details class="tool-card">
+      <summary class="tool-card-header">
+        {@render toolCardHeader(headerLabel, headerSummary, tool.status, isSubAgentParent, tool.subAgentName)}
+      </summary>
+      <div class="tool-card-body">
+        {@render toolBody(tool, outputModel)}
+      </div>
+    </details>
+  {:else}
+    <div class="tool-card tool-card-flat">
+      <div class="tool-card-header">
+        {@render toolCardHeader(headerLabel, headerSummary, tool.status, isSubAgentParent, tool.subAgentName)}
+      </div>
     </div>
-  </details>
+  {/if}
+{/snippet}
+
+{#snippet toolCardHeader(
+  label: string,
+  summary: string,
+  status: UnifiedToolCall["status"],
+  isSubAgentParent: boolean,
+  subAgentName: string | undefined,
+)}
+  <span class="tool-card-name" class:tool-card-name-failed={status === "failed"}>{label}</span>
+  {#if isSubAgentParent}
+    <span class="tool-card-subagent-badge">subagent</span>
+  {:else if subAgentName}
+    <span class="tool-card-subagent-badge">via {subAgentName}</span>
+  {/if}
+  {#if summary}
+    <span class="tool-card-summary">{summary}</span>
+  {/if}
+{/snippet}
+
+{#snippet toolBody(tool: UnifiedToolCall, outputModel: ToolOutputRenderModel | undefined)}
+  <!-- Raw input args are hidden from users by default; the plain-language label
+       already restates them. Developer mode reveals the exact arguments. -->
+  {#if showRawIO && formatToolInput(tool.input).length > 0}
+    <div class="tool-io-section">
+      <div class="tool-io-label">Input</div>
+      <div class="tool-io-entries">
+        {#each formatToolInput(tool.input) as { key, value } (key)}
+          <div class="tool-io-entry">
+            <span class="tool-io-key">{key}</span>
+            <MarkdownRenderer content={formatValue(value)} class="tool-io-value [&_p]:m-0" />
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  <!-- Friendly, structured result — always shown when present. -->
+  {#if hasFriendlyResult(outputModel)}
+    <div class="tool-io-section">
+      <div class="tool-io-output">
+        {@render outputRenderer(outputModel!)}
+      </div>
+    </div>
+  {:else if showRawIO && tool.status !== "running"}
+    <div class="tool-io-section">
+      <div class="tool-io-label">Output</div>
+      <span class="tool-io-empty">(no output)</span>
+    </div>
+  {/if}
 {/snippet}
 
 {#snippet subAgentBranch(children: UnifiedToolCall[])}
@@ -394,6 +384,39 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   </div>
 {/snippet}
 
+{#snippet mergedToolRow(group: ToolCallGroup)}
+  {@const status = mergedGroupStatus(group)}
+  {@const summary = buildMergedToolSummary(group.name, toMergedCalls(group), status)}
+  <details class="tool-card tool-card-merged">
+    <summary class="tool-card-header">
+      <span class="tool-card-name" class:tool-card-name-failed={status === "failed"}>{summary.label}</span>
+      <span class="tool-card-merged-count">{group.calls.length}×</span>
+      {#if summary.summary}
+        <span class="tool-card-summary">{summary.summary}</span>
+      {/if}
+    </summary>
+
+    <!-- Each merged call keeps its own friendly result (and raw I/O in dev mode). -->
+    <div class="tool-card-merged-list">
+      {#each group.calls as call, callIdx (call.id)}
+        {@const callSummary = buildToolSummary(call.name, call.input, toOutputModel(call), call.status)}
+        <div class="tool-card-merged-item">
+          <div class="tool-card-merged-item-label">
+            <span class="tool-card-merged-item-index">{callIdx + 1}.</span>
+            <span class:tool-card-name-failed={call.status === "failed"}>{callSummary.label}</span>
+            {#if callSummary.summary}
+              <span class="tool-card-summary">{callSummary.summary}</span>
+            {/if}
+          </div>
+          <div class="tool-card-body tool-card-body-merged">
+            {@render toolBody(call, toOutputModel(call))}
+          </div>
+        </div>
+      {/each}
+    </div>
+  </details>
+{/snippet}
+
 {#snippet stepRow(
   step: TimelineStep,
   stepIdx: number,
@@ -418,45 +441,50 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
 
     <div class="tool-step-content">
       <div class="tool-step-tools">
-        {#each step.tools as tool (tool.id)}
-          {@const isSubAgentParent = tool.name === "task" && !!tool.subAgentName}
-          {@const branchChildren = tool.children ?? []}
-          {#if isSubAgentParent && branchChildren.length > 0}
-            {@const expanded = subAgentExpanded[tool.id] ?? false}
-            {@const runningCount = branchChildren.filter((c) => c.status === "running").length}
-            <div class="tool-subagent-group">
-              {@render toolCard(tool)}
-              <button
-                type="button"
-                class="tool-subagent-toggle"
-                class:is-expanded={expanded}
-                onclick={() => toggleSubAgent(tool.id)}
-                aria-expanded={expanded}
-              >
-                <svg viewBox="0 0 16 16" fill="none" class="tool-subagent-toggle-chevron">
-                  <path
-                    d="M6 4L10 8L6 12"
-                    stroke="currentColor"
-                    stroke-width="1.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-                <span class="tool-subagent-toggle-label">
-                  {expanded ? "Hide" : "Show"}
-                  {branchChildren.length}
-                  {branchChildren.length === 1 ? "step" : "steps"}
-                </span>
-                {#if runningCount > 0}
-                  <span class="tool-subagent-toggle-running">running…</span>
-                {/if}
-              </button>
-              {#if expanded}
-                {@render subAgentBranch(branchChildren)}
-              {/if}
-            </div>
+        {#each groupStepTools(step.tools) as group (group.id)}
+          {#if group.merged}
+            {@render mergedToolRow(group)}
           {:else}
-            {@render toolCard(tool)}
+            {@const tool = group.calls[0]}
+            {@const isSubAgentParent = tool.name === "task" && !!tool.subAgentName}
+            {@const branchChildren = tool.children ?? []}
+            {#if isSubAgentParent && branchChildren.length > 0}
+              {@const expanded = subAgentExpanded[tool.id] ?? false}
+              {@const runningCount = branchChildren.filter((c) => c.status === "running").length}
+              <div class="tool-subagent-group">
+                {@render toolCard(tool)}
+                <button
+                  type="button"
+                  class="tool-subagent-toggle"
+                  class:is-expanded={expanded}
+                  onclick={() => toggleSubAgent(tool.id)}
+                  aria-expanded={expanded}
+                >
+                  <svg viewBox="0 0 16 16" fill="none" class="tool-subagent-toggle-chevron">
+                    <path
+                      d="M6 4L10 8L6 12"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                  <span class="tool-subagent-toggle-label">
+                    {expanded ? "Hide" : "Show"}
+                    {branchChildren.length}
+                    {branchChildren.length === 1 ? "step" : "steps"}
+                  </span>
+                  {#if runningCount > 0}
+                    <span class="tool-subagent-toggle-running">running…</span>
+                  {/if}
+                </button>
+                {#if expanded}
+                  {@render subAgentBranch(branchChildren)}
+                {/if}
+              </div>
+            {:else}
+              {@render toolCard(tool)}
+            {/if}
           {/if}
         {/each}
       </div>
@@ -720,7 +748,7 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
         />
       </div>
     {/if}
-    {#if model.payload.code}
+    {#if showRawIO && model.payload.code}
       <details class="tool-output-raw-toggle">
         <summary class="tool-output-raw-summary">Executed Code</summary>
         <MarkdownRenderer
@@ -729,7 +757,7 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
         />
       </details>
     {/if}
-    {#if model.payload.inputJson}
+    {#if showRawIO && model.payload.inputJson}
       <details class="tool-output-raw-toggle">
         <summary class="tool-output-raw-summary">Input</summary>
         <MarkdownRenderer
@@ -742,7 +770,7 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
     <div class="tool-io-empty">(no output)</div>
   {/if}
 
-  {#if model.rawText.trim() && model.kind !== "markdown"}
+  {#if showRawIO && model.rawText.trim() && model.kind !== "markdown"}
     <details class="tool-output-raw-toggle">
       <summary class="tool-output-raw-summary">Raw output</summary>
       <MarkdownRenderer
@@ -1046,43 +1074,24 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   .tool-step-tools {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 1px;
   }
 
-  /* ── Tool card ── */
+  /* ── Tool row (chromeless: no card border/background) ── */
   .tool-card {
-    border-radius: 8px;
-    background: var(--background-primary);
-    border: 1px solid var(--background-modifier-border);
-    overflow: hidden;
-    transition:
-      box-shadow 0.15s,
-      border-color 0.15s;
-  }
-  .tool-card:hover {
-    border-color: color-mix(
-      in srgb,
-      var(--interactive-accent) 30%,
-      var(--background-modifier-border)
-    );
-  }
-  .tool-card[open] {
-    box-shadow: 0 1px 4px color-mix(in srgb, var(--background-modifier-border) 40%, transparent);
+    border-radius: 6px;
   }
 
   .tool-card-header {
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 8px 10px;
+    padding: 3px 6px;
     cursor: pointer;
     user-select: none;
     list-style: none;
     font-size: 0.82rem;
-    transition: background 0.12s;
-  }
-  .tool-card-header:hover {
-    background: var(--background-modifier-hover);
+    border-radius: 6px;
   }
   .tool-card-header::-webkit-details-marker {
     display: none;
@@ -1090,19 +1099,93 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
 
   .tool-card-name {
     font-weight: 500;
-    color: var(--text-normal);
-    flex: 1;
+    /* Faint by default, like the "Thinking process" summary label: the preamble
+       carries intent, so the tool row reads as a quiet receipt. Hover changes
+       only the text color — no background highlight, no chevron. */
+    color: var(--text-faint);
+    transition: color 0.15s;
+    /* Grow to fill when it is the only element, but shrink with ellipsis so a
+       long phrase yields room to the summary. */
+    flex: 1 1 auto;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-
-  /* ── Subagent nesting ── */
-  .tool-card-subagent {
-    border-color: color-mix(in srgb, var(--interactive-accent) 45%, var(--background-modifier-border));
+  .tool-card-header:hover .tool-card-name {
+    color: var(--text-normal);
   }
 
+  /* Failed calls override the faint label to red so errors don't blend into the
+     quiet grey of routine rows (kept red on hover too). */
+  .tool-card-name-failed,
+  .tool-card-header:hover .tool-card-name-failed {
+    color: var(--color-red);
+  }
+
+  /* Muted one-line result summary shown after the plain-language label
+     (e.g. "3 notes", "512 lines"). Hugs its content on the right; the label's
+     flex-grow keeps the chevron pinned to the edge. */
+  .tool-card-summary {
+    flex: 0 1 auto;
+    min-width: 0;
+    color: var(--text-faint);
+    font-size: 0.76rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* ── Merged multi-call row ── */
+  /* Small "3×" count chip after the merged sentence; grows to keep the summary
+     and chevron right-aligned like the single-row layout. */
+  .tool-card-merged-count {
+    flex: 1 1 auto;
+    color: var(--text-faint);
+    font-size: 0.72rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Expanded body of a merged row: one indented sub-entry per call, each with its
+     own label and full input/output, under the same left rule as a single row. */
+  .tool-card-merged-list {
+    margin: 2px 0 6px 12px;
+    padding-left: 12px;
+    border-left: 2px solid var(--background-modifier-border);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .tool-card-merged-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .tool-card-merged-item-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8rem;
+    color: var(--text-normal);
+    padding: 2px 0;
+  }
+
+  .tool-card-merged-item-index {
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+
+  /* Inside a merged item the body's own left rule is redundant with the list's. */
+  .tool-card-body-merged {
+    margin-left: 0;
+    border-left: none;
+    padding-left: 14px;
+  }
+
+  /* ── Subagent nesting ── */
   .tool-card-subagent-badge {
     flex-shrink: 0;
     padding: 1px 7px;
@@ -1249,119 +1332,22 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
     padding: 4px 0;
   }
 
-  /* Child tool cards are visually lighter than the parent `task` card. */
-  .tool-subagent-branch-content :global(.tool-card) {
-    background: color-mix(in srgb, var(--background-secondary) 22%, var(--background-primary));
-  }
-
-  .tool-card-input-preview {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    min-width: 0;
-    max-width: 55%;
-    overflow: hidden;
-    margin-right: 4px;
-  }
-
-  .tool-card-input-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 3px;
-    /* Allow chips to shrink so multiple chips (e.g. task's subagent_type +
-       description) truncate individually instead of overflowing and visually
-       overlapping inside the clipped preview container. */
-    min-width: 0;
-    flex-shrink: 1;
-    padding: 1px 6px;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--background-modifier-border) 60%, transparent);
-    color: var(--text-muted);
-    font-size: 0.7rem;
-  }
-
-  .tool-card-input-key {
-    color: var(--text-faint);
-    flex-shrink: 0;
-  }
-
-  .tool-card-input-value {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .tool-card-input-more {
-    flex-shrink: 0;
-    color: var(--text-faint);
-    font-size: 0.7rem;
-  }
-
-  .tool-card-expand-hint {
-    flex-shrink: 0;
-    color: var(--text-faint);
-    transition: transform 0.2s;
-  }
-  .tool-card[open] .tool-card-expand-hint {
-    transform: rotate(90deg);
-  }
-  .tool-expand-chevron {
-    width: 12px;
-    height: 12px;
-    display: block;
-  }
-
-  /* ── Status icons ── */
-  .tool-status-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-  .status-running {
-    color: var(--text-accent);
-  }
-  .status-done {
-    color: var(--interactive-accent);
-    background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
-  }
-  .status-failed {
-    color: var(--color-red);
-    background: color-mix(in srgb, var(--color-red) 12%, transparent);
-  }
-  .tool-icon-svg {
-    width: 12px;
-    height: 12px;
-  }
-
-  .tool-spinner {
-    display: block;
-    width: 12px;
-    height: 12px;
-    border: 2px solid color-mix(in srgb, var(--text-accent) 25%, transparent);
-    border-top-color: var(--text-accent);
-    border-radius: 50%;
-    animation: spin 0.7s linear infinite;
-  }
-
-  @keyframes spin {
-    to {
-      transform: rotate(360deg);
-    }
+  /* A row with nothing to reveal renders flat: no expand affordance, so drop the
+     interactive cursor and leave it as a static one-liner. */
+  .tool-card-flat .tool-card-header {
+    cursor: default;
   }
 
   /* ── I/O sections ── */
+  /* Expanded detail region: indented under the row's label with a subtle left
+     rule instead of a bordered card, so it reads as belonging to the row above. */
   .tool-card-body {
-    border-top: 1px solid var(--background-modifier-border);
-    padding: 10px 12px;
+    margin: 2px 0 6px 12px;
+    padding: 6px 0 2px 12px;
+    border-left: 2px solid var(--background-modifier-border);
     display: flex;
     flex-direction: column;
     gap: 10px;
-    background: color-mix(in srgb, var(--background-secondary) 30%, transparent);
   }
 
   .tool-io-section {

--- a/src/components/chat/ToolCallsSection.svelte
+++ b/src/components/chat/ToolCallsSection.svelte
@@ -1098,7 +1098,13 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   }
 
   .tool-card-header {
-    display: flex;
+    /* inline-flex so the clickable/hoverable area hugs the text instead of
+       spanning the full card width — clicking empty space to the right no
+       longer toggles the row or selects the label (matches the compact feel
+       of the "Thinking process" summary). max-width keeps long labels from
+       overflowing the card; ellipsis on the name handles the overflow. */
+    display: inline-flex;
+    max-width: 100%;
     align-items: center;
     gap: 8px;
     padding: 3px 6px;
@@ -1119,9 +1125,9 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
        only the text color — no background highlight, no chevron. */
     color: var(--text-faint);
     transition: color 0.15s;
-    /* Grow to fill when it is the only element, but shrink with ellipsis so a
-       long phrase yields room to the summary. */
-    flex: 1 1 auto;
+    /* Size to content, but shrink with ellipsis if the label alone would
+       exceed the card width (header is capped at max-width: 100%). */
+    flex: 0 1 auto;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/components/chat/toolSummaryModel.ts
+++ b/src/components/chat/toolSummaryModel.ts
@@ -2,17 +2,17 @@ import type { ToolCallStatus } from "../../stores/chatStore.svelte";
 import type { ToolOutputRenderModel } from "./toolOutputRenderModel";
 
 /**
- * A compact, one-line description of a tool call — a short plain-language phrase
- * (e.g. `Searched notes for "vector store"`, `Read main.ts`) plus an optional
- * muted result summary shown on the collapsed row.
+ * A compact, one-line description of a tool call: a plain-language `label` and an
+ * `summary` outcome clause that the UI folds into one sentence
+ * (e.g. label `Read main.md` + summary `512 lines` → `Read main.md, 512 lines`).
  *
- * `label` is the primary line, written as a short sentence an average user can
- * read at a glance (not `verb(target)` function syntax) and tense-matched to the
- * tool's status: **present continuous while running** (`Reading main.ts`), **past
- * tense once finished** (`Read main.ts`). `summary` is the muted trailing detail
- * describing the outcome (e.g. `3 notes`, `512 lines`, `no matches`). Either can
- * be empty when there is nothing meaningful to show yet (e.g. a tool still
- * running with no input).
+ * `label` is written as a short sentence an average user can read at a glance (not
+ * `verb(target)` function syntax) and tense-matched to the tool's status:
+ * **present continuous while running** (`Reading main.ts`), **past tense once
+ * finished** (`Read main.ts`). `summary` is the outcome, phrased to read as a
+ * natural continuation of the label (`found 3 notes`, `found no matches`,
+ * `512 lines`). Either can be empty when there is nothing meaningful to show yet
+ * (e.g. a tool still running with no input).
  */
 export interface ToolSummary {
 	label: string;
@@ -152,7 +152,7 @@ function summarizeSearchNotes(
 
 	if (model?.kind !== "search_notes") return { label, summary: "" };
 	const total = model.payload.totalResults ?? model.payload.results?.length ?? 0;
-	return { label, summary: total === 0 ? "no matches" : pluralize(total, "note") };
+	return { label, summary: total === 0 ? "found no matches" : `found ${pluralize(total, "note")}` };
 }
 
 function summarizeGrepNotes(
@@ -170,9 +170,9 @@ function summarizeGrepNotes(
 		const total = numberProp(payload, "total_matches");
 		const files = numberProp(payload, "files_searched");
 		if (total !== undefined) {
-			if (total === 0) return { label, summary: "no matches" };
+			if (total === 0) return { label, summary: "found no matches" };
 			const filePart = files !== undefined ? ` in ${pluralize(files, "file")}` : "";
-			return { label, summary: `${pluralize(total, "match", "matches")}${filePart}` };
+			return { label, summary: `found ${pluralize(total, "match", "matches")}${filePart}` };
 		}
 	}
 	return { label, summary: "" };
@@ -194,7 +194,7 @@ function summarizeListDirectory(
 	const parts: string[] = [];
 	if (folders > 0) parts.push(pluralize(folders, "folder"));
 	parts.push(pluralize(files, "file"));
-	return { label, summary: parts.join(", ") };
+	return { label, summary: `found ${parts.join(" and ")}` };
 }
 
 function summarizeReadContent(
@@ -220,25 +220,25 @@ function summarizeManageNotes(model: ToolOutputRenderModel | undefined): RawSumm
 		paths === 1
 			? { verb: verb("Editing a note", "Edited a note") }
 			: { verb: verb("Editing notes", "Edited notes") };
-	return { label, summary: `${pluralize(operations, "operation")} · ${pluralize(paths, "note")}` };
+	return { label, summary: `${pluralize(operations, "operation")} across ${pluralize(paths, "note")}` };
 }
 
 function summarizeExecuteJavaScript(model: ToolOutputRenderModel | undefined): RawSummary {
 	const label: Label = { verb: verb("Running JavaScript", "Ran JavaScript") };
 	if (model?.kind !== "execute_javascript") return { label, summary: "" };
-	if (model.payload.state === "error") return { label, summary: "error" };
+	if (model.payload.state === "error") return { label, summary: "errored" };
 	const logs = model.payload.logs.length;
 	const parts: string[] = [];
-	if (logs > 0) parts.push(pluralize(logs, "log"));
-	if (model.payload.resultText) parts.push("returned value");
-	if (model.payload.durationMs !== undefined) parts.push(`${model.payload.durationMs}ms`);
-	return { label, summary: parts.join(" · ") };
+	if (logs > 0) parts.push(`logged ${pluralize(logs, "line")}`);
+	if (model.payload.resultText) parts.push("returned a value");
+	if (model.payload.durationMs !== undefined) parts.push(`in ${model.payload.durationMs}ms`);
+	return { label, summary: parts.join(" ") };
 }
 
 function summarizeGetAllTags(model: ToolOutputRenderModel | undefined): RawSummary {
 	const label: Label = { verb: verb("Listing all tags", "Listed all tags") };
 	const count = listLength(model);
-	return { label, summary: count !== undefined ? pluralize(count, "tag") : "" };
+	return { label, summary: count !== undefined ? `found ${pluralize(count, "tag")}` : "" };
 }
 
 function summarizeGetProperties(input: Record<string, unknown> | null | undefined): RawSummary {
@@ -266,7 +266,7 @@ function summarizeWebSearch(
 		? { verb: verb("Searching the web for", "Searched the web for"), rest: `“${truncateTarget(query)}”` }
 		: { verb: verb("Searching the web", "Searched the web") };
 	const count = listLength(model);
-	return { label, summary: count !== undefined ? pluralize(count, "result") : "" };
+	return { label, summary: count !== undefined ? `found ${pluralize(count, "result")}` : "" };
 }
 
 function summarizeLoadSkill(input: Record<string, unknown> | null | undefined): RawSummary {
@@ -298,13 +298,13 @@ function summarizeGeneric(
 	if (model) {
 		switch (model.kind) {
 			case "list":
-				summary = pluralize(model.items.length, "item");
+				summary = `found ${pluralize(model.items.length, "item")}`;
 				break;
 			case "table":
-				summary = pluralize(model.rows.length, "row");
+				summary = `found ${pluralize(model.rows.length, "row")}`;
 				break;
 			case "keyValue":
-				summary = pluralize(model.entries.length, "field");
+				summary = `found ${pluralize(model.entries.length, "field")}`;
 				break;
 			default:
 				summary = "";
@@ -462,7 +462,7 @@ const MERGE_SPECS: Partial<Record<BuiltInTool, MergeSpec>> = {
 					? (c.model.payload.totalResults ?? c.model.payload.results?.length ?? 0)
 					: undefined,
 			);
-			return total === undefined ? "" : total === 0 ? "no matches" : pluralize(total, "note");
+			return total === undefined ? "" : total === 0 ? "found no matches" : `found ${pluralize(total, "note")}`;
 		},
 	},
 	grep_notes: {
@@ -474,7 +474,11 @@ const MERGE_SPECS: Partial<Record<BuiltInTool, MergeSpec>> = {
 				const payload = parseRawJson(c.model?.rawText);
 				return payload && typeof payload === "object" ? numberProp(payload, "total_matches") : undefined;
 			});
-			return total === undefined ? "" : total === 0 ? "no matches" : pluralize(total, "match", "matches");
+			return total === undefined
+				? ""
+				: total === 0
+					? "found no matches"
+					: `found ${pluralize(total, "match", "matches")}`;
 		},
 	},
 	read_content: {

--- a/src/components/chat/toolSummaryModel.ts
+++ b/src/components/chat/toolSummaryModel.ts
@@ -1,0 +1,576 @@
+import type { ToolCallStatus } from "../../stores/chatStore.svelte";
+import type { ToolOutputRenderModel } from "./toolOutputRenderModel";
+
+/**
+ * A compact, one-line description of a tool call — a short plain-language phrase
+ * (e.g. `Searched notes for "vector store"`, `Read main.ts`) plus an optional
+ * muted result summary shown on the collapsed row.
+ *
+ * `label` is the primary line, written as a short sentence an average user can
+ * read at a glance (not `verb(target)` function syntax) and tense-matched to the
+ * tool's status: **present continuous while running** (`Reading main.ts`), **past
+ * tense once finished** (`Read main.ts`). `summary` is the muted trailing detail
+ * describing the outcome (e.g. `3 notes`, `512 lines`, `no matches`). Either can
+ * be empty when there is nothing meaningful to show yet (e.g. a tool still
+ * running with no input).
+ */
+export interface ToolSummary {
+	label: string;
+	summary: string;
+}
+
+/**
+ * A verb whose tense is chosen from the tool's status: the present-continuous
+ * form while the call is running, the past-tense form once it has finished (or
+ * failed). Kept as a pair so summarizers stay declarative and the tense rule
+ * lives in one place ({@link renderLabel}).
+ */
+interface Verb {
+	/** Present continuous, shown while running — e.g. "Reading", "Searching notes for". */
+	running: string;
+	/** Past tense, shown when done/failed — e.g. "Read", "Searched notes for". */
+	done: string;
+}
+
+/** A tense-aware label: a status-driven {@link Verb} plus optional trailing text. */
+interface Label {
+	verb: Verb;
+	/** Text appended after the verb (e.g. a quoted query or a note name). */
+	rest?: string;
+}
+
+function verb(running: string, done: string): Verb {
+	return { running, done };
+}
+
+/** Resolves a {@link Label} to a display string, choosing the verb tense by status. */
+function renderLabel(label: Label, status: ToolCallStatus): string {
+	const v = status === "running" ? label.verb.running : label.verb.done;
+	return label.rest ? `${v} ${label.rest}` : v;
+}
+
+/**
+ * Maps a (possibly user-renamed) tool name to the canonical built-in kind so
+ * summary logic keys off tool *identity*, not the display name. The output
+ * render model already special-cases the default names; we mirror that set and
+ * additionally recognise the tools that fall through to generic rendering
+ * (grep_notes, get_all_tags, …) so they still get a tailored label. Unknown /
+ * renamed tools return `undefined` and fall back to a generic summary.
+ */
+type BuiltInTool =
+	| "search_notes"
+	| "grep_notes"
+	| "list_directory"
+	| "read_content"
+	| "manage_notes"
+	| "execute_javascript"
+	| "get_all_tags"
+	| "get_properties"
+	| "fetch_url"
+	| "web_search"
+	| "load_skill"
+	| "task";
+
+const BUILT_IN_TOOLS: ReadonlySet<string> = new Set<BuiltInTool>([
+	"search_notes",
+	"grep_notes",
+	"list_directory",
+	"read_content",
+	"manage_notes",
+	"execute_javascript",
+	"get_all_tags",
+	"get_properties",
+	"fetch_url",
+	"web_search",
+	"load_skill",
+	"task",
+]);
+
+function asBuiltIn(toolName: string): BuiltInTool | undefined {
+	return BUILT_IN_TOOLS.has(toolName) ? (toolName as BuiltInTool) : undefined;
+}
+
+/* ── Small formatting helpers ── */
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+	return `${count} ${count === 1 ? singular : plural}`;
+}
+
+/** Truncate a target string so the phrase stays a single tidy line. */
+function truncateTarget(value: string, max = 48): string {
+	const trimmed = value.trim();
+	if (trimmed.length <= max) return trimmed;
+	return `${trimmed.slice(0, max - 1)}…`;
+}
+
+/** The basename of a vault path (last non-empty segment), for compact labels. */
+function basename(path: string): string {
+	const segments = path.split("/").filter(Boolean);
+	return segments.at(-1) ?? path;
+}
+
+function stringInput(input: Record<string, unknown> | null | undefined, key: string): string | undefined {
+	const value = input?.[key];
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+/** Title-case a raw tool name as a fallback label (`get_all_tags` → `Get All Tags`). */
+function titleCaseToolName(name: string): string {
+	if (!name) return "Tool";
+	return name
+		.replace(/_/g, " ")
+		.replace(/([a-z])([A-Z])/g, "$1 $2")
+		.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function countLines(text: string): number {
+	if (!text) return 0;
+	// A trailing newline shouldn't count as an extra empty line.
+	const normalized = text.endsWith("\n") ? text.slice(0, -1) : text;
+	return normalized.split(/\r?\n/).length;
+}
+
+/* ── Per-tool summaries ── */
+
+/** Internal per-tool result: a tense-aware {@link Label} plus the muted summary. */
+interface RawSummary {
+	label: Label;
+	summary: string;
+}
+
+function summarizeSearchNotes(
+	input: Record<string, unknown> | null | undefined,
+	model: ToolOutputRenderModel | undefined,
+): RawSummary {
+	const query = stringInput(input, "query");
+	const recentOnly = input?.recentOnly === true;
+	const label: Label = query
+		? { verb: verb("Searching notes for", "Searched notes for"), rest: `“${truncateTarget(query)}”` }
+		: recentOnly
+			? { verb: verb("Looking at recent notes", "Looked at recent notes") }
+			: { verb: verb("Searching notes", "Searched notes") };
+
+	if (model?.kind !== "search_notes") return { label, summary: "" };
+	const total = model.payload.totalResults ?? model.payload.results?.length ?? 0;
+	return { label, summary: total === 0 ? "no matches" : pluralize(total, "note") };
+}
+
+function summarizeGrepNotes(
+	input: Record<string, unknown> | null | undefined,
+	model: ToolOutputRenderModel | undefined,
+): RawSummary {
+	const pattern = stringInput(input, "pattern");
+	const label: Label = pattern
+		? { verb: verb("Searching for text", "Searched for text"), rest: `“${truncateTarget(pattern)}”` }
+		: { verb: verb("Searching note text", "Searched note text") };
+
+	// grep_notes returns generic JSON — pull totals straight off the raw payload.
+	const payload = parseRawJson(model?.rawText);
+	if (payload && typeof payload === "object") {
+		const total = numberProp(payload, "total_matches");
+		const files = numberProp(payload, "files_searched");
+		if (total !== undefined) {
+			if (total === 0) return { label, summary: "no matches" };
+			const filePart = files !== undefined ? ` in ${pluralize(files, "file")}` : "";
+			return { label, summary: `${pluralize(total, "match", "matches")}${filePart}` };
+		}
+	}
+	return { label, summary: "" };
+}
+
+function summarizeListDirectory(
+	input: Record<string, unknown> | null | undefined,
+	model: ToolOutputRenderModel | undefined,
+): RawSummary {
+	const path = stringInput(input, "path") ?? stringInput(input, "root");
+	const label: Label =
+		path && path !== "/"
+			? { verb: verb("Listing folder", "Listed folder"), rest: truncateTarget(basename(path)) }
+			: { verb: verb("Listing the vault", "Listed the vault") };
+
+	if (model?.kind !== "list_directory") return { label, summary: "" };
+	const folders = model.payload.totalFolders ?? 0;
+	const files = model.payload.totalFiles ?? 0;
+	const parts: string[] = [];
+	if (folders > 0) parts.push(pluralize(folders, "folder"));
+	parts.push(pluralize(files, "file"));
+	return { label, summary: parts.join(", ") };
+}
+
+function summarizeReadContent(
+	input: Record<string, unknown> | null | undefined,
+	model: ToolOutputRenderModel | undefined,
+): RawSummary {
+	const target = stringInput(input, "target") ?? stringInput(input, "path");
+	const label: Label = target
+		? { verb: verb("Reading", "Read"), rest: truncateTarget(basename(target)) }
+		: { verb: verb("Reading a note", "Read a note") };
+
+	if (model?.kind !== "read_content") return { label, summary: "" };
+	const lines = countLines(model.payload.content);
+	const summary = model.payload.truncated ? `${pluralize(lines, "line")} (truncated)` : pluralize(lines, "line");
+	return { label, summary };
+}
+
+function summarizeManageNotes(model: ToolOutputRenderModel | undefined): RawSummary {
+	// The operation set can be large; a plain "Edited notes" reads cleaner than a list.
+	if (model?.kind !== "manage_notes") return { label: { verb: verb("Editing notes", "Edited notes") }, summary: "" };
+	const { operations, paths } = model.summary;
+	const label: Label =
+		paths === 1
+			? { verb: verb("Editing a note", "Edited a note") }
+			: { verb: verb("Editing notes", "Edited notes") };
+	return { label, summary: `${pluralize(operations, "operation")} · ${pluralize(paths, "note")}` };
+}
+
+function summarizeExecuteJavaScript(model: ToolOutputRenderModel | undefined): RawSummary {
+	const label: Label = { verb: verb("Running JavaScript", "Ran JavaScript") };
+	if (model?.kind !== "execute_javascript") return { label, summary: "" };
+	if (model.payload.state === "error") return { label, summary: "error" };
+	const logs = model.payload.logs.length;
+	const parts: string[] = [];
+	if (logs > 0) parts.push(pluralize(logs, "log"));
+	if (model.payload.resultText) parts.push("returned value");
+	if (model.payload.durationMs !== undefined) parts.push(`${model.payload.durationMs}ms`);
+	return { label, summary: parts.join(" · ") };
+}
+
+function summarizeGetAllTags(model: ToolOutputRenderModel | undefined): RawSummary {
+	const label: Label = { verb: verb("Listing all tags", "Listed all tags") };
+	const count = listLength(model);
+	return { label, summary: count !== undefined ? pluralize(count, "tag") : "" };
+}
+
+function summarizeGetProperties(input: Record<string, unknown> | null | undefined): RawSummary {
+	const target = stringInput(input, "path") ?? stringInput(input, "target");
+	const label: Label = target
+		? { verb: verb("Reading properties of", "Read properties of"), rest: truncateTarget(basename(target)) }
+		: { verb: verb("Reading note properties", "Read note properties") };
+	return { label, summary: "" };
+}
+
+function summarizeFetchUrl(input: Record<string, unknown> | null | undefined): RawSummary {
+	const url = stringInput(input, "url");
+	const label: Label = url
+		? { verb: verb("Fetching", "Fetched"), rest: truncateTarget(hostOf(url)) }
+		: { verb: verb("Fetching a page", "Fetched a page") };
+	return { label, summary: "" };
+}
+
+function summarizeWebSearch(
+	input: Record<string, unknown> | null | undefined,
+	model: ToolOutputRenderModel | undefined,
+): RawSummary {
+	const query = stringInput(input, "query");
+	const label: Label = query
+		? { verb: verb("Searching the web for", "Searched the web for"), rest: `“${truncateTarget(query)}”` }
+		: { verb: verb("Searching the web", "Searched the web") };
+	const count = listLength(model);
+	return { label, summary: count !== undefined ? pluralize(count, "result") : "" };
+}
+
+function summarizeLoadSkill(input: Record<string, unknown> | null | undefined): RawSummary {
+	const name = stringInput(input, "name") ?? stringInput(input, "skill");
+	const label: Label = name
+		? { verb: verb("Loading skill", "Loaded skill"), rest: truncateTarget(name) }
+		: { verb: verb("Loading a skill", "Loaded a skill") };
+	return { label, summary: "" };
+}
+
+/* ── Generic fallback (unknown / renamed tools) ── */
+
+function summarizeGeneric(
+	toolName: string,
+	input: Record<string, unknown> | null | undefined,
+	model: ToolOutputRenderModel | undefined,
+): RawSummary {
+	const name = titleCaseToolName(toolName);
+	// A renamed/unknown tool has no known verb, so it can't be tensed — show a
+	// neutral "Using <name>" / "Used <name>" frame that still reads as a sentence.
+	const primary = firstStringInput(input);
+	const rest = primary ? truncateTarget(primary) : name;
+	const label: Label = primary
+		? { verb: verb(`Using ${name}:`, `Used ${name}:`), rest }
+		: { verb: verb(`Using ${name}`, `Used ${name}`) };
+
+	// Pull a light outcome hint from the shape the render model already computed.
+	let summary = "";
+	if (model) {
+		switch (model.kind) {
+			case "list":
+				summary = pluralize(model.items.length, "item");
+				break;
+			case "table":
+				summary = pluralize(model.rows.length, "row");
+				break;
+			case "keyValue":
+				summary = pluralize(model.entries.length, "field");
+				break;
+			default:
+				summary = "";
+		}
+	}
+	return { label, summary };
+}
+
+/* ── Shared payload helpers ── */
+
+function parseRawJson(rawText: string | undefined): unknown {
+	if (!rawText) return undefined;
+	const trimmed = rawText.trim();
+	if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return undefined;
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return undefined;
+	}
+}
+
+function numberProp(obj: unknown, key: string): number | undefined {
+	if (!obj || typeof obj !== "object") return undefined;
+	const value = (obj as Record<string, unknown>)[key];
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/** Count items for tools that render as a scalar/list of results, if determinable. */
+function listLength(model: ToolOutputRenderModel | undefined): number | undefined {
+	if (!model) return undefined;
+	if (model.kind === "list") return model.items.length;
+	if (model.kind === "table") return model.rows.length;
+	const parsed = parseRawJson(model.rawText);
+	if (Array.isArray(parsed)) return parsed.length;
+	return undefined;
+}
+
+function hostOf(url: string): string {
+	try {
+		return new URL(url).host || url;
+	} catch {
+		return url;
+	}
+}
+
+function firstStringInput(input: Record<string, unknown> | null | undefined): string | undefined {
+	if (!input || typeof input !== "object") return undefined;
+	for (const value of Object.values(input)) {
+		if (typeof value === "string" && value.trim().length > 0) return value.trim();
+	}
+	return undefined;
+}
+
+/**
+ * Builds the compact plain-language label and one-line result summary for a tool
+ * call, dispatching on the canonical built-in tool identity. `model` is the
+ * already-normalised output render model (undefined while the tool is still
+ * running or produced no output); `status` lets callers keep the summary empty
+ * until an outcome exists if they prefer.
+ */
+export function buildToolSummary(
+	toolName: string,
+	input: Record<string, unknown> | null | undefined,
+	model: ToolOutputRenderModel | undefined,
+	status: ToolCallStatus,
+): ToolSummary {
+	const builtIn = asBuiltIn(toolName);
+
+	const raw = ((): RawSummary => {
+		switch (builtIn) {
+			case "search_notes":
+				return summarizeSearchNotes(input, model);
+			case "grep_notes":
+				return summarizeGrepNotes(input, model);
+			case "list_directory":
+				return summarizeListDirectory(input, model);
+			case "read_content":
+				return summarizeReadContent(input, model);
+			case "manage_notes":
+				return summarizeManageNotes(model);
+			case "execute_javascript":
+				return summarizeExecuteJavaScript(model);
+			case "get_all_tags":
+				return summarizeGetAllTags(model);
+			case "get_properties":
+				return summarizeGetProperties(input);
+			case "fetch_url":
+				return summarizeFetchUrl(input);
+			case "web_search":
+				return summarizeWebSearch(input, model);
+			case "load_skill":
+				return summarizeLoadSkill(input);
+			default:
+				return summarizeGeneric(toolName, input, model);
+		}
+	})();
+
+	const label = renderLabel(raw.label, status);
+
+	// While running with nothing decoded yet, a failed tool should still read as
+	// failed rather than showing a stale summary from a prior render.
+	if (status === "failed" && !model) {
+		return { label, summary: "failed" };
+	}
+	return { label, summary: raw.summary };
+}
+
+/* ── Merged multi-call summaries ── */
+
+/** One call in a merged group: its input plus already-normalised output model. */
+export interface MergedCall {
+	input: Record<string, unknown> | null | undefined;
+	model: ToolOutputRenderModel | undefined;
+}
+
+/**
+ * Per-tool recipe for merging several consecutive same-tool calls into one
+ * sentence: the shared {@link Verb}, how to pull each call's target for the list,
+ * whether targets read as quoted queries, and how to aggregate the result counts.
+ */
+interface MergeSpec {
+	verb: Verb;
+	/** The target shown in the list for one call (query, path basename, host…). */
+	target: (input: Record<string, unknown> | null | undefined) => string | undefined;
+	/** Whether list targets are wrapped in typographic quotes (queries vs paths). */
+	quoted: boolean;
+	/** Aggregated result summary across all calls (e.g. total matches/notes). */
+	aggregate?: (calls: MergedCall[]) => string;
+}
+
+/** How many targets to name inline before collapsing the tail into "+N more". */
+const MAX_LISTED_TARGETS = 4;
+
+function sumBy(calls: MergedCall[], pick: (c: MergedCall) => number | undefined): number | undefined {
+	let total = 0;
+	let seen = false;
+	for (const c of calls) {
+		const n = pick(c);
+		if (n !== undefined) {
+			total += n;
+			seen = true;
+		}
+	}
+	return seen ? total : undefined;
+}
+
+const MERGE_SPECS: Partial<Record<BuiltInTool, MergeSpec>> = {
+	search_notes: {
+		verb: verb("Searching notes for", "Searched notes for"),
+		target: (input) => stringInput(input, "query"),
+		quoted: true,
+		aggregate: (calls) => {
+			const total = sumBy(calls, (c) =>
+				c.model?.kind === "search_notes"
+					? (c.model.payload.totalResults ?? c.model.payload.results?.length ?? 0)
+					: undefined,
+			);
+			return total === undefined ? "" : total === 0 ? "no matches" : pluralize(total, "note");
+		},
+	},
+	grep_notes: {
+		verb: verb("Searching for text", "Searched for text"),
+		target: (input) => stringInput(input, "pattern"),
+		quoted: true,
+		aggregate: (calls) => {
+			const total = sumBy(calls, (c) => {
+				const payload = parseRawJson(c.model?.rawText);
+				return payload && typeof payload === "object" ? numberProp(payload, "total_matches") : undefined;
+			});
+			return total === undefined ? "" : total === 0 ? "no matches" : pluralize(total, "match", "matches");
+		},
+	},
+	read_content: {
+		verb: verb("Reading", "Read"),
+		target: (input) => {
+			const t = stringInput(input, "target") ?? stringInput(input, "path");
+			return t ? basename(t) : undefined;
+		},
+		quoted: false,
+		aggregate: (calls) => {
+			const total = sumBy(calls, (c) =>
+				c.model?.kind === "read_content" ? countLines(c.model.payload.content) : undefined,
+			);
+			return total === undefined ? "" : `${pluralize(total, "line")} total`;
+		},
+	},
+	get_properties: {
+		verb: verb("Reading properties of", "Read properties of"),
+		target: (input) => {
+			const t = stringInput(input, "path") ?? stringInput(input, "target");
+			return t ? basename(t) : undefined;
+		},
+		quoted: false,
+	},
+	fetch_url: {
+		verb: verb("Fetching", "Fetched"),
+		target: (input) => {
+			const url = stringInput(input, "url");
+			return url ? hostOf(url) : undefined;
+		},
+		quoted: false,
+	},
+	web_search: {
+		verb: verb("Searching the web for", "Searched the web for"),
+		target: (input) => stringInput(input, "query"),
+		quoted: true,
+	},
+	load_skill: {
+		verb: verb("Loading skill", "Loaded skill"),
+		target: (input) => stringInput(input, "name") ?? stringInput(input, "skill"),
+		quoted: false,
+	},
+};
+
+/** Joins listed targets into "a, b and c", capping the tail as "a, b and N more". */
+function joinTargets(targets: string[], quoted: boolean): string {
+	const wrap = (t: string) => (quoted ? `“${truncateTarget(t, 32)}”` : truncateTarget(t, 32));
+	if (targets.length <= MAX_LISTED_TARGETS) {
+		const wrapped = targets.map(wrap);
+		if (wrapped.length === 1) return wrapped[0];
+		return `${wrapped.slice(0, -1).join(", ")} and ${wrapped.at(-1)}`;
+	}
+	const head = targets.slice(0, MAX_LISTED_TARGETS).map(wrap);
+	const remaining = targets.length - MAX_LISTED_TARGETS;
+	return `${head.join(", ")} and ${remaining} more`;
+}
+
+/**
+ * Builds one combined, tense-aware summary for a run of consecutive calls to the
+ * same tool. When the tool has a clear per-call target (a query or path), the
+ * label lists them (e.g. `Searched for text "a", "b" and "c"`); otherwise it
+ * falls back to a count phrase (e.g. `Read 3 notes`). The result summary is the
+ * tool's aggregate across all calls where one is defined. `status` is the merged
+ * status of the group (running if any call is still running).
+ */
+export function buildMergedToolSummary(toolName: string, calls: MergedCall[], status: ToolCallStatus): ToolSummary {
+	// Degenerate group: defer to the single-call summary.
+	if (calls.length === 1) {
+		return buildToolSummary(toolName, calls[0].input, calls[0].model, status);
+	}
+
+	const builtIn = asBuiltIn(toolName);
+	const spec = builtIn ? MERGE_SPECS[builtIn] : undefined;
+
+	// No merge recipe (or a tool whose calls don't share a target): fall back to a
+	// count phrase using the single-call verb, so the row still reads as a sentence.
+	if (!spec) {
+		const one = buildToolSummary(toolName, calls[0].input, calls[0].model, status);
+		// Re-tense the single label's verb by swapping its leading clause is fragile;
+		// instead append a count. The single label already carries the right tense.
+		return { label: `${one.label} ×${calls.length}`, summary: "" };
+	}
+
+	const targets = calls.map((c) => spec.target(c.input)).filter((t): t is string => !!t);
+	const noun = builtIn === "read_content" || builtIn === "get_properties" ? "note" : "item";
+
+	let rest: string;
+	if (targets.length === calls.length && targets.length > 0) {
+		rest = joinTargets(targets, spec.quoted);
+	} else {
+		// Some calls had no extractable target — summarise by count instead of a
+		// partial, misleading list.
+		rest = pluralize(calls.length, noun);
+	}
+
+	const label = renderLabel({ verb: spec.verb, rest }, status);
+	const summary = status === "running" ? "" : (spec.aggregate?.(calls) ?? "");
+	return { label, summary };
+}

--- a/src/components/chat/toolSummaryModel.ts
+++ b/src/components/chat/toolSummaryModel.ts
@@ -556,10 +556,15 @@ export function buildMergedToolSummary(toolName: string, calls: MergedCall[], st
 	// No merge recipe (or a tool whose calls don't share a target): fall back to a
 	// count phrase using the single-call verb, so the row still reads as a sentence.
 	if (!spec) {
-		const one = buildToolSummary(toolName, calls[0].input, calls[0].model, status);
-		// Re-tense the single label's verb by swapping its leading clause is fragile;
-		// instead append a count. The single label already carries the right tense.
-		return { label: `${one.label} ×${calls.length}`, summary: "" };
+		// Re-summarize with empty input so the label is just the tense-aware verb
+		// (e.g. "Listed all tags"), never the *first* call's target clause — that
+		// clause describes one call and would misrepresent the whole group.
+		const base = buildToolSummary(toolName, {}, undefined, status);
+		const label = `${base.label} ×${calls.length}`;
+		// Sum the count-based outcomes each call already computed so a merged
+		// generic tool still reports its result (e.g. two get_all_tags → "found N tags").
+		const summary = status === "failed" ? "failed" : mergedGenericSummary(calls);
+		return { label, summary };
 	}
 
 	const targets = calls.map((c) => spec.target(c.input)).filter((t): t is string => !!t);
@@ -575,6 +580,36 @@ export function buildMergedToolSummary(toolName: string, calls: MergedCall[], st
 	}
 
 	const label = renderLabel({ verb: spec.verb, rest }, status);
+	// A failed group must not display a positive aggregate ("found 3 notes") in red —
+	// mirror the single-call failed guard. Aggregates are also empty while running.
+	if (status === "failed") return { label, summary: "failed" };
 	const summary = status === "running" ? "" : (spec.aggregate?.(calls) ?? "");
 	return { label, summary };
+}
+
+/**
+ * Sums the count-based outcomes (list/table/keyValue) across a merged run of a
+ * generic tool with no dedicated merge recipe, so the row still reports a result.
+ * Returns an empty string when no call produced a countable shape.
+ */
+function mergedGenericSummary(calls: MergedCall[]): string {
+	let total = 0;
+	let noun: string | undefined;
+	for (const c of calls) {
+		switch (c.model?.kind) {
+			case "list":
+				total += c.model.items.length;
+				noun ??= "item";
+				break;
+			case "table":
+				total += c.model.rows.length;
+				noun ??= "row";
+				break;
+			case "keyValue":
+				total += c.model.entries.length;
+				noun ??= "field";
+				break;
+		}
+	}
+	return noun ? `found ${pluralize(total, noun)}` : "";
 }

--- a/src/components/chat/toolTimelineModel.ts
+++ b/src/components/chat/toolTimelineModel.ts
@@ -206,3 +206,47 @@ export function toolDisplayName(tool: UnifiedToolCall): string {
 	}
 	return tool.name;
 }
+
+/**
+ * A run of consecutive tool calls in a step that render as a single row. Most
+ * groups hold one call; a group of several always shares the same tool name and
+ * is merged into one sentence (e.g. three `grep_notes` calls → one "Searched for
+ * text …" row listing each pattern), expanding to the individual calls.
+ *
+ * `id` is stable (the first call's id) so Svelte keying survives streaming as a
+ * group grows. `merged` is a convenience flag for `calls.length > 1`.
+ */
+export interface ToolCallGroup {
+	id: string;
+	name: string;
+	calls: UnifiedToolCall[];
+	merged: boolean;
+}
+
+/**
+ * Groups a step's tools into rows, merging *consecutive* calls to the same tool
+ * so repeated calls collapse into one sentence. Calls that must stay individually
+ * legible are never merged and always form a group of one:
+ *  - `task` calls (each subagent is its own labelled node), and
+ *  - any call with folded subagent `children` (its own sub-timeline hangs off it).
+ * Order is preserved; only adjacent same-name calls coalesce, so an A A B A
+ * sequence yields [A A] [B] [A] rather than reordering.
+ */
+export function groupStepTools(tools: UnifiedToolCall[]): ToolCallGroup[] {
+	const groups: ToolCallGroup[] = [];
+
+	const isMergeable = (tool: UnifiedToolCall): boolean =>
+		tool.name !== "task" && !(tool.children && tool.children.length > 0);
+
+	for (const tool of tools) {
+		const last = groups.at(-1);
+		if (last && isMergeable(tool) && last.name === tool.name && isMergeable(last.calls[0])) {
+			last.calls.push(tool);
+			last.merged = true;
+			continue;
+		}
+		groups.push({ id: tool.id, name: tool.name, calls: [tool], merged: false });
+	}
+
+	return groups;
+}

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -485,6 +485,7 @@ export const DEFAULT_SETTINGS: PluginData = {
 
 	// UI state
 	isVerbose: false,
+	showToolIODetails: false,
 	chatOpenLocation: "tab" as ChatOpenLocation,
 	lastActiveChatId: null,
 	onboardingComplete: false,
@@ -1271,6 +1272,14 @@ export class PluginDataStore {
 	}
 	set isVerbose(val: boolean) {
 		this.#data.isVerbose = val;
+		this.saveSettings();
+	}
+
+	get showToolIODetails() {
+		return this.#data.showToolIODetails ?? false;
+	}
+	set showToolIODetails(val: boolean) {
+		this.#data.showToolIODetails = val;
 		this.saveSettings();
 	}
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -578,6 +578,14 @@ export interface PluginData {
 	langSmithEndpoint: string;
 	isVerbose: boolean;
 
+	/**
+	 * Show raw tool input/output (arg key-values + raw output blob) in the chat
+	 * tool-call rows. Off by default: users see only the plain-language summary and
+	 * the friendly structured result. A developer escape hatch for inspecting the
+	 * exact I/O; surfaced only in the DEV-only Developer settings tab.
+	 */
+	showToolIODetails: boolean;
+
 	// ============================================================================
 	// Other
 	// ============================================================================

--- a/src/views/settings/DeveloperSettings.svelte
+++ b/src/views/settings/DeveloperSettings.svelte
@@ -3,6 +3,7 @@ import { Notice } from "obsidian";
 import SettingGroup from "../../components/settings/SettingGroup.svelte";
 import SettingItem from "../../components/settings/SettingItem.svelte";
 import Button from "../../components/ui/Button.svelte";
+import Toggle from "../../components/ui/Toggle.svelte";
 import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
 
@@ -29,5 +30,18 @@ function openOnboardingView() {
       <Button buttonText="Reset intro" iconId="rotate-ccw" onClick={replayOnboardingIntro} />
       <Button buttonText="Open Welcome view" iconId="zap" onClick={openOnboardingView} />
     </div>
+  </SettingItem>
+</SettingGroup>
+
+<!-- Chat -->
+<SettingGroup heading="Chat">
+  <SettingItem
+    name="Show raw tool input/output"
+    desc="Reveal the exact tool arguments and raw output blob in chat tool-call rows. Off by default — users see only the plain-language summary and the friendly structured result."
+  >
+    <Toggle
+      checked={pluginData.showToolIODetails}
+      onchange={(checked) => (pluginData.showToolIODetails = checked)}
+    />
   </SettingItem>
 </SettingGroup>

--- a/test/components/toolOutputRenderModel.test.ts
+++ b/test/components/toolOutputRenderModel.test.ts
@@ -157,6 +157,23 @@ describe("buildToolOutputRenderModel", () => {
 		expect(model.sections.map((section) => section.key)).toEqual(["meta", "items"]);
 	});
 
+	it("preserves the full payload for a heterogeneous array (rendered when no sections exist)", () => {
+		// A non-scalar, non-tabular array reduces to an item count with no nested
+		// sections; the complete payload must still live in `json` so the UI can
+		// render it as the friendly result (issue: it must not be lost behind the
+		// developer-only raw-I/O toggle).
+		const model = buildToolOutputRenderModel("mcp_tool", [{ a: 1 }, "text", 42]);
+
+		expect(model.kind).toBe("structured");
+		if (model.kind !== "structured") return;
+		expect(model.sections).toEqual([]);
+		expect(model.summaryEntries).toEqual([{ key: "items", value: "3" }]);
+		// The full contents survive in `json` (not just the count).
+		expect(model.json).toContain('"a": 1');
+		expect(model.json).toContain("text");
+		expect(model.json).toContain("42");
+	});
+
 	it("unwraps langchain content blocks", () => {
 		const model = buildToolOutputRenderModel("mcp_tool", [{ type: "json", data: { count: 2 } }]);
 

--- a/test/components/toolSummaryModel.test.ts
+++ b/test/components/toolSummaryModel.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from "vitest";
+import { buildToolOutputRenderModel } from "../../src/components/chat/toolOutputRenderModel";
+import { buildToolSummary, buildMergedToolSummary } from "../../src/components/chat/toolSummaryModel";
+
+/** Build the output render model the way ToolCallsSection does before summarizing. */
+function model(toolName: string, output: unknown, input?: Record<string, unknown>) {
+	return buildToolOutputRenderModel(toolName, output, input);
+}
+
+describe("buildToolSummary", () => {
+	describe("tense", () => {
+		it("uses present continuous while running", () => {
+			const s = buildToolSummary("read_content", { target: "Notes/main.md" }, undefined, "running");
+			expect(s.label).toBe("Reading main.md");
+		});
+
+		it("uses past tense once completed", () => {
+			const out = model("read_content", 'Content of "Notes/main.md":\n\na\nb\nc');
+			const s = buildToolSummary("read_content", { target: "Notes/main.md" }, out, "completed");
+			expect(s.label).toBe("Read main.md");
+		});
+
+		it("uses past tense when failed", () => {
+			const s = buildToolSummary("read_content", { target: "Notes/main.md" }, undefined, "failed");
+			expect(s.label).toBe("Read main.md");
+			expect(s.summary).toBe("failed");
+		});
+	});
+
+	describe("search_notes", () => {
+		it("labels with the query and counts notes", () => {
+			const out = model(
+				"search_notes",
+				JSON.stringify({ query: "vector store", totalResults: 3, results: [{ rank: 1, name: "A" }] }),
+			);
+			const s = buildToolSummary("search_notes", { query: "vector store" }, out, "completed");
+			expect(s.label).toBe("Searched notes for “vector store”");
+			expect(s.summary).toBe("3 notes");
+		});
+
+		it("reports no matches for an empty result set", () => {
+			const out = model("search_notes", JSON.stringify({ query: "zzz", totalResults: 0, results: [] }));
+			const s = buildToolSummary("search_notes", { query: "zzz" }, out, "completed");
+			expect(s.summary).toBe("no matches");
+		});
+
+		it("handles recent-only searches without a query", () => {
+			const s = buildToolSummary("search_notes", { recentOnly: true }, undefined, "running");
+			expect(s.label).toBe("Looking at recent notes");
+		});
+	});
+
+	describe("grep_notes", () => {
+		it("counts matches and files from the raw payload", () => {
+			const payload = JSON.stringify({ pattern: "TODO", total_matches: 5, files_searched: 2, results: [] });
+			const out = model("grep_notes", payload);
+			const s = buildToolSummary("grep_notes", { pattern: "TODO" }, out, "completed");
+			expect(s.label).toBe("Searched for text “TODO”");
+			expect(s.summary).toBe("5 matches in 2 files");
+		});
+
+		it("reports no matches", () => {
+			const out = model("grep_notes", JSON.stringify({ pattern: "TODO", total_matches: 0, files_searched: 4 }));
+			const s = buildToolSummary("grep_notes", { pattern: "TODO" }, out, "completed");
+			expect(s.summary).toBe("no matches");
+		});
+	});
+
+	describe("list_directory", () => {
+		it("labels with the folder basename and counts entries", () => {
+			const out = model("list_directory", {
+				root: "Projects",
+				tree: { folders: {}, files: [{ name: "a.md" }] },
+				totalFolders: 1,
+				totalFiles: 2,
+			});
+			const s = buildToolSummary("list_directory", { path: "Notes/Projects" }, out, "completed");
+			expect(s.label).toBe("Listed folder Projects");
+			expect(s.summary).toBe("1 folder, 2 files");
+		});
+
+		it("labels the vault root", () => {
+			const s = buildToolSummary("list_directory", { path: "/" }, undefined, "running");
+			expect(s.label).toBe("Listing the vault");
+		});
+	});
+
+	describe("read_content", () => {
+		it("counts lines in the returned content", () => {
+			const out = model("read_content", 'Content of "Notes/deep/main.md":\n\none\ntwo\nthree');
+			const s = buildToolSummary("read_content", { target: "Notes/deep/main.md" }, out, "completed");
+			expect(s.label).toBe("Read main.md");
+			expect(s.summary).toBe("3 lines");
+		});
+
+		it("flags truncated reads", () => {
+			const out = model("read_content", 'Content of "big.md":\n\na\nb\n[Content truncated at 2 lines]');
+			const s = buildToolSummary("read_content", { target: "big.md" }, out, "completed");
+			expect(s.summary).toContain("truncated");
+		});
+	});
+
+	describe("manage_notes", () => {
+		it("summarizes operations and note count", () => {
+			const out = model("manage_notes", "Proposed 2 note operation(s) across 1 path(s) (1 create, 1 append)");
+			const s = buildToolSummary("manage_notes", {}, out, "completed");
+			expect(s.label).toBe("Edited a note");
+			expect(s.summary).toBe("2 operations · 1 note");
+		});
+
+		it("uses present tense while editing", () => {
+			const s = buildToolSummary("manage_notes", {}, undefined, "running");
+			expect(s.label).toBe("Editing notes");
+		});
+	});
+
+	describe("execute_javascript", () => {
+		it("reports an error state", () => {
+			const out = model("execute_javascript", "JavaScript execution failed: boom", { code: "throw 1" });
+			const s = buildToolSummary("execute_javascript", { code: "throw 1" }, out, "completed");
+			expect(s.label).toBe("Ran JavaScript");
+			expect(s.summary).toBe("error");
+		});
+
+		it("summarizes logs and duration on success", () => {
+			const out = model(
+				"execute_javascript",
+				"Execution completed in 12ms.\n\nConsole output:\nhello\nworld\n\nReturn value:\n42",
+				{ code: "console.log('hi')" },
+			);
+			const s = buildToolSummary("execute_javascript", { code: "console.log('hi')" }, out, "completed");
+			expect(s.summary).toContain("2 logs");
+			expect(s.summary).toContain("12ms");
+		});
+
+		it("uses present tense while running", () => {
+			const s = buildToolSummary("execute_javascript", {}, undefined, "running");
+			expect(s.label).toBe("Running JavaScript");
+		});
+	});
+
+	describe("web_search", () => {
+		it("labels with the query", () => {
+			const s = buildToolSummary("web_search", { query: "svelte runes" }, undefined, "running");
+			expect(s.label).toBe("Searching the web for “svelte runes”");
+		});
+	});
+
+	describe("fetch_url", () => {
+		it("labels with the host", () => {
+			const s = buildToolSummary("fetch_url", { url: "https://example.com/a/b?c=1" }, undefined, "completed");
+			expect(s.label).toBe("Fetched example.com");
+		});
+
+		it("falls back gracefully for a malformed url", () => {
+			const s = buildToolSummary("fetch_url", { url: "not a url" }, undefined, "completed");
+			expect(s.label).toBe("Fetched not a url");
+		});
+	});
+
+	describe("load_skill", () => {
+		it("labels with the skill name", () => {
+			const s = buildToolSummary("load_skill", { name: "canvas" }, undefined, "completed");
+			expect(s.label).toBe("Loaded skill canvas");
+		});
+	});
+
+	describe("generic fallback (unknown / renamed tools)", () => {
+		it("title-cases the tool name and uses a neutral frame", () => {
+			const s = buildToolSummary("my_custom_tool", {}, undefined, "running");
+			expect(s.label).toBe("Using My Custom Tool");
+		});
+
+		it("uses past tense when completed", () => {
+			const s = buildToolSummary("my_custom_tool", {}, undefined, "completed");
+			expect(s.label).toBe("Used My Custom Tool");
+		});
+
+		it("appends the first string input as a target hint", () => {
+			const s = buildToolSummary("my_custom_tool", { path: "Notes/x.md" }, undefined, "running");
+			expect(s.label).toBe("Using My Custom Tool: Notes/x.md");
+		});
+
+		it("derives a count hint from list output", () => {
+			const out = model("my_custom_tool", ["a", "b", "c"]);
+			const s = buildToolSummary("my_custom_tool", {}, out, "completed");
+			expect(s.summary).toBe("3 items");
+		});
+	});
+
+	describe("truncation", () => {
+		it("truncates a very long query", () => {
+			const longQuery = "x".repeat(100);
+			const s = buildToolSummary("search_notes", { query: longQuery }, undefined, "running");
+			expect(s.label.length).toBeLessThan(longQuery.length + 30);
+			expect(s.label).toContain("…");
+		});
+	});
+});
+
+describe("buildMergedToolSummary", () => {
+	const mergedCall = (toolName: string, output: unknown, input: Record<string, unknown>) => ({
+		input,
+		model: buildToolOutputRenderModel(toolName, output, input),
+	});
+
+	it("defers to the single-call summary for a group of one", () => {
+		const s = buildMergedToolSummary(
+			"search_notes",
+			[mergedCall("search_notes", JSON.stringify({ totalResults: 2, results: [] }), { query: "a" })],
+			"completed",
+		);
+		expect(s.label).toBe("Searched notes for “a”");
+	});
+
+	it("lists grep patterns and sums matches", () => {
+		const calls = [
+			mergedCall("grep_notes", JSON.stringify({ total_matches: 3, files_searched: 1 }), { pattern: "foo" }),
+			mergedCall("grep_notes", JSON.stringify({ total_matches: 2, files_searched: 1 }), { pattern: "bar" }),
+		];
+		const s = buildMergedToolSummary("grep_notes", calls, "completed");
+		expect(s.label).toBe("Searched for text “foo” and “bar”");
+		expect(s.summary).toBe("5 matches");
+	});
+
+	it("lists search queries with an Oxford-style 'and' and sums notes", () => {
+		const calls = [
+			mergedCall("search_notes", JSON.stringify({ totalResults: 2, results: [] }), { query: "a" }),
+			mergedCall("search_notes", JSON.stringify({ totalResults: 1, results: [] }), { query: "b" }),
+			mergedCall("search_notes", JSON.stringify({ totalResults: 4, results: [] }), { query: "c" }),
+		];
+		const s = buildMergedToolSummary("search_notes", calls, "completed");
+		expect(s.label).toBe("Searched notes for “a”, “b” and “c”");
+		expect(s.summary).toBe("7 notes");
+	});
+
+	it("caps a long target list with '+N more'", () => {
+		const calls = ["a", "b", "c", "d", "e", "f"].map((q) =>
+			mergedCall("search_notes", JSON.stringify({ totalResults: 0, results: [] }), { query: q }),
+		);
+		const s = buildMergedToolSummary("search_notes", calls, "completed");
+		expect(s.label).toBe("Searched notes for “a”, “b”, “c”, “d” and 2 more");
+	});
+
+	it("lists read targets by basename and sums lines", () => {
+		const calls = [
+			mergedCall("read_content", 'Content of "Notes/a.md":\n\none\ntwo', { target: "Notes/a.md" }),
+			mergedCall("read_content", 'Content of "Notes/b.md":\n\none\ntwo\nthree', { target: "Notes/b.md" }),
+		];
+		const s = buildMergedToolSummary("read_content", calls, "completed");
+		expect(s.label).toBe("Read a.md and b.md");
+		expect(s.summary).toBe("5 lines total");
+	});
+
+	it("falls back to a count when some calls lack a target", () => {
+		const calls = [
+			mergedCall("search_notes", JSON.stringify({ totalResults: 1, results: [] }), { query: "a" }),
+			mergedCall("search_notes", JSON.stringify({ totalResults: 1, results: [] }), {}),
+		];
+		const s = buildMergedToolSummary("search_notes", calls, "completed");
+		expect(s.label).toBe("Searched notes for 2 items");
+	});
+
+	it("uses present tense and empty summary while running", () => {
+		const calls = [
+			mergedCall("grep_notes", JSON.stringify({ total_matches: 3 }), { pattern: "foo" }),
+			mergedCall("grep_notes", JSON.stringify({ total_matches: 2 }), { pattern: "bar" }),
+		];
+		const s = buildMergedToolSummary("grep_notes", calls, "running");
+		expect(s.label).toBe("Searching for text “foo” and “bar”");
+		expect(s.summary).toBe("");
+	});
+
+	it("falls back to a ×N label for tools without a merge recipe", () => {
+		const calls = [
+			mergedCall("get_all_tags", ["#a", "#b"], {}),
+			mergedCall("get_all_tags", ["#a", "#b"], {}),
+		];
+		const s = buildMergedToolSummary("get_all_tags", calls, "completed");
+		expect(s.label).toContain("×2");
+	});
+});

--- a/test/components/toolSummaryModel.test.ts
+++ b/test/components/toolSummaryModel.test.ts
@@ -272,11 +272,50 @@ describe("buildMergedToolSummary", () => {
 	});
 
 	it("falls back to a ×N label for tools without a merge recipe", () => {
+		const calls = [mergedCall("get_all_tags", ["#a", "#b"], {}), mergedCall("get_all_tags", ["#a", "#b"], {})];
+		const s = buildMergedToolSummary("get_all_tags", calls, "completed");
+		expect(s.label).toContain("×2");
+	});
+
+	it("keeps the verb-only label for a ×N fallback (never the first call's target)", () => {
+		// The generic fallback re-summarizes with empty input so the label is the
+		// tense-aware verb, not the first call's argument clause.
+		const calls = [
+			mergedCall("my_custom_tool", ["a"], { path: "Notes/first.md" }),
+			mergedCall("my_custom_tool", ["b"], { path: "Notes/second.md" }),
+		];
+		const s = buildMergedToolSummary("my_custom_tool", calls, "completed");
+		expect(s.label).toBe("Used My Custom Tool ×2");
+		expect(s.label).not.toContain("first.md");
+	});
+
+	it("aggregates count-based outcomes for a ×N generic merge", () => {
+		// Two list-returning generic calls (2 + 3 items) → the merged row still
+		// reports the summed count rather than dropping the outcome.
 		const calls = [
 			mergedCall("get_all_tags", ["#a", "#b"], {}),
-			mergedCall("get_all_tags", ["#a", "#b"], {}),
+			mergedCall("get_all_tags", ["#a", "#b", "#c"], {}),
 		];
 		const s = buildMergedToolSummary("get_all_tags", calls, "completed");
+		expect(s.summary).toBe("found 5 items");
+	});
+
+	it("does not show a positive aggregate for a failed merged group", () => {
+		// One call failed; the group status is failed. The merged row must read as
+		// failed, not "found N notes" (which would render in red implying success).
+		const calls = [
+			mergedCall("search_notes", JSON.stringify({ totalResults: 3, results: [] }), { query: "a" }),
+			mergedCall("search_notes", JSON.stringify({ totalResults: 2, results: [] }), { query: "b" }),
+		];
+		const s = buildMergedToolSummary("search_notes", calls, "failed");
+		expect(s.summary).toBe("failed");
+		expect(s.label).toBe("Searched notes for “a” and “b”");
+	});
+
+	it("does not show an aggregate for a failed ×N fallback group", () => {
+		const calls = [mergedCall("get_all_tags", ["#a"], {}), mergedCall("get_all_tags", ["#b"], {})];
+		const s = buildMergedToolSummary("get_all_tags", calls, "failed");
+		expect(s.summary).toBe("failed");
 		expect(s.label).toContain("×2");
 	});
 });

--- a/test/components/toolSummaryModel.test.ts
+++ b/test/components/toolSummaryModel.test.ts
@@ -35,13 +35,13 @@ describe("buildToolSummary", () => {
 			);
 			const s = buildToolSummary("search_notes", { query: "vector store" }, out, "completed");
 			expect(s.label).toBe("Searched notes for “vector store”");
-			expect(s.summary).toBe("3 notes");
+			expect(s.summary).toBe("found 3 notes");
 		});
 
 		it("reports no matches for an empty result set", () => {
 			const out = model("search_notes", JSON.stringify({ query: "zzz", totalResults: 0, results: [] }));
 			const s = buildToolSummary("search_notes", { query: "zzz" }, out, "completed");
-			expect(s.summary).toBe("no matches");
+			expect(s.summary).toBe("found no matches");
 		});
 
 		it("handles recent-only searches without a query", () => {
@@ -56,13 +56,13 @@ describe("buildToolSummary", () => {
 			const out = model("grep_notes", payload);
 			const s = buildToolSummary("grep_notes", { pattern: "TODO" }, out, "completed");
 			expect(s.label).toBe("Searched for text “TODO”");
-			expect(s.summary).toBe("5 matches in 2 files");
+			expect(s.summary).toBe("found 5 matches in 2 files");
 		});
 
 		it("reports no matches", () => {
 			const out = model("grep_notes", JSON.stringify({ pattern: "TODO", total_matches: 0, files_searched: 4 }));
 			const s = buildToolSummary("grep_notes", { pattern: "TODO" }, out, "completed");
-			expect(s.summary).toBe("no matches");
+			expect(s.summary).toBe("found no matches");
 		});
 	});
 
@@ -76,7 +76,7 @@ describe("buildToolSummary", () => {
 			});
 			const s = buildToolSummary("list_directory", { path: "Notes/Projects" }, out, "completed");
 			expect(s.label).toBe("Listed folder Projects");
-			expect(s.summary).toBe("1 folder, 2 files");
+			expect(s.summary).toBe("found 1 folder and 2 files");
 		});
 
 		it("labels the vault root", () => {
@@ -105,7 +105,7 @@ describe("buildToolSummary", () => {
 			const out = model("manage_notes", "Proposed 2 note operation(s) across 1 path(s) (1 create, 1 append)");
 			const s = buildToolSummary("manage_notes", {}, out, "completed");
 			expect(s.label).toBe("Edited a note");
-			expect(s.summary).toBe("2 operations · 1 note");
+			expect(s.summary).toBe("2 operations across 1 note");
 		});
 
 		it("uses present tense while editing", () => {
@@ -119,7 +119,7 @@ describe("buildToolSummary", () => {
 			const out = model("execute_javascript", "JavaScript execution failed: boom", { code: "throw 1" });
 			const s = buildToolSummary("execute_javascript", { code: "throw 1" }, out, "completed");
 			expect(s.label).toBe("Ran JavaScript");
-			expect(s.summary).toBe("error");
+			expect(s.summary).toBe("errored");
 		});
 
 		it("summarizes logs and duration on success", () => {
@@ -129,7 +129,7 @@ describe("buildToolSummary", () => {
 				{ code: "console.log('hi')" },
 			);
 			const s = buildToolSummary("execute_javascript", { code: "console.log('hi')" }, out, "completed");
-			expect(s.summary).toContain("2 logs");
+			expect(s.summary).toContain("logged 2 lines");
 			expect(s.summary).toContain("12ms");
 		});
 
@@ -184,7 +184,7 @@ describe("buildToolSummary", () => {
 		it("derives a count hint from list output", () => {
 			const out = model("my_custom_tool", ["a", "b", "c"]);
 			const s = buildToolSummary("my_custom_tool", {}, out, "completed");
-			expect(s.summary).toBe("3 items");
+			expect(s.summary).toBe("found 3 items");
 		});
 	});
 
@@ -220,7 +220,7 @@ describe("buildMergedToolSummary", () => {
 		];
 		const s = buildMergedToolSummary("grep_notes", calls, "completed");
 		expect(s.label).toBe("Searched for text “foo” and “bar”");
-		expect(s.summary).toBe("5 matches");
+		expect(s.summary).toBe("found 5 matches");
 	});
 
 	it("lists search queries with an Oxford-style 'and' and sums notes", () => {
@@ -231,7 +231,7 @@ describe("buildMergedToolSummary", () => {
 		];
 		const s = buildMergedToolSummary("search_notes", calls, "completed");
 		expect(s.label).toBe("Searched notes for “a”, “b” and “c”");
-		expect(s.summary).toBe("7 notes");
+		expect(s.summary).toBe("found 7 notes");
 	});
 
 	it("caps a long target list with '+N more'", () => {

--- a/test/components/toolTimelineModel.test.ts
+++ b/test/components/toolTimelineModel.test.ts
@@ -4,6 +4,7 @@ import {
 	buildStepsFromEvents,
 	buildStepsFromToolCalls,
 	foldSubAgentChildren,
+	groupStepTools,
 	toolDisplayName,
 	type TimelineStep,
 	type UnifiedToolCall,
@@ -200,5 +201,68 @@ describe("toolTimelineModel — subagent nesting", () => {
 		expect(steps).toHaveLength(2);
 		expect(steps[0].tools[0].preamble).toBe("First thought.");
 		expect(steps[1].tools[0].preamble).toBe("Second thought.");
+	});
+});
+
+describe("groupStepTools — merging consecutive same-tool calls", () => {
+	const call = (id: string, name: string, extra: Partial<UnifiedToolCall> = {}): UnifiedToolCall => ({
+		id,
+		name,
+		status: "completed",
+		...extra,
+	});
+
+	it("merges consecutive same-tool calls into one group", () => {
+		const groups = groupStepTools([
+			call("1", "grep_notes"),
+			call("2", "grep_notes"),
+			call("3", "grep_notes"),
+		]);
+		expect(groups).toHaveLength(1);
+		expect(groups[0].merged).toBe(true);
+		expect(groups[0].calls).toHaveLength(3);
+		expect(groups[0].id).toBe("1");
+		expect(groups[0].name).toBe("grep_notes");
+	});
+
+	it("keeps different tools in separate groups", () => {
+		const groups = groupStepTools([call("1", "grep_notes"), call("2", "read_content")]);
+		expect(groups).toHaveLength(2);
+		expect(groups.every((g) => !g.merged)).toBe(true);
+	});
+
+	it("only merges adjacent runs (A A B A → three groups)", () => {
+		const groups = groupStepTools([
+			call("1", "search_notes"),
+			call("2", "search_notes"),
+			call("3", "read_content"),
+			call("4", "search_notes"),
+		]);
+		expect(groups.map((g) => g.calls.length)).toEqual([2, 1, 1]);
+		expect(groups.map((g) => g.merged)).toEqual([true, false, false]);
+	});
+
+	it("never merges task (subagent) calls", () => {
+		const groups = groupStepTools([
+			call("1", "task", { subAgentName: "Researcher" }),
+			call("2", "task", { subAgentName: "Writer" }),
+		]);
+		expect(groups).toHaveLength(2);
+		expect(groups.every((g) => !g.merged)).toBe(true);
+	});
+
+	it("never merges calls that carry subagent children", () => {
+		const groups = groupStepTools([
+			call("1", "search_notes", { children: [call("c1", "read_content")] }),
+			call("2", "search_notes", { children: [call("c2", "read_content")] }),
+		]);
+		expect(groups).toHaveLength(2);
+	});
+
+	it("wraps a single call as an unmerged group of one", () => {
+		const groups = groupStepTools([call("1", "read_content")]);
+		expect(groups).toHaveLength(1);
+		expect(groups[0].merged).toBe(false);
+		expect(groups[0].calls).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
Closes #350.

Reworks chat tool-call rendering to be denser and read like short natural-language sentences, inspired by how Claude Code and similar agent harnesses present tool activity.

## What changed

- **Plain-language, tense-aware rows.** Each tool call renders as a compact, chromeless one-liner with a sentence label — present continuous while running (`Searching notes for "vector store"`), past tense once done (`Searched notes for "vector store"`) — plus a muted result summary (`3 notes`, `5 matches in 2 files`, `no matches`).
- **Merged consecutive calls.** A run of consecutive same-tool calls collapses into a single row that lists each target (`Searched for text "foo" and "bar"`) and aggregates the counts, expanding to show each individual call with its own result.
- **Quiet styling.** Rows use `--text-faint` like the "Thinking process" label, with a color-only hover (to `--text-normal`) — no chevron, no background highlight. Failed rows go red so errors still stand out.
- **Raw I/O hidden by default.** Raw tool arguments and the raw output blob are no longer shown to users. A new **DEV-only** `showToolIODetails` toggle (Developer settings) reveals the exact input/output for debugging. Users still get a friendly, structured *result* view (search hits, read content, directory tree, JS console/return value, etc.) — just not raw JSON.

## New code

- `src/components/chat/toolSummaryModel.ts` — builds the plain-language label + result summary per tool (canonical tool-identity keyed, tense-aware) and the merged-group summary.
- `groupStepTools()` in `src/components/chat/toolTimelineModel.ts` — coalesces consecutive same-tool calls within a timeline step (never merges `task`/subagent calls).
- Unit tests for both (48 tests).

## Verification

- `bun run check` — clean (only 4 pre-existing, unrelated `GraphCanvas.svelte` errors).
- `bun run test` (tool-model suites) — 48 passing.
- `bun run format` applied; dev build succeeds.
- Manual rendering verified in the test vault.

> Note: the Developer settings tab that hosts the `showToolIODetails` toggle only renders in DEV builds (`import.meta.env.DEV`), so production users get the clean default with no raw-I/O escape hatch — by design.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._