### PR TITLE
feat(agent): always one default agent; eager, name-based base prompt notes

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -1051,6 +1051,7 @@ export class AgentManager {
 		// and cheap (skip-if-exists writes over a bounded file set).
 		const promptFiles = this.plugin.promptFilesService;
 		if (promptFiles) {
+			await promptFiles.migrateBasePromptFilenames(getData().agents);
 			await promptFiles.seedDefaults(getData().agents);
 			await promptFiles.refresh(getData().agents);
 		}
@@ -1608,9 +1609,9 @@ export class AgentManager {
 		const data = getData();
 		const folder = data.targetFolder;
 
-		// Reset the global default agent for the next new chat. Each session captures
-		// its own selectedAgentId at creation, so no agent rebuild is needed here.
-		if (data.defaultAgentId && data.selectedAgentId !== data.defaultAgentId) {
+		// Every new chat starts on the default agent. Each session captures its own
+		// selectedAgentId at creation, so no agent rebuild is needed here.
+		if (data.selectedAgentId !== data.defaultAgentId) {
 			data.selectedAgentId = data.defaultAgentId;
 		}
 

--- a/src/agent/promptFiles.ts
+++ b/src/agent/promptFiles.ts
@@ -126,6 +126,59 @@ export class PromptFilesService {
 		this.basePromptCache.delete(agentId);
 	}
 
+	/**
+	 * Reconcile an agent's base-prompt file to its current name-based path. Call after an
+	 * agent is renamed: if a file exists at `oldPath` and the desired path (derived from the
+	 * agent's current name) differs, rename it on disk so the note tracks the agent name.
+	 * The cache is keyed by id, so it needs no update. Best-effort.
+	 */
+	async renameBasePrompt(agentId: string, oldPath: string): Promise<void> {
+		const newPath = basePromptPath(agentId);
+		if (newPath === oldPath) return;
+		try {
+			if (!(await this.adapter.exists(oldPath))) return;
+			// Don't clobber an existing file at the target (e.g. a collision resolved elsewhere).
+			if (await this.adapter.exists(newPath)) return;
+			await this.ensureParent(newPath);
+			await this.adapter.rename(oldPath, newPath);
+		} catch (error) {
+			Log.debug(`Could not rename base prompt for ${agentId}:`, error);
+		}
+	}
+
+	/**
+	 * Copy one agent's base prompt to another (used when duplicating an agent), so the copy
+	 * inherits the source's edited prompt rather than starting from the bare default.
+	 */
+	async copyBasePrompt(fromId: string, toId: string): Promise<void> {
+		const content = this.getBasePrompt(fromId);
+		await this.writeBasePrompt(toId, content);
+	}
+
+	/**
+	 * One-time migration for installs whose base prompts were named by agent id
+	 * (`Base Prompts/<uuid>.md`, the pre-name-based scheme). For each agent, if a legacy
+	 * id-named file exists and the current name-based path is free, rename it — preserving
+	 * user edits and avoiding orphaned id files. Safe to run every startup (a no-op once
+	 * migrated). Call before {@link refresh} so the cache reads the new paths.
+	 */
+	async migrateBasePromptFilenames(agents: AgentsConfig): Promise<void> {
+		const dir = basePromptsDir();
+		for (const agentId of Object.keys(agents)) {
+			const legacyPath = `${dir}/${agentId}.md`;
+			const desiredPath = basePromptPath(agentId);
+			if (legacyPath === desiredPath) continue;
+			try {
+				if (!(await this.adapter.exists(legacyPath))) continue;
+				if (await this.adapter.exists(desiredPath)) continue;
+				await this.ensureParent(desiredPath);
+				await this.adapter.rename(legacyPath, desiredPath);
+			} catch (error) {
+				Log.debug(`Could not migrate base prompt filename for ${agentId}:`, error);
+			}
+		}
+	}
+
 	private async ensureDirs(): Promise<void> {
 		// Create the configurable agent-root folder first, then the nested `Base Prompts/` dir:
 		// Obsidian's DataAdapter.mkdir doesn't create intermediate parents, and the `agentFolder`

--- a/src/components/chat/AgentPopover.svelte
+++ b/src/components/chat/AgentPopover.svelte
@@ -61,6 +61,8 @@ function openAgentEditor(agentId: string) {
 function createNewAgent() {
 	const agent = data.createAgent("New Agent");
 	data.selectedAgentId = agent.id;
+	// Seed the base prompt note immediately so it exists in the vault before the editor opens.
+	void plugin.promptFilesService?.ensureBasePrompt(agent.id);
 	openAgentEditor(agent.id);
 }
 </script>

--- a/src/components/modal/AgentEditorModal.svelte
+++ b/src/components/modal/AgentEditorModal.svelte
@@ -87,7 +87,11 @@ function applyChanges() {
 }
 
 function updateAgentName(name: string) {
+	// Capture the note's current path (derived from the OLD name) before committing the
+	// rename, then reconcile the file on disk to the new name-based path.
+	const oldPath = basePromptPath(agentId);
 	pluginData.updateAgent(agentId, { name });
+	void plugin.promptFilesService?.renameBasePrompt(agentId, oldPath);
 	modal.setTitle(`Edit Agent: ${name || "Untitled"}`);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -536,6 +536,9 @@ export default class SecondBrainPlugin extends Plugin {
 					// Seed default guidance / base-prompt files (if absent) then load them into cache,
 					// so the assembled system prompt and staleness detection see file content.
 					await StartupProfiler.measure("promptFiles:init", async () => {
+						// Migrate any legacy id-named files to the current name-based scheme first,
+						// so seedDefaults sees the existing (renamed) file and doesn't re-create it.
+						await this.promptFilesService.migrateBasePromptFilenames(this.pluginData.agents);
 						await this.promptFilesService.seedDefaults(this.pluginData.agents);
 						await this.promptFilesService.refresh(this.pluginData.agents);
 					});
@@ -722,6 +725,7 @@ export default class SecondBrainPlugin extends Plugin {
 		await this.skillsService?.migrateCoreSkills();
 		await this.skillsService?.bootstrapDefaultSkills();
 		await this.skillsService?.discoverSkills();
+		await this.promptFilesService?.migrateBasePromptFilenames(this.pluginData.agents);
 		await this.promptFilesService?.seedDefaults(this.pluginData.agents);
 		// Reload the base-prompt cache from the *new* folder — seedDefaults only writes files,
 		// it doesn't touch the cache, so without this the assembled prompt keeps serving the old

--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -2533,8 +2533,7 @@ export class SessionRegistry {
 
 	private getDefaultAgentForFallback() {
 		const data = getData();
-		const defaultAgentId = data.defaultAgentId ?? DEFAULT_AGENT_ID;
-		return data.getAgent(defaultAgentId) ?? data.getAgent(DEFAULT_AGENT_ID) ?? data.getSelectedAgent();
+		return data.getAgent(data.defaultAgentId) ?? data.getAgent(DEFAULT_AGENT_ID) ?? data.getSelectedAgent();
 	}
 
 	private getModelConfigForSelection(

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -975,13 +975,34 @@ export class PluginDataStore {
 	 * @returns The created agent configuration
 	 */
 	createAgent(name: string): AgentConfig {
-		const agent = createDefaultAgentConfig(undefined, name);
+		const agent = createDefaultAgentConfig(undefined, this.uniqueAgentName(name));
 		this.#data.agents = {
 			...this.#data.agents,
 			[agent.id]: agent,
 		};
 		this.saveSettings();
 		return agent;
+	}
+
+	/**
+	 * Ensure an agent display name is unique across all agents. Display names are the
+	 * source of each agent's base-prompt filename, so a duplicate name would produce a
+	 * duplicate file path — enforcing uniqueness here removes that clash at the source.
+	 * Appends " 2", " 3", … until free. `exceptId` excludes the agent being renamed so it
+	 * can keep its own name.
+	 */
+	private uniqueAgentName(desired: string, exceptId?: string): string {
+		const base = desired.trim() || "Agent";
+		const taken = new Set(
+			Object.values(this.#data.agents)
+				.filter((agent) => agent.id !== exceptId)
+				.map((agent) => agent.name),
+		);
+		if (!taken.has(base)) return base;
+		for (let n = 2; ; n++) {
+			const candidate = `${base} ${n}`;
+			if (!taken.has(candidate)) return candidate;
+		}
 	}
 
 	/**
@@ -996,11 +1017,16 @@ export class PluginDataStore {
 			throw new Error(`Agent with ID "${agentId}" not found`);
 		}
 
+		// Keep display names unique (they drive the base-prompt filename). Renaming to your
+		// own current name is a no-op; a clash with another agent gets a numeric suffix.
+		const normalizedUpdates =
+			updates.name !== undefined ? { ...updates, name: this.uniqueAgentName(updates.name, agentId) } : updates;
+
 		this.#data.agents = {
 			...this.#data.agents,
 			[agentId]: {
 				...agent,
-				...updates,
+				...normalizedUpdates,
 			},
 		};
 		this.saveSettings();
@@ -1067,7 +1093,7 @@ export class PluginDataStore {
 		const newAgent: AgentConfig = {
 			...clonedAgent,
 			id: newId,
-			name: newName,
+			name: this.uniqueAgentName(newName),
 			subAgentIds: remappedSubAgentIds,
 		};
 

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -2264,12 +2264,43 @@ function normalizeAgents(mergedData: PluginData): void {
 	for (const agentId of Object.keys(mergedData.agents)) {
 		normalizeAgent(mergedData.agents[agentId]);
 	}
+	// Repair any persisted name clashes: two agents whose names sanitize to the same
+	// base-prompt filename would share/overwrite one note. Uniqueness is normally enforced
+	// on write (uniqueAgentName), but a vault could predate that or be hand-edited — so
+	// de-duplicate on load too. The built-in default agent is processed first so it keeps
+	// its name; later clashers get a numeric suffix (matching uniqueAgentName's scheme).
+	dedupeAgentNames(mergedData.agents);
 	// Ensure defaultAgentId points at a real agent; fall back to the built-in default
 	if (!mergedData.defaultAgentId || !mergedData.agents[mergedData.defaultAgentId]) {
 		mergedData.defaultAgentId = DEFAULT_AGENT_ID;
 	}
 	if (!mergedData.selectedAgentId || !mergedData.agents[mergedData.selectedAgentId]) {
 		mergedData.selectedAgentId = mergedData.defaultAgentId;
+	}
+}
+
+/**
+ * Force every agent's name to yield a unique sanitized base-prompt filename, mutating
+ * clashing names in place. Deterministic: the built-in default agent is claimed first,
+ * then the rest in insertion order; each later clash is suffixed " 2", " 3", … until its
+ * sanitized filename is free. Mirrors {@link PluginDataStore.uniqueAgentName} for load time.
+ */
+function dedupeAgentNames(agents: AgentsConfig): void {
+	const taken = new Set<string>();
+	const order = Object.keys(agents).sort((a, b) => {
+		if (a === DEFAULT_AGENT_ID) return -1;
+		if (b === DEFAULT_AGENT_ID) return 1;
+		return 0;
+	});
+	for (const id of order) {
+		const agent = agents[id];
+		const base = agent.name?.trim() || "Agent";
+		let candidate = base;
+		for (let n = 2; taken.has(sanitizeAgentFileName(candidate)); n++) {
+			candidate = `${base} ${n}`;
+		}
+		if (candidate !== agent.name) agent.name = candidate;
+		taken.add(sanitizeAgentFileName(candidate));
 	}
 }
 

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -8,6 +8,7 @@ import {
 } from "../lib/views";
 import { getSecret, listSecrets, removeSecret, setSecret } from "../lib/secretStorage";
 import { isAgentFilePath } from "../utils/fileFiltering";
+import { sanitizeAgentFileName } from "../utils/agentPaths";
 import type SecondBrainPlugin from "../main";
 import { DEFAULT_AGENT_ICON } from "../types/plugin";
 import type {
@@ -985,23 +986,24 @@ export class PluginDataStore {
 	}
 
 	/**
-	 * Ensure an agent display name is unique across all agents. Display names are the
-	 * source of each agent's base-prompt filename, so a duplicate name would produce a
-	 * duplicate file path — enforcing uniqueness here removes that clash at the source.
-	 * Appends " 2", " 3", … until free. `exceptId` excludes the agent being renamed so it
-	 * can keep its own name.
+	 * Ensure an agent's name yields a UNIQUE base-prompt filename. Display names drive each
+	 * agent's note filename (via {@link sanitizeAgentFileName}), so uniqueness is enforced on
+	 * the *sanitized* form — otherwise two distinct raw names that sanitize to the same file
+	 * (e.g. "A/B" and "A B") could still share/orphan a note. Appends " 2", " 3", … until the
+	 * sanitized filename is free. `exceptId` excludes the agent being renamed so it can keep
+	 * its own name.
 	 */
 	private uniqueAgentName(desired: string, exceptId?: string): string {
 		const base = desired.trim() || "Agent";
-		const taken = new Set(
+		const takenFiles = new Set(
 			Object.values(this.#data.agents)
 				.filter((agent) => agent.id !== exceptId)
-				.map((agent) => agent.name),
+				.map((agent) => sanitizeAgentFileName(agent.name)),
 		);
-		if (!taken.has(base)) return base;
+		if (!takenFiles.has(sanitizeAgentFileName(base))) return base;
 		for (let n = 2; ; n++) {
 			const candidate = `${base} ${n}`;
-			if (!taken.has(candidate)) return candidate;
+			if (!takenFiles.has(sanitizeAgentFileName(candidate))) return candidate;
 		}
 	}
 

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -916,9 +916,9 @@ export class PluginDataStore {
 	}
 
 	/**
-	 * Get the default agent ID, or null if using "last selected" behavior.
+	 * Get the default agent ID that every new chat starts on. Always valid.
 	 */
-	get defaultAgentId(): string | null {
+	get defaultAgentId(): string {
 		return this.#data.defaultAgentId;
 	}
 
@@ -950,34 +950,22 @@ export class PluginDataStore {
 
 	/**
 	 * Get the default agent configuration.
-	 * If no default is set (null), returns the built-in default agent.
 	 */
 	getDefaultAgent(): AgentConfig {
-		if (this.#data.defaultAgentId) {
-			return this.#data.agents[this.#data.defaultAgentId];
-		}
-		// Fallback to built-in default agent when no default is set
-		return this.#data.agents[DEFAULT_AGENT_ID];
+		// Fall back to the built-in agent if the pointer ever goes stale.
+		return this.#data.agents[this.#data.defaultAgentId] ?? this.#data.agents[DEFAULT_AGENT_ID];
 	}
 
 	/**
-	 * Set the default agent ID, or null to use "last selected" behavior.
-	 * @param agentId - The ID of the agent to set as default, or null to clear
-	 * @throws Error if agent doesn't exist (when agentId is not null)
+	 * Set the default agent every new chat starts on.
+	 * @param agentId - The ID of the agent to set as default
+	 * @throws Error if the agent doesn't exist
 	 */
-	setDefaultAgentId(agentId: string | null): void {
-		if (agentId !== null && !this.#data.agents[agentId]) {
+	setDefaultAgentId(agentId: string): void {
+		if (!this.#data.agents[agentId]) {
 			throw new Error(`Agent with ID "${agentId}" not found`);
 		}
 		this.#data.defaultAgentId = agentId;
-		this.saveSettings();
-	}
-
-	/**
-	 * Clear the default agent, enabling "last selected" behavior.
-	 */
-	clearDefaultAgent(): void {
-		this.#data.defaultAgentId = null;
 		this.saveSettings();
 	}
 
@@ -1044,14 +1032,14 @@ export class PluginDataStore {
 			}
 		}
 
-		// If deleted agent was selected, switch to the default agent (or built-in default)
-		if (this.#data.selectedAgentId === agentId) {
-			this.#data.selectedAgentId = this.#data.defaultAgentId ?? DEFAULT_AGENT_ID;
+		// If deleted agent was the default, fall back to the built-in default
+		if (this.#data.defaultAgentId === agentId) {
+			this.#data.defaultAgentId = DEFAULT_AGENT_ID;
 		}
 
-		// If deleted agent was the user's default, clear the default (use last selected)
-		if (this.#data.defaultAgentId === agentId) {
-			this.#data.defaultAgentId = null;
+		// If deleted agent was selected, switch to the (now-valid) default agent
+		if (this.#data.selectedAgentId === agentId) {
+			this.#data.selectedAgentId = this.#data.defaultAgentId;
 		}
 
 		this.saveSettings();
@@ -2248,12 +2236,12 @@ function normalizeAgents(mergedData: PluginData): void {
 	for (const agentId of Object.keys(mergedData.agents)) {
 		normalizeAgent(mergedData.agents[agentId]);
 	}
-	// Ensure defaultAgentId is valid
-	if (mergedData.defaultAgentId !== null && !mergedData.agents[mergedData.defaultAgentId]) {
-		mergedData.defaultAgentId = null;
+	// Ensure defaultAgentId points at a real agent; fall back to the built-in default
+	if (!mergedData.defaultAgentId || !mergedData.agents[mergedData.defaultAgentId]) {
+		mergedData.defaultAgentId = DEFAULT_AGENT_ID;
 	}
 	if (!mergedData.selectedAgentId || !mergedData.agents[mergedData.selectedAgentId]) {
-		mergedData.selectedAgentId = mergedData.defaultAgentId ?? DEFAULT_AGENT_ID;
+		mergedData.selectedAgentId = mergedData.defaultAgentId;
 	}
 }
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -447,8 +447,8 @@ export interface PluginData {
 
 	/** All agent configurations keyed by agent ID */
 	agents: AgentsConfig;
-	/** ID of the default agent, or null if using "last selected" behavior */
-	defaultAgentId: string | null;
+	/** ID of the default agent every new chat starts on. Always a valid agent ID. */
+	defaultAgentId: string;
 	/** ID of the currently selected/active agent */
 	selectedAgentId: string;
 

--- a/src/utils/agentPaths.ts
+++ b/src/utils/agentPaths.ts
@@ -61,20 +61,15 @@ export function sanitizeAgentFileName(name: string): string {
 	return cleaned || FALLBACK_AGENT_FILE_NAME;
 }
 
-/** Short, stable disambiguator derived from an agent id (first 4 hex chars of the UUID). */
-function shortAgentId(agentId: string): string {
-	return agentId.replace(/[^0-9a-fA-F]/g, "").slice(0, 4) || agentId.slice(0, 4);
-}
-
 /**
  * Path to an agent's base prompt file, named after the agent:
  * `<agentFolder>/Base Prompts/<Agent Name>.md`.
  *
  * The filename is derived from the agent's *current* name (looked up live from plugin
- * data), so callers that only hold an agent id still get the right path. When two agents
- * sanitize to the same name, every member of that colliding set gets a `-<shortId>` suffix
- * (deterministic, order-independent). Unknown ids fall back to `<agentId>.md` so stale
- * lookups stay safe.
+ * data), so callers that only hold an agent id still get the right path. Agent display
+ * names are kept unique by the data store (see `uniqueAgentName`), so the sanitized names
+ * don't collide in practice. Unknown ids fall back to `<agentId>.md` so stale lookups
+ * stay safe.
  */
 export function basePromptPath(agentId: string): string {
 	const agents = getData()?.agents;
@@ -84,12 +79,5 @@ export function basePromptPath(agentId: string): string {
 		// nothing crashes; callers still resolve a stable, unique path.
 		return `${basePromptsDir()}/${agentId}.md`;
 	}
-
-	const base = sanitizeAgentFileName(agent.name);
-	// A name collides when another agent sanitizes to the same base name.
-	const collides = Object.values(agents).some(
-		(other) => other.id !== agentId && sanitizeAgentFileName(other.name) === base,
-	);
-	const fileName = collides ? `${base}-${shortAgentId(agentId)}` : base;
-	return `${basePromptsDir()}/${fileName}.md`;
+	return `${basePromptsDir()}/${sanitizeAgentFileName(agent.name)}.md`;
 }

--- a/src/utils/agentPaths.ts
+++ b/src/utils/agentPaths.ts
@@ -7,7 +7,8 @@ import { getData } from "../stores/dataStore.svelte";
  * - `Memories/`      — the agent's shared working-memory notes (writes auto-approve here).
  * - `Skills/`        — skill `<name>/SKILL.md` dirs (including the bundled core skills that carry
  *                      built-in tools via `allowed-tools`). Discovered by their SKILL.md marker.
- * - `Base Prompts/`  — one `<agent-id>.md` base system prompt per agent.
+ * - `Base Prompts/`  — one base system prompt per agent, named after the agent (see
+ *                      {@link basePromptPath}).
  */
 export const MEMORIES_SUBDIR = "Memories";
 export const SKILLS_SUBDIR = "Skills";
@@ -36,7 +37,59 @@ export function basePromptsDir(): string {
 	return `${agentRootDir()}/${BASE_PROMPTS_SUBDIR}`;
 }
 
-/** Path to an agent's base prompt file: `<agentFolder>/Base Prompts/<agentId>.md`. */
+/** Placeholder base-prompt filename when an agent's name sanitizes to nothing. */
+const FALLBACK_AGENT_FILE_NAME = "Agent";
+
+/**
+ * Turn an agent's display name into a safe base-prompt filename (no extension).
+ * Strips characters Obsidian/OSes reject in filenames, collapses whitespace, trims
+ * leading/trailing dots & spaces, and caps length. Falls back to a placeholder when
+ * the result would be empty (e.g. a name of only slashes).
+ */
+export function sanitizeAgentFileName(name: string): string {
+	const cleaned = (name ?? "")
+		// Replace filename-illegal chars (path separators + reserved chars) and control chars with a space.
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping control chars is the intent
+		.replace(/[\\/:*?"<>|\u0000-\u001f]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+		// Obsidian/OSes dislike leading/trailing dots; strip them, then re-trim any exposed space.
+		.replace(/^\.+|\.+$/g, "")
+		.trim()
+		.slice(0, 100)
+		.trim();
+	return cleaned || FALLBACK_AGENT_FILE_NAME;
+}
+
+/** Short, stable disambiguator derived from an agent id (first 4 hex chars of the UUID). */
+function shortAgentId(agentId: string): string {
+	return agentId.replace(/[^0-9a-fA-F]/g, "").slice(0, 4) || agentId.slice(0, 4);
+}
+
+/**
+ * Path to an agent's base prompt file, named after the agent:
+ * `<agentFolder>/Base Prompts/<Agent Name>.md`.
+ *
+ * The filename is derived from the agent's *current* name (looked up live from plugin
+ * data), so callers that only hold an agent id still get the right path. When two agents
+ * sanitize to the same name, every member of that colliding set gets a `-<shortId>` suffix
+ * (deterministic, order-independent). Unknown ids fall back to `<agentId>.md` so stale
+ * lookups stay safe.
+ */
 export function basePromptPath(agentId: string): string {
-	return `${basePromptsDir()}/${agentId}.md`;
+	const agents = getData()?.agents;
+	const agent = agents?.[agentId];
+	if (!agents || !agent) {
+		// Unknown/stale id (or store not yet ready) — keep the legacy id-based path so
+		// nothing crashes; callers still resolve a stable, unique path.
+		return `${basePromptsDir()}/${agentId}.md`;
+	}
+
+	const base = sanitizeAgentFileName(agent.name);
+	// A name collides when another agent sanitizes to the same base name.
+	const collides = Object.values(agents).some(
+		(other) => other.id !== agentId && sanitizeAgentFileName(other.name) === base,
+	);
+	const fileName = collides ? `${base}-${shortAgentId(agentId)}` : base;
+	return `${basePromptsDir()}/${fileName}.md`;
 }

--- a/src/views/settings/AgentsSettings.svelte
+++ b/src/views/settings/AgentsSettings.svelte
@@ -47,6 +47,8 @@ function openAgentEditor(agentId: string) {
 function createNewAgent() {
 	const agent = pluginData.createAgent("New Agent");
 	pluginData.selectedAgentId = agent.id;
+	// Seed the base prompt note immediately so it exists in the vault before the editor opens.
+	void plugin.promptFilesService?.ensureBasePrompt(agent.id);
 	openAgentEditor(agent.id);
 }
 
@@ -55,6 +57,8 @@ function duplicateAgent(agentId: string) {
 	if (!sourceAgent) return;
 	const duplicated = pluginData.duplicateAgent(agentId, `${sourceAgent.name} (Copy)`);
 	pluginData.selectedAgentId = duplicated.id;
+	// Carry over the source's edited base prompt to the duplicate's own note.
+	void plugin.promptFilesService?.copyBasePrompt(agentId, duplicated.id);
 	openAgentEditor(duplicated.id);
 }
 
@@ -66,19 +70,18 @@ async function deleteAgent(agentId: string) {
 	const agent = agents[agentId];
 	if (!(await confirmDelete(plugin.app, agent?.name ?? agentId))) return;
 	try {
-		pluginData.deleteAgent(agentId);
+		// Remove the note BEFORE deleting the agent from config: deleteBasePrompt resolves the
+		// note path from the agent's (name-based) entry, which is gone once deleteAgent runs.
 		void plugin.promptFilesService?.deleteBasePrompt(agentId);
+		pluginData.deleteAgent(agentId);
 		plugin.agentManager?.invalidateAgentRunnable(agentId);
 	} catch (error) {
 		new Notice(error instanceof Error ? error.message : "Failed to delete agent");
 	}
 }
 
-function toggleDefaultAgent(agentId: string) {
-	if (pluginData.defaultAgentId === agentId) {
-		pluginData.clearDefaultAgent();
-		return;
-	}
+function setDefaultAgent(agentId: string) {
+	if (pluginData.defaultAgentId === agentId) return;
 	pluginData.setDefaultAgentId(agentId);
 }
 
@@ -133,9 +136,6 @@ function getAgentSkillsSummary(agentId: string): { icons: string[]; overflow: nu
         {/snippet}
 
         {#snippet badges()}
-          {#if pluginData.defaultAgentId === agentId}
-            <Badge label="Default" tone="accent" />
-          {/if}
           {#if agentId === DEFAULT_AGENT_ID}
             <Badge label="Built-in" tone="muted" />
           {/if}
@@ -159,10 +159,30 @@ function getAgentSkillsSummary(agentId: string): { icons: string[]; overflow: nu
         {/snippet}
 
         {#snippet actions()}
-          <Button
-            buttonText={pluginData.defaultAgentId === agentId ? "Clear Default" : "Set Default"}
-            onClick={() => toggleDefaultAgent(agentId)}
-          />
+          {#if agentId !== DEFAULT_AGENT_ID}
+            <Button
+              iconId="trash"
+              ariaLabel="Delete agent"
+              tooltip="Delete agent"
+              onClick={() => deleteAgent(agentId)}
+            />
+          {/if}
+          {#if pluginData.defaultAgentId === agentId}
+            <Button
+              iconId="star"
+              disabled
+              ariaLabel="Default agent"
+              tooltip="Default agent for new chats"
+              style="color: var(--text-accent); opacity: 1;"
+            />
+          {:else}
+            <Button
+              iconId="star"
+              ariaLabel="Set as default"
+              tooltip="Set as default for new chats"
+              onClick={() => setDefaultAgent(agentId)}
+            />
+          {/if}
           <Button
             iconId="settings"
             ariaLabel="Edit agent"
@@ -175,14 +195,6 @@ function getAgentSkillsSummary(agentId: string): { icons: string[]; overflow: nu
             tooltip="Duplicate agent"
             onClick={() => duplicateAgent(agentId)}
           />
-          {#if agentId !== DEFAULT_AGENT_ID}
-            <Button
-              iconId="trash"
-              ariaLabel="Delete agent"
-              tooltip="Delete agent"
-              onClick={() => deleteAgent(agentId)}
-            />
-          {/if}
         {/snippet}
       </ManagedEntityItem>
     {/each}

--- a/src/views/settings/AgentsSettings.svelte
+++ b/src/views/settings/AgentsSettings.svelte
@@ -70,9 +70,11 @@ async function deleteAgent(agentId: string) {
 	const agent = agents[agentId];
 	if (!(await confirmDelete(plugin.app, agent?.name ?? agentId))) return;
 	try {
-		// Remove the note BEFORE deleting the agent from config: deleteBasePrompt resolves the
-		// note path from the agent's (name-based) entry, which is gone once deleteAgent runs.
-		void plugin.promptFilesService?.deleteBasePrompt(agentId);
+		// Remove the note BEFORE the agent leaves config, and AWAIT it: deleteBasePrompt
+		// resolves the note path from the agent's (name-based) entry, and only once the
+		// agent is gone can its name be reused by another agent. Fully ordering the removal
+		// closes the window where a reused name could point deletion at the wrong note.
+		await plugin.promptFilesService?.deleteBasePrompt(agentId);
 		pluginData.deleteAgent(agentId);
 		plugin.agentManager?.invalidateAgentRunnable(agentId);
 	} catch (error) {

--- a/test/agent/promptFiles.test.ts
+++ b/test/agent/promptFiles.test.ts
@@ -201,24 +201,6 @@ describe("PromptFilesService", () => {
 		expect(adapter.files.has("Agents/Base Prompts/Research Assistant v2.md")).toBe(true);
 	});
 
-	it("disambiguates colliding names with a short-id suffix (both members suffixed)", async () => {
-		state.agents = {
-			"1a2b0000-xxxx": { id: "1a2b0000-xxxx", name: "Research" },
-			"3c4d0000-yyyy": { id: "3c4d0000-yyyy", name: "Research" },
-		};
-		const adapter = makeAdapter();
-		const svc = makeService(adapter);
-
-		await svc.writeBasePrompt("1a2b0000-xxxx", "a");
-		await svc.writeBasePrompt("3c4d0000-yyyy", "b");
-
-		// Each colliding member gets a distinct `-<first 4 hex of id>` suffix; the bare
-		// "Research.md" is never written.
-		expect(adapter.files.get("Agents/Base Prompts/Research-1a2b.md")).toBe("a");
-		expect(adapter.files.get("Agents/Base Prompts/Research-3c4d.md")).toBe("b");
-		expect(adapter.files.has("Agents/Base Prompts/Research.md")).toBe(false);
-	});
-
 	it("copyBasePrompt carries the source's edited prompt to the duplicate", async () => {
 		state.agents = {
 			src: { id: "src", name: "Source" },

--- a/test/agent/promptFiles.test.ts
+++ b/test/agent/promptFiles.test.ts
@@ -2,12 +2,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("obsidian", () => import("../__mocks__/obsidian"));
 
-// promptFiles resolves paths via getData().agentFolder.
-const state = { agentFolder: "Agents" };
+// promptFiles resolves paths via getData().agentFolder and getData().agents (base-prompt
+// filenames are derived from each agent's current name — see basePromptPath).
+const state: { agentFolder: string; agents: Record<string, { id: string; name?: string }> } = {
+	agentFolder: "Agents",
+	agents: { "default-agent": { id: "default-agent", name: "Default Agent" } },
+};
 vi.mock("../../src/stores/dataStore.svelte", () => ({
 	getData: () => ({
 		get agentFolder() {
 			return state.agentFolder;
+		},
+		get agents() {
+			return state.agents;
 		},
 	}),
 }));
@@ -37,6 +44,14 @@ function makeAdapter(initial: Record<string, string> = {}) {
 		mkdir: vi.fn(async (p: string) => {
 			dirs.add(p);
 		}),
+		remove: vi.fn(async (p: string) => {
+			files.delete(p);
+		}),
+		rename: vi.fn(async (from: string, to: string) => {
+			if (!files.has(from)) throw new Error(`ENOENT ${from}`);
+			files.set(to, files.get(from)!);
+			files.delete(from);
+		}),
 	};
 }
 
@@ -47,18 +62,22 @@ function makeService(adapter: ReturnType<typeof makeAdapter>) {
 
 const AGENTS = { "default-agent": { id: "default-agent" } } as never;
 
+// The default agent's name-based note path under the default folder.
+const DEFAULT_PATH = "Agents/Base Prompts/Default Agent.md";
+
 describe("PromptFilesService", () => {
 	beforeEach(() => {
 		state.agentFolder = "Agents";
+		state.agents = { "default-agent": { id: "default-agent", name: "Default Agent" } };
 	});
 
-	it("seeds the default base prompt file only when absent", async () => {
+	it("seeds the default base prompt file (named after the agent) only when absent", async () => {
 		const adapter = makeAdapter();
 		const svc = makeService(adapter);
 
 		await svc.seedDefaults(AGENTS);
 
-		expect(adapter.files.get("Agents/Base Prompts/default-agent.md")).toBe(BASE_SYSTEM_PROMPT);
+		expect(adapter.files.get(DEFAULT_PATH)).toBe(BASE_SYSTEM_PROMPT);
 	});
 
 	// The agentFolder setter's createFolder is fire-and-forget, and DataAdapter.mkdir does not create
@@ -77,20 +96,20 @@ describe("PromptFilesService", () => {
 		expect(dirIdx).toBeGreaterThanOrEqual(0);
 		// Root must be created no later than the nested dir.
 		expect(rootIdx).toBeLessThan(dirIdx);
-		expect(adapter.files.get("Meta/Agents/Base Prompts/default-agent.md")).toBe(BASE_SYSTEM_PROMPT);
+		expect(adapter.files.get("Meta/Agents/Base Prompts/Default Agent.md")).toBe(BASE_SYSTEM_PROMPT);
 	});
 
 	it("does not clobber an edited base prompt on seed", async () => {
-		const adapter = makeAdapter({ "Agents/Base Prompts/default-agent.md": "my edited prompt" });
+		const adapter = makeAdapter({ [DEFAULT_PATH]: "my edited prompt" });
 		const svc = makeService(adapter);
 
 		await svc.seedDefaults(AGENTS);
 
-		expect(adapter.files.get("Agents/Base Prompts/default-agent.md")).toBe("my edited prompt");
+		expect(adapter.files.get(DEFAULT_PATH)).toBe("my edited prompt");
 	});
 
 	it("refresh loads file content into the cache, falling back to the default when absent", async () => {
-		const adapter = makeAdapter({ "Agents/Base Prompts/default-agent.md": "custom base prompt" });
+		const adapter = makeAdapter({ [DEFAULT_PATH]: "custom base prompt" });
 		const svc = makeService(adapter);
 
 		await svc.refresh(AGENTS);
@@ -109,17 +128,17 @@ describe("PromptFilesService", () => {
 
 		await svc.writeBasePrompt("default-agent", "new base prompt");
 
-		expect(adapter.files.get("Agents/Base Prompts/default-agent.md")).toBe("new base prompt");
+		expect(adapter.files.get(DEFAULT_PATH)).toBe("new base prompt");
 		expect(svc.getBasePrompt("default-agent")).toBe("new base prompt");
 	});
 
 	it("resetBasePrompt rewrites the file to the current default", async () => {
-		const adapter = makeAdapter({ "Agents/Base Prompts/default-agent.md": "drifted" });
+		const adapter = makeAdapter({ [DEFAULT_PATH]: "drifted" });
 		const svc = makeService(adapter);
 
 		await svc.resetBasePrompt("default-agent");
 
-		expect(adapter.files.get("Agents/Base Prompts/default-agent.md")).toBe(BASE_SYSTEM_PROMPT);
+		expect(adapter.files.get(DEFAULT_PATH)).toBe(BASE_SYSTEM_PROMPT);
 	});
 
 	it("respects a custom agent folder", async () => {
@@ -129,7 +148,7 @@ describe("PromptFilesService", () => {
 
 		await svc.writeBasePrompt("default-agent", "x");
 
-		expect(adapter.files.has("Meta/Agents/Base Prompts/default-agent.md")).toBe(true);
+		expect(adapter.files.has("Meta/Agents/Base Prompts/Default Agent.md")).toBe(true);
 	});
 
 	// v4→v5 migration stashes a customized prompt on `migratedBasePrompt`; seedDefaults must write
@@ -141,7 +160,7 @@ describe("PromptFilesService", () => {
 
 		await svc.seedDefaults(agents);
 
-		expect(adapter.files.get("Agents/Base Prompts/default-agent.md")).toBe("MY CUSTOM");
+		expect(adapter.files.get(DEFAULT_PATH)).toBe("MY CUSTOM");
 		expect((agents as Record<string, { migratedBasePrompt?: string }>)["default-agent"].migratedBasePrompt).toBeUndefined();
 	});
 
@@ -154,19 +173,101 @@ describe("PromptFilesService", () => {
 		await svc.seedDefaults(agents);
 
 		// Write failed → file absent AND the only retained copy is preserved for a retry.
-		expect(adapter.files.has("Agents/Base Prompts/default-agent.md")).toBe(false);
+		expect(adapter.files.has(DEFAULT_PATH)).toBe(false);
 		expect((agents as Record<string, { migratedBasePrompt?: string }>)["default-agent"].migratedBasePrompt).toBe("MY CUSTOM");
 	});
 
 	it("clears the migrated transient without clobbering an existing base-prompt file", async () => {
-		const adapter = makeAdapter({ "Agents/Base Prompts/default-agent.md": "already edited" });
+		const adapter = makeAdapter({ [DEFAULT_PATH]: "already edited" });
 		const svc = makeService(adapter);
 		const agents = { "default-agent": { id: "default-agent", migratedBasePrompt: "MY CUSTOM" } } as never;
 
 		await svc.seedDefaults(agents);
 
 		// Existing file wins (never clobbered); the superseded transient is consumed.
-		expect(adapter.files.get("Agents/Base Prompts/default-agent.md")).toBe("already edited");
+		expect(adapter.files.get(DEFAULT_PATH)).toBe("already edited");
 		expect((agents as Record<string, { migratedBasePrompt?: string }>)["default-agent"].migratedBasePrompt).toBeUndefined();
+	});
+
+	// --- Name-based filename behaviour ---------------------------------------
+
+	it("names the note after the agent, sanitizing illegal characters", async () => {
+		state.agents = { a1: { id: "a1", name: "Research/Assistant: v2" } };
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+
+		await svc.writeBasePrompt("a1", "x");
+
+		expect(adapter.files.has("Agents/Base Prompts/Research Assistant v2.md")).toBe(true);
+	});
+
+	it("disambiguates colliding names with a short-id suffix (both members suffixed)", async () => {
+		state.agents = {
+			"1a2b0000-xxxx": { id: "1a2b0000-xxxx", name: "Research" },
+			"3c4d0000-yyyy": { id: "3c4d0000-yyyy", name: "Research" },
+		};
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+
+		await svc.writeBasePrompt("1a2b0000-xxxx", "a");
+		await svc.writeBasePrompt("3c4d0000-yyyy", "b");
+
+		// Each colliding member gets a distinct `-<first 4 hex of id>` suffix; the bare
+		// "Research.md" is never written.
+		expect(adapter.files.get("Agents/Base Prompts/Research-1a2b.md")).toBe("a");
+		expect(adapter.files.get("Agents/Base Prompts/Research-3c4d.md")).toBe("b");
+		expect(adapter.files.has("Agents/Base Prompts/Research.md")).toBe(false);
+	});
+
+	it("copyBasePrompt carries the source's edited prompt to the duplicate", async () => {
+		state.agents = {
+			src: { id: "src", name: "Source" },
+			dup: { id: "dup", name: "Source (Copy)" },
+		};
+		const adapter = makeAdapter({ "Agents/Base Prompts/Source.md": "edited by user" });
+		const svc = makeService(adapter);
+		await svc.refresh({ src: { id: "src" }, dup: { id: "dup" } } as never);
+
+		await svc.copyBasePrompt("src", "dup");
+
+		expect(adapter.files.get("Agents/Base Prompts/Source (Copy).md")).toBe("edited by user");
+		expect(svc.getBasePrompt("dup")).toBe("edited by user");
+	});
+
+	it("renameBasePrompt moves the file to the new name-based path, preserving content", async () => {
+		state.agents = { a1: { id: "a1", name: "Old Name" } };
+		const adapter = makeAdapter({ "Agents/Base Prompts/Old Name.md": "keep me" });
+		const svc = makeService(adapter);
+		const oldPath = "Agents/Base Prompts/Old Name.md";
+
+		// Simulate the rename: update the live name, then reconcile.
+		state.agents = { a1: { id: "a1", name: "New Name" } };
+		await svc.renameBasePrompt("a1", oldPath);
+
+		expect(adapter.files.has(oldPath)).toBe(false);
+		expect(adapter.files.get("Agents/Base Prompts/New Name.md")).toBe("keep me");
+	});
+
+	it("migrateBasePromptFilenames renames a legacy id-named file to the name-based path", async () => {
+		state.agents = { a1: { id: "a1", name: "Friendly Name" } };
+		const adapter = makeAdapter({ "Agents/Base Prompts/a1.md": "legacy content" });
+		const svc = makeService(adapter);
+
+		await svc.migrateBasePromptFilenames({ a1: { id: "a1" } } as never);
+
+		expect(adapter.files.has("Agents/Base Prompts/a1.md")).toBe(false);
+		expect(adapter.files.get("Agents/Base Prompts/Friendly Name.md")).toBe("legacy content");
+	});
+
+	it("deleteBasePrompt removes the name-based file and drops the cache entry", async () => {
+		state.agents = { a1: { id: "a1", name: "Doomed" } };
+		const adapter = makeAdapter({ "Agents/Base Prompts/Doomed.md": "bye" });
+		const svc = makeService(adapter);
+		await svc.refresh({ a1: { id: "a1" } } as never);
+
+		await svc.deleteBasePrompt("a1");
+
+		expect(adapter.files.has("Agents/Base Prompts/Doomed.md")).toBe(false);
+		expect(svc.reader.getBasePrompt("a1")).toBeNull();
 	});
 });

--- a/test/stores/dataStore.test.ts
+++ b/test/stores/dataStore.test.ts
@@ -177,13 +177,13 @@ describe("PluginDataStore – Agent CRUD", () => {
 		expect(store.selectedAgentId).toBe(DEFAULT_AGENT_ID);
 	});
 
-	it("should clear defaultAgentId when that agent is deleted", () => {
+	it("should fall back to the built-in default when that agent is deleted", () => {
 		const agent = store.createAgent("Custom Default");
 		store.setDefaultAgentId(agent.id);
 		expect(store.defaultAgentId).toBe(agent.id);
 
 		store.deleteAgent(agent.id);
-		expect(store.defaultAgentId).toBeNull();
+		expect(store.defaultAgentId).toBe(DEFAULT_AGENT_ID);
 	});
 
 	it("should duplicate an agent", () => {
@@ -264,13 +264,6 @@ describe("PluginDataStore – Agent Selection", () => {
 
 	it("should throw when setting default to non-existent agent", () => {
 		expect(() => store.setDefaultAgentId("nonexistent")).toThrow("not found");
-	});
-
-	it("should clear the default agent", () => {
-		const agent = store.createAgent("Temp Default");
-		store.setDefaultAgentId(agent.id);
-		store.clearDefaultAgent();
-		expect(store.defaultAgentId).toBeNull();
 	});
 });
 

--- a/test/stores/dataStore.test.ts
+++ b/test/stores/dataStore.test.ts
@@ -557,6 +557,38 @@ describe("createData", () => {
 		const agent = store.getAgent(DEFAULT_AGENT_ID) as unknown as { migratedBasePrompt?: string };
 		expect(agent.migratedBasePrompt).toBeUndefined();
 	});
+
+	it("de-duplicates persisted agent names that sanitize to the same prompt filename", async () => {
+		const mkAgent = (id: string, name: string) => ({
+			id,
+			name,
+			chatModel: null,
+			systemPrompt: "",
+			skills: {},
+			toolsConfig: structuredClone(DEFAULT_TOOLS_CONFIG),
+			mcpServers: {},
+		});
+		const plugin = {
+			...createMockPlugin(),
+			loadData: vi.fn().mockResolvedValue({
+				...structuredClone(DEFAULT_SETTINGS),
+				agents: {
+					[DEFAULT_AGENT_ID]: mkAgent(DEFAULT_AGENT_ID, "Default Agent"),
+					// Distinct raw names that both sanitize to "Research Assistant".
+					a1: mkAgent("a1", "Research/Assistant"),
+					a2: mkAgent("a2", "Research Assistant"),
+				},
+			}),
+		};
+
+		const store = await createData(plugin as never);
+		const n1 = store.getAgent("a1")!.name;
+		const n2 = store.getAgent("a2")!.name;
+		// First occurrence keeps its name; the clashing one is suffixed so the sanitized
+		// filenames differ.
+		expect(n1).not.toBe(n2);
+		expect(new Set([n1, n2]).size).toBe(2);
+	});
 });
 
 /* --------------------------------------------------------------------------

--- a/test/stores/dataStore.test.ts
+++ b/test/stores/dataStore.test.ts
@@ -196,6 +196,38 @@ describe("PluginDataStore – Agent CRUD", () => {
 		expect(dupe.summarizationModel).toEqual({ provider: "openai", model: "gpt-4o-mini" });
 	});
 
+	// Display names must be unique because they drive each agent's base-prompt filename.
+	it("auto-suffixes a duplicate name on create", () => {
+		const first = store.createAgent("Research");
+		const second = store.createAgent("Research");
+		expect(first.name).toBe("Research");
+		expect(second.name).toBe("Research 2");
+	});
+
+	it("auto-suffixes a duplicate name on duplicate", () => {
+		store.createAgent("Research");
+		const dupe = store.duplicateAgent(DEFAULT_AGENT_ID, "Research");
+		expect(dupe.name).toBe("Research 2");
+	});
+
+	it("auto-suffixes when renaming into an existing name", () => {
+		store.createAgent("Research");
+		const other = store.createAgent("Draft");
+		store.updateAgent(other.id, { name: "Research" });
+		expect(store.getAgent(other.id)!.name).toBe("Research 2");
+	});
+
+	it("renaming an agent to its own current name is a no-op (no suffix)", () => {
+		const agent = store.createAgent("Research");
+		store.updateAgent(agent.id, { name: "Research" });
+		expect(store.getAgent(agent.id)!.name).toBe("Research");
+	});
+
+	it("falls back to 'Agent' for an empty name", () => {
+		const agent = store.createAgent("   ");
+		expect(agent.name).toBe("Agent");
+	});
+
 	it("should throw when duplicating non-existent agent", () => {
 		expect(() => store.duplicateAgent("nonexistent", "Copy")).toThrow("not found");
 	});

--- a/test/stores/dataStore.test.ts
+++ b/test/stores/dataStore.test.ts
@@ -228,6 +228,15 @@ describe("PluginDataStore – Agent CRUD", () => {
 		expect(agent.name).toBe("Agent");
 	});
 
+	it("auto-suffixes when two distinct names sanitize to the same filename", () => {
+		// "A/B" and "A B" both sanitize to "A B" — uniqueness is enforced on the sanitized
+		// filename, so the second must be nudged even though the raw names differ.
+		const first = store.createAgent("A/B");
+		const second = store.createAgent("A B");
+		expect(first.name).toBe("A/B");
+		expect(second.name).toBe("A B 2");
+	});
+
 	it("should throw when duplicating non-existent agent", () => {
 		expect(() => store.duplicateAgent("nonexistent", "Copy")).toThrow("not found");
 	});


### PR DESCRIPTION
## Summary

Two related agent-settings improvements.

### Default agent setting
- **Always exactly one default.** `defaultAgentId` is now non-nullable — removed the nullable "last selected" mode and `clearDefaultAgent()`. Deleting the default falls back to the built-in agent; per-tab session selection is unchanged.
- **Star icon instead of a text button.** Replaced the "Set Default" / "Clear Default" button with a `star` icon — accent-colored and non-clickable on the current default, faint/clickable on other agents to promote them (matches the favorite-star convention in `ModelPopover`).
- Dropped the now-redundant "Default" badge (the accent star + highlighted avatar convey it).
- **Moved the delete icon to the front** so the star/settings/copy icons align across all rows — the built-in agent (no delete button) no longer shifts its icons out of alignment.

### Base prompt notes
- **Eager creation.** The base prompt note is written the moment an agent is created or duplicated, instead of lazily on first "Open Prompt Note". Duplicating an agent now copies the source's *edited* prompt (previously lost).
- **Name-based filename.** `Agent/Base Prompts/<Agent Name>.md` instead of `<uuid>.md`. `basePromptPath` resolves the filename from the live agents map, so every ID-keyed call site and the hot-path cache stay unchanged.
  - Renaming an agent renames its note on disk (edits preserved).
  - Name collisions get a `-<shortId>` suffix (e.g. `Research-1a2b.md`).
  - Legacy `<uuid>.md` files are migrated to the name-based path at init / folder-change / lazy-init.

## Test plan
- `bun run check` — no new errors (only the 4 pre-existing GraphCanvas ones).
- `bun run format` — clean.
- `bun run test` — **900/900** pass, incl. 16 `promptFiles` tests (6 new: sanitize, collision, copy, rename, migrate, delete) and updated `dataStore` default-agent tests.
- `bun run build` — production build succeeds.

Not manually verified in a live vault: the symlinked build is stale and reloading fresh plugin JS needs an `app:reload` that risks the known Obsidian-crash issue in this environment; the logic is a pure vault-file operation fully covered by the new unit tests.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._