### PR TITLE
Add property-based privacy rules; fix empty-folder fail-open

### DIFF
--- a/src/components/graph/ViewFilterBuilder.svelte
+++ b/src/components/graph/ViewFilterBuilder.svelte
@@ -30,6 +30,8 @@ interface Props {
 	availableFolders?: string[];
 	/** Available tags for autocomplete */
 	availableTags?: string[];
+	/** Available frontmatter property keys for autocomplete */
+	availableProperties?: string[];
 }
 
 let {
@@ -41,10 +43,11 @@ let {
 	onLiveLeafChange,
 	availableFolders = [],
 	availableTags = [],
+	availableProperties = [],
 }: Props = $props();
 
 // ── Leaf vs group detection ─────────────────────────────
-const leafTypes = ["folder", "tag", "extension"] as const;
+const leafTypes = ["folder", "tag", "extension", "property"] as const;
 type LeafType = (typeof leafTypes)[number];
 
 let isGroup = $derived(filter.type === "all" || filter.type === "any" || filter.type === "none");
@@ -54,6 +57,7 @@ const baseLeafTypeOptions = [
 	{ display: "Folder", value: "folder" as LeafType },
 	{ display: "Tag", value: "tag" as LeafType },
 	{ display: "Extension", value: "extension" as LeafType },
+	{ display: "Property", value: "property" as LeafType },
 ];
 
 function getLeafTypeOptions(selectedType?: LeafType) {
@@ -74,11 +78,29 @@ let comboQuery = $state("");
 let comboTarget: "leaf" | "live" | null = $state(null);
 let closeTimeout: ReturnType<typeof setTimeout> | null = null;
 
+function getSuggestionPool(type: LeafType): string[] {
+	if (type === "folder") return availableFolders;
+	if (type === "tag") return availableTags;
+	if (type === "property") return availableProperties;
+	return [];
+}
+
 function getSuggestions(type: LeafType, query: string): string[] {
-	const pool = type === "folder" ? availableFolders : type === "tag" ? availableTags : [];
+	const pool = getSuggestionPool(type);
 	if (pool.length === 0) return [];
 	const q = query.toLowerCase();
 	return pool.filter((v) => v.toLowerCase().includes(q)).slice(0, 10);
+}
+
+/**
+ * A vault with no frontmatter anywhere yields no property suggestions. Without a
+ * hint the field just sits silent on focus, which reads as a broken control rather
+ * than an empty pool — the value is still free text, so typing a key works fine.
+ * Only shown for `property`: every vault has folders and tags, so those pools are
+ * never legitimately empty.
+ */
+function showsEmptyPoolHint(type: LeafType): boolean {
+	return type === "property" && getSuggestionPool(type).length === 0;
 }
 
 function openCombo(target: "leaf" | "live", currentValue: string) {
@@ -171,7 +193,34 @@ function handleAddGroup() {
 
 // Whether a leaf type supports combobox suggestions
 function hasCombo(type: string): boolean {
-	return type === "folder" || type === "tag";
+	return type === "folder" || type === "tag" || type === "property";
+}
+
+/**
+ * Serialize the optional `values` list of a property leaf for the text input.
+ * Empty list and `undefined` both render as "" — the leaf then means
+ * "this property exists", regardless of value.
+ */
+function formatPropertyValues(values: string[] | undefined): string {
+	return (values ?? []).join(", ");
+}
+
+/**
+ * Build a property leaf from a key and the comma-separated values input.
+ * An empty input clears `values` entirely (back to an existence check) rather
+ * than storing an empty array, so the two states stay distinguishable in saved data.
+ */
+function buildPropertyLeaf(key: string, rawValues: string): ViewFilterLeaf {
+	const parsed = rawValues
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter((entry) => entry.length > 0);
+	return { type: "property", value: key, values: parsed.length > 0 ? parsed : undefined };
+}
+
+function handlePropertyValuesChange(raw: string) {
+	const leaf = filter as ViewFilterLeaf;
+	onchange(buildPropertyLeaf(leaf.value as string, raw));
 }
 </script>
 
@@ -202,6 +251,7 @@ function hasCombo(type: string): boolean {
           depth={depth + 1}
           {availableFolders}
           {availableTags}
+          {availableProperties}
         />
       {/each}
 
@@ -225,7 +275,11 @@ function hasCombo(type: string): boolean {
                     class="filter-combo-input"
                     type="text"
                     value={liveLeaf.value as string}
-                    placeholder={liveType === "folder" ? "Work/projects" : "#my-tag"}
+                    placeholder={liveType === "folder"
+                      ? "Work/projects"
+                      : liveType === "property"
+                        ? "property name"
+                        : "#my-tag"}
                     oninput={(e) => {
                       const v = (e.target as HTMLInputElement).value;
                       onLiveLeafChange?.({ ...liveLeaf!, value: v } as ViewFilterLeaf);
@@ -246,8 +300,24 @@ function hasCombo(type: string): boolean {
                         {/each}
                       </div>
                     </div>
+                  {:else if comboOpen && comboTarget === "live" && showsEmptyPoolHint(liveType)}
+                    <div class="filter-combo-list picker-popover-content">
+                      <div class="filter-combo-empty">
+                        No properties found in vault — type a name to use it anyway.
+                      </div>
+                    </div>
                   {/if}
                 </div>
+                {#if liveType === "property"}
+                  <Text
+                    inputType="text"
+                    value={formatPropertyValues((liveLeaf as ViewFilterLeaf & { values?: string[] }).values)}
+                    placeholder="any value"
+                    onchange={(v: string) =>
+                      onLiveLeafChange?.(buildPropertyLeaf(liveLeaf!.value as string, v))}
+                    class="filter-leaf-value"
+                  />
+                {/if}
               {:else}
                 <Text
                   inputType="text"
@@ -319,7 +389,11 @@ function hasCombo(type: string): boolean {
             class="filter-combo-input"
             type="text"
             value={(filter as ViewFilterLeaf).value as string}
-            placeholder={leafType === "folder" ? "Work/projects" : "#my-tag"}
+            placeholder={leafType === "folder"
+              ? "Work/projects"
+              : leafType === "property"
+                ? "property name"
+                : "#my-tag"}
             oninput={(e) => {
               const v = (e.target as HTMLInputElement).value;
               handleLeafValueChange(v);
@@ -340,8 +414,21 @@ function hasCombo(type: string): boolean {
                 {/each}
               </div>
             </div>
+          {:else if comboOpen && comboTarget === "leaf" && showsEmptyPoolHint(leafType)}
+            <div class="filter-combo-list picker-popover-content">
+              <div class="filter-combo-empty">No properties found in vault — type a name to use it anyway.</div>
+            </div>
           {/if}
         </div>
+        {#if leafType === "property"}
+          <Text
+            inputType="text"
+            value={formatPropertyValues((filter as ViewFilterLeaf & { values?: string[] }).values)}
+            placeholder="any value"
+            onchange={handlePropertyValuesChange}
+            class="filter-leaf-value"
+          />
+        {/if}
       {:else}
         <Text
           inputType="text"
@@ -442,6 +529,12 @@ function hasCombo(type: string): boolean {
     z-index: 100;
     max-height: 180px;
     overflow: hidden auto;
+  }
+
+  .filter-combo-empty {
+    padding: 8px 10px;
+    color: var(--text-muted);
+    font-size: var(--font-smaller);
   }
 
   /* ── Add row ────────────────────────────────────── */

--- a/src/components/graph/ViewFilterBuilder.svelte
+++ b/src/components/graph/ViewFilterBuilder.svelte
@@ -8,6 +8,7 @@
  *
  * The component mutates a `ViewFilter` object in-place via `onchange`.
  */
+import { formatPropertyValues, parsePropertyValues } from "../../lib/propertyValues";
 import type { ViewFilter, ViewFilterLeaf, ViewFilterGroup } from "../../types/graph";
 import Dropdown from "../ui/Dropdown.svelte";
 import Text from "../ui/Text.svelte";
@@ -197,24 +198,12 @@ function hasCombo(type: string): boolean {
 }
 
 /**
- * Serialize the optional `values` list of a property leaf for the text input.
- * Empty list and `undefined` both render as "" — the leaf then means
- * "this property exists", regardless of value.
- */
-function formatPropertyValues(values: string[] | undefined): string {
-	return (values ?? []).join(", ");
-}
-
-/**
  * Build a property leaf from a key and the comma-separated values input.
  * An empty input clears `values` entirely (back to an existence check) rather
  * than storing an empty array, so the two states stay distinguishable in saved data.
  */
 function buildPropertyLeaf(key: string, rawValues: string): ViewFilterLeaf {
-	const parsed = rawValues
-		.split(",")
-		.map((entry) => entry.trim())
-		.filter((entry) => entry.length > 0);
+	const parsed = parsePropertyValues(rawValues);
 	return { type: "property", value: key, values: parsed.length > 0 ? parsed : undefined };
 }
 

--- a/src/components/modal/FileSetEditor.svelte
+++ b/src/components/modal/FileSetEditor.svelte
@@ -52,6 +52,7 @@ interface Props {
 	filterBuilderFilter?: ViewFilter | null;
 	availableFolders?: string[];
 	availableTags?: string[];
+	availableProperties?: string[];
 	onFilterChange?: ((nextFilter: ViewFilter) => void) | undefined;
 	excludedEntries?: FileSetListEntry[];
 	excludedTitle?: string;
@@ -88,6 +89,7 @@ let {
 	filterBuilderFilter = null,
 	availableFolders = [],
 	availableTags = [],
+	availableProperties = [],
 	onFilterChange,
 	excludedEntries = [],
 	excludedTitle = "Excluded files",
@@ -166,6 +168,7 @@ function handleAddButtonClick() {
         onchange={onFilterChange}
         {availableFolders}
         {availableTags}
+        {availableProperties}
       />
     </div>
   {/if}
@@ -378,7 +381,9 @@ function handleAddButtonClick() {
     overflow: auto;
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    /* Rows are flat with a hover highlight, so they sit close rather than
+       being separated like cards. */
+    gap: 1px;
   }
 
   .file-set-editor-empty {

--- a/src/components/modal/FileSetEntryRow.svelte
+++ b/src/components/modal/FileSetEntryRow.svelte
@@ -172,27 +172,25 @@ function previewFileLink(event: Event): void {
 </script>
 
 <div class="space-file-row" class:space-file-row--compact={compact} title={entry.path}>
-  <div class="min-w-0 flex-1">
-    <div class="space-file-link-row">
-      <span
-        class="space-file-link-icon s2b-search-result-note-icon"
-        aria-hidden="true"
-        use:iconDirective={getFileIconName(entry.path)}
-        use:lazyFileIcon={{ app, path: entry.path }}
-      ></span>
-      <a
-        class="internal-link space-file-link truncate"
-        href={entry.path}
-        data-href={entry.path}
-        onclick={handleFileLinkClick}
-        onmouseover={previewFileLink}
-        onfocus={previewFileLink}
-      >
-        {entry.displayName ?? getFileDisplayName(entry.path)}
-      </a>
-    </div>
+  <div class="space-file-link-row">
+    <span
+      class="space-file-link-icon s2b-search-result-note-icon"
+      aria-hidden="true"
+      use:iconDirective={getFileIconName(entry.path)}
+      use:lazyFileIcon={{ app, path: entry.path }}
+    ></span>
+    <a
+      class="internal-link space-file-link truncate"
+      href={entry.path}
+      data-href={entry.path}
+      onclick={handleFileLinkClick}
+      onmouseover={previewFileLink}
+      onfocus={previewFileLink}
+    >
+      {entry.displayName ?? getFileDisplayName(entry.path)}
+    </a>
     {#if entry.contextLabel}
-      <div class="space-file-context truncate">{entry.contextLabel}</div>
+      <span class="space-file-context truncate">{entry.contextLabel}</span>
     {/if}
   </div>
 
@@ -204,32 +202,44 @@ function previewFileLink(event: Event): void {
 </div>
 
 <style>
+  /*
+   * Flat rows with a hover highlight, matching Obsidian's own list surfaces
+   * (file explorer, search results) rather than boxing each entry in a card.
+   * Keeps long lists scannable and the row height uniform whether or not the
+   * entry has a context label.
+   */
   .space-file-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 10px;
-    padding: 8px 10px;
-    border: 1px solid var(--background-modifier-border);
-    border-radius: 6px;
+    gap: 8px;
+    padding: 2px 6px;
+    border-radius: var(--radius-s);
+    min-height: 28px;
+  }
+
+  .space-file-row:hover {
+    background: var(--background-modifier-hover);
   }
 
   .space-file-row--compact {
-    padding-block: 7px;
     opacity: 0.85;
   }
 
   .space-file-link-row {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     gap: 6px;
     min-width: 0;
-    max-width: 100%;
+    flex: 1;
   }
 
   .space-file-link-icon {
     flex-shrink: 0;
     color: var(--text-faint);
+    align-self: center;
+    display: flex;
+    align-items: center;
   }
 
   .space-file-link {
@@ -243,16 +253,29 @@ function previewFileLink(event: Event): void {
     text-decoration: underline;
   }
 
+  /* Trails the filename inline; shrinks first so the name keeps priority. */
   .space-file-context {
-    font-size: 0.75rem;
-    color: var(--text-muted);
+    font-size: var(--font-smallest);
+    color: var(--text-faint);
+    flex-shrink: 1;
+    min-width: 0;
   }
 
   .space-file-actions {
     display: flex;
-    flex-wrap: wrap;
     justify-content: flex-end;
-    gap: 6px;
+    gap: 4px;
     flex-shrink: 0;
+  }
+
+  /*
+   * Shrink the action buttons to match the tighter row. Scoped to this row's
+   * buttons so the modal's other controls keep their normal sizing.
+   */
+  .space-file-actions :global(button) {
+    height: auto;
+    padding: 3px 8px;
+    font-size: var(--font-smaller);
+    box-shadow: none;
   }
 </style>

--- a/src/components/modal/PrivacyListModal.svelte
+++ b/src/components/modal/PrivacyListModal.svelte
@@ -11,6 +11,7 @@ import {
 	parseSpaceMembershipFilter,
 	resolveViewFilter,
 	resolveSpaceMembershipDraft,
+	rewriteViewFilterForRename,
 } from "../../lib/views";
 import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
@@ -88,6 +89,19 @@ let showFilters = $state(initialParsed.draft.autoIncludeRules.length > 0);
 // condition (e.g. a folder field mid-edit) is never briefly live for tool calls,
 // and closing the modal without saving discards the in-progress edit entirely.
 let privacyMode = $state<PrivacyMode>(data.privacyMode);
+
+// `dataStore` already follows vault renames for the *persisted* filter (see its
+// constructor), but that rewrite lands underneath this modal's local draft. Without
+// this, a rename while the modal is open would be invisible here, and clicking Save
+// would overwrite the store's just-rewritten filter with this stale draft — silently
+// re-introducing the exact staleness the store-level fix closes. Mirror the same
+// rewrite onto the draft so Save can't regress it.
+$effect(() => {
+	const ref = app.vault.on("rename", (file, oldPath) => {
+		privacyFilter = rewriteViewFilterForRename(privacyFilter, oldPath, file.path);
+	});
+	return () => app.vault.offref(ref);
+});
 const parsedMembership = $derived.by(() => parseSpaceMembershipFilter(privacyFilter));
 const privacyUniverse = $derived.by(
 	() =>

--- a/src/components/modal/PrivacyListModal.svelte
+++ b/src/components/modal/PrivacyListModal.svelte
@@ -260,6 +260,15 @@ const introBody = $derived.by(() =>
 		? "Untrusted providers can only access the files listed below. Everything else stays private unless the provider is marked as trusted."
 		: "Untrusted providers can access vault files by default, except for the files listed below as private. Trusted providers always bypass this restriction.",
 );
+// This protects file *content*. File and folder names/paths in the vault are not
+// hidden from untrusted providers — they can appear in search results, directory
+// listings, and elsewhere regardless of a file's privacy status. Renaming/moving
+// files and folders is safe: rules that reference a path (folder, or a wikilink
+// inside a property value) follow the rename automatically, so this list won't
+// drift out of date.
+const pathVisibilityNote =
+	"This controls file content, not file or folder names — those can still appear to any provider. " +
+	"Rules here follow renames automatically, so you can freely rename or move files without breaking this list.";
 const sectionTitle = $derived.by(() =>
 	privacyMode === "private-by-default" ? "Files exposed to untrusted providers" : "Private files",
 );
@@ -307,6 +316,7 @@ const excludedTitle = $derived.by(() => (privacyMode === "private-by-default" ? 
             ? ""
             : "s"}. {privateFileCount} file{privateFileCount === 1 ? "" : "s"} remain private.
         </p>
+        <p class="privacy-mode-note">{pathVisibilityNote}</p>
       </div>
 
       <div class="privacy-mode-toggle" role="tablist" aria-label="Privacy mode">
@@ -409,6 +419,11 @@ const excludedTitle = $derived.by(() => (privacyMode === "private-by-default" ? 
 
   .privacy-mode-copy p {
     margin: 0;
+  }
+
+  .privacy-mode-note {
+    color: var(--text-muted);
+    font-size: var(--font-smaller);
   }
 
   .privacy-mode-title {

--- a/src/components/modal/PrivacyListModal.svelte
+++ b/src/components/modal/PrivacyListModal.svelte
@@ -83,7 +83,11 @@ const initialParsed = parseSpaceMembershipFilter(data.privacyFilter);
 let privacyFilter = $state<ViewFilter>(ensureGroup(data.privacyFilter ?? createEmptySpaceFilter()));
 let showFilters = $state(initialParsed.draft.autoIncludeRules.length > 0);
 
-const privacyMode = $derived.by(() => data.privacyMode);
+// Working copy — edits only touch this local state. `data.setPrivacyFilter` /
+// `data.setPrivacyMode` are called once, from `saveChanges`, so a half-typed
+// condition (e.g. a folder field mid-edit) is never briefly live for tool calls,
+// and closing the modal without saving discards the in-progress edit entirely.
+let privacyMode = $state<PrivacyMode>(data.privacyMode);
 const parsedMembership = $derived.by(() => parseSpaceMembershipFilter(privacyFilter));
 const privacyUniverse = $derived.by(
 	() =>
@@ -134,13 +138,18 @@ const excludedEntries = $derived.by(() =>
 	})),
 );
 
-function savePrivacyFilter(nextFilter: ViewFilter) {
+function updatePrivacyFilter(nextFilter: ViewFilter) {
 	privacyFilter = ensureGroup(nextFilter);
-	data.setPrivacyFilter(nextFilter);
 }
 
-function setPrivacyMode(mode: PrivacyMode) {
-	data.setPrivacyMode(mode);
+function updatePrivacyMode(mode: PrivacyMode) {
+	privacyMode = mode;
+}
+
+function saveChanges() {
+	data.setPrivacyFilter(privacyFilter);
+	data.setPrivacyMode(privacyMode);
+	modal.close();
 }
 
 function updateDraft(mutator: (draft: ReturnType<typeof cloneSpaceMembershipDraft>) => void) {
@@ -148,7 +157,7 @@ function updateDraft(mutator: (draft: ReturnType<typeof cloneSpaceMembershipDraf
 	const draft = cloneSpaceMembershipDraft(currentParsedMembership.draft);
 	mutator(draft);
 	showFilters = showFilters || draft.autoIncludeRules.length > 0;
-	savePrivacyFilter(compileSpaceMembershipDraft(draft));
+	updatePrivacyFilter(compileSpaceMembershipDraft(draft));
 }
 
 function getParentPath(path: string): string {
@@ -181,7 +190,7 @@ function handleRulesFilterChange(nextFilter: ViewFilter) {
 	const simpleRules = extractSpaceMembershipRulesFilter(nextFilter);
 	if (!simpleRules) {
 		showFilters = true;
-		savePrivacyFilter(cloneViewFilter(nextFilter));
+		updatePrivacyFilter(cloneViewFilter(nextFilter));
 		return;
 	}
 
@@ -292,7 +301,7 @@ const excludedTitle = $derived.by(() => (privacyMode === "private-by-default" ? 
           class="privacy-mode-button"
           class:privacy-mode-button--active={privacyMode === "private-by-default"}
           aria-pressed={privacyMode === "private-by-default"}
-          onclick={() => setPrivacyMode("private-by-default")}
+          onclick={() => updatePrivacyMode("private-by-default")}
         >
           Private by default
         </button>
@@ -301,7 +310,7 @@ const excludedTitle = $derived.by(() => (privacyMode === "private-by-default" ? 
           class="privacy-mode-button"
           class:privacy-mode-button--active={privacyMode === "public-by-default"}
           aria-pressed={privacyMode === "public-by-default"}
-          onclick={() => setPrivacyMode("public-by-default")}
+          onclick={() => updatePrivacyMode("public-by-default")}
         >
           Public by default
         </button>
@@ -344,7 +353,7 @@ const excludedTitle = $derived.by(() => (privacyMode === "private-by-default" ? 
   </div>
 
   <div class="modal-button-container">
-    <Button buttonText="Done" onClick={() => modal.close()} />
+    <Button buttonText="Save" cta onClick={saveChanges} />
   </div>
 </div>
 

--- a/src/components/modal/PrivacyListModal.svelte
+++ b/src/components/modal/PrivacyListModal.svelte
@@ -57,6 +57,21 @@ const availableTags = $derived.by(() => {
 	return [...tags].sort();
 });
 
+const availableProperties = $derived.by(() => {
+	const keys = new Set<string>();
+	for (const file of app.vault.getMarkdownFiles()) {
+		if (isAgentFilePath(file.path)) continue;
+		const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
+		if (!frontmatter) continue;
+		for (const key of Object.keys(frontmatter)) {
+			// `position` is Obsidian's internal frontmatter range marker, not a user property.
+			if (key === "position") continue;
+			keys.add(key);
+		}
+	}
+	return [...keys].sort();
+});
+
 function ensureGroup(filter: ViewFilter): ViewFilter {
 	if (filter.type === "all" || filter.type === "any" || filter.type === "none") {
 		return filter;
@@ -319,6 +334,7 @@ const excludedTitle = $derived.by(() => (privacyMode === "private-by-default" ? 
   		: buildSpaceMembershipRulesEditorFilter(parsedMembership.draft.autoIncludeRules)}
       {availableFolders}
       {availableTags}
+      {availableProperties}
       onFilterChange={handleRulesFilterChange}
       {excludedEntries}
       {excludedTitle}

--- a/src/lib/propertyValues.ts
+++ b/src/lib/propertyValues.ts
@@ -1,0 +1,50 @@
+/**
+ * Serialization for the `property` filter leaf's optional value list.
+ *
+ * The editor exposes values as a single comma-separated text field, which is
+ * readable for the common `Acme, Globex` case but ambiguous the moment a
+ * frontmatter value contains a comma of its own (`client: "Acme, Inc"`). These
+ * helpers add just enough quoting to make that round-trip losslessly while
+ * leaving ordinary values bare.
+ */
+
+/**
+ * Render a value list for the text input. Values containing a comma or a double
+ * quote are wrapped in quotes (with inner quotes backslash-escaped); everything
+ * else is emitted as-is.
+ */
+export function formatPropertyValues(values: string[] | undefined): string {
+	return (values ?? []).map((value) => (/[",]/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value)).join(", ");
+}
+
+/**
+ * Split the text input back into values, honouring double-quoted segments so a
+ * value containing a comma stays intact instead of being torn into two that
+ * match nothing. Blank segments are dropped, so trailing separators and stray
+ * whitespace are forgiving rather than producing empty values.
+ */
+export function parsePropertyValues(rawValues: string): string[] {
+	const values: string[] = [];
+	let current = "";
+	let inQuotes = false;
+	let escaped = false;
+
+	for (const char of rawValues) {
+		if (escaped) {
+			current += char;
+			escaped = false;
+		} else if (char === "\\") {
+			escaped = true;
+		} else if (char === '"') {
+			inQuotes = !inQuotes;
+		} else if (char === "," && !inQuotes) {
+			values.push(current);
+			current = "";
+		} else {
+			current += char;
+		}
+	}
+	values.push(current);
+
+	return values.map((value) => value.trim()).filter((value) => value.length > 0);
+}

--- a/src/lib/views.ts
+++ b/src/lib/views.ts
@@ -14,7 +14,7 @@
 
 import { type App, type TFile, getAllTags } from "obsidian";
 import type { SpaceSegment, ViewFilter, ViewFilterGroup, ViewFilterLeaf } from "../types/graph";
-import { matchesPathPrefix } from "../utils/pathUtils";
+import { matchesPathPrefix, normalizeVaultPath } from "../utils/pathUtils";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -59,6 +59,68 @@ export function cloneViewFilter(filter: ViewFilter): ViewFilter {
 		type: filter.type,
 		conditions: filter.conditions.map((condition) => cloneViewFilter(condition)),
 	};
+}
+
+/**
+ * Rewrite a `ViewFilter` tree to follow a vault rename, so a filter that
+ * references a moved file or folder keeps meaning what the user set it up to
+ * mean instead of silently going stale.
+ *
+ * This matters most for a *privacy* filter under `public-by-default`: there,
+ * the filter lists what's private, so a stale entry means a note the user
+ * marked private silently becomes readable by untrusted providers — a security
+ * regression with no corresponding edit. `private-by-default` fails the other
+ * way (a stale entry just drops out of what's exposed), but both directions are
+ * wrong, so both leaf kinds below are rewritten unconditionally.
+ *
+ * - `paths` leaves: an entry equal to `oldPath` becomes `newPath`.
+ * - `folder` leaves: a value equal to `oldPath` becomes `newPath`. Obsidian
+ *   fires a `rename` event for every descendant folder as well as the renamed
+ *   item itself (verified: renaming `A` containing `A/Sub` fires events for
+ *   both `A → B` and `A/Sub → B/Sub`), so a leaf naming a nested folder gets
+ *   its own exact-match event rather than needing prefix rewriting here. The
+ *   prefix branch below is kept as a defensive fallback in case a caller ever
+ *   invokes this with a coarser-grained rename than Obsidian itself emits.
+ * - Other leaf types (`tag`, `extension`, `property`, `query`) don't reference
+ *   paths and are returned unchanged.
+ *
+ * Returns the original `filter` reference when nothing changed, so callers can
+ * skip a write (and the resulting save/re-render) with a simple identity check.
+ */
+export function rewriteViewFilterForRename(filter: ViewFilter, oldPath: string, newPath: string): ViewFilter {
+	const normalizedOld = normalizeVaultPath(oldPath);
+	const normalizedNew = normalizeVaultPath(newPath);
+
+	if (isLeaf(filter)) {
+		if (filter.type === "paths") {
+			if (!filter.value.some((p) => normalizeVaultPath(p) === normalizedOld)) return filter;
+			return {
+				type: "paths",
+				value: filter.value.map((p) => (normalizeVaultPath(p) === normalizedOld ? newPath : p)),
+			};
+		}
+
+		if (filter.type === "folder") {
+			const normalizedValue = normalizeVaultPath(filter.value);
+			if (normalizedValue === normalizedOld) {
+				return { type: "folder", value: newPath };
+			}
+			if (normalizedValue.startsWith(`${normalizedOld}/`)) {
+				return { type: "folder", value: normalizedNew + normalizedValue.slice(normalizedOld.length) };
+			}
+			return filter;
+		}
+
+		return filter;
+	}
+
+	let changed = false;
+	const conditions = filter.conditions.map((condition) => {
+		const rewritten = rewriteViewFilterForRename(condition, oldPath, newPath);
+		if (rewritten !== condition) changed = true;
+		return rewritten;
+	});
+	return changed ? { type: filter.type, conditions } : filter;
 }
 
 export function cloneSpaceMembershipDraft(draft: SpaceMembershipDraft): SpaceMembershipDraft {

--- a/src/lib/views.ts
+++ b/src/lib/views.ts
@@ -31,7 +31,8 @@ export type SpaceMembershipRule =
 	| { type: "folder"; value: string }
 	| { type: "tag"; value: string }
 	| { type: "extension"; value: string }
-	| { type: "query"; value: string; algorithm: "lexical" | "semantic" | "hybrid" };
+	| { type: "query"; value: string; algorithm: "lexical" | "semantic" | "hybrid" }
+	| { type: "property"; value: string; values?: string[] };
 
 export interface SpaceMembershipDraft {
 	manualPaths: string[];
@@ -379,7 +380,13 @@ function collectExcludedPaths(filter: ViewFilterGroup): string[] {
 }
 
 function isSpaceMembershipRule(filter: ViewFilter): filter is SpaceMembershipRule {
-	return filter.type === "folder" || filter.type === "tag" || filter.type === "extension" || filter.type === "query";
+	return (
+		filter.type === "folder" ||
+		filter.type === "tag" ||
+		filter.type === "extension" ||
+		filter.type === "query" ||
+		filter.type === "property"
+	);
 }
 
 function mergeResolvedMembership(
@@ -412,13 +419,19 @@ function describeMembershipRule(rule: SpaceMembershipRule): string {
 			return `Type: ${rule.value.startsWith(".") ? rule.value.slice(1) : rule.value}`;
 		case "query":
 			return `Query: ${rule.value}`;
+		case "property":
+			return rule.values && rule.values.length > 0
+				? `Property: ${rule.value} = ${rule.values.join(", ")}`
+				: `Property: ${rule.value}`;
 	}
 }
 
 function matchesSpaceMembershipRulePath(app: App, rule: SpaceMembershipRule, filePath: string): boolean {
 	switch (rule.type) {
 		case "folder":
-			return matchesPathPrefix(filePath, rule.value);
+			// See `resolveFolder`: a blank folder is an unfinished condition and
+			// must match nothing, not the whole vault.
+			return rule.value.trim() ? matchesPathPrefix(filePath, rule.value) : false;
 		case "extension": {
 			const normalizedExt = rule.value.startsWith(".")
 				? rule.value.slice(1).toLowerCase()
@@ -437,6 +450,8 @@ function matchesSpaceMembershipRulePath(app: App, rule: SpaceMembershipRule, fil
 				return normalizedTag === normalizedFilter || normalizedTag.startsWith(`${normalizedFilter}/`);
 			});
 		}
+		case "property":
+			return matchesPropertyLeaf(app, filePath, rule.value, rule.values);
 		case "query":
 			return false;
 	}
@@ -452,6 +467,8 @@ function cloneSpaceMembershipRule(rule: SpaceMembershipRule): SpaceMembershipRul
 			return { type: "extension", value: rule.value };
 		case "query":
 			return { type: "query", value: rule.value, algorithm: rule.algorithm };
+		case "property":
+			return { type: "property", value: rule.value, values: rule.values ? [...rule.values] : undefined };
 	}
 }
 
@@ -467,6 +484,8 @@ function cloneViewFilterLeaf(filter: ViewFilterLeaf): ViewFilterLeaf {
 			return { type: "paths", value: [...filter.value] };
 		case "query":
 			return { type: "query", value: filter.value, algorithm: filter.algorithm };
+		case "property":
+			return { type: "property", value: filter.value, values: filter.values ? [...filter.values] : undefined };
 	}
 }
 
@@ -503,7 +522,8 @@ function isLeaf(filter: ViewFilter): filter is ViewFilterLeaf {
 		filter.type === "tag" ||
 		filter.type === "extension" ||
 		filter.type === "paths" ||
-		filter.type === "query"
+		filter.type === "query" ||
+		filter.type === "property"
 	);
 }
 
@@ -526,6 +546,8 @@ function resolveLeaf(app: App, leaf: ViewFilterLeaf, universe: Set<string>): Res
 			return resolveExtension(leaf.value, universe);
 		case "paths":
 			return resolvePaths(app, leaf.value);
+		case "property":
+			return resolveProperty(app, leaf.value, leaf.values, universe);
 		case "query":
 			// Query leaves must be resolved async via resolveViewFilterAsync.
 			// Sync fallback returns empty — callers needing real results use the async path.
@@ -534,6 +556,16 @@ function resolveLeaf(app: App, leaf: ViewFilterLeaf, universe: Set<string>): Res
 }
 
 function resolveFolder(folder: string, universe: Set<string>): ResolvedView {
+	// An empty/whitespace folder value is an unfinished condition, not "match
+	// everything". `matchesPathPrefix` treats a blank prefix as matching every
+	// path, which is right for search scoping but wrong here: while the user is
+	// still typing a folder name, a half-written filter would briefly select the
+	// entire vault — and for the privacy filter that means exposing every note.
+	// Match nothing instead, consistent with the extension and property leaves.
+	if (!folder.trim()) {
+		return { paths: new Set(), stalePaths: [] };
+	}
+
 	const paths = new Set<string>();
 	for (const p of universe) {
 		if (matchesPathPrefix(p, folder)) {
@@ -568,6 +600,67 @@ function resolveExtension(ext: string, universe: Set<string>): ResolvedView {
 	for (const p of universe) {
 		const fileExt = p.split(".").pop()?.toLowerCase() ?? "";
 		if (fileExt === normalizedExt) {
+			paths.add(p);
+		}
+	}
+	return { paths, stalePaths: [] };
+}
+
+/**
+ * Normalize a frontmatter value to a flat array of comparable strings.
+ *
+ * YAML gives us strings, numbers, booleans, `null`, or lists of those. Treating a
+ * scalar as a one-element list means `exists` and `equals-any` need only one code
+ * path and list-valued properties work for free. Dates are deliberately compared as
+ * opaque strings — no before/after operators, since a time-relative privacy rule
+ * would let a note change visibility with no edit to the vault.
+ */
+function normalizePropertyValues(raw: unknown): string[] {
+	if (raw === null || raw === undefined) return [];
+	const items = Array.isArray(raw) ? raw : [raw];
+	const out: string[] = [];
+	for (const item of items) {
+		if (item === null || item === undefined) continue;
+		if (typeof item === "object") continue;
+		out.push(String(item).trim().toLowerCase());
+	}
+	return out;
+}
+
+/**
+ * Match a single file against a `property` leaf.
+ *
+ * With no `values`, the leaf means "this key is present and non-empty". With
+ * `values`, it means "this key equals any of them" (case-insensitive, exact —
+ * no substring matching).
+ */
+function matchesPropertyLeaf(app: App, filePath: string, key: string, values: string[] | undefined): boolean {
+	const trimmedKey = key.trim();
+	if (!trimmedKey) return false;
+
+	const file = app.vault.getAbstractFileByPath(filePath);
+	if (!file || !("extension" in file)) return false;
+
+	const frontmatter = app.metadataCache.getFileCache(file as TFile)?.frontmatter;
+	if (!frontmatter) return false;
+
+	// Property keys are matched case-insensitively to mirror how users type them.
+	const matchedKey = Object.keys(frontmatter).find((k) => k.toLowerCase() === trimmedKey.toLowerCase());
+	if (matchedKey === undefined) return false;
+
+	const actual = normalizePropertyValues(frontmatter[matchedKey]);
+	if (actual.length === 0) return false;
+
+	const wanted = (values ?? []).map((v) => v.trim().toLowerCase()).filter((v) => v.length > 0);
+	if (wanted.length === 0) return true;
+
+	return actual.some((v) => wanted.includes(v));
+}
+
+function resolveProperty(app: App, key: string, values: string[] | undefined, universe: Set<string>): ResolvedView {
+	const paths = new Set<string>();
+	for (const p of universe) {
+		if (matchesPropertyLeaf(app, p, key, values)) {
 			paths.add(p);
 		}
 	}
@@ -663,6 +756,10 @@ function describeLeaf(leaf: ViewFilterLeaf): string {
 			return `${leaf.value.length} note${leaf.value.length === 1 ? "" : "s"}`;
 		case "query":
 			return `query(${leaf.algorithm}):${leaf.value.slice(0, 30)}${leaf.value.length > 30 ? "…" : ""}`;
+		case "property":
+			return leaf.values && leaf.values.length > 0
+				? `prop:${leaf.value}=${leaf.values.join("|")}`
+				: `prop:${leaf.value}`;
 	}
 }
 

--- a/src/lib/views.ts
+++ b/src/lib/views.ts
@@ -81,12 +81,68 @@ export function cloneViewFilter(filter: ViewFilter): ViewFilter {
  *   its own exact-match event rather than needing prefix rewriting here. The
  *   prefix branch below is kept as a defensive fallback in case a caller ever
  *   invokes this with a coarser-grained rename than Obsidian itself emits.
- * - Other leaf types (`tag`, `extension`, `property`, `query`) don't reference
- *   paths and are returned unchanged.
+ * - `property` leaves: values that are wikilinks (`[[Acme Corp]]`) are rewritten
+ *   to the renamed note, preserving subpath and alias. Obsidian rewrites the
+ *   *frontmatter* on rename, so a filter left alone would drift out of sync with
+ *   the very notes it targets. Plain (non-link) values are left alone.
+ * - Other leaf types (`tag`, `extension`, `query`) don't reference paths and are
+ *   returned unchanged.
  *
  * Returns the original `filter` reference when nothing changed, so callers can
  * skip a write (and the resulting save/re-render) with a simple identity check.
  */
+/** Strip a path's directory and extension, e.g. `Work/Acme Corp.md` → `Acme Corp`. */
+function pathToLinkText(path: string): string {
+	const withoutFolder = path.slice(path.lastIndexOf("/") + 1);
+	return withoutFolder.replace(/\.md$/i, "");
+}
+
+/**
+ * Rewrite a property-filter value that is a wikilink (`[[Acme Corp]]`) to follow a
+ * rename, preserving any subpath and alias (`[[Note#Heading|Display]]`).
+ *
+ * Users filter on link-valued properties by typing the link exactly as it appears
+ * in the frontmatter. Obsidian rewrites the *note's* frontmatter on rename, so
+ * without this the vault would say `[[New Name]]` while the saved filter still
+ * said `[[Old Name]]` — the rule silently stops matching, which under
+ * `public-by-default` means a note the user marked private becomes readable.
+ *
+ * Links may be written by basename (`[[Acme Corp]]`, the common case) or by full
+ * vault path (`[[Work/Acme Corp]]`); both are matched. A link carrying its own
+ * alias keeps that alias, since the user's chosen display text isn't ours to change.
+ * Non-link values are returned unchanged.
+ */
+function rewriteWikiLinkValue(value: string, normalizedOldPath: string, normalizedNewPath: string): string {
+	const match = /^\[\[([^\]]+)\]\]$/.exec(value.trim());
+	if (!match) return value;
+
+	const inner = match[1];
+	const aliasSplit = inner.indexOf("|");
+	const target = aliasSplit === -1 ? inner : inner.slice(0, aliasSplit);
+	const alias = aliasSplit === -1 ? "" : inner.slice(aliasSplit);
+
+	const subpathSplit = target.search(/[#^]/);
+	const linkPath = subpathSplit === -1 ? target : target.slice(0, subpathSplit);
+	const subpath = subpathSplit === -1 ? "" : target.slice(subpathSplit);
+
+	const trimmedLink = linkPath.trim();
+	const oldLinkText = pathToLinkText(normalizedOldPath);
+	// Match either the bare basename or the full vault path, case-insensitively —
+	// Obsidian resolves links case-insensitively too.
+	const matchesOld =
+		trimmedLink.toLowerCase() === oldLinkText.toLowerCase() ||
+		trimmedLink.toLowerCase() === normalizedOldPath.toLowerCase() ||
+		trimmedLink.toLowerCase() === normalizedOldPath.replace(/\.md$/i, "").toLowerCase();
+	if (!matchesOld) return value;
+
+	// Keep the reference style the user wrote: a basename link stays a basename
+	// link, a full-path link stays a full-path link.
+	const wroteFullPath = trimmedLink.toLowerCase() !== oldLinkText.toLowerCase();
+	const replacement = wroteFullPath ? normalizedNewPath.replace(/\.md$/i, "") : pathToLinkText(normalizedNewPath);
+
+	return `[[${replacement}${subpath}${alias}]]`;
+}
+
 export function rewriteViewFilterForRename(filter: ViewFilter, oldPath: string, newPath: string): ViewFilter {
 	const normalizedOld = normalizeVaultPath(oldPath);
 	const normalizedNew = normalizeVaultPath(newPath);
@@ -109,6 +165,16 @@ export function rewriteViewFilterForRename(filter: ViewFilter, oldPath: string, 
 				return { type: "folder", value: normalizedNew + normalizedValue.slice(normalizedOld.length) };
 			}
 			return filter;
+		}
+
+		if (filter.type === "property" && filter.values) {
+			let changedValue = false;
+			const values = filter.values.map((value) => {
+				const rewritten = rewriteWikiLinkValue(value, normalizedOld, normalizedNew);
+				if (rewritten !== value) changedValue = true;
+				return rewritten;
+			});
+			return changedValue ? { type: "property", value: filter.value, values } : filter;
 		}
 
 		return filter;

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -5,6 +5,7 @@ import {
 	matchesSpaceMembershipDraftPath,
 	parseSpaceMembershipFilter,
 	resolveViewFilter,
+	rewriteViewFilterForRename,
 } from "../lib/views";
 import { getSecret, listSecrets, removeSecret, setSecret } from "../lib/secretStorage";
 import { isAgentFilePath } from "../utils/fileFiltering";
@@ -623,6 +624,23 @@ export class PluginDataStore {
 	constructor(plugin: SecondBrainPlugin, initialData: PluginData) {
 		this._plugin = plugin;
 		this.#data = $state(initialData);
+
+		// Keep the privacy filter following renames instead of silently going stale.
+		// Under `public-by-default` a stale entry drops out of the *private* set —
+		// a note the user marked private would then be readable by untrusted
+		// providers with no corresponding edit — so this isn't just UI hygiene.
+		// Obsidian fires a `rename` event for every renamed file AND folder
+		// (including each descendant folder of a renamed parent), so a single
+		// exact-match rewrite per event is sufficient; see `rewriteViewFilterForRename`.
+		this._plugin.registerEvent(
+			this._plugin.app.vault.on("rename", (file, oldPath) => {
+				const rewritten = rewriteViewFilterForRename(this.#data.privacyFilter, oldPath, file.path);
+				if (rewritten !== this.#data.privacyFilter) {
+					this.#data.privacyFilter = rewritten;
+					this.saveSettings();
+				}
+			}),
+		);
 	}
 
 	/**

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -65,13 +65,15 @@ export interface SpaceSegment {
  * - "extension": file extension (e.g. "md", "pdf")
  * - "paths": explicit frozen path list (for semantic clusters / lasso selections)
  * - "query": semantic/lexical/hybrid search query, resolved eagerly to a paths list
+ * - "property": frontmatter property match — key exists, or key equals one of `values`
  */
 export type ViewFilterLeaf =
 	| { type: "folder"; value: string }
 	| { type: "tag"; value: string }
 	| { type: "extension"; value: string }
 	| { type: "paths"; value: string[] }
-	| { type: "query"; value: string; algorithm: "lexical" | "semantic" | "hybrid" };
+	| { type: "query"; value: string; algorithm: "lexical" | "semantic" | "hybrid" }
+	| { type: "property"; value: string; values?: string[] };
 
 /**
  * A composite filter that combines child conditions with a logic operator.

--- a/test/lib/propertyValues.test.ts
+++ b/test/lib/propertyValues.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { formatPropertyValues, parsePropertyValues } from "../../src/lib/propertyValues";
+
+describe("parsePropertyValues", () => {
+	it("splits a plain comma-separated list", () => {
+		expect(parsePropertyValues("Acme, Globex")).toEqual(["Acme", "Globex"]);
+	});
+
+	it("trims surrounding whitespace", () => {
+		expect(parsePropertyValues("  Acme  ,   Globex ")).toEqual(["Acme", "Globex"]);
+	});
+
+	it("drops empty segments", () => {
+		expect(parsePropertyValues("Acme, , Globex,")).toEqual(["Acme", "Globex"]);
+		expect(parsePropertyValues("")).toEqual([]);
+		expect(parsePropertyValues("   ")).toEqual([]);
+	});
+
+	it("keeps a quoted value containing a comma intact", () => {
+		// The bug this guards: `client: "Acme, Inc"` was split into two values,
+		// neither of which matched the frontmatter.
+		expect(parsePropertyValues('"Acme, Inc"')).toEqual(["Acme, Inc"]);
+	});
+
+	it("mixes quoted and bare values", () => {
+		expect(parsePropertyValues('"Acme, Inc", Globex')).toEqual(["Acme, Inc", "Globex"]);
+	});
+
+	it("unescapes inner quotes", () => {
+		expect(parsePropertyValues('"He said \\"hi\\""')).toEqual(['He said "hi"']);
+	});
+});
+
+describe("formatPropertyValues", () => {
+	it("renders undefined and empty lists as an empty string", () => {
+		expect(formatPropertyValues(undefined)).toBe("");
+		expect(formatPropertyValues([])).toBe("");
+	});
+
+	it("leaves ordinary values bare", () => {
+		expect(formatPropertyValues(["Acme", "Globex"])).toBe("Acme, Globex");
+	});
+
+	it("quotes values containing a comma", () => {
+		expect(formatPropertyValues(["Acme, Inc"])).toBe('"Acme, Inc"');
+	});
+
+	it("escapes inner quotes", () => {
+		expect(formatPropertyValues(['He said "hi"'])).toBe('"He said \\"hi\\""');
+	});
+});
+
+describe("format → parse round-trip", () => {
+	const CASES: string[][] = [
+		["Acme"],
+		["Acme", "Globex"],
+		["Acme, Inc"],
+		["Acme, Inc", "Globex"],
+		['He said "hi"'],
+		["trailing space is trimmed"],
+		["3"],
+		["true"],
+	];
+
+	for (const values of CASES) {
+		it(`round-trips ${JSON.stringify(values)}`, () => {
+			expect(parsePropertyValues(formatPropertyValues(values))).toEqual(values);
+		});
+	}
+});

--- a/test/lib/views.test.ts
+++ b/test/lib/views.test.ts
@@ -22,6 +22,7 @@ import type { App, CachedMetadata, TFile } from "obsidian";
 function createMockApp(
 	files: string[],
 	fileTags: Record<string, string[]> = {},
+	fileFrontmatter: Record<string, Record<string, unknown>> = {},
 ): App {
 	const mockFiles = files.map((path) => ({
 		path,
@@ -32,12 +33,21 @@ function createMockApp(
 
 	const getFileCache = vi.fn((file: TFile): CachedMetadata | null => {
 		const tags = fileTags[file.path];
-		if (!tags) return null;
+		const frontmatter = fileFrontmatter[file.path];
+		if (!tags && !frontmatter) return null;
 		return {
-			tags: tags.map((tag) => ({
-				tag,
-				position: { start: { line: 0, col: 0, offset: 0 }, end: { line: 0, col: 0, offset: 0 } },
-			})),
+			...(tags
+				? {
+						tags: tags.map((tag) => ({
+							tag,
+							position: {
+								start: { line: 0, col: 0, offset: 0 },
+								end: { line: 0, col: 0, offset: 0 },
+							},
+						})),
+					}
+				: {}),
+			...(frontmatter ? { frontmatter: frontmatter as CachedMetadata["frontmatter"] } : {}),
 		};
 	});
 
@@ -626,5 +636,211 @@ describe("space membership draft helpers", () => {
 		expect(matchesSpaceMembershipDraftPath(app, draft, "Assets/diagram.pdf")).toBe(true);
 		expect(matchesSpaceMembershipDraftPath(app, draft, "Research/skip.md")).toBe(false);
 		expect(matchesSpaceMembershipDraftPath(app, draft, "Other/file.md")).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Property leaf
+// ---------------------------------------------------------------------------
+
+describe("property leaf", () => {
+	const FILES = [
+		"Clients/acme.md",
+		"Clients/globex.md",
+		"Clients/untagged.md",
+		"Work/listed.md",
+		"Work/numeric.md",
+		"Work/boolish.md",
+		"Work/empty-value.md",
+		"Personal/none.md",
+	];
+
+	const FRONTMATTER: Record<string, Record<string, unknown>> = {
+		"Clients/acme.md": { client: "Acme" },
+		"Clients/globex.md": { client: "Globex" },
+		"Clients/untagged.md": { unrelated: "x" },
+		// List-valued property — should behave exactly like a scalar per element.
+		"Work/listed.md": { client: ["Acme", "Initech"] },
+		"Work/numeric.md": { revision: 3 },
+		"Work/boolish.md": { confidential: true },
+		// Present key with an empty value must NOT count as "exists".
+		"Work/empty-value.md": { client: null },
+	};
+
+	function app() {
+		return createMockApp(FILES, {}, FRONTMATTER);
+	}
+
+	it("matches key existence when no values are given", () => {
+		const filter: ViewFilter = { type: "property", value: "client" };
+		const result = resolveViewFilter(app(), filter, new Set(FILES));
+
+		expect(result.paths).toEqual(
+			new Set(["Clients/acme.md", "Clients/globex.md", "Work/listed.md"]),
+		);
+	});
+
+	it("treats a present-but-empty value as absent", () => {
+		const filter: ViewFilter = { type: "property", value: "client" };
+		const result = resolveViewFilter(app(), filter, new Set(FILES));
+
+		expect(result.paths.has("Work/empty-value.md")).toBe(false);
+	});
+
+	it("matches a single value exactly", () => {
+		const filter: ViewFilter = { type: "property", value: "client", values: ["Acme"] };
+		const result = resolveViewFilter(app(), filter, new Set(FILES));
+
+		expect(result.paths).toEqual(new Set(["Clients/acme.md", "Work/listed.md"]));
+	});
+
+	it("matches any of several values (equals-any)", () => {
+		const filter: ViewFilter = {
+			type: "property",
+			value: "client",
+			values: ["Acme", "Globex"],
+		};
+		const result = resolveViewFilter(app(), filter, new Set(FILES));
+
+		expect(result.paths).toEqual(
+			new Set(["Clients/acme.md", "Clients/globex.md", "Work/listed.md"]),
+		);
+	});
+
+	it("matches list-valued properties per element", () => {
+		const filter: ViewFilter = { type: "property", value: "client", values: ["Initech"] };
+		const result = resolveViewFilter(app(), filter, new Set(FILES));
+
+		expect(result.paths).toEqual(new Set(["Work/listed.md"]));
+	});
+
+	it("compares keys and values case-insensitively", () => {
+		const filter: ViewFilter = { type: "property", value: "CLIENT", values: ["acme"] };
+		const result = resolveViewFilter(app(), filter, new Set(FILES));
+
+		expect(result.paths).toEqual(new Set(["Clients/acme.md", "Work/listed.md"]));
+	});
+
+	it("does not substring-match values", () => {
+		const filter: ViewFilter = { type: "property", value: "client", values: ["Acm"] };
+		const result = resolveViewFilter(app(), filter, new Set(FILES));
+
+		expect(result.paths.size).toBe(0);
+	});
+
+	it("coerces non-string scalars for comparison", () => {
+		const numeric = resolveViewFilter(
+			app(),
+			{ type: "property", value: "revision", values: ["3"] },
+			new Set(FILES),
+		);
+		expect(numeric.paths).toEqual(new Set(["Work/numeric.md"]));
+
+		const boolish = resolveViewFilter(
+			app(),
+			{ type: "property", value: "confidential", values: ["true"] },
+			new Set(FILES),
+		);
+		expect(boolish.paths).toEqual(new Set(["Work/boolish.md"]));
+	});
+
+	it("matches nothing for a blank key", () => {
+		const filter: ViewFilter = { type: "property", value: "   " };
+		const result = resolveViewFilter(app(), filter, new Set(FILES));
+
+		expect(result.paths.size).toBe(0);
+	});
+
+	it("composes with groups like any other leaf", () => {
+		const filter: ViewFilter = {
+			type: "all",
+			conditions: [
+				{ type: "folder", value: "Clients" },
+				{ type: "property", value: "client", values: ["Acme"] },
+			],
+		};
+		const result = resolveViewFilter(app(), filter, new Set(FILES));
+
+		// Work/listed.md also has client: Acme but is outside the Clients folder.
+		expect(result.paths).toEqual(new Set(["Clients/acme.md"]));
+	});
+
+	it("survives a compile → parse round-trip as a simple rule", () => {
+		const draft = {
+			manualPaths: [],
+			autoIncludeRules: [{ type: "property", value: "client", values: ["Acme"] } as const],
+			excludedPaths: [],
+		};
+
+		const parsed = parseSpaceMembershipFilter(compileSpaceMembershipDraft(draft));
+
+		expect(parsed.isAdvanced).toBe(false);
+		expect(parsed.draft.autoIncludeRules).toEqual([
+			{ type: "property", value: "client", values: ["Acme"] },
+		]);
+	});
+
+	it("agrees between the sync path matcher and the set resolver", () => {
+		const rule = { type: "property", value: "client", values: ["Acme"] } as const;
+		const draft = { manualPaths: [], autoIncludeRules: [rule], excludedPaths: [] };
+		const resolved = resolveViewFilter(app(), rule, new Set(FILES));
+
+		// isFilePrivate() uses the sync matcher in tool loops; it must not
+		// disagree with the set-based resolver used to render the UI.
+		for (const path of FILES) {
+			expect(matchesSpaceMembershipDraftPath(app(), draft, path)).toBe(resolved.paths.has(path));
+		}
+	});
+
+	it("describes property leaves with and without values", () => {
+		expect(describeViewFilter({ type: "property", value: "client" })).toBe("prop:client");
+		expect(
+			describeViewFilter({ type: "property", value: "client", values: ["Acme", "Globex"] }),
+		).toBe("prop:client=Acme|Globex");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Unfinished conditions must not select the whole vault
+// ---------------------------------------------------------------------------
+
+describe("empty leaf values", () => {
+	const FILES = ["Work/a.md", "Work/b.md", "Personal/c.md", "Root.md"];
+
+	it("matches nothing for a blank folder value", () => {
+		const app = createMockApp(FILES);
+		// `matchesPathPrefix` treats a blank prefix as matching everything, which
+		// would expose the entire vault mid-typing. The leaf must not inherit that.
+		for (const blank of ["", "   "]) {
+			const result = resolveViewFilter(app, { type: "folder", value: blank }, new Set(FILES));
+			expect(result.paths.size).toBe(0);
+		}
+	});
+
+	it("matches nothing for a blank folder value via the sync matcher", () => {
+		const app = createMockApp(FILES);
+		const draft = {
+			manualPaths: [],
+			autoIncludeRules: [{ type: "folder", value: "" } as const],
+			excludedPaths: [],
+		};
+
+		for (const path of FILES) {
+			expect(matchesSpaceMembershipDraftPath(app, draft, path)).toBe(false);
+		}
+	});
+
+	it("still matches a real folder value", () => {
+		const app = createMockApp(FILES);
+		const result = resolveViewFilter(app, { type: "folder", value: "Work" }, new Set(FILES));
+
+		expect(result.paths).toEqual(new Set(["Work/a.md", "Work/b.md"]));
+	});
+
+	it("matches nothing for blank extension and tag values", () => {
+		const app = createMockApp(FILES, { "Work/a.md": ["#work"] });
+
+		expect(resolveViewFilter(app, { type: "extension", value: "" }, new Set(FILES)).paths.size).toBe(0);
+		expect(resolveViewFilter(app, { type: "tag", value: "" }, new Set(FILES)).paths.size).toBe(0);
 	});
 });

--- a/test/lib/views.test.ts
+++ b/test/lib/views.test.ts
@@ -8,6 +8,7 @@ import {
 	parseSpaceMembershipFilter,
 	resolveSpaceMembershipDraft,
 	resolveViewFilter,
+	rewriteViewFilterForRename,
 } from "../../src/lib/views";
 import type { ViewFilter, ViewFilterGroup } from "../../src/types/graph";
 import type { App, CachedMetadata, TFile } from "obsidian";
@@ -842,5 +843,117 @@ describe("empty leaf values", () => {
 
 		expect(resolveViewFilter(app, { type: "extension", value: "" }, new Set(FILES)).paths.size).toBe(0);
 		expect(resolveViewFilter(app, { type: "tag", value: "" }, new Set(FILES)).paths.size).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// rewriteViewFilterForRename — keep the filter following moved files/folders
+// ---------------------------------------------------------------------------
+
+describe("rewriteViewFilterForRename", () => {
+	it("rewrites a paths leaf entry that matches the old path", () => {
+		const filter: ViewFilter = { type: "paths", value: ["Work/a.md", "Personal/b.md"] };
+		const rewritten = rewriteViewFilterForRename(filter, "Work/a.md", "Archive/a.md");
+
+		expect(rewritten).toEqual({ type: "paths", value: ["Archive/a.md", "Personal/b.md"] });
+	});
+
+	it("leaves a paths leaf untouched when no entry matches", () => {
+		const filter: ViewFilter = { type: "paths", value: ["Work/a.md"] };
+		const rewritten = rewriteViewFilterForRename(filter, "Other/x.md", "Other/y.md");
+
+		// Identity preserved, not just structural equality — callers rely on this
+		// to skip a write when nothing changed.
+		expect(rewritten).toBe(filter);
+	});
+
+	it("rewrites a folder leaf that exactly names the renamed folder", () => {
+		const filter: ViewFilter = { type: "folder", value: "Work" };
+		const rewritten = rewriteViewFilterForRename(filter, "Work", "Projects");
+
+		expect(rewritten).toEqual({ type: "folder", value: "Projects" });
+	});
+
+	it("rewrites a nested folder leaf via its own exact-match rename event", () => {
+		// Obsidian fires a dedicated rename event for every descendant folder of a
+		// renamed parent (verified against a live vault: renaming `A` containing
+		// `A/Sub` fires both `A -> B` and `A/Sub -> B/Sub`), so a leaf naming a
+		// nested folder is rewritten by its own event, not by prefix-matching the
+		// parent's event.
+		const filter: ViewFilter = { type: "folder", value: "Work/Q1" };
+		const rewritten = rewriteViewFilterForRename(filter, "Work/Q1", "Projects/Q1");
+
+		expect(rewritten).toEqual({ type: "folder", value: "Projects/Q1" });
+	});
+
+	it("leaves a folder leaf untouched when it names an unrelated folder", () => {
+		const filter: ViewFilter = { type: "folder", value: "Personal" };
+		const rewritten = rewriteViewFilterForRename(filter, "Work", "Projects");
+
+		expect(rewritten).toBe(filter);
+	});
+
+	it("does not touch tag, extension, or property leaves", () => {
+		const tag: ViewFilter = { type: "tag", value: "#work" };
+		const ext: ViewFilter = { type: "extension", value: "pdf" };
+		const prop: ViewFilter = { type: "property", value: "client", values: ["Acme"] };
+
+		expect(rewriteViewFilterForRename(tag, "Work", "Projects")).toBe(tag);
+		expect(rewriteViewFilterForRename(ext, "Work", "Projects")).toBe(ext);
+		expect(rewriteViewFilterForRename(prop, "Work", "Projects")).toBe(prop);
+	});
+
+	it("recurses through groups and rewrites only the matching leaf", () => {
+		const filter: ViewFilter = {
+			type: "all",
+			conditions: [
+				{ type: "folder", value: "Work" },
+				{
+					type: "none",
+					conditions: [{ type: "paths", value: ["Work/secret.md"] }],
+				},
+			],
+		};
+
+		const rewritten = rewriteViewFilterForRename(filter, "Work/secret.md", "Archive/secret.md");
+
+		expect(rewritten).toEqual({
+			type: "all",
+			conditions: [
+				{ type: "folder", value: "Work" },
+				{
+					type: "none",
+					conditions: [{ type: "paths", value: ["Archive/secret.md"] }],
+				},
+			],
+		});
+	});
+
+	it("preserves identity through a group when nothing inside changed", () => {
+		const filter: ViewFilter = {
+			type: "any",
+			conditions: [
+				{ type: "folder", value: "Personal" },
+				{ type: "tag", value: "#work" },
+			],
+		};
+
+		const rewritten = rewriteViewFilterForRename(filter, "Work", "Projects");
+		expect(rewritten).toBe(filter);
+	});
+
+	it("closes the fail-open this guards: a private file kept private after rename", () => {
+		// Under public-by-default, `privacyFilter` lists what's PRIVATE. If a
+		// rename isn't followed, the moved file drops out of that list and
+		// becomes readable by untrusted providers with no corresponding edit.
+		const privacyFilter: ViewFilter = { type: "paths", value: ["Journal/secret.md"] };
+		const app = createMockApp(["Archive/secret.md"]);
+
+		const rewritten = rewriteViewFilterForRename(privacyFilter, "Journal/secret.md", "Archive/secret.md");
+		const stillPrivate = resolveViewFilter(app, rewritten, new Set(["Archive/secret.md"])).paths.has(
+			"Archive/secret.md",
+		);
+
+		expect(stillPrivate).toBe(true);
 	});
 });

--- a/test/lib/views.test.ts
+++ b/test/lib/views.test.ts
@@ -893,14 +893,90 @@ describe("rewriteViewFilterForRename", () => {
 		expect(rewritten).toBe(filter);
 	});
 
-	it("does not touch tag, extension, or property leaves", () => {
+	it("does not touch tag or extension leaves, or plain property values", () => {
 		const tag: ViewFilter = { type: "tag", value: "#work" };
 		const ext: ViewFilter = { type: "extension", value: "pdf" };
+		// A non-link property value is just a string — a note rename must not
+		// rewrite it even if the text happens to resemble the renamed note.
 		const prop: ViewFilter = { type: "property", value: "client", values: ["Acme"] };
 
 		expect(rewriteViewFilterForRename(tag, "Work", "Projects")).toBe(tag);
 		expect(rewriteViewFilterForRename(ext, "Work", "Projects")).toBe(ext);
-		expect(rewriteViewFilterForRename(prop, "Work", "Projects")).toBe(prop);
+		expect(rewriteViewFilterForRename(prop, "Acme.md", "Acme Holdings.md")).toBe(prop);
+	});
+
+	describe("wikilink property values", () => {
+		it("rewrites a basename wikilink to the renamed note", () => {
+			const filter: ViewFilter = { type: "property", value: "client", values: ["[[Acme Corp]]"] };
+			const rewritten = rewriteViewFilterForRename(filter, "Acme Corp.md", "Acme Holdings.md");
+
+			expect(rewritten).toEqual({ type: "property", value: "client", values: ["[[Acme Holdings]]"] });
+		});
+
+		it("rewrites only the matching value in a multi-value leaf", () => {
+			const filter: ViewFilter = {
+				type: "property",
+				value: "client",
+				values: ["[[Acme Corp]]", "[[Globex]]", "Plain Text"],
+			};
+			const rewritten = rewriteViewFilterForRename(filter, "Acme Corp.md", "Acme Holdings.md");
+
+			expect(rewritten).toEqual({
+				type: "property",
+				value: "client",
+				values: ["[[Acme Holdings]]", "[[Globex]]", "Plain Text"],
+			});
+		});
+
+		it("preserves an alias", () => {
+			const filter: ViewFilter = { type: "property", value: "client", values: ["[[Acme Corp|The Client]]"] };
+			const rewritten = rewriteViewFilterForRename(filter, "Acme Corp.md", "Acme Holdings.md");
+
+			expect(rewritten).toEqual({
+				type: "property",
+				value: "client",
+				values: ["[[Acme Holdings|The Client]]"],
+			});
+		});
+
+		it("preserves a subpath", () => {
+			const filter: ViewFilter = { type: "property", value: "client", values: ["[[Acme Corp#Billing]]"] };
+			const rewritten = rewriteViewFilterForRename(filter, "Acme Corp.md", "Acme Holdings.md");
+
+			expect(rewritten).toEqual({
+				type: "property",
+				value: "client",
+				values: ["[[Acme Holdings#Billing]]"],
+			});
+		});
+
+		it("keeps a full-path link written as a full path", () => {
+			const filter: ViewFilter = { type: "property", value: "client", values: ["[[Work/Acme Corp]]"] };
+			const rewritten = rewriteViewFilterForRename(filter, "Work/Acme Corp.md", "Archive/Acme Corp.md");
+
+			expect(rewritten).toEqual({
+				type: "property",
+				value: "client",
+				values: ["[[Archive/Acme Corp]]"],
+			});
+		});
+
+		it("matches link text case-insensitively, as Obsidian resolves links", () => {
+			const filter: ViewFilter = { type: "property", value: "client", values: ["[[acme corp]]"] };
+			const rewritten = rewriteViewFilterForRename(filter, "Acme Corp.md", "Acme Holdings.md");
+
+			expect(rewritten).toEqual({ type: "property", value: "client", values: ["[[Acme Holdings]]"] });
+		});
+
+		it("leaves a wikilink pointing at an unrelated note alone", () => {
+			const filter: ViewFilter = { type: "property", value: "client", values: ["[[Globex]]"] };
+			expect(rewriteViewFilterForRename(filter, "Acme Corp.md", "Acme Holdings.md")).toBe(filter);
+		});
+
+		it("leaves a values-less (existence-check) property leaf alone", () => {
+			const filter: ViewFilter = { type: "property", value: "client" };
+			expect(rewriteViewFilterForRename(filter, "Acme Corp.md", "Acme Holdings.md")).toBe(filter);
+		});
 	});
 
 	it("recurses through groups and rewrites only the matching leaf", () => {

--- a/test/stores/dataStore.test.ts
+++ b/test/stores/dataStore.test.ts
@@ -56,11 +56,16 @@ function createMockPlugin() {
 				getAbstractFileByPath: vi.fn(),
 				getFolderByPath: vi.fn().mockReturnValue(null),
 				createFolder: vi.fn().mockResolvedValue(undefined),
+				// `PluginDataStore` subscribes to vault renames (to keep the privacy
+				// filter from going stale) directly in its constructor, so every store
+				// under test needs this even when the test has nothing to do with renames.
+				on: vi.fn().mockReturnValue({}),
 			},
 			appId: "test-vault-id",
 		},
 		manifest: { id: "smart-second-brain", dir: "smart-second-brain" },
 		saveData: vi.fn().mockResolvedValue(undefined),
+		registerEvent: vi.fn(),
 	};
 }
 


### PR DESCRIPTION
## Summary

- Adds a `property` leaf to the privacy/space filter tree, matching frontmatter values (e.g. `client = Acme`) alongside the existing folder/tag/extension leaves. Case-insensitive exact match, list-valued properties matched per element, no substring or date-comparison operators.
- **Fixes a fail-open**: an empty/unfinished folder condition previously matched every file in the vault. Now matches nothing.
- **Defers privacy edits to an explicit Save**: edits stay in local component state and commit once; closing via X/Escape discards them. Button renamed "Done" → "Save".
- **Follows vault renames automatically**: a folder/path/wikilink-valued-property referenced by the filter used to go stale on rename — under `public-by-default` that meant a note marked private could silently become readable again. `paths`, `folder`, and wikilink values inside `property` leaves (`[[Note]]`, preserving alias/subpath) now all follow renames, both at the store level and in an open modal's unsaved draft.
- Preserves commas in property filter values (`client: "Acme, Inc"` no longer gets torn into two non-matching values).
- Adds an empty-pool hint to the property-key autocomplete.
- Tightens file-row density in the privacy/space file list to match Obsidian's native list surfaces.
- **Clarifies scope in the modal itself**: a note now states that this protects file *content*, not file/folder names/paths (those can still surface to a provider — tracked separately in #380), and that renaming/moving files is now safe with respect to this filter.

## Test plan

- [x] `bun run check` — clean (same 4 pre-existing `GraphCanvas.svelte` errors on a clean `dev` checkout)
- [x] `bun run format` — clean
- [x] `bun run test` — 996 passing, including coverage for: property matching semantics, the empty-folder regression, comma round-tripping, and `rewriteViewFilterForRename` (paths/folder/wikilink-in-property leaves, group recursion, identity preservation, alias/subpath preservation, case-insensitive link matching, and a regression test that a rename can't flip a private note to publicly readable under `public-by-default`)
- [x] Verified live against the Obsidian test vault:
  - Property leaf resolves on real frontmatter (scalars, lists, numbers, booleans, comma-containing values, wikilinks); autocomplete populates from real vault properties
  - Empty-folder condition confirmed going from "72 of 72 files exposed" to "0 of 72"
  - Toggling privacy mode/filters then closing via Escape leaves the persisted store unchanged; Save persists the draft
  - Renamed a folder referenced by a saved filter — persisted filter followed automatically
  - Renamed a folder *while the modal was open* with the filter showing the old name — draft updated live, Save persisted the corrected value
  - Set `client = [[Acme Corp]]`, confirmed it matched a note, renamed `Acme Corp` → `Acme Holdings` — both the vault's frontmatter (Obsidian's own doing) and the filter's stored value moved together, match still held
  - Confirmed Obsidian fires a `rename` event for every descendant folder of a renamed parent, not just files — informed the rewrite design
  - Confirmed the new clarifying note renders correctly in the modal (screenshot-checked)

## Follow-up (not in this PR)

- #380 — `search_notes` includes the path/name of privacy-restricted files in its results even though it already redacts their content-derived fields; `list_directory`/`grep_notes` fully skip such files instead. Flagged as a separate issue rather than scope-creeping this PR further.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._