### PR TITLE
fix: subagent 400 (name pattern) + subagent answer leaking into parent content

### DIFF
--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -146,6 +146,22 @@ export interface AgentOptions {
 }
 
 /**
+ * Sanitizes a subagent display name into a value safe to stamp onto a message's
+ * `name` field. OpenAI/Azure/OpenAI-compatible chat endpoints enforce the pattern
+ * `^[^\s<|\\/>]+$` on `messages[N].name` (also used for LangGraph runnable names,
+ * which leak into the subagent's `AIMessage.name`). Names with spaces or `()` —
+ * e.g. "Default Agent (isolated)" — otherwise 400 the subagent's second turn.
+ * Collapses every disallowed character to `_`; falls back to `subagent` if empty.
+ */
+export function sanitizeRunnableName(name: string): string {
+	const cleaned = name
+		.replace(/[\s<|\\/>()]+/g, "_")
+		.replace(/_+/g, "_")
+		.replace(/^_+|_+$/g, "");
+	return cleaned || "subagent";
+}
+
+/**
  * A fully-resolved subagent, ready to hand to deepagents' subagent middleware.
  * Carries instances (not IDs): each subagent runs with its own model, tools,
  * and prompt — resolved by AgentManager from a referenced agent's config.
@@ -582,7 +598,15 @@ export class Agent {
 						systemPrompt: s.systemPrompt,
 						tools: [...s.tools] as never,
 						middleware: [] as never,
-						name: s.name,
+						// The runnable name is stamped onto the subagent's AIMessage.name,
+						// which serializes into the OpenAI/Azure request as `messages[N].name`.
+						// OpenAI-compatible endpoints enforce the pattern `^[^\s<|\\/>]+$`
+						// (no whitespace, no `<|\/>`), so a display name like
+						// "Default Agent (isolated)" makes the subagent's second turn (after
+						// its first tool call) 400 with "Invalid 'messages[N].name'". Sanitize
+						// to a pattern-safe slug; the human-facing selector name (the `task`
+						// tool's `subagent_type`) stays untouched below.
+						name: sanitizeRunnableName(s.name),
 					});
 					subgraph.invoke = (state: never, config?: never) => {
 						const c = config as Record<string, unknown> | undefined;
@@ -923,8 +947,16 @@ export class Agent {
 				}
 
 				if (mode === "messages") {
-					const [message] = payload as [BaseMessage, Record<string, unknown>];
+					const [message, msgMeta] = payload as [BaseMessage, Record<string, unknown>];
 					if (message.getType() === "ai") {
+						// Tokens authored by a subagent carry `lc_agent_name` in their stream
+						// metadata (set by deepagents' `task` tool). The subagent's answer is
+						// delivered to the parent via the `task` ToolMessage (rendered under the
+						// task card), so its streamed tokens must NOT append to the parent's main
+						// content — otherwise the subagent's final answer leaks into the parent
+						// message. Skip subagent tokens (and their preamble accounting) here.
+						const isSubAgentToken = typeof msgMeta?.lc_agent_name === "string";
+						if (isSubAgentToken) continue;
 						// Reset accumulator when a new AI message starts.
 						if (message.id && message.id !== lastAiMessageId) {
 							lastAiMessageId = message.id;
@@ -1207,8 +1239,12 @@ export class Agent {
 				}
 
 				if (mode === "messages") {
-					const [message] = payload as [BaseMessage, Record<string, unknown>];
+					const [message, msgMeta] = payload as [BaseMessage, Record<string, unknown>];
 					if (message.getType() === "ai") {
+						// Subagent tokens carry `lc_agent_name` — suppress them from the parent's
+						// main content (they're delivered via the `task` ToolMessage). See the
+						// streamTokens loop for the full rationale.
+						if (typeof msgMeta?.lc_agent_name === "string") continue;
 						if (message.id && message.id !== lastAiMessageId) {
 							lastAiMessageId = message.id;
 							preambleAccumulator = "";
@@ -1463,8 +1499,12 @@ export class Agent {
 				}
 
 				if (mode === "messages") {
-					const [message] = payload as [BaseMessage, Record<string, unknown>];
+					const [message, msgMeta] = payload as [BaseMessage, Record<string, unknown>];
 					if (message.getType() === "ai") {
+						// Subagent tokens carry `lc_agent_name` — suppress them from the parent's
+						// main content (they're delivered via the `task` ToolMessage). See the
+						// streamTokens loop for the full rationale.
+						if (typeof msgMeta?.lc_agent_name === "string") continue;
 						if (message.id && message.id !== lastAiMessageId) {
 							lastAiMessageId = message.id;
 							preambleAccumulator = "";

--- a/test/agent/Agent.test.ts
+++ b/test/agent/Agent.test.ts
@@ -170,3 +170,73 @@ describe("sanitizeRunnableName", () => {
 		}
 	});
 });
+
+describe("Agent streamTokens subagent-content suppression", () => {
+	// Regression coverage for the leak fix: tokens authored by a subagent carry
+	// `lc_agent_name` in the messages-mode stream metadata and must NOT surface as
+	// parent-content `token` chunks (the subagent answer is delivered via the
+	// `task` ToolMessage instead). Parent tokens (no `lc_agent_name`) must survive.
+	type StreamTuple = ["messages" | "tools" | "values", unknown];
+
+	function aiMessage(id: string, content: string) {
+		return {
+			id,
+			content,
+			getType: () => "ai",
+		};
+	}
+
+	/** Builds a resolved run whose runnable streams the given tuples. */
+	function makeResolvedRun(tuples: StreamTuple[]) {
+		return {
+			runnable: {
+				// biome-ignore lint/suspicious/useAwait: async generator for the stream contract
+				stream: async () =>
+					(async function* () {
+						for (const t of tuples) yield t;
+					})(),
+			},
+			selectedModel: { provider: "openai", name: "gpt-4o", instance: {} },
+			supportsVision: false,
+			currentProvider: "openai",
+		} as never;
+	}
+
+	async function collectTokens(tuples: StreamTuple[]): Promise<string[]> {
+		const agent = new Agent({ registry: makeRegistry() as never });
+		const tokens: string[] = [];
+		// Append a terminal `values` payload so streamTokens resolves a final output
+		// (otherwise it throws "completed without producing a final output").
+		const withFinal: StreamTuple[] = [...tuples, ["values", { messages: [aiMessage("final", "done")] }]];
+		for await (const chunk of agent.streamTokens({
+			query: "hi",
+			threadId: "t1",
+			resolved: makeResolvedRun(withFinal),
+		} as never)) {
+			if ((chunk as { type: string }).type === "token") {
+				tokens.push((chunk as { token: string }).token);
+			}
+		}
+		return tokens;
+	}
+
+	it("suppresses subagent tokens and preserves parent tokens", async () => {
+		const tokens = await collectTokens([
+			["messages", [aiMessage("p1", "Parent before. "), { langgraph_node: "model_request" }]],
+			["messages", [aiMessage("s1", "Subagent answer."), { lc_agent_name: "Default Agent (isolated)" }]],
+			["messages", [aiMessage("p1", "Parent after."), { langgraph_node: "model_request" }]],
+		]);
+
+		expect(tokens).toEqual(["Parent before. ", "Parent after."]);
+		expect(tokens.join("")).not.toContain("Subagent answer.");
+	});
+
+	it("emits parent tokens normally when no subagent is involved", async () => {
+		const tokens = await collectTokens([
+			["messages", [aiMessage("p1", "Hello "), { langgraph_node: "model_request" }]],
+			["messages", [aiMessage("p1", "world"), {}]],
+		]);
+
+		expect(tokens).toEqual(["Hello ", "world"]);
+	});
+});

--- a/test/agent/Agent.test.ts
+++ b/test/agent/Agent.test.ts
@@ -13,7 +13,7 @@ vi.mock("langchain", () => ({
 }));
 
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import { Agent } from "../../src/agent/Agent";
+import { Agent, sanitizeRunnableName } from "../../src/agent/Agent";
 
 function makeRegistry() {
 	return {
@@ -135,5 +135,38 @@ describe("Agent stream tool output normalization", () => {
 		).normalizeStreamToolOutput(undefined);
 
 		expect(output).toBeUndefined();
+	});
+});
+
+describe("sanitizeRunnableName", () => {
+	// OpenAI/Azure/OpenAI-compatible endpoints enforce `^[^\s<|\\/>]+$` on
+	// `messages[N].name`; a subagent runnable name leaks into AIMessage.name and
+	// would 400 the subagent's second turn if it contains disallowed characters.
+	const disallowed = /[\s<|\\/>]/;
+
+	it("replaces spaces and parentheses with underscores", () => {
+		expect(sanitizeRunnableName("Default Agent (isolated)")).toBe("Default_Agent_isolated");
+	});
+
+	it("leaves an already-safe name untouched", () => {
+		expect(sanitizeRunnableName("research-agent")).toBe("research-agent");
+	});
+
+	it("collapses runs of disallowed characters into a single underscore", () => {
+		expect(sanitizeRunnableName("a   /  b")).toBe("a_b");
+	});
+
+	it("trims leading and trailing underscores", () => {
+		expect(sanitizeRunnableName("  spaced  ")).toBe("spaced");
+	});
+
+	it("falls back to 'subagent' for an all-disallowed name", () => {
+		expect(sanitizeRunnableName("  <|>  ")).toBe("subagent");
+	});
+
+	it("produces a name matching the provider pattern for tricky inputs", () => {
+		for (const input of ["Default Agent (isolated)", "My/Weird\\Name", "a|b<c>d", "  "]) {
+			expect(sanitizeRunnableName(input)).not.toMatch(disallowed);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Two independent defects that surfaced when the main agent delegates to a subagent via the `task` tool. Both are fixed in `src/agent/Agent.ts`.

### 1. Subagent `400 (no body)` — invalid `messages[N].name`

The subagent subgraph was created with its **human display name** (e.g. `"Default Agent (isolated)"`). LangChain stamps that onto the subagent's `AIMessage.name`, which serializes into the chat request as `messages[N].name`. OpenAI / Azure / OpenAI-compatible endpoints enforce the pattern `^[^\s<|\\/>]+$` (no whitespace, `<`, `|`, `\`, `/`, `>`), so any subagent whose name contains a space or `()` **400s the subagent's second turn** — i.e. after it has already run its first tool call. That's why the subagent appears to run one tool successfully, then the `task` errors.

**Fix:** new `sanitizeRunnableName()` collapses disallowed characters to `_`, applied only to the runnable's `name`. The human-facing `task` selector name (`subagent_type`) is unchanged.

### 2. Subagent final answer leaking into the parent's content

The `messages`-mode token handler emitted **every** streamed AI token as a parent-content `token` chunk, ignoring stream metadata. LangGraph's `messages` stream includes the subagent's own model tokens, so the subagent's final answer appended into the main agent's message. The subagent answer is already delivered to the parent via the `task` ToolMessage (rendered under the task card), so the streamed tokens were pure leakage.

**Fix:** subagent tokens carry `lc_agent_name` in their stream metadata; skip them in all three streaming loops (`streamTokens`, `editFromCheckpoint`, `regenerate`).

## Testing

- Added unit tests for `sanitizeRunnableName` (`test/agent/Agent.test.ts`); full agent suite passes (157 tests).
- `bun run check` clean for changed files (the 4 pre-existing `GraphCanvas.svelte` errors are unrelated).
- Verified live against a LiteLLM (OpenAI-compatible) endpoint:
  - **Before:** `task` returns `Error: 400 status code`; parent content contains the subagent's answer.
  - **After:** subagent completes and its answer is returned via the task card only; the parent message contains only its own text.

## Notes

This name-pattern 400 is a **distinct** bug from the earlier `__pregel`/checkpoint config leak (which returns a readable "tool_use without tool_result" body). Distinguish by the response body: this one says `Invalid 'messages[N].name'`.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._