### PR TITLE
fix(chat): enabling a skill from chat view now creates the skill file

### DIFF
--- a/src/components/chat/ChatRecommendations.svelte
+++ b/src/components/chat/ChatRecommendations.svelte
@@ -166,12 +166,16 @@ async function enablePlugin(nudge: PluginNudge): Promise<void> {
 	// AgentEditorModal.toggleAutoIntegration, shared via confirmEnableIntegrationPrivacy.
 	if (!(await confirmEnableIntegrationPrivacy(plugin.app, data, nudge.displayName))) return;
 
-	// Mirror AgentEditorModal.toggleAutoIntegration exactly: for an auto-discovered
-	// plugin with no documenting skill yet (nudge.skillId absent), seed one on demand
-	// (prewritten bundled skill if available, else an introspect-first template) and
-	// re-discover so it enters the cache — otherwise enabling only the exec tool leaves
-	// the integration with no editable skill note (no pencil / generic description).
-	let skillId = nudge.skillId;
+	// Mirror AgentEditorModal.toggleAutoIntegration: resolve the skill from what is actually
+	// *discovered on disk*, not from the nudge's id. A curated integration carries a hardcoded
+	// skillId in CURATED_PLUGIN_INTEGRATIONS even before its SKILL.md is seeded (community
+	// integration skills seed on demand, not at startup), so trusting nudge.skillId here would
+	// flip the skill on for an agent while no skill file exists (issue #382).
+	let skillId = plugin.skillsService?.isDiscovered()
+		? [...plugin.skillsService.getCachedSkills()].find(
+				([, metadata]) => metadata.linkedPluginId === nudge.pluginId,
+			)?.[0]
+		: undefined;
 	if (!skillId) {
 		const service = plugin.skillsService;
 		if (!service) {


### PR DESCRIPTION
## Summary
- Curated plugin integrations (dataview, tasks, tasknotes) carry a hardcoded `skillId` in `CURATED_PLUGIN_INTEGRATIONS`, but their `SKILL.md` is only seeded on demand, not at startup.
- The chat-view "Enable" nudge (`ChatRecommendations.svelte`) trusted that hardcoded id and skipped `seedIntegrationSkill()` whenever it was present, so clicking Enable flipped the skill on for the agent with no file backing it — confirmed live in the test vault (`tasknotes` enabled, curated, but `Agents/Skills/tasknotes/` never existed).
- Fix resolves `skillId` from the discovered skills cache by `linkedPluginId` instead (mirroring `AgentEditorModal.toggleAutoIntegration`), so an unseeded curated skill still falls through to `seedIntegrationSkill()`.

Fixes #382

## Test plan
- [x] `bun run check` — clean (pre-existing unrelated `GraphCanvas.svelte` errors only)
- [x] `bun run format` — no changes needed
- [x] Verified live in the test vault: TaskNotes nudge in chat view now creates `Agents/Skills/tasknotes/SKILL.md` on Enable

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._