### PR TITLE
fix(transport): handle cross-realm AbortSignal

### DIFF
--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -833,14 +833,6 @@ export class Agent {
 		// context (run()-scoped, concurrency-safe). Without this the fetch issued
 		// deep inside the stream would read whichever context another concurrent
 		// run last set.
-		const stream = bindAsyncIterableToTransportContext(
-			await agent.stream(streamInput, {
-				...invokeConfig,
-				streamMode: ["messages", "tools", "values"] as const,
-			}),
-			transportContext,
-		);
-
 		let rawResult: unknown;
 		// Track tool calls in progress to correlate start/end events
 		const pendingToolCalls = new Map<string, { name: string; input: unknown }>();
@@ -863,6 +855,15 @@ export class Agent {
 		// Running text accumulator for the current AI message (reset on new aiMessageId).
 		let preambleAccumulator = "";
 		try {
+			const stream = bindAsyncIterableToTransportContext(
+				await runWithAiTransportContext(transportContext, () =>
+					agent.stream(streamInput, {
+						...invokeConfig,
+						streamMode: ["messages", "tools", "values"] as const,
+					}),
+				),
+				transportContext,
+			);
 			for await (const chunk of stream) {
 				// Check if aborted before processing
 				if (options.signal?.aborted) {
@@ -1138,14 +1139,6 @@ export class Agent {
 		const transportLabel = `agent.editFromCheckpoint:${runId}`;
 		const transportContext = createAiTransportContext("default", transportLabel);
 
-		const stream = bindAsyncIterableToTransportContext(
-			await agent.stream(input, {
-				...invokeConfig,
-				streamMode: ["messages", "tools", "values"] as const,
-			}),
-			transportContext,
-		);
-
 		let rawResult: unknown;
 		const pendingToolCalls = new Map<string, { name: string; input: unknown }>();
 		const taskCallStack: string[] = [];
@@ -1156,6 +1149,15 @@ export class Agent {
 		const toolCallPreambles = new Map<string, string>();
 		let preambleAccumulator = "";
 		try {
+			const stream = bindAsyncIterableToTransportContext(
+				await runWithAiTransportContext(transportContext, () =>
+					agent.stream(input, {
+						...invokeConfig,
+						streamMode: ["messages", "tools", "values"] as const,
+					}),
+				),
+				transportContext,
+			);
 			for await (const chunk of stream) {
 				if (options.signal?.aborted) {
 					Logger.debug("agent.editFromCheckpoint.aborted", { runId, threadId });
@@ -1398,14 +1400,6 @@ export class Agent {
 		const transportLabel = `agent.regenerateFromCheckpoint:${runId}`;
 		const transportContext = createAiTransportContext("default", transportLabel);
 
-		const stream = bindAsyncIterableToTransportContext(
-			await agent.stream(input, {
-				...invokeConfig,
-				streamMode: ["messages", "tools", "values"] as const,
-			}),
-			transportContext,
-		);
-
 		let rawResult: unknown;
 		const pendingToolCalls = new Map<string, { name: string; input: unknown }>();
 		const taskCallStack: string[] = [];
@@ -1416,6 +1410,15 @@ export class Agent {
 		const toolCallPreambles = new Map<string, string>();
 		let preambleAccumulator = "";
 		try {
+			const stream = bindAsyncIterableToTransportContext(
+				await runWithAiTransportContext(transportContext, () =>
+					agent.stream(input, {
+						...invokeConfig,
+						streamMode: ["messages", "tools", "values"] as const,
+					}),
+				),
+				transportContext,
+			);
 			for await (const chunk of stream) {
 				if (options.signal?.aborted) {
 					Logger.debug("agent.regenerateFromCheckpoint.aborted", { runId, threadId });

--- a/src/components/chat/toolOutputRenderModel.ts
+++ b/src/components/chat/toolOutputRenderModel.ts
@@ -141,6 +141,8 @@ export type ToolOutputRenderModel =
 	  };
 
 const JSON_FENCE = /^```(?:json)?\s*([\s\S]*?)\s*```$/i;
+export const MAX_RENDERED_TOOL_OUTPUT_CHARS = 20_000;
+const UI_TRUNCATION_MARKER = "[UI preview truncated:";
 const MARKDOWN_PATTERNS = [
 	/^#{1,6}\s/m,
 	/^[-*+]\s/m,
@@ -194,7 +196,8 @@ function buildStringOutputRenderModel(
 	output: string,
 	input?: Record<string, unknown> | null,
 ): ToolOutputRenderModel {
-	const trimmed = output.trim();
+	const renderOutput = truncateToolOutputForRendering(output);
+	const trimmed = renderOutput.trim();
 	if (!trimmed) return { kind: "empty", rawText: output };
 
 	const parsed = parseJsonString(trimmed);
@@ -210,6 +213,13 @@ function buildStringOutputRenderModel(
 	}
 
 	return { kind: "markdown", markdown: trimmed, rawText: trimmed };
+}
+
+function truncateToolOutputForRendering(output: string): string {
+	if (output.length <= MAX_RENDERED_TOOL_OUTPUT_CHARS) return output;
+
+	const omitted = output.length - MAX_RENDERED_TOOL_OUTPUT_CHARS;
+	return `${output.slice(0, MAX_RENDERED_TOOL_OUTPUT_CHARS)}\n\n${UI_TRUNCATION_MARKER} ${omitted} characters omitted]`;
 }
 
 function buildSpecializedStringModel(
@@ -441,7 +451,7 @@ function parseReadContentPayload(value: string): ReadContentPayload | undefined 
 			label: pdfMatch[2],
 			content: pdfMatch[3],
 			analysisLabel,
-			truncated: pdfMatch[3].includes("[Content truncated at"),
+			truncated: isContentTruncated(pdfMatch[3]),
 		};
 	}
 
@@ -453,7 +463,7 @@ function parseReadContentPayload(value: string): ReadContentPayload | undefined 
 			label: excalidrawMatch[2],
 			content: excalidrawMatch[3],
 			analysisLabel,
-			truncated: excalidrawMatch[3].includes("[Content truncated at"),
+			truncated: isContentTruncated(excalidrawMatch[3]),
 		};
 	}
 
@@ -465,11 +475,15 @@ function parseReadContentPayload(value: string): ReadContentPayload | undefined 
 			label: fileMatch[2],
 			content: fileMatch[3],
 			analysisLabel,
-			truncated: fileMatch[3].includes("[Content truncated at"),
+			truncated: isContentTruncated(fileMatch[3]),
 		};
 	}
 
 	return undefined;
+}
+
+function isContentTruncated(content: string): boolean {
+	return content.includes("[Content truncated at") || content.includes(UI_TRUNCATION_MARKER);
 }
 
 function buildExecuteJavaScriptPayload(

--- a/src/lib/aiTransport.ts
+++ b/src/lib/aiTransport.ts
@@ -68,7 +68,7 @@ export function runWithAiTransportContext<T>(context: AiTransportContext, fn: ()
  * scope; a plain run() around the generator body would lose the context on
  * every yield. Binding each pull instead keeps the context active precisely
  * when the underlying LangChain stream resumes (and issues its fetch, which
- * reads the context via getCurrentMode) — isolated per run even under
+ * reads the context via getCurrentMode), isolated per run even under
  * concurrent streams. See src/lib/aiTransport ALS notes.
  */
 export function bindAsyncIterableToTransportContext<T>(
@@ -120,18 +120,10 @@ async function getElectronNetFetch(): Promise<typeof fetch | null> {
 				net?: { fetch?: typeof fetch };
 				remote?: { net?: { fetch?: typeof fetch } };
 			};
-
-			const remoteNet = electron.remote?.net;
-			const remoteFetch = remoteNet?.fetch;
-			if (typeof remoteFetch === "function") {
-				Logger.debug("aiTransport.electron_fetch_resolved", { source: "electron.remote.net.fetch" });
-				return remoteFetch.bind(remoteNet);
-			}
-
-			const electronFetch = electron.net?.fetch;
-			if (typeof electronFetch === "function") {
-				Logger.debug("aiTransport.electron_fetch_resolved", { source: "electron.net.fetch" });
-				return electronFetch.bind(electron.net);
+			const electronNet = electron.remote?.net ?? electron.net;
+			if (typeof electronNet?.fetch === "function") {
+				Logger.debug("aiTransport.electron_fetch_resolved");
+				return electronNet.fetch.bind(electronNet);
 			}
 		} catch {
 			// Try the next resolution path.
@@ -143,26 +135,9 @@ async function getElectronNetFetch(): Promise<typeof fetch | null> {
 			net?: { fetch?: typeof fetch };
 			remote?: { net?: { fetch?: typeof fetch } };
 		};
-
-		const remoteNet = electron.remote?.net;
-		const remoteFetch = remoteNet?.fetch;
-		if (typeof remoteFetch === "function") {
-			Logger.debug("aiTransport.electron_fetch_resolved", {
-				source: "imported electron.remote.net.fetch",
-			});
-			return remoteFetch.bind(remoteNet);
-		}
-
-		const electronFetch = electron.net?.fetch;
-		if (typeof electronFetch === "function") {
-			Logger.debug("aiTransport.electron_fetch_resolved", { source: "imported electron.net.fetch" });
-			return electronFetch.bind(electron.net);
-		}
-
-		Logger.debug("aiTransport.electron_fetch_unavailable");
-		return null;
+		const electronNet = electron.remote?.net ?? electron.net;
+		return typeof electronNet?.fetch === "function" ? electronNet.fetch.bind(electronNet) : null;
 	} catch {
-		Logger.debug("aiTransport.electron_fetch_unavailable");
 		return null;
 	}
 }
@@ -172,76 +147,26 @@ function cloneHeaders(headers: HeadersInit | undefined): Headers {
 }
 
 function toHeaderRecord(headers: HeadersInit | undefined): Record<string, string> {
-	const result: Record<string, string> = {};
-	new Headers(headers).forEach((value, key) => {
-		result[key] = value;
-	});
-	return result;
+	return Object.fromEntries(new Headers(headers).entries());
 }
 
-function normalizeResponseHeaders(headers: unknown): Headers {
-	if (headers instanceof Headers) {
-		return headers;
-	}
+/** Remove renderer-owned objects before RequestInit crosses Electron's remote bridge. */
+export function normalizeElectronNetRequestInit(init: RequestInit): RequestInit {
+	if (init.signal == null) return init;
 
-	try {
-		return new Headers(headers as HeadersInit);
-	} catch {
-		const normalized = new Headers();
-
-		if (headers && typeof headers === "object") {
-			const maybeIterable = headers as {
-				forEach?: (callback: (value: string, key: string) => void) => void;
-				raw?: () => Record<string, string | string[]>;
-				toJSON?: () => Record<string, string>;
-			};
-
-			if (typeof maybeIterable.forEach === "function") {
-				maybeIterable.forEach((value, key) => normalized.append(key, value));
-				return normalized;
-			}
-
-			if (typeof maybeIterable.raw === "function") {
-				const raw = maybeIterable.raw();
-				for (const [key, value] of Object.entries(raw)) {
-					if (Array.isArray(value)) {
-						for (const entry of value) normalized.append(key, entry);
-					} else {
-						normalized.append(key, value);
-					}
-				}
-				return normalized;
-			}
-
-			if (typeof maybeIterable.toJSON === "function") {
-				const json = maybeIterable.toJSON();
-				for (const [key, value] of Object.entries(json)) {
-					normalized.append(key, value);
-				}
-				return normalized;
-			}
-
-			for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
-				if (typeof value === "string") {
-					normalized.append(key, value);
-				}
-			}
-		}
-
-		return normalized;
-	}
+	const { signal: _rendererSignal, ...electronInit } = init;
+	return electronInit;
 }
 
 function normalizeFetchLikeResponse(response: Response): Response {
 	try {
 		Object.defineProperty(response, "headers", {
-			value: normalizeResponseHeaders((response as Response & { headers: unknown }).headers),
+			value: new Headers(response.headers as unknown as HeadersInit),
 			configurable: true,
 		});
 	} catch {
-		// If the runtime makes headers non-configurable, fall back to the original response.
+		// Keep the original headers if this runtime already exposes compatible ones.
 	}
-
 	return response;
 }
 
@@ -465,25 +390,28 @@ function isTransportFailure(error: unknown): boolean {
 
 async function performPrimaryFetch(normalized: NormalizedRequest): Promise<Response> {
 	const electronFetch = await getElectronNetFetch();
-	const primaryFetch = electronFetch ?? globalThis.fetch.bind(globalThis);
+	const rendererSignal = normalized.init.signal;
+	rendererSignal?.throwIfAborted();
 	const parsedBody = parseRequestBody(normalized.init.body);
 	const normalizedBody =
 		parsedBody && normalized.url.includes("/chat/completions")
 			? normalizeChatCompletionMessages(parsedBody)
 			: undefined;
 	const requestBody = normalizedBody ? stringifyRequestBody(normalizedBody) : normalized.init.body;
-	const requestInit =
-		electronFetch && normalized.init.headers
-			? {
+	const response = await (electronFetch ?? globalThis.fetch.bind(globalThis))(
+		normalized.url,
+		electronFetch
+			? normalizeElectronNetRequestInit({
 					...normalized.init,
 					body: requestBody,
 					headers: toHeaderRecord(normalized.init.headers),
-				}
-			: {
-					...normalized.init,
-					body: requestBody,
-				};
-	const response = await primaryFetch(normalized.url, requestInit);
+				})
+			: { ...normalized.init, body: requestBody },
+	);
+	if (electronFetch && rendererSignal?.aborted) {
+		await response.body?.cancel().catch(() => undefined);
+		rendererSignal.throwIfAborted();
+	}
 	if (!response.ok && normalized.url.includes("/chat/completions")) {
 		let responseText: string | undefined;
 		try {
@@ -560,10 +488,10 @@ export function createAiProviderFetch(providerId: string): typeof fetch {
 }
 
 /**
- * Fetch implementation that always routes through Obsidian's buffered `requestUrl`
- * (never Electron's `net.fetch`). Subagent models are invoked non-streaming (via the
+ * Fetch implementation that always routes through Obsidian's buffered `requestUrl`.
+ * Subagent models are invoked non-streaming (via the
  * deepagents `task` tool's `.invoke()`), and the LiteLLM/OpenAI-compatible endpoints
- * used here return an empty body for a non-streaming request served over `net.fetch` —
+ * used here can return an empty body for a non-streaming request served over renderer fetch,
  * which surfaces as "Cannot read properties of undefined (reading 'message')" inside
  * `BaseChatModel.invoke`. Routing through `requestUrl` returns a usable buffered body.
  * Pair with `disableStreaming: true` on the model (see chatProviders) so LangChain

--- a/test/__mocks__/obsidian.ts
+++ b/test/__mocks__/obsidian.ts
@@ -189,6 +189,8 @@ export const setIcon = vi.fn((node: HTMLElement, iconId: string) => {
 	node.setAttribute("data-icon", iconId);
 });
 
+export const requestUrl = vi.fn();
+
 export function getAllTags(cache: CachedMetadata | null): string[] {
 	if (!cache) return [];
 	const tags: string[] = [];

--- a/test/agent/Agent.test.ts
+++ b/test/agent/Agent.test.ts
@@ -14,6 +14,7 @@ vi.mock("langchain", () => ({
 
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { Agent, sanitizeRunnableName } from "../../src/agent/Agent";
+import { AiTransportDowngradeRequiredError, getCurrentAiTransportModeForTest } from "../../src/lib/aiTransport";
 
 function makeRegistry() {
 	return {
@@ -238,5 +239,48 @@ describe("Agent streamTokens subagent-content suppression", () => {
 		]);
 
 		expect(tokens).toEqual(["Hello ", "world"]);
+	});
+});
+
+describe("Agent stream transport downgrade", () => {
+	it("uses buffered fallback when stream initialization fails", async () => {
+		const agent = new Agent({ registry: makeRegistry() as never });
+		const streamError = new AiTransportDowngradeRequiredError(
+			"openai-compatible",
+			"http://localhost:10100/v1/chat/completions",
+			new TypeError("Failed to fetch"),
+		);
+		let fallbackMode: string | undefined;
+		const runnable = {
+			stream: vi.fn().mockRejectedValue(streamError),
+			invoke: vi.fn().mockImplementation(async () => {
+				fallbackMode = getCurrentAiTransportModeForTest();
+				return {
+					messages: [
+						{ id: "final", content: "buffered response", getType: () => "ai", text: "buffered response" },
+					],
+				};
+			}),
+		};
+
+		const chunks = [];
+		for await (const chunk of agent.streamTokens({
+			query: "hi",
+			threadId: "t1",
+			resolved: {
+				runnable,
+				selectedModel: { provider: "openai-compatible", name: "local", instance: {} },
+				supportsVision: false,
+				currentProvider: "openai-compatible",
+			},
+		} as never)) {
+			chunks.push(chunk);
+		}
+
+		expect(runnable.stream).toHaveBeenCalledOnce();
+		expect(runnable.invoke).toHaveBeenCalledOnce();
+		expect(fallbackMode).toBe("buffered");
+		expect(chunks).toHaveLength(1);
+		expect(chunks[0]).toMatchObject({ type: "result" });
 	});
 });

--- a/test/components/toolOutputRenderModel.test.ts
+++ b/test/components/toolOutputRenderModel.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildToolOutputRenderModel } from "../../src/components/chat/toolOutputRenderModel";
+import {
+	buildToolOutputRenderModel,
+	MAX_RENDERED_TOOL_OUTPUT_CHARS,
+} from "../../src/components/chat/toolOutputRenderModel";
 
 describe("buildToolOutputRenderModel", () => {
 	it("renders search_notes payloads as a specialized model", () => {
@@ -91,6 +94,18 @@ describe("buildToolOutputRenderModel", () => {
 		expect(model.payload.target).toBe("Spec.pdf");
 		expect(model.payload.analysisLabel).toBe("Analyzed via vision model");
 		expect(model.payload.label).toBe("page(s) 2 of 4");
+	});
+
+	it("caps large read_content previews before markdown rendering", () => {
+		const content = "x".repeat(MAX_RENDERED_TOOL_OUTPUT_CHARS * 8);
+		const model = buildToolOutputRenderModel("read_content", `Content of "Large.md":\n\n${content}`);
+
+		expect(model.kind).toBe("read_content");
+		if (model.kind !== "read_content") return;
+		expect(model.payload.truncated).toBe(true);
+		expect(model.payload.content.length).toBeLessThan(MAX_RENDERED_TOOL_OUTPUT_CHARS + 100);
+		expect(model.payload.content).toContain("[UI preview truncated:");
+		expect(model.rawText.length).toBeLessThan(MAX_RENDERED_TOOL_OUTPUT_CHARS + 100);
 	});
 
 	it("renders execute_javascript outputs as a specialized model", () => {

--- a/test/lib/aiTransportRendererFetch.test.ts
+++ b/test/lib/aiTransportRendererFetch.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { normalizeElectronNetRequestInit, performAiFetch } from "../../src/lib/aiTransport";
+
+describe("performAiFetch renderer transport", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("uses renderer fetch and preserves its AbortSignal", async () => {
+		const controller = new AbortController();
+		const rendererFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			expect(init?.signal).toBe(controller.signal);
+			return new Response("ok");
+		});
+		vi.stubGlobal("fetch", rendererFetch);
+
+		const response = await performAiFetch("test-provider", "https://example.com/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ stream: true, messages: [] }),
+			signal: controller.signal,
+		});
+
+		expect(await response.text()).toBe("ok");
+		expect(rendererFetch).toHaveBeenCalledOnce();
+	});
+
+	it("uses Electron net fetch without passing a renderer AbortSignal", async () => {
+		const controller = new AbortController();
+		const electronFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			expect(init?.signal).toBeUndefined();
+			expect(JSON.parse(String(init?.body))).toMatchObject({ stream: true });
+			return new Response('data: {"choices":[]}\n\ndata: [DONE]\n\n', {
+				headers: { "content-type": "text/event-stream" },
+			});
+		});
+		vi.stubGlobal("require", (id: string) => {
+			if (id !== "electron") throw new Error(`Unexpected module: ${id}`);
+			return { remote: { net: { fetch: electronFetch } } };
+		});
+
+		const response = await performAiFetch("test-provider", "http://localhost:10100/v1/chat/completions", {
+			method: "POST",
+			body: JSON.stringify({ stream: true, messages: [] }),
+			signal: controller.signal,
+		});
+
+		expect(electronFetch).toHaveBeenCalledOnce();
+		expect(await response.text()).toContain("[DONE]");
+	});
+
+	it("does not mutate signal-free Electron request options", () => {
+		const init: RequestInit = { method: "GET" };
+		expect(normalizeElectronNetRequestInit(init)).toBe(init);
+	});
+});


### PR DESCRIPTION
## Summary

Fix chat requests failing on Obsidian 1.13.7 with Electron 43.1.1, plus two failure paths found while reproducing the renderer crash.

The transport failure is reproducible by passing a renderer `AbortSignal` through `electron.remote.net.fetch`. Electron validates it against the main process realm and throws:

```
RequestInit: Expected signal (...) to be an instance of AbortSignal.
```

## Changes

- Keep Electron `net.fetch` as the CORS bypass and preserve incremental streaming.
- Remove the renderer `AbortSignal` only from the Electron `RequestInit` boundary.
- Keep the signal for renderer fetch, check cancellation before Electron fetch, and cancel a response received after the renderer signal aborts.
- Remove the direct loopback `requestUrl` branch. Local providers keep incremental streaming.
- Catch transport failures raised while `agent.stream()` initializes, not only while consuming the stream.
- Apply the initialization fix to new, edited, and regenerated messages.
- Limit tool output UI previews to 20,000 characters before markdown rendering. Full output remains in checkpoints and model context.

## Verification

- `bun run test`: 1000 tests passed across 64 files
- `bun run build`: production build succeeded
- `bun format`: clean
- Live runtime reproduction: Obsidian 1.13.7, Electron 43.1.1, Chrome 150, Node 24.18.0
- Regression coverage for Electron signal removal, renderer signal preservation, stream initialization fallback, and large tool output previews

`bun check` reports the same 18 diagnostics present on `dev`, all in unchanged files. They cover missing Node builtin declarations and nullable Pixi screen coordinates.