### PR TITLE
feat(agent): split Note Management into its own capability

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -9,6 +9,7 @@ import { READ_CONTENT_GUIDANCE_DEFAULTS, getData, getReadContentGuidance } from 
 import {
 	CAPABILITIES,
 	VAULT_TOOL_IDS,
+	NOTE_TOOL_IDS,
 	WEB_TOOL_IDS,
 	type BuiltInToolId,
 	type CapabilityId,
@@ -410,12 +411,12 @@ export class AgentManager {
 			prompt += `\n\n${memoryPrompt}`;
 		}
 
-		// Per-capability guidance. Each capability (vault, web) becomes a top-level `#`
+		// Per-capability guidance. Each capability (vault, notes, web) becomes a top-level `#`
 		// section: its own guidance (user override or default) followed by its enabled
 		// tools' per-tool guidance as `##` subheaders. Replaces the old flat
 		// `# Write Tool Guidelines` + `# Tool Guidelines` sections. The write-staging
-		// policy now lives inside the vault capability's default guidance (manage_notes
-		// is a vault tool); the no-write honesty guard below still handles the empty case.
+		// policy lives inside the Note management capability's default guidance (manage_notes
+		// is its only tool); the no-write honesty guard below still handles the empty case.
 		const toolsConfig = selectedAgent.toolsConfig;
 		const isToolEnabled = (toolId: BuiltInToolId): boolean => toolsConfig[toolId]?.enabled ?? false;
 
@@ -903,7 +904,9 @@ export class AgentManager {
 	/**
 	 * Count the capabilities switched on for an agent, using the "one capability card =
 	 * one capability" model the agent editor renders:
-	 *   - the Core · Vault exploration card counts as 1 when any built-in tool is enabled;
+	 *   - the Core · Vault exploration card counts as 1 when any read/explore tool is enabled;
+	 *   - the Note management card counts as 1 when any write tool is enabled;
+	 *   - the Web card counts as 1 when any web tool is enabled;
 	 *   - each core / community / auto-discovered plugin card counts as 1 when its skill
 	 *     (or, for an uncurated auto-discovered plugin, its exec tool) is enabled and the
 	 *     linked plugin is available;
@@ -918,6 +921,8 @@ export class AgentManager {
 
 		// Core card: any vault-exploration tool on.
 		const anyVaultToolOn = VAULT_TOOL_IDS.some((toolId) => agent.toolsConfig[toolId]?.enabled ?? true);
+		// Note management card (separate capability): any write tool on.
+		const anyNoteToolOn = NOTE_TOOL_IDS.some((toolId) => agent.toolsConfig[toolId]?.enabled ?? true);
 		// Web card (separate capability): any web tool on.
 		const anyWebToolOn = WEB_TOOL_IDS.some((toolId) => agent.toolsConfig[toolId]?.enabled ?? true);
 		const skillsService = this.plugin.skillsService;
@@ -931,6 +936,7 @@ export class AgentManager {
 		};
 
 		let count = anyVaultToolOn ? 1 : 0;
+		if (anyNoteToolOn) count++;
 		if (anyWebToolOn) count++;
 
 		// Plugin / community cards: enabled + available skills, excluding user-authored

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -62,8 +62,8 @@ The \`${folder}/\` folder is your own working memory — an intermediate layer b
  * Default guidance for the Vault exploration capability. Rendered as the body of the
  * `# Vault exploration` section in the assembled system prompt (above the enabled
  * vault tools' per-tool `##` subheaders). Contains the note-finding procedure (moved
- * here out of BASE_SYSTEM_PROMPT so it only appears when a vault tool is enabled) plus
- * the write-staging policy (manage_notes is a vault tool). User-editable via the
+ * here out of BASE_SYSTEM_PROMPT so it only appears when a vault tool is enabled).
+ * Write policy lives in the separate Note management capability. User-editable via the
  * capability pencil; `capabilityPrompts.vault` overrides it.
  */
 export const DEFAULT_VAULT_CAPABILITY_GUIDANCE = `## Finding Notes
@@ -80,9 +80,16 @@ export const DEFAULT_VAULT_CAPABILITY_GUIDANCE = `## Finding Notes
 3. **Reading Content**:
    - \`search_notes\` will give you a list of potential matches with metadata.
    - If the user query contains explicit Obsidian wiki links (e.g. [[Project Plan]]), you may call \`read_content\` directly with those links.
-   - If you need to read the full content of a note and no explicit wiki link is provided, use \`read_content\` with the specific file path from the search results.
+   - If you need to read the full content of a note and no explicit wiki link is provided, use \`read_content\` with the specific file path from the search results.`;
 
-## Write Operations
+/**
+ * Default guidance for the Note management capability. Rendered as the body of the
+ * `# Note management` section in the assembled system prompt (above the enabled
+ * `manage_notes` `##` subheader). Holds the write-staging policy previously bundled
+ * into the vault guidance (issue #368). User-editable via the capability pencil;
+ * `capabilityPrompts.notes` overrides it.
+ */
+export const DEFAULT_NOTES_CAPABILITY_GUIDANCE = `## Write Operations
 - All write operations (create, update, delete, move) are staged for user approval. Never say a change has already been applied.
 - Modify only what the user asked for and preserve surrounding content.
 - Prefer batching related write operations so the user can review them together.
@@ -105,6 +112,8 @@ export function buildDefaultCapabilityGuidance(id: CapabilityId): string {
 	switch (id) {
 		case "vault":
 			return DEFAULT_VAULT_CAPABILITY_GUIDANCE;
+		case "notes":
+			return DEFAULT_NOTES_CAPABILITY_GUIDANCE;
 		case "web":
 			return DEFAULT_WEB_CAPABILITY_GUIDANCE;
 	}
@@ -128,6 +137,7 @@ export const HISTORICAL_SYSTEM_PROMPTS: ReadonlyMap<number, string> = new Map([[
  */
 export const HISTORICAL_CAPABILITY_GUIDANCE: ReadonlyMap<CapabilityId, ReadonlySet<string>> = new Map([
 	["vault", new Set([DEFAULT_VAULT_CAPABILITY_GUIDANCE])],
+	["notes", new Set([DEFAULT_NOTES_CAPABILITY_GUIDANCE])],
 	["web", new Set([DEFAULT_WEB_CAPABILITY_GUIDANCE])],
 ]);
 
@@ -171,6 +181,7 @@ export const HISTORICAL_TOOL_GUIDANCE: ReadonlyMap<
  */
 export const CAPABILITY_GUIDANCE_VERSION: ReadonlyMap<CapabilityId, number> = new Map([
 	["vault", 1],
+	["notes", 1],
 	["web", 1],
 ]);
 

--- a/src/components/chat/AgentPopover.svelte
+++ b/src/components/chat/AgentPopover.svelte
@@ -149,8 +149,6 @@ function createNewAgent() {
 <style>
   :global(.agent-popover-trigger) {
     max-width: 190px;
-    padding: 1px 3px;
-    border-radius: 999px;
   }
 
   .agent-pill {

--- a/src/components/modal/AgentEditorModal.svelte
+++ b/src/components/modal/AgentEditorModal.svelte
@@ -32,6 +32,7 @@ import { buildPluginApiSkill } from "../../skills/templates/pluginApiScripting";
 import {
 	DEFAULT_AGENT_ICON,
 	VAULT_TOOL_IDS,
+	NOTE_TOOL_IDS,
 	WEB_TOOL_IDS,
 	type AgentConfig,
 	type BuiltInToolId,
@@ -534,6 +535,7 @@ function openCapabilitySettingsModal(capId: CapabilityId) {
 // --- Core · Vault exploration + Web capability cards (bulk-toggle their built-in tools) ---
 
 const vaultTools = $derived(TOOLS.filter((tool) => (VAULT_TOOL_IDS as readonly string[]).includes(tool.id)));
+const noteTools = $derived(TOOLS.filter((tool) => (NOTE_TOOL_IDS as readonly string[]).includes(tool.id)));
 const webTools = $derived(TOOLS.filter((tool) => (WEB_TOOL_IDS as readonly string[]).includes(tool.id)));
 
 // Each card's master is a plain on/off switch: OFF turns every tool in the card off; ON turns
@@ -556,6 +558,7 @@ function toggleAllTools(tools: ToolInfo[], next: boolean) {
 }
 
 const vaultAnyOn = $derived(anyEnabledIn(vaultTools));
+const noteAnyOn = $derived(anyEnabledIn(noteTools));
 const webAnyOn = $derived(anyEnabledIn(webTools));
 
 // --- Subagents (references to other agents) ---
@@ -862,24 +865,43 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
       <section class="agent-editor-section">
         <SettingGroup heading="Core Capabilities">
           <div class="setting-item-description mb-3">
-            Built-in capabilities every agent can use — vault exploration and web access.
+            Built-in capabilities every agent can use — vault exploration, note management, and web
+            access.
           </div>
 
-          <!-- Vault exploration — configure guidance + per-tool settings via the gear. -->
+          <!-- Vault Exploration — configure guidance + per-tool settings via the gear. -->
           <SettingItem
-            name="Vault exploration"
-            desc="Search, read, edit, and explore your vault with the built-in tools."
+            name="Vault Exploration"
+            desc="Search, read, and explore your vault with the built-in tools."
           >
             {#snippet namePrefix()}
               <Icon name="compass" size="s" />
             {/snippet}
             <Button
               iconId="settings"
-              ariaLabel="Vault exploration settings"
-              tooltip="Vault exploration settings"
+              ariaLabel="Vault Exploration settings"
+              tooltip="Vault Exploration settings"
               onClick={() => openCapabilitySettingsModal("vault")}
             />
             <Toggle checked={vaultAnyOn} onchange={(next) => toggleAllTools(vaultTools, next)} />
+          </SettingItem>
+
+          <!-- Note Management — the write tools (create/update/delete/move). Kept separate from
+               vault exploration so read access can be granted without write access (issue #368). -->
+          <SettingItem
+            name="Note Management"
+            desc="Create, update, delete, and move notes. All writes are staged for your review."
+          >
+            {#snippet namePrefix()}
+              <Icon name="file-pen" size="s" />
+            {/snippet}
+            <Button
+              iconId="settings"
+              ariaLabel="Note Management settings"
+              tooltip="Note Management settings"
+              onClick={() => openCapabilitySettingsModal("notes")}
+            />
+            <Toggle checked={noteAnyOn} onchange={(next) => toggleAllTools(noteTools, next)} />
           </SettingItem>
 
           <!-- Web — tools that reach the public internet (fetch URL, web search). -->

--- a/src/components/modal/MemorySettingsModal.svelte
+++ b/src/components/modal/MemorySettingsModal.svelte
@@ -55,7 +55,7 @@ $effect(() => {
           <Badge label="Needs Manage notes" tone="warning" />
           <span>
             Memory records notes with the <strong>Manage Notes</strong> tool. Enable it in the
-            Vault exploration capability so this agent can write memories.
+            Note Management capability so this agent can write memories.
           </span>
         </div>
       {/if}

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -2128,6 +2128,7 @@ let _pluginDataStore: PluginDataStore | null = null;
 /** Human label for a capability's guidance, shown in the "updated" notice. */
 const CAPABILITY_GUIDANCE_LABEL: Record<CapabilityId, string> = {
 	vault: "Vault guidance",
+	notes: "Note Management guidance",
 	web: "Web guidance",
 };
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -128,10 +128,20 @@ export type BuiltInToolId = (typeof BUILT_IN_TOOL_IDS)[number];
  */
 export const WEB_TOOL_IDS = ["fetch_url", "web_search"] as const satisfies readonly BuiltInToolId[];
 
-/** Built-in tools that operate on the vault (everything not in `WEB_TOOL_IDS`) — the Core card. */
+/**
+ * Built-in tools that mutate the vault (create/update/delete/move notes). Split out from
+ * vault *exploration* into their own "Note management" capability so read access can be
+ * granted without write access — the only mutating built-in tool is `manage_notes` (issue #368).
+ */
+export const NOTE_TOOL_IDS = ["manage_notes"] as const satisfies readonly BuiltInToolId[];
+
+/**
+ * Built-in tools that read/explore the vault — everything that is neither a web tool nor a
+ * note-management (write) tool. Surfaced as the "Vault exploration" (Core) card.
+ */
 export const VAULT_TOOL_IDS = BUILT_IN_TOOL_IDS.filter(
-	(id): id is Exclude<BuiltInToolId, (typeof WEB_TOOL_IDS)[number]> =>
-		!(WEB_TOOL_IDS as readonly string[]).includes(id),
+	(id): id is Exclude<BuiltInToolId, (typeof WEB_TOOL_IDS)[number] | (typeof NOTE_TOOL_IDS)[number]> =>
+		!(WEB_TOOL_IDS as readonly string[]).includes(id) && !(NOTE_TOOL_IDS as readonly string[]).includes(id),
 );
 
 /**
@@ -139,7 +149,7 @@ export const VAULT_TOOL_IDS = BUILT_IN_TOOL_IDS.filter(
  * surfaced as one card in the Agent editor and one `#` section in the assembled system
  * prompt. (Memory is a separate folder feature, not a capability, so it is not listed.)
  */
-export type CapabilityId = "vault" | "web";
+export type CapabilityId = "vault" | "notes" | "web";
 
 /**
  * A built-in prompt or guidance default that changed in a plugin update while the
@@ -178,10 +188,17 @@ export interface CapabilityDef {
 export const CAPABILITIES: readonly CapabilityDef[] = [
 	{
 		id: "vault",
-		title: "Vault exploration",
-		description: "Search, read, edit, and explore your vault with the built-in tools.",
+		title: "Vault Exploration",
+		description: "Search, read, and explore your vault with the built-in tools.",
 		icon: "compass",
 		toolIds: VAULT_TOOL_IDS,
+	},
+	{
+		id: "notes",
+		title: "Note Management",
+		description: "Create, update, delete, and move notes. All writes are staged for your review.",
+		icon: "file-pen",
+		toolIds: NOTE_TOOL_IDS,
 	},
 	{
 		id: "web",


### PR DESCRIPTION
Closes #368.

## What & why

`manage_notes` was part of the **Vault exploration** capability only because `VAULT_TOOL_IDS` was defined as "every built-in tool that isn't a web tool". That lumped the one *mutating* built-in tool in with the read-only exploration tools (`search_notes`, `read_content`, `grep_notes`, …), so a user couldn't grant read access without also granting write access.

This splits note-writing into its own **Note Management** capability, so read and write vault access are independently grantable — and makes the "Vault exploration" label honest (it no longer contains a write tool).

## Changes

- **`src/types/plugin.ts`** — add `NOTE_TOOL_IDS = ["manage_notes"]`, redefine `VAULT_TOOL_IDS` as "neither web nor note tools", add `"notes"` to `CapabilityId`, add the `Note Management` entry to `CAPABILITIES` (icon `file-pen`). Also title-case the capability titles (`Vault Exploration`, `Note Management`, `Web`).
- **`src/agent/prompts.ts`** — move the write-staging policy out of `DEFAULT_VAULT_CAPABILITY_GUIDANCE` into a new `DEFAULT_NOTES_CAPABILITY_GUIDANCE`; register `notes` in `buildDefaultCapabilityGuidance`, `HISTORICAL_CAPABILITY_GUIDANCE`, and `CAPABILITY_GUIDANCE_VERSION`.
- **`src/agent/AgentManager.ts`** — import `NOTE_TOOL_IDS`, add a `notes` branch to `countEnabledCapabilities`. Prompt assembly already iterates `CAPABILITIES`, so the new `# Note Management` section appears automatically.
- **`src/components/modal/AgentEditorModal.svelte`** — new "Note Management" card between Vault Exploration and Web.
- **`src/stores/dataStore.svelte.ts`** — add the `notes` label to `CAPABILITY_GUIDANCE_LABEL`.
- **`src/components/modal/MemorySettingsModal.svelte`** — point the "enable manage_notes" hint at the Note Management capability.
- **`src/components/chat/AgentPopover.svelte`** — drop the pill padding/border-radius from the agent popover trigger (minor UI tidy-up carried along).

## Notes

- No config migration — consistent with the "no backwards-compat needed" stance. `manage_notes`'s stored `toolsConfig` key is unchanged, so existing enable/disable state carries over; agents re-derive from the new capability defaults.
- **Out of scope:** bundled skill cards (bases, canvas, dataview, …) still render lowercase titles — tracked separately as a follow-up.

## Verification

- `bun run check` — clean (the 4 `GraphCanvas.svelte` errors are pre-existing on `dev`, untouched here).
- `bun run format` — no changes. `bun run test` — 838 pass.
- `bun run build` (prod) and `bun run dev` (watch) both build cleanly.
- Not yet driven in a live vault via the Obsidian CLI.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._