### PR TITLE
feat: thinking-process timeline — carry-through collapse, persisted duration, cleanup

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -1504,6 +1504,15 @@ export class AgentManager {
 		return this.chatManager.readCheckpointHistory(this.normalizeThreadId(threadId));
 	}
 
+	/**
+	 * Persists the thinking duration (ms) for a finished turn onto the checkpoint's
+	 * final AI message, so the "Thought for Ns" label survives reload. Called from
+	 * ChatSession after a run settles and the checkpoint graph has synced.
+	 */
+	async annotateThinkingDuration(threadId: string, checkpointId: string, durationMs: number): Promise<void> {
+		await this.chatManager.annotateThinkingDuration(this.normalizeThreadId(threadId), checkpointId, durationMs);
+	}
+
 	async getCheckpointMessages(threadId: string, checkpointId: string): Promise<BaseMessage[]> {
 		const agent = await this.ensureAgent();
 		return agent.getCheckpointMessages(this.normalizeThreadId(threadId), checkpointId);

--- a/src/agent/ObsidianChatManager.ts
+++ b/src/agent/ObsidianChatManager.ts
@@ -917,6 +917,43 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 		}
 	}
 
+	/**
+	 * Stamps the wall-clock thinking duration (ms) for a finished turn onto the
+	 * final AI message of the given checkpoint, so the "Thought for Ns" label
+	 * survives reload. Mirrors annotateCheckpointMessagesWithGeneration: writes a
+	 * scalar into the message's response_metadata, which round-trips through the
+	 * NDJSON checkpoint. Called post-completion from ChatSession (the duration isn't
+	 * known during the graph's own `put`). Targets the LAST AI serialized message in
+	 * the checkpoint — the final answer — matching the read side, which takes the
+	 * last top-level non-empty AI message as the duration carrier.
+	 */
+	async annotateThinkingDuration(threadId: string, checkpointId: string, durationMs: number): Promise<void> {
+		if (!threadId || !checkpointId || !Number.isFinite(durationMs) || durationMs < 0) return;
+		const threadData = await this.ensureThreadLoaded(threadId);
+		const entry = threadData?.checkpoints[checkpointId];
+		if (!entry) return;
+
+		const messages = this.getCheckpointMessages(entry.checkpoint);
+		// Find the last AI message in the checkpoint (the final answer).
+		let target: Record<string, unknown> | undefined;
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const message = messages[i];
+			if (this.isRecord(message) && this.isAiSerializedMessage(message)) {
+				target = message;
+				break;
+			}
+		}
+		if (!target) return;
+
+		const responseMetadata = this.getOrCreateResponseMetadata(target);
+		if (!responseMetadata) return;
+		if (responseMetadata.thinking_duration_ms === durationMs) return; // no-op if unchanged
+
+		responseMetadata.thinking_duration_ms = durationMs;
+		this.markThreadDirty(threadId);
+		this.saveDebounced(threadId);
+	}
+
 	async put(
 		config: RunnableConfig,
 		checkpoint: Checkpoint,

--- a/src/components/chat/MessageContainer.svelte
+++ b/src/components/chat/MessageContainer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { Notice } from "obsidian";
-import { tick, untrack } from "svelte";
+import { tick } from "svelte";
 import {
 	type AssistantMessage,
 	AssistantState,
@@ -10,7 +10,7 @@ import {
 } from "../../stores/chatStore.svelte";
 import type { UUIDv7 } from "../../utils/uuid7Validator";
 import { Logger } from "../../utils/logging";
-import { getPlugin } from "../../stores/state.svelte";
+import { getPlugin, thinkingProcessPref } from "../../stores/state.svelte";
 import { VIEW_TYPE_CHAT } from "../../views/chat/Chat";
 import Button from "../ui/Button.svelte";
 import DotAnimation from "../ui/DotAnimation.svelte";
@@ -410,41 +410,68 @@ function getGenerationLabel(messagePair: MessagePair): string | null {
 	return agentLabel ?? modelLabel ?? null;
 }
 
-// Pre-populate so the very first render is already correct for history messages,
-// preventing a one-frame flash where completed timelines appear expanded before
-// the $effect below runs and collapses them.
-// Capture the initial snapshot via untrack() - ongoing message state changes
-// are handled by the $effect; we only need this for messages loaded from history.
-let timelineCollapsed: Record<string, boolean | undefined> = $state(
-	Object.fromEntries(
-		untrack(() => messages ?? []).map((p) => {
-			const a = p.assistantMessage;
-			const finished = a.state !== AssistantState.streaming && a.state !== AssistantState.idle;
-			return [p.id, finished && (a.toolCalls?.length ?? 0) > 0 ? true : undefined];
-		}),
-	),
-);
+// ── Timeline collapse state ──────────────────────────────────────────────
+// NOTHING collapses or expands automatically — the user drives the collapse state and
+// whatever it is while a turn streams simply carries through unchanged after it settles.
+// Two controls feed it:
+//
+//  1. GLOBAL session preference (`thinkingProcessPref.streamingExpanded`, session-scoped,
+//     default expanded). This is the default a turn shows when the user hasn't toggled it
+//     individually. Toggling the chevron on a turn that is still STREAMING (its per-turn
+//     key isn't stable yet) flips this global pref, so every other untouched turn follows.
+//  2. TRANSIENT per-turn override (`perTurnOverride`, keyed by the turn's stable
+//     `regenerateFromCheckpointId`, only settable once the turn has settled). Toggling a
+//     settled turn opens/closes just that turn. Not persisted; never touches the pref.
+//
+// The effective collapsed value is a pure function of these two — no $effect, no phase-
+// dependent default, no auto-collapse. A run left expanded settles expanded; a run
+// collapsed mid-stream settles collapsed. Both fall back to the same global pref, so the
+// value the user sees while streaming is exactly the value after settle: no seam.
+const perTurnOverride: Record<string, boolean> = $state({});
 
-$effect(() => {
-	const messageList = messages ?? [];
-	for (const messagePair of messageList) {
-		const assistantMessage = messagePair.assistantMessage;
-		const hasToolCalls = (assistantMessage.toolCalls?.length ?? 0) > 0;
-		const isStreaming =
-			assistantMessage.state === AssistantState.streaming || assistantMessage.state === AssistantState.idle;
-		const streamFinished = !isStreaming;
+// Stable key for a settled turn's transient override. `regenerateFromCheckpointId` is the
+// checkpoint where this human message is last — turn-unique and stable across the settle
+// rebuild and future runs (unlike `id`, which is a fresh UUID every rebuild). Error/
+// cancelled turns that never checkpointed have no id here; they also have no thinking
+// process worth persisting, so `id` is a fine fallback key for them.
+function overrideKey(pair: MessagePair): string {
+	return pair.regenerateFromCheckpointId ?? pair.id;
+}
 
-		// Clear the collapsed state when a new stream starts so the timeline
-		// expands automatically during regeneration, matching first-run behaviour.
-		if (isStreaming && timelineCollapsed[messagePair.id] !== undefined) {
-			timelineCollapsed[messagePair.id] = undefined;
-		}
+// Whether this pair has a STABLE per-turn key yet. `regenerateFromCheckpointId` is only
+// stable once the turn has settled onto a real checkpoint; before that it's either absent
+// (fresh send) or a temporary `optimistic-…` id (regenerate/edit) that the settle rebuild
+// replaces. A per-turn override written under a temporary key orphans at settle → the turn
+// falls back to the pref and appears to "auto-expand". So the override branch is only taken
+// when the key is stable; otherwise the click flips the global pref instead.
+function hasStableKey(pair: MessagePair): boolean {
+	const id = pair.regenerateFromCheckpointId;
+	return !!id && !id.startsWith("optimistic-");
+}
 
-		if (hasToolCalls && streamFinished && timelineCollapsed[messagePair.id] === undefined) {
-			timelineCollapsed[messagePair.id] = true;
-		}
+// The effective collapsed state a turn's process renders with. A per-turn override wins,
+// but ONLY when read under a stable key (a temporary streaming key can't have a meaningful
+// override — those clicks go to the pref); otherwise the turn follows the global pref.
+function isCollapsed(pair: MessagePair): boolean {
+	if (hasStableKey(pair)) {
+		const override = perTurnOverride[overrideKey(pair)];
+		if (override !== undefined) return override;
 	}
-});
+	return !thinkingProcessPref.streamingExpanded;
+}
+
+// Chevron toggle. A per-turn override is only meaningful once the turn has a STABLE key
+// (settled onto a real checkpoint). Until then — while streaming, or in the brief window
+// where state has flipped to success but the checkpoint id hasn't been assigned — flip the
+// global pref instead, so the choice can't be stranded under a temporary key and lost at
+// the settle rebuild (the intermittent "collapsed turn auto-expands" bug).
+function toggleCollapsed(pair: MessagePair): void {
+	if (!hasStableKey(pair)) {
+		thinkingProcessPref.toggleStreamingExpanded();
+		return;
+	}
+	perTurnOverride[overrideKey(pair)] = !isCollapsed(pair);
+}
 
 // Recompute the active message + nav availability from the DOM after the thread
 // or message list changes (switching chats, new replies). This is a legitimate
@@ -701,24 +728,16 @@ $effect(() => {
                      the component never unmounts mid-stream, preventing the jarring flash
                      where preamble content appears as plain text before the timeline builds. -->
                   {@const renderInfo = getRenderableAssistantContent(messagePair.assistantMessage)}
-                  {@const isAssistantProcessing =
-                    (messagePair.assistantMessage.state === AssistantState.idle ||
-                      messagePair.assistantMessage.state === AssistantState.streaming) &&
-                    !messagePair.assistantMessage.content &&
-                    !messagePair.assistantMessage.toolCalls?.length}
                   <ToolCallsSection
-                    toolCalls={messagePair.assistantMessage.toolCalls}
                     assistantTimeline={messagePair.assistantMessage.assistantTimeline}
-                    collapsed={timelineCollapsed[messagePair.id] ?? false}
+                    collapsed={isCollapsed(messagePair)}
                     answerContent={renderInfo.renderContent && renderInfo.content
                       ? renderInfo.content
                       : undefined}
+                    contentAiMessageId={messagePair.assistantMessage.contentAiMessageId}
                     isStreaming={messagePair.assistantMessage.state === AssistantState.streaming}
-                    isError={messagePair.assistantMessage.state === AssistantState.error}
-                    isProcessing={isAssistantProcessing}
-                    ontoggle={() => {
-                      timelineCollapsed[messagePair.id] = !(timelineCollapsed[messagePair.id] ?? false);
-                    }}
+                    thinkingDurationMs={messagePair.assistantMessage.thinkingDurationMs}
+                    ontoggle={() => toggleCollapsed(messagePair)}
                   />
                 {:else}
                   <!-- Content Section: only reached for completed messages with no tool calls / timeline -->

--- a/src/components/chat/ToolCallsSection.svelte
+++ b/src/components/chat/ToolCallsSection.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-import type { AssistantTimelineEvent, ToolCallState } from "../../stores/chatStore.svelte";
+import type { AssistantTimelineEvent } from "../../stores/chatStore.svelte";
 import { getData } from "../../stores/dataStore.svelte";
 import { buildToolOutputRenderModel, type ToolOutputRenderModel } from "./toolOutputRenderModel";
 import {
 	buildStepsFromEvents,
-	buildStepsFromToolCalls,
 	groupStepTools,
 	toolDisplayName,
 	type TimelineStep,
@@ -13,20 +12,30 @@ import {
 } from "./toolTimelineModel";
 import { buildToolSummary, buildMergedToolSummary, type MergedCall, type ToolSummary } from "./toolSummaryModel";
 import MarkdownRenderer from "../ui/MarkdownRenderer.svelte";
+import Icon from "../ui/Icon.svelte";
 
 interface Props {
-	toolCalls?: ToolCallState[];
 	assistantTimeline?: AssistantTimelineEvent[];
 	collapsed: boolean;
 	answerContent?: string;
+	/** aiMessageId of the text currently in `answerContent` (streaming); folds the last
+	 *  tool step once it differs from that step (the next AI message has begun). */
+	contentAiMessageId?: string;
 	isStreaming?: boolean;
-	isError?: boolean;
-	isProcessing?: boolean;
+	/** Persisted wall-clock duration of the turn (ms), for the "Thought for Ns" label. */
+	thinkingDurationMs?: number;
 	ontoggle?: () => void;
 }
 
-const { toolCalls, assistantTimeline, collapsed, answerContent, isStreaming, isError, isProcessing, ontoggle }: Props =
-	$props();
+const {
+	assistantTimeline,
+	collapsed,
+	answerContent,
+	contentAiMessageId,
+	isStreaming,
+	thinkingDurationMs,
+	ontoggle,
+}: Props = $props();
 
 const pluginData = getData();
 
@@ -35,7 +44,7 @@ const pluginData = getData();
 // Developer settings) to also see the exact I/O for debugging.
 const showRawIO = $derived(pluginData.showToolIODetails);
 
-let hoveringFinalControl = $state(false);
+let hoveringRail = $state(false);
 
 // Per-`task`-card expansion of the nested subagent sub-timeline, keyed by the
 // task tool-call id. Collapsed by default — a subagent (especially several in
@@ -247,48 +256,130 @@ function hasStepFailure(step: TimelineStep): boolean {
 	return step.tools.some((t) => t.status === "failed");
 }
 
-function getOverallStatus(stepsArg: TimelineStep[]): "running" | "completed" {
-	return stepsArg.some(isStepRunning) ? "running" : "completed";
-}
-
-function getThinkingSummaryLabel(stepsArg: TimelineStep[]): string {
-	return stepsArg.length === 1 ? "Thinking process (1 step)" : `Thinking process (${stepsArg.length} steps)`;
-}
-
 /* ── Derived state ── */
 
-const steps = $derived(
-	assistantTimeline && assistantTimeline.length > 0
-		? buildStepsFromEvents(assistantTimeline)
-		: buildStepsFromToolCalls(toolCalls),
-);
-const overallStatus = $derived(getOverallStatus(steps));
+const steps = $derived(buildStepsFromEvents(assistantTimeline ?? []));
 
-// Show answer as a final timeline step when there's content or tools finished streaming.
-// Guard with steps.length > 0 so that during initial processing (no tool-call steps yet)
-// showProcessingDot takes over instead of the answer step pre-empting it.
-const showAnswerStep = $derived(
-	!!(answerContent || (isStreaming && overallStatus === "completed" && steps.length > 0)),
+// A new timeline step is created only when a new AI message begins that CALLS A TOOL
+// (buildStepsFromEvents groups tool events by aiMessageId), so a text-only final answer
+// creates NO step. The last tool step therefore stays the "current run" (rendered below
+// the label with its tools) only until the model begins the NEXT AI message — the exact
+// moment the user identified: "the first token of the next AI message is streamed". That
+// moment is an aiMessageId change: the live content (`answerContent`) carries a different
+// aiMessageId than the last step. Until then the step is current and does not fold; once
+// content is a newer message, the step folds into the process and the new content streams
+// in the single spot below. No id yet (pre-first-token, or content cleared on tool_start)
+// keeps the step current — an empty/idless content spot never triggers a fold.
+const lastStep = $derived(steps.at(-1));
+const contentIsNewerMessage = $derived(
+	!!contentAiMessageId && !!lastStep?.aiMessageId && contentAiMessageId !== lastStep.aiMessageId,
 );
-// Show a lone processing dot when nothing has arrived yet
-const showProcessingDot = $derived(!!isProcessing && steps.length === 0 && !showAnswerStep);
-const effectiveTotal = $derived(steps.length + (showAnswerStep ? 1 : 0) + (showProcessingDot ? 1 : 0));
+// The separate current-run block below the process exists ONLY to keep the in-flight run
+// visible while the process is COLLAPSED (the grid is 0-height then). While the process is
+// EXPANDED the grid already shows every step, so rendering the last step ALSO in the
+// current block — then moving it up into the grid the instant the next AI message folds it
+// — relocated the step across containers and made its preamble visibly jump. So the split
+// only applies when collapsed: when expanded, the current step stays in the grid the whole
+// time and nothing moves on fold.
+const currentStep = $derived(collapsed && isStreaming && lastStep && !contentIsNewerMessage ? lastStep : undefined);
+const priorSteps = $derived(currentStep ? steps.slice(0, -1) : steps);
 
-// When content is streaming but no tool-call steps have arrived yet, render the
-// answer inline (no timeline dot/rail) so the layout matches the plain-text
-// MarkdownRenderer that takes over once streaming completes.  This prevents a
-// visible layout jump when the stream ends and the else-branch mounts.
-const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && showAnswerStep);
+// The header is in its live "running" state (shimmer word + elapsed timer) for the
+// entire stream, and settles to the static "Thought for Ns" the moment streaming
+// stops. No latch, no mid-stream freeze — the "thinking process" spans the whole turn.
+const summaryRunning = $derived(!!isStreaming);
+
+// While streaming, the header shows an animated live status instead of the static
+// settled label: a word that rotates through the set below (the agent is thinking
+// AND taking actions, so a single word undersells it) plus a live elapsed-seconds
+// timer, à la Claude Code. Not clickable while running.
+const RUNNING_WORDS = ["Working", "Thinking", "Exploring", "Investigating", "Reasoning", "Digging in"];
+const WORD_ROTATE_SECONDS = 10;
+let runningSeconds = $state(0);
+let runningWordIndex = $state(0);
+
+// Drive the timer from a wall-clock anchor captured once on the rising edge of the
+// stream, so elapsed is monotonic and can't drift or reset on mid-stream state
+// churn. The anchor is set on the isStreaming rising edge; the interval ticks while
+// summaryRunning (i.e. the whole stream) and stops when streaming ends, at which
+// point the precise persisted duration takes over via settledSeconds below.
+let runStartMs = 0;
+let wasStreaming = false;
+
+$effect(() => {
+	if (isStreaming && !wasStreaming) {
+		runStartMs = Date.now();
+		runningSeconds = 0;
+		runningWordIndex = 0;
+	}
+	wasStreaming = !!isStreaming;
+
+	if (!summaryRunning) return;
+
+	const tick = () => {
+		const elapsed = Math.floor((Date.now() - runStartMs) / 1000);
+		runningSeconds = elapsed;
+		runningWordIndex = Math.floor(elapsed / WORD_ROTATE_SECONDS) % RUNNING_WORDS.length;
+	};
+	tick();
+	const timer = setInterval(tick, 1000);
+	return () => clearInterval(timer);
+});
+
+const runningLabel = $derived(`${RUNNING_WORDS[runningWordIndex]}… ${runningSeconds}s`);
+// Settled label after the run finishes: the total time it took. Prefers the
+// PERSISTED duration (survives reload) → the live timer (this session). A settled
+// turn always took SOME time, so floor at 1s — we never fall back to a step-count
+// phrasing ("Thinking process (N steps)"), which regressed the header to the old
+// wording the instant a sub-second run (or a history message with no stored
+// duration) settled and got collapsed.
+const settledSeconds = $derived(
+	thinkingDurationMs !== undefined && thinkingDurationMs >= 0
+		? Math.max(1, Math.round(thinkingDurationMs / 1000))
+		: Math.max(1, runningSeconds),
+);
+const settledLabel = $derived(`Thought for ${settledSeconds}s`);
+
+// The single content spot below the label. `answerContent` (the reducer's `content`)
+// holds ONLY the current message's uncommitted text: while streaming it's the run's
+// live text (opening text pre-tool, or the answer tail post-tool); once settled it's
+// the final answer. We render it in ONE place, in the full answer style, whenever it's
+// non-empty — so it streams live and simply STAYS put on completion (no restyle, no
+// relocation). It never duplicates a folded step's committed preamble: the reducer moves
+// that text onto the timeline step and clears `content` on every `tool_start`, so this
+// only ever carries text not yet committed to a step.
+const liveContent = $derived(answerContent ?? "");
+
+// True in the narrow window where the model is streaming its opening text BEFORE the
+// first tool call (no steps yet). That text lives in the answer spot now, but the instant
+// the first tool_start arrives the reducer re-homes it as that step's preamble — which
+// sits inside the step with ~7px of top padding (.tool-step-content 4px + preamble 3px).
+// Without matching that offset here the text visibly drops when the tool call lands. So in
+// this window only, pad the answer spot to the same offset; the final answer (steps exist,
+// or not streaming) stays flush. Kept in a class rather than inline so it's easy to tune.
+const isPreFirstToolText = $derived(!!isStreaming && steps.length === 0 && !!liveContent);
+
+// The thinking-process header (chevron + shimmer/settled label) is shown whenever
+// there is a thinking process to represent: any built step, OR we're streaming.
+// Keying it on `isStreaming` (not on a per-content flag) keeps the header present for
+// the entire turn, so it never vanishes while a preamble streams and reappears when
+// the first step lands. It stays hidden for a settled tool-free answer (no steps, not
+// streaming).
+const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
 </script>
+
+{#snippet preambleBlock(text: string)}
+  <div class="tool-timeline-preamble">
+    <MarkdownRenderer
+      content={text}
+      class="message-text markdown-preview-view leading-[1.5] !p-0 !w-full !max-w-full !m-0 [&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0"
+    />
+  </div>
+{/snippet}
 
 {#snippet toolCard(tool: UnifiedToolCall)}
   {#if tool.preamble}
-    <div class="tool-timeline-preamble">
-      <MarkdownRenderer
-        content={tool.preamble}
-        class="message-text markdown-preview-view leading-[1.5] !p-0 !w-full !max-w-full !m-0 [&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0"
-      />
-    </div>
+    {@render preambleBlock(tool.preamble)}
   {/if}
   {@const outputModel =
     tool.output !== undefined
@@ -327,7 +418,10 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   isSubAgentParent: boolean,
   subAgentName: string | undefined,
 )}
-  <span class="tool-card-name" class:tool-card-name-failed={status === "failed"}>{label}</span>
+  <span
+    class="tool-card-name"
+    class:tool-card-name-failed={status === "failed"}
+    class:is-running={status === "running"}>{label}</span>
   {#if isSubAgentParent}
     <span class="tool-card-subagent-badge">subagent</span>
   {:else if subAgentName}
@@ -397,9 +491,20 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
 {#snippet mergedToolRow(group: ToolCallGroup)}
   {@const status = mergedGroupStatus(group)}
   {@const summary = buildMergedToolSummary(group.name, toMergedCalls(group), status)}
-  <details class="tool-card tool-card-merged">
+  {@const mergedPreamble = group.calls.find((c) => c.preamble)?.preamble}
+  {#if mergedPreamble}
+    <!-- The preamble is attached to a single tool call, but when consecutive
+         same-type calls merge into one group the individual toolCard (which
+         renders the preamble) is bypassed for mergedToolRow. Surface the group's
+         preamble here too so it doesn't vanish the moment a second call merges in. -->
+    {@render preambleBlock(mergedPreamble)}
+  {/if}
+  <details class="tool-card">
     <summary class="tool-card-header">
-      <span class="tool-card-name" class:tool-card-name-failed={status === "failed"}>{foldOutcome(summary)}</span>
+      <span
+        class="tool-card-name"
+        class:tool-card-name-failed={status === "failed"}
+        class:is-running={status === "running"}>{foldOutcome(summary)}</span>
     </summary>
 
     <!-- Each merged call keeps its own friendly result (and raw I/O in dev mode). -->
@@ -427,8 +532,6 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
 )}
   <div
     class="tool-step"
-    class:step-running={isStepRunning(step)}
-    class:step-failed={hasStepFailure(step)}
     class:step-first={stepIdx === 0}
     class:step-last={stepIdx === totalSteps - 1}
     class:step-only={totalSteps === 1}
@@ -472,7 +575,7 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
                       stroke-linejoin="round"
                     />
                   </svg>
-                  <span class="tool-subagent-toggle-label">
+                  <span>
                     {expanded ? "Hide" : "Show"}
                     {branchChildren.length}
                     {branchChildren.length === 1 ? "step" : "steps"}
@@ -571,7 +674,7 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
     </div>
   {:else if model.kind === "structured"}
     {#if model.summaryEntries.length > 0}
-      <div class="tool-output-kv-list tool-output-structured-summary">
+      <div class="tool-output-kv-list">
         {#each model.summaryEntries as entry (entry.key)}
           <div class="tool-output-kv-row">
             <span class="tool-output-kv-key">{entry.key}</span>
@@ -792,146 +895,255 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   {/if}
 {/snippet}
 
-{#if noTimelineWrap}
-  <!-- Inline rendering: content streaming with no tool-call steps yet.
-       Renders identical to the completed plain-MarkdownRenderer path so there
-       is no layout shift when streaming ends and the else-branch takes over. -->
-  {#if answerContent}
-    <MarkdownRenderer
-      content={answerContent}
-      class="message-text markdown-preview-view leading-[1.5] !p-0 !w-full !max-w-full !m-0 [&_p]:my-2 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_strong]:font-semibold [&_code]:bg-code-background [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[0.9em]"
-    />
+{#snippet answerContentBlock()}
+  {#if liveContent}
+    <div class:answer-spot-pre-tool={isPreFirstToolText}>
+      <MarkdownRenderer
+        content={liveContent}
+        class="message-text markdown-preview-view leading-[1.5] !p-0 !w-full !max-w-full !m-0 [&_p]:my-2 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_strong]:font-semibold [&_code]:bg-code-background [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[0.9em]"
+      />
+    </div>
   {/if}
-{:else}
-  <div class="tool-timeline" class:tool-timeline-highlight-all={hoveringFinalControl}>
-    {#if showProcessingDot}
-      <div class="tool-step step-only">
-        <div class="tool-step-rail">
-          <div class="tool-step-dot dot-running"></div>
-        </div>
-        <div class="tool-step-content"></div>
-      </div>
-    {/if}
+{/snippet}
 
-    {#if collapsed && steps.length > 0}
-      <!-- Single summary node: entire thinking process collapsed into one clickable row -->
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <!-- svelte-ignore a11y_click_events_have_key_events -->
-      <div
-        class="tool-step thinking-summary-step step-first"
-        class:step-last={!showAnswerStep}
-        class:step-only={effectiveTotal === 1}
-        onclick={ontoggle}
-      >
-        <div class="tool-step-rail thinking-summary-rail">
-          <div
-            class="tool-step-dot"
-            class:dot-failed={steps.some(hasStepFailure)}
-            class:dot-done={!steps.some(hasStepFailure)}
-          ></div>
-        </div>
-        <div class="tool-step-content thinking-summary-content">
-          <span class="thinking-summary-label">{getThinkingSummaryLabel(steps)}</span>
-        </div>
-      </div>
-    {:else}
-      <!-- All steps expanded — wrap in animated grid for smooth collapse/expand transition -->
-      <div class="steps-expand-grid" class:steps-expanded={!collapsed}>
-        <div class="steps-expand-inner">
-          {#each steps as step, stepIdx (step.id)}
-            {@render stepRow(step, stepIdx, showAnswerStep ? steps.length + 1 : effectiveTotal - (showProcessingDot ? 1 : 0))}
-          {/each}
-        </div>
-      </div>
-    {/if}
+<!-- Single render branch — NEVER a top-level {#if} that swaps the whole subtree.
+     A previous `{#if noTimelineWrap}` inline branch vs. the timeline branch caused
+     the header to unmount/remount when an early preamble briefly surfaced as
+     answerContent (before the first step was built) and then the step landed — the
+     flicker at the first step. Now the timeline container is always present; only
+     its INNER header/steps render when there's a thinking process. When there's no
+     process (pure answer), the container is empty (zero-height) and just the answer
+     shows below — same layout as before, but no subtree swap. -->
+<div class="tool-timeline no-rail" class:tool-timeline-highlight-all={hoveringRail}>
+  {#if showThinkingHeader}
+    <!-- The header is ALWAYS a clickable chevron toggle — in BOTH the running and
+         settled states — so (a) the process can be collapsed mid-stream to just
+         watch for the answer, and (b) the chevron never appears/disappears on
+         completion, so the label doesn't shift when the run settles. Only the
+         label content swaps: a shimmering rotating word + timer while running,
+         the static "Thought for Ns" once done. -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <button
+      type="button"
+      class="thinking-summary-header"
+      class:is-collapsed={collapsed}
+      onclick={ontoggle}
+      onmouseenter={() => {
+        hoveringRail = true;
+      }}
+      onmouseleave={() => {
+        hoveringRail = false;
+      }}
+    >
+      <span class="thinking-summary-chevron" class:is-open={!collapsed}>
+        <Icon name="chevron-right" size="xs" />
+      </span>
+      <!-- One persistent label node: only its text + `is-running` class toggle across
+           the streaming→settled boundary. Swapping two separate spans here used to tear
+           down the shimmer's background-clip paint and (with a fit-content header) snap
+           the row width when the text changed — visible motion at completion even when
+           the process was already collapsed. A single node makes it a pure in-place
+           color/text change. -->
+      <span class="thinking-summary-status" class:is-running={summaryRunning}>
+        {summaryRunning ? runningLabel : settledLabel}
+      </span>
+    </button>
 
-    {#if showAnswerStep}
-      <div
-        class="tool-step step-last"
-        class:step-first={steps.length === 0 && !showProcessingDot}
-        class:step-only={effectiveTotal === 1}
-      >
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <div
-          class="tool-step-rail"
-          class:tool-step-rail-clickable={!collapsed && steps.length > 0 && !!ontoggle}
-          onclick={!collapsed && steps.length > 0 && ontoggle ? ontoggle : undefined}
-          onmouseenter={() => {
-            if (!collapsed && steps.length > 0 && ontoggle) hoveringFinalControl = true;
-          }}
-          onmouseleave={() => {
-            hoveringFinalControl = false;
-          }}
-        >
-          <div
-            class="tool-step-dot"
-            class:dot-running={isStreaming}
-            class:dot-failed={!isStreaming && isError}
-            class:dot-done={!isStreaming && !isError}
-          ></div>
-        </div>
-        <div class="tool-step-content">
-          {#if answerContent}
-            <MarkdownRenderer
-              content={answerContent}
-              class="message-text markdown-preview-view leading-[1.5] !p-0 !w-full !max-w-full !m-0 [&_p]:my-2 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_strong]:font-semibold [&_code]:bg-code-background [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[0.9em]"
-            />
-          {/if}
-        </div>
+    <!-- Steps animate open/closed via a 0fr↔1fr grid-rows transition. The header
+         above stays put; only this block grows/shrinks. While streaming this holds
+         only the PRIOR (finished) runs; the current run renders below the process so
+         it doesn't hop up until the next AI message starts and folds it in. -->
+    <div class="steps-expand-grid" class:steps-expanded={!collapsed}>
+      <div class="steps-expand-inner">
+        {#each priorSteps as step, stepIdx (step.id)}
+          {@render stepRow(step, stepIdx, priorSteps.length)}
+        {/each}
       </div>
-    {/if}
+    </div>
+  {/if}
+</div>
+
+<!-- Current run's tool rows (streaming only), rendered below the process and OUTSIDE
+     the collapsible grid so they stay visible even when the process is collapsed —
+     the user chose to keep the in-flight tool calls shown while collapsed; only the
+     FOLDED prior messages' tool calls hide. When the next AI message begins, this run
+     becomes a prior step and folds into the process above; a fresh current run's tools
+     take its place here. The current run's committed preamble rides along on the step
+     (rendered by stepRow); its live/uncommitted text streams in the single content spot
+     below. -->
+{#if isStreaming && currentStep}
+  <div class="tool-timeline no-rail tool-timeline-current">
+    {@render stepRow(currentStep, 0, 1)}
   </div>
 {/if}
 
+<!-- The single content spot: `content` in full answer style, whenever non-empty. It
+     streams live here and STAYS here on completion — same node, same style, no move. -->
+{@render answerContentBlock()}
+
 <style>
   /* ── Timeline container ── */
+  /* The rail bleeds left into the surrounding padding so the answer/preamble
+     text lines up flush with the rest of the chat content. The bleed is capped
+     at the padding that's ALWAYS present (scroll-container px-2 = 8px + message
+     px-2 = 8px → 16px), never the old -24px which overshot that on narrow panes
+     and pushed the dot past the scroll container's `overflow-x: hidden` edge,
+     clipping its left half + glow. A small left padding keeps the dot's glow
+     ring off the very edge even at the tightest width. Raising z-index cannot
+     fix this — the dot is clipped by an ancestor's overflow, not painted over. */
   .tool-timeline {
-    width: calc(100% + 24px);
-    margin-left: -24px;
-    padding: 4px 0;
+    position: relative;
   }
 
-  .tool-timeline-highlight-all .tool-step-dot {
-    transform: scale(1.2);
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--interactive-accent) 20%, transparent);
+  /* When the process is collapsed the header is a single quiet row; the parent
+     `.group`'s 0.75rem flex gap then leaves an outsized space below it. Pull whatever
+     follows (the live current-run block while streaming, or the answer once settled) up
+     so the collapsed label sits close to it. Applied in BOTH phases with the SAME value
+     so nothing shifts at the streaming→settled boundary — an earlier settled-only gate
+     made the gap snap tighter the instant the run settled. Transitioned so any residual
+     height change (e.g. the current-run block unmounting at settle) eases rather than
+     jumps. */
+  .tool-timeline:has(.thinking-summary-header.is-collapsed) {
+    margin-bottom: -0.95rem;
+    transition: margin-bottom 0.2s ease;
   }
 
-  .tool-timeline-highlight-all .tool-step-rail::before {
-    background: var(--interactive-accent);
-    opacity: 0.55;
+  /* Rail-less mode: the vertical timeline rail (dots + connecting line) is hidden
+     and its 24px column collapses to zero, so the "Thinking process" header and
+     the expanded step content sit flush with the answer below — no indent, no
+     negative-margin bleed into the chat history, nothing to clip on narrow panes. */
+  .tool-timeline.no-rail .tool-step-rail {
+    display: none;
+  }
+  .tool-timeline.no-rail .tool-step {
+    /* Was flex [rail | content]; with the rail gone the content is the only child
+       and should fill the row flush-left. */
+    gap: 0;
   }
 
-  /* ── Thinking-process summary node (collapsed state) ── */
-  .thinking-summary-step {
-    cursor: pointer;
-    user-select: none;
+  /* The current-run block (streaming) sits directly below the process, holding the
+     run in flight. It reuses the same rail-less step layout as the process so a run
+     looks identical whether it's live here or folded into the process above — no
+     shift when it folds. No extra chrome; the step's own padding provides spacing. */
+  .tool-timeline-current {
+    margin-top: 0;
   }
-  .thinking-summary-step:hover .tool-step-dot {
-    transform: scale(1.3);
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--interactive-accent) 20%, transparent);
-  }
-  .thinking-summary-step:hover .tool-step-rail::before {
-    background: var(--interactive-accent);
-    opacity: 0.5;
-  }
-  .thinking-summary-rail {
-    padding-top: 6px;
-  }
-  .thinking-summary-content {
-    padding: 4px 0 10px;
-    justify-content: center;
-  }
-  .thinking-summary-label {
+
+  /* ── Header status label (single node for both states) ──
+     One persistent span carries both the running and settled label. The base rule is
+     the settled look (solid faint text); `.is-running` layers the shimmer gradient +
+     animation on top. Same node in both states, so completion is a pure color/text
+     change — no span teardown, no paint jolt. */
+  .thinking-summary-status {
     font-size: 0.76rem;
+    line-height: 20px;
     color: var(--text-faint);
     transition: color 0.15s;
   }
-  .thinking-summary-step:hover .thinking-summary-label {
+  .thinking-summary-status.is-running,
+  .tool-card-name.is-running {
+    /* Animated gradient sweep across the text: a faint→bright→faint band scrolls
+       left→right via background-position, clipped to the glyphs. Shared by the
+       thinking-process header label and any running tool-call name so an in-flight
+       tool reads with the same "live" treatment as the header. */
+    background: linear-gradient(
+      100deg,
+      var(--text-faint) 0%,
+      var(--text-faint) 35%,
+      var(--text-normal) 50%,
+      var(--text-faint) 65%,
+      var(--text-faint) 100%
+    );
+    background-size: 220% 100%;
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    animation: thinking-shimmer 1.8s linear infinite;
+  }
+  @keyframes thinking-shimmer {
+    0% {
+      background-position: 130% 0;
+    }
+    100% {
+      background-position: -30% 0;
+    }
+  }
+  /* Respect reduced-motion: drop the sweep, keep a readable static color. */
+  @media (prefers-reduced-motion: reduce) {
+    .thinking-summary-status.is-running,
+    .tool-card-name.is-running {
+      animation: none;
+      background: none;
+      color: var(--text-muted);
+      -webkit-text-fill-color: var(--text-muted);
+    }
+  }
+
+  /* ── Thinking-process summary header (collapsed toggle) ── */
+  /* A plain, rail-less toggle: chevron + label, flush with the answer. Clicking
+     (or the whole row hover, via .tool-timeline-highlight-all) toggles the steps. */
+  .thinking-summary-header {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 0;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    cursor: pointer;
+    user-select: none;
+    /* Full-width flow row (not fit-content): the label text changes length across the
+       streaming→settled boundary ("Working… Ns" → "Thought for Ns"); a fit-content row
+       would snap its width on that change, a visible reflow at completion. A normal-flow
+       row keeps the chevron + label left-aligned and the row width stable. */
+    align-self: flex-start;
+    color: inherit;
+  }
+  .thinking-summary-chevron {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-faint);
+    transition:
+      transform 0.18s ease,
+      color 0.15s;
+    flex-shrink: 0;
+  }
+  .thinking-summary-chevron.is-open {
+    transform: rotate(90deg);
+  }
+  /* Whole-header hover feedback, driven off the shared hoveringRail state so the
+     header and (former) rail highlight as one unit with no competing mechanism. */
+  .tool-timeline-highlight-all .thinking-summary-status,
+  .tool-timeline-highlight-all .thinking-summary-chevron {
     color: var(--text-normal);
   }
 
+  /* When a SETTLED process is collapsed, the "Thought for Ns" label + chevron are
+     ambient: hidden until the mouse is over the whole assistant message (the process
+     header AND its answer, i.e. the parent `.group`), so a quiet, collapsed turn reads
+     as just the answer. The label still occupies its row (opacity, not display) so the
+     answer below doesn't shift when it fades in. While RUNNING the label is the progress
+     indicator and stays visible — so this only applies when the status is not running. */
+  .thinking-summary-header.is-collapsed .thinking-summary-status:not(.is-running),
+  .thinking-summary-header.is-collapsed:not(:has(.is-running)) .thinking-summary-chevron {
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+  :global(.group:hover) .thinking-summary-header.is-collapsed .thinking-summary-status,
+  :global(.group:hover) .thinking-summary-header.is-collapsed .thinking-summary-chevron,
+  .thinking-summary-header.is-collapsed:hover .thinking-summary-status,
+  .thinking-summary-header.is-collapsed:hover .thinking-summary-chevron {
+    opacity: 1;
+  }
+
   /* ── Steps expand/collapse wrapper ── */
+  /* Both the expanded steps and the collapsed summary use a 0fr↔1fr grid-rows
+     transition — the standard trick for animating to/from intrinsic height.
+     The inner wrapper must clip (overflow: hidden) or the content spills past
+     the collapsing track and the height animation reads as an instant pop. */
   .steps-expand-grid {
     display: grid;
     grid-template-columns: 100%;
@@ -947,29 +1159,28 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
   }
   .steps-expand-inner {
     min-height: 0;
-    overflow: visible;
+    overflow: hidden;
   }
 
-  /* ── Rail clickable (answer-dot collapse trigger) ── */
-  .tool-step-rail-clickable {
-    cursor: pointer;
-    border-radius: 4px;
-  }
-  .tool-step-rail-clickable:hover .tool-step-dot {
-    transform: scale(1.3);
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--interactive-accent) 20%, transparent);
-  }
-  .tool-step-rail-clickable:hover::before {
-    background: var(--interactive-accent);
-    opacity: 0.5;
+  /* ── Answer spot ── */
+  /* The single live-content spot below the header. Before the first tool call the model's
+     opening text streams here; the instant that first tool call lands, the reducer re-homes
+     the text as the step's preamble, which sits with ~7px of top padding inside the step
+     (.tool-step-content 4px + .tool-timeline-preamble 3px). Match that offset ONLY in the
+     pre-first-tool window so the text doesn't jump down when it becomes a preamble. The
+     final answer (steps present, or settled) keeps this at 0 for a tight header→answer gap. */
+  .answer-spot-pre-tool {
+    padding-top: 7px;
   }
 
   /* ── Preamble ── */
   .tool-timeline-preamble {
-    padding: 6px 0;
+    /* Match the tool-card-header's 3px top padding so the first text line starts
+       at the same offset whether a step opens with a preamble or a tool row —
+       keeps the step dot aligned to the first line in both cases. */
+    padding: 3px 0;
     font-size: 0.82rem;
     color: var(--text-muted);
-    font-style: italic;
     flex: 1;
     min-width: 0;
   }
@@ -993,7 +1204,11 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
     align-self: stretch;
     width: 24px;
     flex-shrink: 0;
-    padding-top: 8px;
+    /* Push the dot down so its center (padding-top + 5px dot radius) lands on the
+       first content line's optical center. Content adds 4px top padding and the
+       preamble/header add 3px, and the first line is ~19px tall — its center sits
+       ~16px below the step top, so 12px + 5px ≈ 17px keeps the dot on that line. */
+    padding-top: 12px;
   }
 
   .tool-step-rail::before {
@@ -1013,13 +1228,13 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
 
   /* First step: line starts at dot center */
   .step-first .tool-step-rail::before {
-    top: 13px;
+    top: 17px;
   }
 
   /* Last step: line ends at dot center */
   .step-last .tool-step-rail::before {
     bottom: auto;
-    height: 13px;
+    height: 17px;
   }
 
   /* Single step: no connecting line needed */
@@ -1099,7 +1314,10 @@ const noTimelineWrap = $derived(steps.length === 0 && !showProcessingDot && show
     max-width: 100%;
     align-items: center;
     gap: 8px;
-    padding: 3px 6px;
+    /* No left padding: the tool name lines up flush with the preamble text above it
+       (the preamble has no horizontal padding), so the whole step reads as one column
+       with no stray indent. Right padding kept for the hover hit area. */
+    padding: 3px 6px 3px 0;
     cursor: pointer;
     user-select: none;
     list-style: none;

--- a/src/components/chat/ToolCallsSection.svelte
+++ b/src/components/chat/ToolCallsSection.svelte
@@ -46,16 +46,6 @@ const showRawIO = $derived(pluginData.showToolIODetails);
 
 let hoveringRail = $state(false);
 
-// Per-`task`-card expansion of the nested subagent sub-timeline, keyed by the
-// task tool-call id. Collapsed by default — a subagent (especially several in
-// parallel) can emit many child tool calls and clutter the chat; the user
-// expands on demand.
-let subAgentExpanded = $state<Record<string, boolean>>({});
-
-function toggleSubAgent(taskCallId: string) {
-	subAgentExpanded[taskCallId] = !subAgentExpanded[taskCallId];
-}
-
 /* ── Formatters ── */
 
 function formatValue(value: unknown): string {
@@ -385,18 +375,22 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
     tool.output !== undefined
       ? buildToolOutputRenderModel(tool.name, tool.output, tool.input)
       : undefined}
-  {@const isSubAgentParent = tool.name === "task" && !!tool.subAgentName}
   {@const toolSummary = buildToolSummary(tool.name, tool.input, outputModel, tool.status)}
   {@const isTask = tool.name === "task"}
-  <!-- Regular tools fold the outcome into the sentence ("Read main.md, 512 lines");
-       task rows keep the subagent name as the label and the task description as a
-       separate faint subtitle rather than a comma-joined outcome clause. -->
-  {@const headerLabel = isTask ? toolDisplayName(tool) : foldOutcome(toolSummary)}
-  {@const headerSubtitle = isTask ? getTaskSummary(tool.input) : ""}
+  <!-- A `task` (subagent) row reads as one coherent sentence like any other tool
+       call: the subagent name followed by what it was asked to do
+       ("Web Search: Explore the user's OKRs"). No "subagent" pill and no separate
+       subtitle — the delegation is conveyed by the sentence itself. -->
+  {@const taskSentence = (() => {
+    const name = toolDisplayName(tool);
+    const description = getTaskSummary(tool.input);
+    return description ? `${name}: ${description}` : name;
+  })()}
+  {@const headerLabel = isTask ? taskSentence : foldOutcome(toolSummary)}
   {#if isExpandable(tool)}
     <details class="tool-card">
       <summary class="tool-card-header">
-        {@render toolCardHeader(headerLabel, headerSubtitle, tool.status, isSubAgentParent, tool.subAgentName)}
+        {@render toolCardHeader(headerLabel, tool.status, tool.subAgentName, isTask)}
       </summary>
       <div class="tool-card-body">
         {@render toolBody(tool, outputModel)}
@@ -405,7 +399,7 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
   {:else}
     <div class="tool-card tool-card-flat">
       <div class="tool-card-header">
-        {@render toolCardHeader(headerLabel, headerSubtitle, tool.status, isSubAgentParent, tool.subAgentName)}
+        {@render toolCardHeader(headerLabel, tool.status, tool.subAgentName, isTask)}
       </div>
     </div>
   {/if}
@@ -413,22 +407,19 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
 
 {#snippet toolCardHeader(
   label: string,
-  subtitle: string,
   status: UnifiedToolCall["status"],
-  isSubAgentParent: boolean,
   subAgentName: string | undefined,
+  isTask: boolean,
 )}
   <span
     class="tool-card-name"
     class:tool-card-name-failed={status === "failed"}
     class:is-running={status === "running"}>{label}</span>
-  {#if isSubAgentParent}
-    <span class="tool-card-subagent-badge">subagent</span>
-  {:else if subAgentName}
+  <!-- Orphan-child attribution: a subagent tool call whose parent `task` row isn't
+       shown (folding couldn't find it) still notes which subagent it ran in. The
+       `task` row itself needs no chip — its sentence already names the subagent. -->
+  {#if subAgentName && !isTask}
     <span class="tool-card-subagent-badge">via {subAgentName}</span>
-  {/if}
-  {#if subtitle}
-    <span class="tool-card-summary">{subtitle}</span>
   {/if}
 {/snippet}
 
@@ -464,27 +455,50 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
   {/if}
 {/snippet}
 
-{#snippet subAgentBranch(children: UnifiedToolCall[])}
-  <div class="tool-subagent-branch">
-    {#each children as child, childIdx (child.id)}
-      <div
-        class="tool-subagent-branch-row"
-        class:branch-first={childIdx === 0}
-        class:branch-last={childIdx === children.length - 1}
-      >
-        <div class="tool-subagent-branch-rail">
-          <div
-            class="tool-step-dot tool-subagent-dot"
-            class:dot-running={child.status === "running"}
-            class:dot-failed={child.status === "failed"}
-            class:dot-done={child.status === "completed"}
-          ></div>
-        </div>
-        <div class="tool-subagent-branch-content">
-          {@render toolCard(child)}
-        </div>
+{#snippet subAgentGroup(tool: UnifiedToolCall, children: UnifiedToolCall[])}
+  {@const outputModel =
+    tool.output !== undefined
+      ? buildToolOutputRenderModel(tool.name, tool.output, tool.input)
+      : undefined}
+  {@const name = toolDisplayName(tool)}
+  {@const description = getTaskSummary(tool.input)}
+  {@const headerLabel = description ? `${name}: ${description}` : name}
+  <div class="tool-subagent-group">
+    {#if tool.preamble}
+      {@render preambleBlock(tool.preamble)}
+    {/if}
+    <!-- The task sentence is itself the expand toggle (a normal tool-card
+         <details>): clicking it reveals the subagent's child steps and its final
+         output. Collapsed by default so a subagent's many child calls don't
+         clutter the chat until the user opts in. -->
+    <details class="tool-card">
+      <summary class="tool-card-header">
+        <span
+          class="tool-card-name"
+          class:tool-card-name-failed={tool.status === "failed"}
+          class:is-running={tool.status === "running"}>{headerLabel}</span>
+      </summary>
+
+      <!-- Child steps render inline as normal tool rows, indented under the task
+           sentence — no rail, no dots. -->
+      <div class="tool-subagent-branch">
+        {#each children as child (child.id)}
+          <div class="tool-subagent-branch-content">
+            {@render toolCard(child)}
+          </div>
+        {/each}
       </div>
-    {/each}
+
+      <!-- The subagent's final output, below its steps. -->
+      {#if hasFriendlyResult(outputModel)}
+        <div class="tool-subagent-output">
+          <div class="tool-subagent-output-label">Result</div>
+          <div class="tool-io-output">
+            {@render outputBody(outputModel!)}
+          </div>
+        </div>
+      {/if}
+    </details>
   </div>
 {/snippet}
 
@@ -555,39 +569,7 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
             {@const isSubAgentParent = tool.name === "task" && !!tool.subAgentName}
             {@const branchChildren = tool.children ?? []}
             {#if isSubAgentParent && branchChildren.length > 0}
-              {@const expanded = subAgentExpanded[tool.id] ?? false}
-              {@const runningCount = branchChildren.filter((c) => c.status === "running").length}
-              <div class="tool-subagent-group">
-                {@render toolCard(tool)}
-                <button
-                  type="button"
-                  class="tool-subagent-toggle"
-                  class:is-expanded={expanded}
-                  onclick={() => toggleSubAgent(tool.id)}
-                  aria-expanded={expanded}
-                >
-                  <svg viewBox="0 0 16 16" fill="none" class="tool-subagent-toggle-chevron">
-                    <path
-                      d="M6 4L10 8L6 12"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                  <span>
-                    {expanded ? "Hide" : "Show"}
-                    {branchChildren.length}
-                    {branchChildren.length === 1 ? "step" : "steps"}
-                  </span>
-                  {#if runningCount > 0}
-                    <span class="tool-subagent-toggle-running">running…</span>
-                  {/if}
-                </button>
-                {#if expanded}
-                  {@render subAgentBranch(branchChildren)}
-                {/if}
-              </div>
+              {@render subAgentGroup(tool, branchChildren)}
             {:else}
               {@render toolCard(tool)}
             {/if}
@@ -1335,10 +1317,12 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
        only the text color — no background highlight, no chevron. */
     color: var(--text-faint);
     transition: color 0.15s;
-    /* Size to content, but shrink with ellipsis if the label alone would
-       exceed the card width (header is capped at max-width: 100%). */
+    /* Size to content, but ellipsis if the label alone overflows the capped-width
+       header (task rows now fold the subagent name + description into this single
+       label, so there's no competing sibling to crush it). */
     flex: 0 1 auto;
     min-width: 0;
+    max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -1352,19 +1336,6 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
   .tool-card-name-failed,
   .tool-card-header:hover .tool-card-name-failed {
     color: var(--color-red);
-  }
-
-  /* Faint task-description subtitle shown only on a subagent `task` row (the
-     "what it was asked to do"). Regular tools fold their outcome into the label
-     instead, so this never carries a result count. */
-  .tool-card-summary {
-    flex: 0 1 auto;
-    min-width: 0;
-    color: var(--text-faint);
-    font-size: 0.76rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   /* ── Merged multi-call row ── */
@@ -1420,7 +1391,7 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
     background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
   }
 
-  /* ── Subagent branch (git-merge style sub-timeline) ── */
+  /* ── Subagent group (task sentence + inline child steps + final output) ── */
   .tool-subagent-group {
     display: flex;
     flex-direction: column;
@@ -1428,130 +1399,40 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
     position: relative;
   }
 
-  /* Collapsed-by-default toggle for the subagent's nested sub-timeline. Sits
-     indented under the parent `task` card (matching the branch indent) and
-     reveals/hides the child tool calls on demand to keep the chat uncluttered. */
-  .tool-subagent-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    margin-left: 6px;
-    padding: 3px 8px 3px 4px;
-    background: none;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    color: var(--text-muted);
-    font-size: 0.74rem;
-    transition: background 0.12s, color 0.12s;
-  }
-
-  .tool-subagent-toggle:hover {
-    background: var(--background-modifier-hover);
-    color: var(--text-normal);
-  }
-
-  .tool-subagent-toggle-chevron {
-    width: 12px;
-    height: 12px;
-    flex-shrink: 0;
-    transition: transform 0.12s;
-  }
-
-  .tool-subagent-toggle.is-expanded .tool-subagent-toggle-chevron {
-    transform: rotate(90deg);
-  }
-
-  .tool-subagent-toggle-running {
-    color: var(--interactive-accent);
-    font-style: italic;
-  }
-
-  /* The subagent's tool calls hang off the parent `task` card as a nested
-     sub-timeline. A curved elbow diverges from just under the parent card,
-     runs a vertical spine through the child dots, and stops at the last child
-     to "merge" back. Indented so it reads as subordinate to the `task` node
-     without leaving the step's content column. */
+  /* The subagent's tool calls render as a plain indented list under the parent
+     `task` sentence — no rail or dots, always visible. A subtle left rule
+     (matching the expanded tool-body indent) marks them as subordinate without a
+     second timeline. */
   .tool-subagent-branch {
     display: flex;
     flex-direction: column;
-    margin-left: 6px;
-    padding-left: 4px;
-  }
-
-  .tool-subagent-branch-row {
-    display: flex;
-    gap: 0;
-    position: relative;
-  }
-
-  .tool-subagent-branch-rail {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    align-self: stretch;
-    width: 20px;
-    flex-shrink: 0;
-    padding-top: 13px;
-  }
-
-  /* Vertical spine of the branch — a subtler accent tint so the main timeline
-     still reads as primary. */
-  .tool-subagent-branch-rail::before {
-    content: "";
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 2px;
-    background: color-mix(in srgb, var(--interactive-accent) 32%, var(--background-modifier-border));
-    border-radius: 1px;
-    top: 0;
-    bottom: 0;
-  }
-
-  /* First child: the spine begins at the child dot; a curved elbow reaches up
-     and to the left, connecting to the parent `task` card area. The elbow
-     right-edge anchors at the sub-rail spine (left: 50%), and its width
-     extends leftward far enough to reach the parent main-rail spine. */
-  .branch-first .tool-subagent-branch-rail::before {
-    top: 0;
-  }
-  .branch-first .tool-subagent-branch-rail::after {
-    display: none;
-  }
-
-  /* Last child (when not also first): spine stops at the dot, no trailing line. */
-  .branch-last:not(.branch-first) .tool-subagent-branch-rail::before {
-    bottom: auto;
-    height: 18px;
-  }
-
-  /* Single child: only the elbow feeds the dot, no through-spine. */
-  .branch-first.branch-last .tool-subagent-branch-rail::before {
-    display: none;
-  }
-
-  .tool-subagent-dot {
-    width: 8px;
-    height: 8px;
-    border-width: 2px;
-  }
-
-  /* Child dots use a slightly muted accent so they read as secondary to the
-     parent node's dot. */
-  .tool-subagent-dot.dot-done {
-    border-color: color-mix(in srgb, var(--interactive-accent) 70%, var(--background-modifier-border));
-    background: color-mix(in srgb, var(--interactive-accent) 70%, var(--background-modifier-border));
-    box-shadow: none;
+    margin: 2px 0 4px 12px;
+    padding-left: 12px;
+    border-left: 2px solid var(--background-modifier-border);
   }
 
   .tool-subagent-branch-content {
-    flex: 1;
     min-width: 0;
     display: flex;
     flex-direction: column;
-    padding: 4px 0;
+  }
+
+  /* The subagent's final output, shown below its child steps under the same
+     indent so it reads as the branch's conclusion. */
+  .tool-subagent-output {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin: 0 0 4px 12px;
+    padding-left: 12px;
+  }
+
+  .tool-subagent-output-label {
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-faint);
   }
 
   /* A row with nothing to reveal renders flat: no expand affordance, so drop the

--- a/src/components/chat/toolTimelineModel.ts
+++ b/src/components/chat/toolTimelineModel.ts
@@ -1,4 +1,4 @@
-import type { AssistantTimelineEvent, ToolCallState, ToolCallStatus } from "../../stores/chatStore.svelte";
+import type { AssistantTimelineEvent, ToolCallStatus } from "../../stores/chatStore.svelte";
 
 /**
  * A single tool call in the rendered timeline. When a tool ran inside a
@@ -24,6 +24,13 @@ export interface UnifiedToolCall {
 
 export interface TimelineStep {
 	id: string;
+	/**
+	 * The aiMessageId this step's tools were grouped under (the LangGraph AI message
+	 * that made these tool calls). Used by the UI to fold the step into the thinking
+	 * process once live content carries a different aiMessageId (the next message
+	 * began). Undefined for checkpoint-reconstructed steps (settled, not streaming).
+	 */
+	aiMessageId?: string;
 	tools: UnifiedToolCall[];
 }
 
@@ -77,6 +84,7 @@ export function buildStepsFromEvents(rawEvents: AssistantTimelineEvent[]): Timel
 			if (!stepByGroup.has(groupId)) {
 				const step: TimelineStep = {
 					id: `step-${groupId}`,
+					aiMessageId: event.aiMessageId,
 					tools: [],
 				};
 				stepByGroup.set(groupId, step);
@@ -122,31 +130,6 @@ export function buildStepsFromEvents(rawEvents: AssistantTimelineEvent[]): Timel
 	}
 
 	return foldSubAgentChildren(steps);
-}
-
-export function buildStepsFromToolCalls(calls: ToolCallState[] | undefined): TimelineStep[] {
-	if (!calls || calls.length === 0) return [];
-	const step: TimelineStep = { id: "step-0", tools: [] };
-	// Deduplicate identical preamble texts: when checkpoint replay assigns the
-	// same flat-string content to all tool calls in a message, only the first
-	// tool in that group keeps the preamble so it isn't shown N times.
-	const seenPreambles = new Set<string>();
-	for (const tc of calls) {
-		const preambleText = tc.preamble?.trim() || undefined;
-		const preamble = preambleText && !seenPreambles.has(preambleText) ? preambleText : undefined;
-		if (preamble) seenPreambles.add(preamble);
-		step.tools.push({
-			id: tc.id,
-			name: tc.name,
-			preamble,
-			input: tc.input,
-			output: tc.output,
-			status: tc.status,
-			subAgentName: tc.subAgentName,
-			parentToolCallId: tc.parentToolCallId,
-		});
-	}
-	return foldSubAgentChildren([step]);
 }
 
 /**

--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -113,6 +113,19 @@ export interface AssistantMessage {
 	content: string;
 	toolCalls?: ToolCallState[];
 	assistantTimeline?: AssistantTimelineEvent[];
+	// Wall-clock time the assistant spent producing this turn (thinking + tool
+	// calls), in milliseconds. Stamped live in the store when the stream ends and
+	// persisted onto the final AI message's response_metadata so the "Thought for
+	// Ns" label survives reload. Absent for turns predating this / restored history
+	// with no stored duration (the UI falls back to the step count).
+	thinkingDurationMs?: number;
+	// The aiMessageId of the text currently in `content` (streaming only). The UI uses
+	// this to decide when the last tool step folds into the thinking process: the step
+	// stays "current" (rendered below the label with its tools) until live content
+	// carries a DIFFERENT aiMessageId — i.e. the model has begun the next AI message
+	// (the "first token of the next message" fold trigger). Cleared whenever `content`
+	// is cleared (tool_start / step boundary) so an empty spot never drives a fold.
+	contentAiMessageId?: string;
 	nerd_stats?: {
 		tokensPerSecond: number;
 		retrievedDocsNum: number;
@@ -822,6 +835,19 @@ function extractGenerationFromAssistantMessage(msg: BaseMessage): MessageGenerat
 	return extractGenerationFromMetadata(aiMessage.response_metadata);
 }
 
+/**
+ * Reads the persisted thinking duration (ms) off an AI message's response_metadata,
+ * written by ObsidianChatManager on save (mirrors the generation-metadata pattern).
+ * Returns undefined for non-AI messages or turns with no stored duration.
+ */
+function extractThinkingDurationFromMessage(msg: BaseMessage): number | undefined {
+	if (!isAIMessage(msg)) return undefined;
+	const meta = (msg as AIMessage & { response_metadata?: unknown }).response_metadata;
+	if (!meta || typeof meta !== "object" || Array.isArray(meta)) return undefined;
+	const value = (meta as Record<string, unknown>).thinking_duration_ms;
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
 function mergeGeneration(
 	current: MessageGeneration | undefined,
 	next: MessageGeneration | undefined,
@@ -1073,6 +1099,7 @@ export function baseMessageToAssistantMessage(
 		content: textContent,
 		toolCalls,
 		assistantTimeline: buildTimelineFromToolCalls(toolCalls, msg.id),
+		thinkingDurationMs: extractThinkingDurationFromMessage(msg),
 	};
 }
 
@@ -1095,6 +1122,7 @@ function mergeAssistantMessages(
 
 	// Merge multiple assistant messages — each AI message identified by its native id
 	let finalContent = "";
+	let finalDuration: number | undefined;
 	const allToolCalls: ToolCallState[] = [];
 	const allTimelineEvents: AssistantTimelineEvent[] = [];
 
@@ -1119,6 +1147,11 @@ function mergeAssistantMessages(
 		// their text is intermediate subagent reasoning, not the parent answer.
 		if (!parentTaskCallId && converted.content.trim()) {
 			finalContent = converted.content;
+			// The duration is written onto the same final answer message, so carry it
+			// from whichever message supplies finalContent (last top-level non-empty).
+			if (converted.thinkingDurationMs !== undefined) {
+				finalDuration = converted.thinkingDurationMs;
+			}
 		}
 
 		// Collect all tool calls and timeline events.
@@ -1138,6 +1171,7 @@ function mergeAssistantMessages(
 		content: finalContent,
 		toolCalls: allToolCalls.length > 0 ? allToolCalls : undefined,
 		assistantTimeline: allTimelineEvents.length > 0 ? allTimelineEvents : undefined,
+		thinkingDurationMs: finalDuration,
 	};
 }
 
@@ -1839,10 +1873,20 @@ export class ChatSession {
 			this.summarizingHistory = options.predictedSummarization ?? false;
 			pair.assistantMessage.state = AssistantState.streaming;
 
-			const streamPromise = this.consumeStream(pair.assistantMessage, getStream(signal));
+			// Wall-clock start of the turn — used to compute the run duration stamped on
+			// the message (live) and persisted onto the checkpoint below.
+			const runStartedAtMs = Date.now();
 
-			await streamPromise;
+			await this.consumeStream(pair.assistantMessage, getStream(signal));
 			pair.assistantMessage.state = AssistantState.success;
+
+			// Stamp the elapsed time so the "Thought for Ns" label shows immediately
+			// (before any reload) and reads back from persistence later. This is the
+			// FULL-run duration (turn start → stream end): the whole turn is the
+			// "thinking process" — all streamed text renders under the header until the
+			// stream ends, at which point the final answer drops into place below.
+			const thinkingDurationMs = Date.now() - runStartedAtMs;
+			pair.assistantMessage.thinkingDurationMs = thinkingDurationMs;
 
 			// Generate chat title after stream completes for the first user message.
 			// Must be sequential because rename changes this.id (the thread path).
@@ -1865,6 +1909,34 @@ export class ChatSession {
 			}
 
 			await this.syncGraphAfterRun(options.parentCheckpointId, options.beforeCheckpointIds);
+
+			// syncGraphAfterRun rebuilds this.messages from the checkpoint graph, which
+			// replaces the pair object we stamped above with a fresh one whose
+			// thinkingDurationMs is read from response_metadata — not yet written (that
+			// happens below). Without this re-stamp the label flips from "Thought for Ns"
+			// back to the step-count fallback the instant the stream settles.
+			const rebuiltPair = this.findPair(pairId);
+			if (rebuiltPair) {
+				rebuiltPair.assistantMessage.thinkingDurationMs = thinkingDurationMs;
+			}
+
+			// Persist the thinking duration onto the just-created checkpoint's final
+			// AI message (response_metadata) so "Thought for Ns" survives reload. Done
+			// after syncGraphAfterRun, when the active checkpoint id for this turn is
+			// resolved. Best-effort: a failure here only loses the persisted label,
+			// not the answer, so it must never break the run.
+			const settledCheckpointId = this.graphState.activeCheckpointId;
+			if (settledCheckpointId) {
+				try {
+					await getPlugin().agentManager.annotateThinkingDuration(
+						String(this.id),
+						settledCheckpointId,
+						thinkingDurationMs,
+					);
+				} catch (err) {
+					Logger.warn("[ChatSession] Failed to persist thinking duration:", err);
+				}
+			}
 
 			if (options.reloadAfter && this.onNeedReload) {
 				await this.onNeedReload();
@@ -2059,7 +2131,10 @@ export class ChatSession {
 	/**
 	 * Shared stream consumption logic for both normal queries and regeneration.
 	 */
-	private async consumeStream(assistantMsg: AssistantMessage, stream: AsyncIterable<AgentStreamChunk>) {
+	private async consumeStream(
+		assistantMsg: AssistantMessage,
+		stream: AsyncIterable<AgentStreamChunk>,
+	): Promise<void> {
 		let tokenBuffer = "";
 		let hasSeenToolCall = false;
 		// Track preamble texts already emitted during streaming so that parallel tool
@@ -2084,6 +2159,7 @@ export class ChatSession {
 				if (aiIdChanged || pendingStepReset) {
 					tokenBuffer = "";
 					assistantMsg.content = "";
+					assistantMsg.contentAiMessageId = undefined;
 					pendingStepReset = false;
 					emittedStreamPreambles.clear();
 				}
@@ -2091,6 +2167,10 @@ export class ChatSession {
 
 				tokenBuffer += chunk.token;
 				assistantMsg.content = hasSeenToolCall ? tokenBuffer.trimStart() : tokenBuffer;
+				// Stamp the aiMessageId of the text now in `content` so the UI can tell
+				// when the model has moved to a NEW message (fold trigger). See the field
+				// docs on AssistantMessage.
+				assistantMsg.contentAiMessageId = currentTokenAiMessageId;
 				continue;
 			}
 
@@ -2108,6 +2188,7 @@ export class ChatSession {
 				if (isFirstWithPreamble) emittedStreamPreambles.add(preambleTrimmed);
 				tokenBuffer = "";
 				assistantMsg.content = "";
+				assistantMsg.contentAiMessageId = undefined;
 
 				if (!assistantMsg.toolCalls) assistantMsg.toolCalls = [];
 				assistantMsg.toolCalls.push({
@@ -2212,6 +2293,7 @@ export class ChatSession {
 			if (chunk.type === "result") {
 				this.summarizingHistory = false;
 				assistantMsg.content = hasSeenToolCall ? tokenBuffer.trim() : tokenBuffer;
+				assistantMsg.contentAiMessageId = currentTokenAiMessageId;
 				continue;
 			}
 

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -491,6 +491,7 @@ export const DEFAULT_SETTINGS: PluginData = {
 	onboardingComplete: false,
 	onboardingSplashSeen: false,
 	dismissedRecommendations: [],
+	thinkingProcessExpanded: true,
 
 	// Debugging & telemetry
 	enableLangSmith: false,
@@ -1280,6 +1281,14 @@ export class PluginDataStore {
 	}
 	set showToolIODetails(val: boolean) {
 		this.#data.showToolIODetails = val;
+		this.saveSettings();
+	}
+
+	get thinkingProcessExpanded() {
+		return this.#data.thinkingProcessExpanded ?? true;
+	}
+	set thinkingProcessExpanded(val: boolean) {
+		this.#data.thinkingProcessExpanded = val;
 		this.saveSettings();
 	}
 

--- a/src/stores/state.svelte.ts
+++ b/src/stores/state.svelte.ts
@@ -1,4 +1,5 @@
 import type SecondBrainPlugin from "../main";
+import { getData } from "./dataStore.svelte";
 
 let isChatInSidebar: boolean = $state(true);
 
@@ -13,6 +14,27 @@ export const chatLayout = {
 
 	toggleIsSidebar() {
 		isChatInSidebar = !isChatInSidebar;
+	},
+};
+
+// Session preference for the DEFAULT collapse state of a turn's thinking process when the
+// user hasn't toggled that turn individually — expanded (true) or collapsed (false).
+// Toggling the chevron on a still-streaming turn (whose per-turn key isn't stable yet)
+// writes this, so every untouched turn follows the same choice. A settled turn the user
+// toggles gets a transient per-turn override in MessageContainer instead. Backed by
+// dataStore so the choice PERSISTS across reloads; default expanded.
+export const thinkingProcessPref = {
+	get streamingExpanded(): boolean {
+		return getData().thinkingProcessExpanded;
+	},
+
+	set streamingExpanded(val: boolean) {
+		getData().thinkingProcessExpanded = val;
+	},
+
+	toggleStreamingExpanded() {
+		const d = getData();
+		d.thinkingProcessExpanded = !d.thinkingProcessExpanded;
 	},
 };
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -555,6 +555,12 @@ export interface PluginData {
 	onboardingSplashSeen: boolean;
 	/** IDs of new-chat recommendations the user has dismissed. Includes the well-known block id to dismiss the whole surface. */
 	dismissedRecommendations: string[];
+	/**
+	 * Default collapse state of a chat turn's thinking process when the user hasn't
+	 * toggled that turn individually: expanded (true) or collapsed (false). Persisted
+	 * so the choice survives reloads. Default expanded.
+	 */
+	thinkingProcessExpanded: boolean;
 
 	// ============================================================================
 	// Web Search

--- a/test/components/toolTimelineModel.test.ts
+++ b/test/components/toolTimelineModel.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import type { AssistantTimelineEvent } from "../../src/stores/chatStore.svelte";
 import {
 	buildStepsFromEvents,
-	buildStepsFromToolCalls,
 	foldSubAgentChildren,
 	groupStepTools,
 	toolDisplayName,
@@ -142,23 +141,6 @@ describe("toolTimelineModel — subagent nesting", () => {
 		expect(steps[0].tools[0].children?.[0].status).toBe("completed");
 	});
 
-	it("renders a checkpoint-reconstructed task with no children when subagent steps aren't in the checkpoint", () => {
-		const steps = buildStepsFromToolCalls([
-			{
-				id: "task-1",
-				name: "task",
-				input: { subagent_type: "Web Search" },
-				status: "completed",
-				output: "summary",
-				subAgentName: "Web Search",
-			},
-		]);
-		expect(steps[0].tools).toHaveLength(1);
-		const parent = steps[0].tools[0];
-		expect(parent.children).toBeUndefined();
-		expect(toolDisplayName(parent)).toBe("Web Search");
-	});
-
 	it("labels task calls with their subagent name verbatim", () => {
 		const parent: UnifiedToolCall = {
 			id: "task-1",
@@ -201,6 +183,10 @@ describe("toolTimelineModel — subagent nesting", () => {
 		expect(steps).toHaveLength(2);
 		expect(steps[0].tools[0].preamble).toBe("First thought.");
 		expect(steps[1].tools[0].preamble).toBe("Second thought.");
+		// Each step carries the aiMessageId it was grouped under — the UI uses this to
+		// fold the current run once live content belongs to a newer message.
+		expect(steps[0].aiMessageId).toBe("m1");
+		expect(steps[1].aiMessageId).toBe("m2");
 	});
 });
 


### PR DESCRIPTION
## Summary

Reworks the chat **"thinking process"** disclosure into a **carry-through** collapse model, persists the "Thought for Ns" duration across reloads, and cleans up the tool-call timeline rendering that accreted during the iterations.

### Collapse UX (carry-through)
Nothing collapses/expands automatically — a turn's collapse state while streaming carries straight through settle (expanded stays expanded, collapsed stays collapsed; the user drives it entirely). Two inputs:
- **Global session pref** `thinkingProcessPref.streamingExpanded`, persisted via `dataStore.thinkingProcessExpanded` so the choice survives reloads.
- **Transient per-turn override** keyed on the stable `regenerateFromCheckpointId`. `hasStableKey` guards against writing an override under a temporary `optimistic-`/absent streaming key (which would orphan at the settle rebuild and read as a spurious auto-expand).

### Persisted "Thought for Ns"
`ObsidianChatManager.annotateThinkingDuration` stamps the turn's wall-clock duration onto the checkpoint's final AI message (`response_metadata`, round-trips through the NDJSON checkpoint), surfaced via `AgentManager` and read back as `thinkingDurationMs` so the label survives reload.

### Cleanup / refactor
- Remove dead `buildStepsFromToolCalls` (unreachable — the store always populates `assistantTimeline` alongside `toolCalls`) and its test; simplify `steps` to `buildStepsFromEvents(assistantTimeline ?? [])`.
- Drop dead props `toolCalls` / `isError` / `isProcessing` on `ToolCallsSection` and the orphaned `isAssistantProcessing` const in `MessageContainer`.
- Strip inert CSS class applications (`is-failed`, `step-running`/`step-failed`, `tool-card-merged`, `tool-output-structured-summary`, base `answer-spot`, `tool-subagent-toggle-label`).
- Extract the duplicated preamble markup into a shared `preambleBlock` snippet (byte-identical output).

## Test plan
- `bun run check` — clean (only the 4 pre-existing `GraphCanvas.svelte` errors, unrelated).
- `bun run test` — 97 tests green (chatStore / toolSummaryModel / toolTimelineModel).
- `bun run format` — no-op (confirms the extracted snippet's class string is byte-identical).
- Dev build clean, no Svelte warnings.
- Manual QA in the test vault: streaming run with a preamble (single + merged tool group), a failed tool, a subagent branch, and collapse/expand carry-through across settle + reload.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._