### PR TITLE
fix(privacy): close search_notes path leak, gate plugin exec-tool privacy bypass

### DIFF
--- a/src/agent/integrations/pluginIntegrations.ts
+++ b/src/agent/integrations/pluginIntegrations.ts
@@ -1,4 +1,6 @@
 import type { App } from "obsidian";
+import { IntegrationPrivacyWarningModal } from "../../components/modal/IntegrationPrivacyWarningModal";
+import type { PluginDataStore } from "../../stores/dataStore.svelte";
 
 /**
  * A plugin integration exposes another Obsidian community plugin's public api
@@ -90,6 +92,30 @@ export function isInternalPluginEnabled(app: App, pluginId: string): boolean {
 
 /** Config key used to persist the per-plugin exec enable state on an agent. */
 export const toExecToolId = (pluginId: string): string => `exec:${pluginId}`;
+
+/**
+ * Shows the privacy warning before enabling a plugin integration's `exec_<plugin>` tool, unless
+ * the user has suppressed it (`pluginData.suppressIntegrationPrivacyWarning`). Shared by every
+ * enable surface (AgentEditorModal's Integrations list, the chat empty-state plugin nudge) so
+ * the gate can't be skipped by adding a new one — see `createPluginApiExecTool` for why this
+ * tool needs the warning: it bypasses `shouldBlockFile` entirely.
+ *
+ * @returns true if the caller should proceed with enabling the integration.
+ */
+export async function confirmEnableIntegrationPrivacy(
+	app: App,
+	pluginData: Pick<PluginDataStore, "suppressIntegrationPrivacyWarning">,
+	displayName: string,
+): Promise<boolean> {
+	if (pluginData.suppressIntegrationPrivacyWarning) return true;
+
+	const modal = new IntegrationPrivacyWarningModal(app, displayName);
+	const { confirmed, dontAskAgain } = await modal.prompt();
+	if (dontAskAgain) {
+		pluginData.suppressIntegrationPrivacyWarning = true;
+	}
+	return confirmed;
+}
 
 /**
  * Runtime tool name bound to the agent. Must be a valid identifier-ish token for

--- a/src/agent/tools/searchNotes.ts
+++ b/src/agent/tools/searchNotes.ts
@@ -19,7 +19,6 @@ interface SearchToolResultItem {
 	name: string;
 	path?: string;
 	score?: number;
-	privacyRestricted: boolean;
 	frontmatter?: Record<string, unknown>;
 	tags?: string[];
 	matchExplanation?: SearchMatchExplanation;
@@ -34,6 +33,7 @@ interface SearchToolResultPayload {
 	filter?: SearchFilter;
 	totalResults: number;
 	returnedResults: number;
+	skippedPrivateFiles: number;
 	results: SearchToolResultItem[];
 	message?: string;
 }
@@ -53,22 +53,6 @@ function normalizeTags(tags: string[] | undefined): string[] | undefined {
 	}
 
 	return Array.from(new Set(tags.map((tag) => (tag.startsWith("#") ? tag : `#${tag}`))));
-}
-
-function redactRestrictedMatchBadges(
-	badges: SearchMatchBadge[] | undefined,
-	privacyRestricted: boolean,
-): SearchMatchBadge[] | undefined {
-	if (!badges?.length) {
-		return undefined;
-	}
-
-	if (!privacyRestricted) {
-		return badges;
-	}
-
-	const visibleBadges = badges.filter((badge) => badge !== "content" && badge !== "heading" && badge !== "semantic");
-	return visibleBadges.length > 0 ? visibleBadges : undefined;
 }
 
 /**
@@ -253,24 +237,28 @@ export function createSearchNotesTool(app: App) {
 		const results = recentOnly ? getRecentNotes(app, filter) : await performSearch(app, query, algorithm, filter);
 		const currentProvider = pluginData.getSelectedAgent().chatModel?.provider;
 		const store = getPendingChangesStore();
-		const limitedResults = results.slice(0, limit);
-		const items: SearchToolResultItem[] = limitedResults.map((result, index) => {
-			const privacyRestricted = currentProvider ? store.shouldBlockFile(result.path, currentProvider) : false;
 
-			return {
-				rank: index + 1,
-				name: result.name,
-				path: showPath ? result.path : undefined,
-				score: result.score,
-				privacyRestricted,
-				frontmatter: result.frontmatter,
-				tags: showTags ? normalizeTags(result.tags) : undefined,
-				matchExplanation: showMatchContext && !privacyRestricted ? result.matchExplanation : undefined,
-				matchBadges: showMatchBadges
-					? redactRestrictedMatchBadges(result.matchBadges, privacyRestricted)
-					: undefined,
-			};
-		});
+		let skippedPrivateFiles = 0;
+		const visibleResults: SearchResult[] = [];
+		for (const result of results) {
+			if (currentProvider && store.shouldBlockFile(result.path, currentProvider)) {
+				skippedPrivateFiles++;
+				continue;
+			}
+			visibleResults.push(result);
+		}
+
+		const limitedResults = visibleResults.slice(0, limit);
+		const items: SearchToolResultItem[] = limitedResults.map((result, index) => ({
+			rank: index + 1,
+			name: result.name,
+			path: showPath ? result.path : undefined,
+			score: result.score,
+			frontmatter: result.frontmatter,
+			tags: showTags ? normalizeTags(result.tags) : undefined,
+			matchExplanation: showMatchContext ? result.matchExplanation : undefined,
+			matchBadges: showMatchBadges ? result.matchBadges : undefined,
+		}));
 
 		const payload: SearchToolResultPayload = {
 			query,
@@ -278,8 +266,9 @@ export function createSearchNotesTool(app: App) {
 			algorithm,
 			maxResults: limit,
 			filter,
-			totalResults: results.length,
+			totalResults: visibleResults.length,
 			returnedResults: items.length,
+			skippedPrivateFiles,
 			results: items,
 		};
 

--- a/src/components/chat/ChatRecommendations.svelte
+++ b/src/components/chat/ChatRecommendations.svelte
@@ -4,7 +4,11 @@ import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
 import type { SessionRegistry } from "../../stores/chatStore.svelte";
 import { useAvailableModels } from "../../hooks/useAvailableModels.svelte";
-import { getPluginIcon, toExecToolId } from "../../agent/integrations/pluginIntegrations";
+import {
+	confirmEnableIntegrationPrivacy,
+	getPluginIcon,
+	toExecToolId,
+} from "../../agent/integrations/pluginIntegrations";
 import { icon } from "../../utils/utils";
 import { Logger } from "../../utils/logging";
 import { extractErrorMessage } from "../../utils/errorMessage";
@@ -157,6 +161,11 @@ function useSuggestion(s: SuggestedQuery): void {
 
 async function enablePlugin(nudge: PluginNudge): Promise<void> {
 	const agent = data.getSelectedAgent();
+	// Unsandboxed main-thread `app` access bypasses per-provider privacy rules — warn before
+	// seeding anything so a cancel leaves no skill and no exec tool enabled. Same gate as
+	// AgentEditorModal.toggleAutoIntegration, shared via confirmEnableIntegrationPrivacy.
+	if (!(await confirmEnableIntegrationPrivacy(plugin.app, data, nudge.displayName))) return;
+
 	// Mirror AgentEditorModal.toggleAutoIntegration exactly: for an auto-discovered
 	// plugin with no documenting skill yet (nudge.skillId absent), seed one on demand
 	// (prewritten bundled skill if available, else an introspect-first template) and

--- a/src/components/chat/ToolCallsSection.svelte
+++ b/src/components/chat/ToolCallsSection.svelte
@@ -707,6 +707,11 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
       {#if model.payload.recentOnly}
         <span class="tool-output-metric-chip">recent only</span>
       {/if}
+      {#if (model.payload.skippedPrivateFiles ?? 0) > 0}
+        <span class="tool-output-metric-chip tool-output-metric-chip-warning"
+          >skipped private: {model.payload.skippedPrivateFiles}</span
+        >
+      {/if}
     </div>
     {#if model.payload.message}
       <div class="tool-output-message">{model.payload.message}</div>
@@ -720,11 +725,6 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
               <span class="tool-output-result-title"
                 >{result.name ?? result.path ?? "Untitled"}</span
               >
-              {#if result.privacyRestricted}
-                <span class="tool-output-status-badge tool-output-status-badge-warning"
-                  >private</span
-                >
-              {/if}
             </div>
             {#if result.path}
               <div class="tool-output-result-path">{result.path}</div>
@@ -1670,8 +1670,7 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
     word-break: break-word;
   }
 
-  .tool-output-metric-chip,
-  .tool-output-status-badge {
+  .tool-output-metric-chip {
     display: inline-flex;
     align-items: center;
     padding: 2px 7px;
@@ -1686,8 +1685,7 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
     background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
   }
 
-  .tool-output-metric-chip-warning,
-  .tool-output-status-badge-warning {
+  .tool-output-metric-chip-warning {
     color: var(--color-orange);
     background: color-mix(in srgb, var(--color-orange) 12%, transparent);
   }

--- a/src/components/chat/toolOutputRenderModel.ts
+++ b/src/components/chat/toolOutputRenderModel.ts
@@ -3,7 +3,6 @@ interface SearchNotesResult {
 	name?: string;
 	path?: string;
 	score?: number;
-	privacyRestricted?: boolean;
 	tags?: string[];
 	matchExplanation?: string;
 	matchBadges?: string[];
@@ -16,6 +15,7 @@ interface SearchNotesPayload {
 	maxResults?: number;
 	totalResults?: number;
 	returnedResults?: number;
+	skippedPrivateFiles?: number;
 	message?: string;
 	results?: SearchNotesResult[];
 }

--- a/src/components/modal/AgentEditorModal.svelte
+++ b/src/components/modal/AgentEditorModal.svelte
@@ -24,6 +24,7 @@ import { installObsidianFetch } from "../../lib/obsidianFetch";
 import type SecondBrainPlugin from "../../main";
 import {
 	type PluginIntegration,
+	confirmEnableIntegrationPrivacy,
 	getPluginIcon,
 	skillIcon,
 	coreSkillRank,
@@ -435,7 +436,7 @@ function isSkillPluginInstalled(skill: SkillDisplayInfo): boolean {
 	return true;
 }
 
-function toggleSkill(skillId: string, newEnabled: boolean) {
+async function toggleSkill(skillId: string, newEnabled: boolean) {
 	const skill = skills.find((entry) => entry.id === skillId);
 	if (!skill) return;
 	if (skill.category !== "custom") {
@@ -451,10 +452,17 @@ function toggleSkill(skillId: string, newEnabled: boolean) {
 			}
 		}
 	}
-	pluginData.setAgentSkillEnabled(agentId, skillId, newEnabled);
-	// Bundle code-exec with the skill: if the linked plugin exposes a callable `.api`,
-	// enabling the skill also grants API scripting, and disabling revokes it.
+	// Bundle code-exec with the skill: if the linked plugin exposes a callable `.api`, enabling
+	// the skill also grants API scripting (unsandboxed, bypasses per-provider privacy rules —
+	// see createPluginApiExecTool), and disabling revokes it. Warn before granting it; a cancel
+	// here still enables the skill itself, just without the exec tool bundled on.
 	const integration = skillExecIntegration(skill);
+	const grantsExec = newEnabled && !!integration;
+	if (grantsExec && !(await confirmEnableIntegrationPrivacy(plugin.app, pluginData, skill.displayName))) {
+		return;
+	}
+
+	pluginData.setAgentSkillEnabled(agentId, skillId, newEnabled);
 	if (integration) {
 		pluginData.setAgentPluginExecEnabled(agentId, toExecToolId(integration.pluginId), newEnabled);
 	}
@@ -529,6 +537,10 @@ const autoDiscoveredIntegrations = $derived.by<AutoIntegrationDisplay[]>(() => {
 
 async function toggleAutoIntegration(pluginId: string, displayName: string, newEnabled: boolean) {
 	if (newEnabled) {
+		// Unsandboxed main-thread `app` access bypasses per-provider privacy rules — warn
+		// before seeding anything so a cancel leaves no skill and no exec tool enabled.
+		if (!(await confirmEnableIntegrationPrivacy(plugin.app, pluginData, displayName))) return;
+
 		// Seed the integration's skill on demand (prewritten if bundled, else an
 		// introspect-first template), then enable it alongside the exec tool. Re-discover
 		// so the new skill enters the cache and the row re-renders as a curated Plugin Skill.
@@ -988,7 +1000,7 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
             <Toggle
               checked={ext.enabled && pluginAvailable}
               disabled={!pluginAvailable}
-              onchange={() => toggleSkill(ext.id, !ext.enabled)}
+              onchange={() => void toggleSkill(ext.id, !ext.enabled)}
             />
           </SettingItem>
         {/each}
@@ -1030,11 +1042,18 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
               tooltip={`Open ${ext.displayName} skill note`}
               onClick={() => openSkillNote(ext.id)}
             />
-            <Toggle
-              checked={ext.enabled && pluginAvailable}
-              disabled={!pluginAvailable}
-              onchange={() => toggleSkill(ext.id, !ext.enabled)}
-            />
+            <!-- Keyed on the enabled state: toggleSkill can reject asynchronously (the
+                 privacy-warning modal's Cancel) when this row grants an exec tool, and
+                 Toggle's `checked` is $bindable — a one-way prop only seeds its initial
+                 value, so without a remount the switch would stay visually flipped after
+                 a cancel even though the underlying skill/exec state reverted. -->
+            {#key ext.enabled && pluginAvailable}
+              <Toggle
+                checked={ext.enabled && pluginAvailable}
+                disabled={!pluginAvailable}
+                onchange={() => void toggleSkill(ext.id, !ext.enabled)}
+              />
+            {/key}
           </SettingItem>
         {/each}
 
@@ -1052,10 +1071,20 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
                 <Badge label="API scripting" tone="muted" />
               {/if}
             {/snippet}
-            <Toggle
-              checked={integ.execEnabled}
-              onchange={(next) => void toggleAutoIntegration(integ.pluginId, integ.displayName, next)}
-            />
+            <!--
+              Toggle's `checked` is $bindable, so a plain one-way `checked={...}` only seeds
+              its initial value — the child's own state never re-syncs afterward. That's fine
+              for a synchronous onchange, but toggleAutoIntegration can reject asynchronously
+              (the privacy-warning modal's Cancel), which would otherwise leave the switch
+              visually on while the underlying pluginExecTools value is back to false. Keying
+              on execEnabled forces a remount so the toggle re-reads the real state.
+            -->
+            {#key integ.execEnabled}
+              <Toggle
+                checked={integ.execEnabled}
+                onchange={(next) => void toggleAutoIntegration(integ.pluginId, integ.displayName, next)}
+              />
+            {/key}
           </SettingItem>
         {/each}
       </SettingGroup>
@@ -1127,7 +1156,12 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
                 tooltip={`Open ${ext.displayName} skill note`}
                 onClick={() => openSkillNote(ext.id)}
               />
-              <Toggle checked={ext.enabled} onchange={() => toggleSkill(ext.id, !ext.enabled)} />
+              <!-- See the pluginSkills row above for why this is keyed: toggleSkill can
+                   reject asynchronously if a hand-edited custom skill carries a
+                   linkedPluginId (metadata.category overridden to "custom"). -->
+              {#key ext.enabled}
+                <Toggle checked={ext.enabled} onchange={() => void toggleSkill(ext.id, !ext.enabled)} />
+              {/key}
             {/snippet}
           </ManagedEntityItem>
         {/each}

--- a/src/components/modal/IntegrationPrivacyWarningModal.svelte
+++ b/src/components/modal/IntegrationPrivacyWarningModal.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+import Button from "../ui/Button.svelte";
+import Toggle from "../ui/Toggle.svelte";
+
+interface Props {
+	displayName: string;
+	onConfirm: (dontAskAgain: boolean) => void;
+	onCancel: () => void;
+}
+
+let { displayName, onConfirm, onCancel }: Props = $props();
+
+let dontAskAgain = $state(false);
+</script>
+
+<div class="modal-title">Privacy Warning</div>
+<div class="modal-content">
+  <p>
+    Enabling <strong>{displayName}</strong> gives the agent a tool that runs JavaScript against
+    this plugin's API with full vault access on the main thread.
+  </p>
+  <p>
+    <strong>Your privacy rules do not apply to this tool.</strong> Notes you've marked private for
+    the current provider can still be read or written through it, unlike <code>search_notes</code>,
+    <code>read_content</code>, and <code>manage_notes</code>, which respect those rules.
+  </p>
+</div>
+
+<label class="s2b-dont-ask-again">
+  <Toggle checked={dontAskAgain} onchange={(checked) => (dontAskAgain = checked)} />
+  <span>Don't ask again for any integration</span>
+</label>
+
+<div class="modal-button-container">
+  <Button buttonText="Cancel" onClick={onCancel} />
+  <Button buttonText="Enable anyway" styles="mod-warning" onClick={() => onConfirm(dontAskAgain)} />
+</div>
+
+<style>
+  .s2b-dont-ask-again {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 12px;
+    cursor: pointer;
+  }
+
+  .s2b-dont-ask-again span {
+    color: var(--text-muted);
+    font-size: var(--font-ui-small);
+  }
+</style>

--- a/src/components/modal/IntegrationPrivacyWarningModal.ts
+++ b/src/components/modal/IntegrationPrivacyWarningModal.ts
@@ -1,0 +1,61 @@
+import { type App, Modal } from "obsidian";
+import { mount } from "svelte";
+import IntegrationPrivacyWarningComponent from "./IntegrationPrivacyWarningModal.svelte";
+
+export interface IntegrationPrivacyWarningResult {
+	confirmed: boolean;
+	dontAskAgain: boolean;
+}
+
+/**
+ * Warns the user, before enabling a plugin integration's `exec_<plugin>` tool, that the
+ * integration runs unsandboxed JavaScript with full `app` access on the main thread — it does
+ * not go through `shouldBlockFile`, so it can read or write any note regardless of the vault's
+ * per-provider privacy rules (see docs on `createPluginApiExecTool`). Suppressible via a
+ * "Don't ask again" checkbox; the caller is responsible for persisting that choice.
+ */
+export class IntegrationPrivacyWarningModal extends Modal {
+	component!: IntegrationPrivacyWarningComponent;
+	private resolvePromise!: (value: IntegrationPrivacyWarningResult) => void;
+	private resolved = false;
+
+	constructor(
+		app: App,
+		private readonly displayName: string,
+	) {
+		super(app);
+	}
+
+	async prompt(): Promise<IntegrationPrivacyWarningResult> {
+		return new Promise((resolve) => {
+			this.resolvePromise = resolve;
+			this.open();
+		});
+	}
+
+	onOpen() {
+		this.component = mount(IntegrationPrivacyWarningComponent, {
+			target: this.contentEl,
+			props: {
+				displayName: this.displayName,
+				onConfirm: (dontAskAgain: boolean) => {
+					this.resolved = true;
+					this.resolvePromise({ confirmed: true, dontAskAgain });
+					this.close();
+				},
+				onCancel: () => {
+					this.resolved = true;
+					this.resolvePromise({ confirmed: false, dontAskAgain: false });
+					this.close();
+				},
+			},
+		});
+	}
+
+	onClose() {
+		if (!this.resolved) {
+			this.resolvePromise?.({ confirmed: false, dontAskAgain: false });
+		}
+		this.contentEl.empty();
+	}
+}

--- a/src/skills/integrations/dataview/SKILL.md
+++ b/src/skills/integrations/dataview/SKILL.md
@@ -107,6 +107,10 @@ return byStatus;
   the plugin can. Keep snippets small and focused.
 - **Awaited work times out.** Long-running or hanging promises are cut off; a runaway synchronous
   loop cannot be preempted, so avoid unbounded loops.
+- **Prefer `read_content` / `manage_notes` / `search_notes` for plain note reads and writes.**
+  Those tools respect the user's privacy rules — they skip or redact notes marked private for the
+  current provider. `api` and `app` do not. Reach for `exec_dataview` only for query/aggregation
+  logic Dataview's API uniquely provides.
 - **Report honestly.** If the API can't do what the user asked, say so rather than fabricating a method.
 
 ## Displaying Lists/Tables

--- a/src/skills/integrations/tasknotes/SKILL.md
+++ b/src/skills/integrations/tasknotes/SKILL.md
@@ -13,15 +13,24 @@ metadata:
 
 This skill works with tasks managed by the [TaskNotes](https://github.com/callumalpass/tasknotes) plugin. Each task is a Markdown file with YAML frontmatter stored in a configurable folder (default: `TaskNotes/Tasks/`).
 
-**Operate on tasks through the plugin's API, not by editing files.** When this skill is enabled and the integration is approved you have an `exec_tasknotes` tool that runs JavaScript against the TaskNotes `api` object (in scope as `api`) on the main thread. The API is the correct interface: it manages ids, dates, recurrence, and completion for you, and validates input. Prefer it over hand-editing frontmatter for every read, query, create, update, and complete.
+**Operate on task mutations through the plugin's API, not by hand-editing frontmatter.** When this skill is enabled and the integration is approved you have an `exec_tasknotes` tool that runs JavaScript against the TaskNotes `api` object (in scope as `api`) on the main thread. The API is the correct interface for create/update/complete: it manages ids, dates, recurrence, and completion for you, and validates input.
 
 - `api` is the TaskNotes plugin API (`apiVersion === 1`); `app` is the Obsidian app.
 - Tasks are addressed by their file `path`.
 - Init happens at layout-ready. If a call fails early, guard with `if (!api.lifecycle.isReady()) await api.lifecycle.ready()` first.
-- Not sandboxed; awaited work times out. Keep snippets read-only unless the user asked to modify data.
+- **Not sandboxed, and this includes reads.** `api` runs on the main thread with full `app`
+  access, the same as raw `app.vault` calls — `api.getTask`, `api.listTasks`, and
+  `api.query.tasks` read task file content directly and do **not** respect the user's per-provider
+  privacy rules the way `search_notes` / `read_content` / `grep_notes` do. Awaited work times out.
+  Keep snippets read-only unless the user asked to modify data.
 - If unsure of the surface at runtime, introspect: `return Object.keys(api)` or `return api.capabilities`.
 
 ## Reading & Querying
+
+**Prefer `search_notes` / `grep_notes` / `read_content` to find and read individual tasks** — they
+respect the user's privacy rules for restricted notes, `api` reads do not. Reach for
+`api.getTask` / `api.listTasks` only when you specifically need TaskNotes' parsed, typed fields
+(status/priority/recurrence resolved from frontmatter) rather than raw content:
 
 ```javascript
 // One task by path
@@ -31,7 +40,11 @@ return await api.getTask("TaskNotes/Tasks/Buy groceries.md");
 return await api.listTasks();
 ```
 
-For structured queries with predicates, sorting, grouping, and pagination use `api.query.tasks(query)`:
+For structured queries with predicates, sorting, grouping, and pagination across many tasks —
+something `search_notes`/`grep_notes` can't express — use `api.query.tasks(query)`. This is the
+one case where `api` is worth its privacy trade-off: filtering/aggregating by status, priority, or
+due date across the whole task folder in one call. Mention to the user that results may include
+tasks they've marked private if they ask, since this path doesn't filter them:
 
 ```javascript
 // Open tasks due within a week, soonest first
@@ -164,7 +177,7 @@ The `api` reads/writes these; this is for understanding a task file's shape, not
 
 ## Tips & Constraints
 
-- Prefer the `api` for all reads and mutations — it validates input and manages plugin-owned fields. Only fall back to `search_notes`/`read_content`/`manage_notes` if the `exec_tasknotes` tool is not available (integration off), and say so.
+- Prefer `search_notes`/`read_content`/`grep_notes` to find and read individual tasks — they respect the user's privacy rules; `api` reads do not. Prefer the `api` for mutations (create/update/complete) and for cross-task queries/aggregation `search_notes` can't express — it validates input and manages plugin-owned fields. If the `exec_tasknotes` tool is not available (integration off), do everything through `search_notes`/`read_content`/`manage_notes` and say so.
 - Read the user's configured statuses/priorities via `api.catalog.*` before filtering on values that may have been customized.
 - Task folder path is configurable; the `api` resolves paths for you, so you rarely need to know it.
 - Tasks vs TaskNotes: if each task is its own file with YAML frontmatter, this is the right skill; if the user's tasks are `- [ ]` checkbox lines inside notes, use the **tasks** skill instead.

--- a/src/skills/templates/pluginApiScripting.ts
+++ b/src/skills/templates/pluginApiScripting.ts
@@ -81,8 +81,12 @@ a string — read it, adjust, and retry with a corrected call.
   plugin can. Keep snippets small and focused.
 - **Awaited work times out.** Long-running or hanging promises are cut off; a runaway synchronous
   loop cannot be preempted, so avoid unbounded loops.
-- **Prefer existing tools when they fit.** For reading/writing notes use \`read_content\` /
-  \`manage_notes\`; reach for \`${execToolName}\` only for logic ${displayName}'s API uniquely provides.
+- **Prefer existing tools when they fit.** \`read_content\`, \`manage_notes\`, and \`search_notes\`
+  respect the user's privacy rules — they skip or redact notes marked private for the current
+  provider. \`api\` and \`app\` do not: this is unsandboxed main-thread access and a call can read
+  or write any note regardless of privacy settings. Use \`read_content\` / \`manage_notes\` /
+  \`search_notes\` for ordinary note reads and writes; reach for \`${execToolName}\` only for logic
+  ${displayName}'s API uniquely provides.
 - **Report honestly.** If introspection shows the API can't do what the user asked, say so rather
   than fabricating a method.
 

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -567,6 +567,7 @@ export const DEFAULT_SETTINGS: PluginData = {
 	dismissedRecommendations: [],
 	thinkingProcessExpanded: true,
 	showActiveAgentsInStatusBar: true,
+	suppressIntegrationPrivacyWarning: false,
 
 	// Debugging & telemetry
 	enableLangSmith: false,
@@ -1426,6 +1427,14 @@ export class PluginDataStore {
 	}
 	set showActiveAgentsInStatusBar(val: boolean) {
 		this.#data.showActiveAgentsInStatusBar = val;
+		this.saveSettings();
+	}
+
+	get suppressIntegrationPrivacyWarning() {
+		return this.#data.suppressIntegrationPrivacyWarning ?? false;
+	}
+	set suppressIntegrationPrivacyWarning(val: boolean) {
+		this.#data.suppressIntegrationPrivacyWarning = val;
 		this.saveSettings();
 	}
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -523,6 +523,13 @@ export interface PluginData {
 	 */
 	showActiveAgentsInStatusBar: boolean;
 
+	/**
+	 * Suppresses the warning shown before enabling a plugin integration's `exec_<plugin>`
+	 * tool (unsandboxed main-thread `app` access that bypasses per-provider privacy rules).
+	 * Global across all integrations. Off by default; reset from Developer settings.
+	 */
+	suppressIntegrationPrivacyWarning: boolean;
+
 	// ============================================================================
 	// Web Search
 	// ============================================================================

--- a/src/views/settings/DeveloperSettings.svelte
+++ b/src/views/settings/DeveloperSettings.svelte
@@ -42,6 +42,16 @@ function restoreDismissedRecommendations() {
 	);
 }
 
+function restoreIntegrationPrivacyWarning() {
+	const wasSuppressed = pluginData.suppressIntegrationPrivacyWarning;
+	pluginData.suppressIntegrationPrivacyWarning = false;
+	new Notice(
+		wasSuppressed
+			? "Integration privacy warning restored — it will show again next time an integration is enabled."
+			: "Integration privacy warning was not suppressed.",
+	);
+}
+
 function getLangSmithCheckIcon(): string {
 	if (langSmithCheckState === "success") return "check-circle";
 	if (langSmithCheckState === "error") return "x-circle";
@@ -156,6 +166,17 @@ async function handleCheckLangSmithConnection() {
       buttonText="Restore"
       iconId="rotate-ccw"
       onClick={restoreDismissedRecommendations}
+    />
+  </SettingItem>
+
+  <SettingItem
+    name="Restore integration privacy warning"
+    desc="Undo 'Don't ask again' on the warning shown before enabling a plugin integration's code-exec tool (it bypasses per-provider privacy rules)."
+  >
+    <Button
+      buttonText="Restore"
+      iconId="rotate-ccw"
+      onClick={restoreIntegrationPrivacyWarning}
     />
   </SettingItem>
 </SettingGroup>

--- a/test/agent/confirmEnableIntegrationPrivacy.test.ts
+++ b/test/agent/confirmEnableIntegrationPrivacy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { confirmEnableIntegrationPrivacy } from "../../src/agent/integrations/pluginIntegrations";
+
+// Only the suppression short-circuit is unit-tested here. The "show the modal and resolve
+// on Cancel/Confirm/close" path is UI plumbing (Modal + Svelte mount), same shape as the
+// existing PrivacyWarningModal, which likewise has no unit test at this layer — see the
+// manual verification steps in the integration-privacy-warning plan instead.
+describe("confirmEnableIntegrationPrivacy", () => {
+	it("returns true without prompting when the warning is suppressed", async () => {
+		const pluginData = { suppressIntegrationPrivacyWarning: true };
+		const app = {} as never;
+
+		const confirmed = await confirmEnableIntegrationPrivacy(app, pluginData, "Dataview");
+
+		expect(confirmed).toBe(true);
+	});
+
+	it("does not flip the suppression flag when already suppressed", async () => {
+		const pluginData = { suppressIntegrationPrivacyWarning: true };
+		const app = {} as never;
+
+		await confirmEnableIntegrationPrivacy(app, pluginData, "Dataview");
+
+		// Still true — the short-circuit path never touches the setter.
+		expect(pluginData.suppressIntegrationPrivacyWarning).toBe(true);
+	});
+});

--- a/test/agent/searchNotes.test.ts
+++ b/test/agent/searchNotes.test.ts
@@ -77,12 +77,12 @@ interface SearchToolResultPayload {
 	filter?: { pathPrefixes?: string[]; tags?: string[] };
 	totalResults: number;
 	returnedResults: number;
+	skippedPrivateFiles: number;
 	results: Array<{
 		rank: number;
 		name: string;
 		path?: string;
 		score?: number;
-		privacyRestricted: boolean;
 		frontmatter?: Record<string, unknown>;
 		tags?: string[];
 		matchExplanation?: { source: string; text: string; heading?: string };
@@ -384,7 +384,6 @@ describe("performSearch lexical startup behavior", () => {
 				name: "recent-one",
 				path: "Notes/recent-one.md",
 				score: 4.5,
-				privacyRestricted: false,
 				frontmatter: { aliases: ["One"] },
 				tags: ["#one"],
 				matchBadges: ["recent"],
@@ -394,7 +393,6 @@ describe("performSearch lexical startup behavior", () => {
 				name: "recent-two",
 				path: "Notes/recent-two.md",
 				score: 3.75,
-				privacyRestricted: false,
 				tags: ["#two"],
 				matchBadges: ["recent"],
 			},
@@ -427,7 +425,6 @@ describe("performSearch lexical startup behavior", () => {
 				name: "recent-diagram",
 				path: "Assets/recent-diagram.canvas",
 				score: 4.5,
-				privacyRestricted: false,
 				matchBadges: ["recent"],
 			},
 		]);
@@ -673,7 +670,6 @@ describe("performSearch lexical startup behavior", () => {
 				name: "orbital-index",
 				path: "Notes/orbital-index.md",
 				score: 12.345,
-				privacyRestricted: false,
 				frontmatter: { aliases: ["Rocket Science"] },
 				tags: ["#space", "#orbital-index"],
 				matchBadges: ["tag", "content"],
@@ -686,7 +682,7 @@ describe("performSearch lexical startup behavior", () => {
 		]);
 	});
 
-	it("keeps privacy-restricted results visible while redacting content snippets", async () => {
+	it("drops privacy-restricted results entirely instead of exposing their path/name", async () => {
 		mockLexicalSearch.mockResolvedValue([
 			{
 				path: "Private/launch-plan.md",
@@ -713,32 +709,42 @@ describe("performSearch lexical startup behavior", () => {
 		const result = await tool.invoke({ query: "plan" });
 		const parsed: SearchToolResultPayload = JSON.parse(String(result));
 
-		expect(parsed.totalResults).toBe(2);
-		expect(parsed.returnedResults).toBe(2);
+		expect(parsed.totalResults).toBe(1);
+		expect(parsed.returnedResults).toBe(1);
+		expect(parsed.skippedPrivateFiles).toBe(1);
 		expect(parsed.results).toEqual([
 			{
 				rank: 1,
-				name: "launch-plan",
-				path: "Private/launch-plan.md",
-				score: 30,
-				privacyRestricted: true,
-				frontmatter: { owner: "red-team" },
-				tags: ["#secret"],
-				matchBadges: ["title"],
-				matchExplanation: undefined,
-			},
-			{
-				rank: 2,
 				name: "public-plan",
 				path: "Notes/public-plan.md",
 				score: 20,
-				privacyRestricted: false,
 				frontmatter: undefined,
 				tags: ["#public"],
 				matchBadges: undefined,
 				matchExplanation: undefined,
 			},
 		]);
+		expect(parsed.results.some((entry) => entry.name === "launch-plan" || entry.path?.includes("Private"))).toBe(
+			false,
+		);
+	});
+
+	it("fills the result page from beyond the raw limit when leading results are privacy-restricted", async () => {
+		mockToolSettings.showPath = undefined;
+		mockLexicalSearch.mockResolvedValue([
+			{ path: "Private/one.md", name: "private-one", score: 30 },
+			{ path: "Private/two.md", name: "private-two", score: 29 },
+			{ path: "Notes/visible-one.md", name: "visible-one", score: 28 },
+			{ path: "Notes/visible-two.md", name: "visible-two", score: 27 },
+		]);
+		mockShouldBlockFile.mockImplementation((path: string) => path.startsWith("Private/"));
+
+		const tool = createSearchNotesTool({} as App);
+		const result = await tool.invoke({ query: "plan" });
+		const parsed: SearchToolResultPayload = JSON.parse(String(result));
+
+		expect(parsed.skippedPrivateFiles).toBe(2);
+		expect(parsed.results.map((entry) => entry.name)).toEqual(["visible-one", "visible-two"]);
 	});
 
 	it("honors per-tool visibility settings for optional search fields", async () => {
@@ -771,7 +777,6 @@ describe("performSearch lexical startup behavior", () => {
 			rank: 1,
 			name: "orbital-index",
 			score: 12.345,
-			privacyRestricted: false,
 			frontmatter: { aliases: ["Rocket Science"] },
 		});
 	});


### PR DESCRIPTION
## Summary

Two related privacy fixes found while auditing how tools handle privacy-restricted notes for #380.

**1. `search_notes` path/name leak (closes #380)**
- `search_notes` redacted content-derived fields (`matchExplanation`/`matchBadges`) for privacy-restricted hits, but still returned `path`/`name` unconditionally — the only tool that leaked file identity for restricted files, unlike `list_directory`/`grep_notes` which skip them entirely
- Now filters restricted results out entirely before the result-limit slice (so the returned page still fills up from lower-ranked visible results) and reports a `skippedPrivateFiles` count, matching `list_directory`'s existing pattern
- Updated the chat UI (`ToolCallsSection.svelte`) to show a "skipped private: N" chip instead of the now-unreachable per-result "private" badge

**2. Plugin exec-tool privacy bypass — warn the human, nudge the model**
- Enabling a plugin integration's `exec_<plugin>` tool grants unsandboxed main-thread `app`/`api` access that bypasses `shouldBlockFile` entirely — none of the vault's per-provider privacy rules apply to it, unlike `search_notes`/`read_content`/`manage_notes`. That trade-off was previously silent.
- Add `IntegrationPrivacyWarningModal`, shown before granting exec-tool access, with a suppressible "don't ask again" (global `suppressIntegrationPrivacyWarning` flag, resettable from Developer settings). Wired into both places an integration can be enabled: `toggleAutoIntegration` (a brand-new auto-discovered plugin) and `toggleSkill` (re-enabling any already-known integration skill — Dataview, Tasks, TaskNotes, or a previously-seeded plugin), since the latter is the far more common path and had no gate at all.
- Fixed a related `Toggle` desync this surfaced: `Toggle`'s `checked` is `$bindable`, so a plain one-way `checked={...}` only seeds its initial value. Once `onchange` could reject asynchronously (Cancel on the new modal), the switch stayed visually on after a cancelled enable even though the underlying state reverted. Keyed the three affected `Toggle` instances on their enabled value to force a resync.
- Strengthened the generic per-plugin skill template and the `dataview` skill to prefer `read_content`/`manage_notes`/`search_notes` for plain note reads, and fixed `tasknotes/SKILL.md`, which told the agent to prefer `api.getTask`/`listTasks`/`query.tasks` over those tools — backwards for privacy, since those api reads bypass `shouldBlockFile` the same way raw `app` access does.

## Test plan
- [x] `bun run test` — full suite passes (999/999)
- [x] `bun run check` — no new errors (pre-existing unrelated `GraphCanvas.svelte` errors confirmed present on `dev` too)
- [x] `bun run lint` — no new errors introduced
- [x] Manual, live test vault: verified the warning modal fires on both enable paths, Cancel leaves nothing enabled and no skill seeded, "Enable anyway" persists correctly and seeds the skill with the strengthened privacy bullet, the `Toggle` desync fix holds after Cancel, and disabling an integration never triggers the warning

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._