### PR TITLE
fix(search): repair retrieval recall and generalize hybrid ranking

### DIFF
--- a/docs/search-algorithm.html
+++ b/docs/search-algorithm.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Smart Second Brain — search algorithm reference</title>
+<style>
+:root{
+  --bg:#faf9f7; --card:#ffffff; --ink:#22201d; --muted:#63605a; --faint:#8d8a87; --line:#e5e2dc; --accent:#185fa5; --accent-bg:#e6f1fb;
+  --warn:#854f0b; --warn-bg:#faeeda; --ok:#3b6d11; --ok-bg:#eaf3de; --inset:#f2f0ec;
+  --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+}
+@media (prefers-color-scheme:dark){
+  :root{--bg:#171614; --card:#201f1c; --ink:#eceae6; --muted:#a8a49e; --faint:#7d7a77; --line:#332f2b; --accent:#85b7eb; --accent-bg:#0c2740;
+    --warn:#fac775; --warn-bg:#3a2a10; --ok:#c0dd97; --ok-bg:#22300f; --inset:#191816;}
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+  font:400 16px/1.7 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;}
+.wrap{max-width:900px;margin:0 auto;padding:48px 24px 96px}
+h1{font-size:30px;font-weight:600;margin:0 0 6px;letter-spacing:-.02em}
+.lede{color:var(--muted);font-size:15px;margin:0 0 10px}
+.meta{color:var(--muted);font-size:13px;margin:0 0 40px;padding-bottom:20px;border-bottom:1px solid var(--line)}
+h2{font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;
+  color:var(--muted);margin:44px 0 16px;padding-top:4px}
+.card{background:var(--card);border:1px solid var(--line);border-radius:10px;
+  padding:18px 20px;margin:0 0 12px}
+.ct{font-size:16px;font-weight:600;margin:0 0 2px}
+.cf{font-family:var(--mono);font-size:12px;color:var(--muted);margin:0 0 10px}
+p{margin:0 0 10px}
+p:last-child{margin-bottom:0}
+.sm{font-size:14px;color:var(--muted)}
+code{font-family:var(--mono);font-size:13px;background:var(--inset);
+  border:1px solid var(--line);border-radius:4px;padding:1px 5px}
+.formula{font-family:var(--mono);font-size:14px;background:var(--inset);
+  border:1px solid var(--line);border-radius:6px;padding:12px 14px;margin:10px 0;
+  overflow-x:auto;white-space:nowrap}
+.note{border-left:3px solid var(--accent);background:var(--accent-bg);
+  color:var(--accent);padding:10px 14px;margin:12px 0 0;font-size:14px;line-height:1.6}
+.bug{border-left:3px solid var(--warn);background:var(--warn-bg);
+  color:var(--warn);padding:10px 14px;margin:12px 0 0;font-size:14px;line-height:1.6}
+.note strong,.bug strong{font-weight:600}
+table{width:100%;border-collapse:collapse;font-size:14px;margin:10px 0 0}
+th{text-align:left;font-weight:600;font-size:12px;text-transform:uppercase;
+  letter-spacing:.05em;color:var(--muted);padding:8px 10px;border-bottom:1px solid var(--line)}
+td{padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+td.k{font-family:var(--mono);font-size:12px;white-space:nowrap;width:1%}
+tr:last-child td{border-bottom:none}
+.tag{display:inline-block;font-size:12px;font-weight:600;padding:1px 8px;
+  border-radius:20px;white-space:nowrap}
+.tag.ok{background:var(--ok-bg);color:var(--ok)}
+.tag.warn{background:var(--warn-bg);color:var(--warn)}
+.flow{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin:14px 0 0;font-size:13px}
+.step{background:var(--inset);border:1px solid var(--line);border-radius:6px;padding:5px 11px;font-family:var(--mono);font-size:12px}
+.arrow{color:var(--muted)}
+footer{margin-top:56px;padding-top:20px;border-top:1px solid var(--line);
+  font-size:13px;color:var(--muted)}
+footer a{color:var(--accent)}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Search algorithm reference</h1>
+<p class="lede">Hybrid semantic + lexical retrieval with fusion ranking, as implemented in Smart Second Brain.</p>
+<p class="meta">Every constant below is read from source, not recalled. Measurements come from a 300-note generated corpus with an 18-case graded relevance benchmark.</p>
+
+<div class="flow">
+  <span class="step">index</span><span class="arrow">→</span>
+  <span class="step">retrieve ×2</span><span class="arrow">→</span>
+  <span class="step">aggregate</span><span class="arrow">→</span>
+  <span class="step">normalize</span><span class="arrow">→</span>
+  <span class="step">fuse</span><span class="arrow">→</span>
+  <span class="step">boost</span><span class="arrow">→</span>
+  <span class="step">recency</span><span class="arrow">→</span>
+  <span class="step">rank</span>
+</div>
+
+<h2>1 · Indexing</h2>
+
+<div class="card">
+  <div class="ct">Read content</div>
+  <div class="cf">utils/fileFiltering.ts → readIndexableContent()</div>
+  <p class="sm">Every vault file outside the agent folder is indexable. <code>.chat</code> files are gunzipped and deduped by LangChain message id. Binary files (images, PDFs) return an empty body and are indexed by title alone.</p>
+  <div class="bug"><strong>Why the dedupe matters.</strong> Conversation history is a tree of checkpoints, and each checkpoint re-contains every prior message. Concatenating them repeated the same text about 9×: 54 chat files expanded to 12.3 M characters (~373 chunks) versus ~45 chunks for all real notes combined.</div>
+</div>
+
+<div class="card">
+  <div class="ct">Section-aware chunking</div>
+  <div class="cf">utils/chunkText.ts → chunkText()</div>
+  <p class="sm">Splits on every heading, H1 through H6, regardless of size — not only when the token budget is exceeded. Each chunk is prefixed with <code>Note: &lt;title&gt;</code> plus the full parent-heading breadcrumb, so an orphaned paragraph still carries its context. Headings inside fenced code blocks do not split.</p>
+  <p class="sm">The title is deliberately <em>not</em> rendered as <code># title</code>: <code>#</code> is ordinary note content, so a body containing <code># Appendix</code> would produce two sibling H1s with nothing marking which is the document.</p>
+  <div class="bug"><strong>Topic dilution.</strong> An embedding averages everything it is given. A 1234-byte note covering four cuisines scored <strong>0.200</strong> against a query that its Greek section answered at <strong>0.492</strong> in isolation — it ranked 286 of 337 and never surfaced. Adding a single off-topic section roughly halves the first topic's signal.</div>
+</div>
+
+<div class="card">
+  <div class="ct">Embed and store</div>
+  <div class="cf">vectorstore/HNSWVectorStore.ts (in a Web Worker)</div>
+  <p class="sm">One vector per chunk. Content budget <code>8191 tokens × 4 chars</code>. Graph parameters <code>M = 16</code>, <code>efConstruction = 100</code>, <code>efSearch = 100</code>.</p>
+  <div class="bug"><strong>clear() must delete the persisted graph.</strong> Recreating the in-memory wrapper left the serialized graph in its own IndexedDB database while <code>nextHnswId</code> reset to 0. Reused numeric ids then collided with resurrected nodes, and <code>search()</code> silently skipped every hit it could not map — 10,161 nodes against 377 mappings, and a 50-result query returning 4.</div>
+</div>
+
+<h2>2 · Retrieval</h2>
+<p class="sm">Both paths run concurrently via <code>Promise.all</code>. Either may legitimately return nothing — a keyword absent from the vault yields no lexical hits, and an unconfigured provider yields no semantic hits.</p>
+
+<div class="card">
+  <div class="ct">Semantic path</div>
+  <div class="cf">vectorstore/VectorStoreService.ts → semanticSearch()</div>
+  <p class="sm">Embeds the query, searches HNSW, applies path and tag filters at <em>chunk</em> level, then aggregates to notes. Over-fetch is <code>10 × topK</code>.</p>
+  <p class="sm">The over-fetch factor is load-bearing rather than cosmetic: a note's supporting chunks only contribute to its score if they were actually retrieved, so under-fetching silently degrades aggregation back into first-hit-wins.</p>
+</div>
+
+<div class="card">
+  <div class="ct">Chunk → note aggregation</div>
+  <div class="cf">vectorstore/chunkAggregation.ts</div>
+  <div class="formula">score = best × (1 + 0.15 × s / (s + 3))</div>
+  <p class="sm"><code>s</code> is the summed strength of the supporting chunks, each measured <em>relative to the note's own best chunk</em>. Three properties follow: the best chunk sets the scale, total lift converges to 15% and can never exceed it, and two sections that nearly match the best outweigh twenty that barely register.</p>
+  <div class="bug"><strong>The previous form diverged.</strong> Summing <code>1/(i+1)</code> is a harmonic series, so support grew without bound in chunk count: +19% at 5 chunks, +39% at 20, +63% at 100. A real 33-chunk note was inflated from a 0.662 best chunk to <strong>0.909</strong>, and a long note scoring 0.55 per chunk beat a short note scoring 0.72.</div>
+</div>
+
+<div class="card">
+  <div class="ct">Lexical path</div>
+  <div class="cf">vectorstore/MiniSearchService.ts — BM25</div>
+  <p class="sm">Two passes are scored separately and merged by max: <em>identity</em> fields (title, aliases, tags, path segments) and <em>content</em>. Field boosts <code>title 2.0</code>, <code>aliases 1.8</code>, <code>tags 1.5</code>, <code>pathSegments 1.2</code>, <code>content 1.0</code>; fuzzy distance <code>0.2</code>.</p>
+  <p class="sm">Separating identity from content is what lets a title match outrank a note that merely mentions the term many times.</p>
+</div>
+
+<h2>3 · Fusion ranking</h2>
+<p class="sm">The governing rule: every signal is normalized <em>within the current result set</em>. No constant is ever compared against a raw BM25 magnitude or a raw cosine, and there are no hard rank cutoffs — so behaviour keeps its shape across vault sizes and embedding models.</p>
+
+<div class="card">
+  <div class="ct">Per-source normalization</div>
+  <div class="cf">floor share 0.15</div>
+  <p class="sm">Each source is mapped onto 0–1 with the floor pulled toward zero rather than to the minimum. Both extremes fail: full min-max stretches <em>any</em> spread to fill the range, so on a small set a 10-vs-9 near-tie becomes 1.0-vs-0.0 and the tail becomes unliftable by any proportional term; divide-by-max collapses narrow cosine bands (0.40–0.55) into a useless cluster near 1.0.</p>
+</div>
+
+<div class="card">
+  <div class="ct">Weighted blend</div>
+  <div class="formula">0.7 × (0.6 · semantic + 0.4 · lexical) + 0.3 × RRF</div>
+  <p class="sm">Normalized score carries the relevance signal. RRF (<code>k = 60</code>) is retained only as a stability term for when one source's magnitudes are degenerate — for example every BM25 hit tied. Semantic leads because it is the only source that can bridge a vocabulary gap; lexical remains the sole signal for exact terms.</p>
+</div>
+
+<div class="card">
+  <div class="ct">Identity boosts</div>
+  <p class="sm">Title <code>0.18</code> and alias <code>0.17</code>, as fractions of the fused 0–1 score (<code>0.30</code> each when only semantic results exist). Applied to lexical-only queries too — these previously required a semantic source, which left an exact alias match on a keyword query with no credit at all and forced an oversized recency bonus to compensate.</p>
+</div>
+
+<h2>4 · Recency</h2>
+<p class="sm">A note's recency boost decays by open order (<code>4.5</code> down to a floor of <code>0.5</code>, decay <code>0.75</code>) over the last 20 opened notes. It then passes three independent guards. Each exists because a specific measured case failed without it.</p>
+
+<div class="card">
+<table>
+<tr><th>Guard</th><th>Value</th><th>Rationale</th></tr>
+<tr><td class="k">eligibility</td><td class="k">≥ 0.80</td><td>Ratio of this note's raw source score to the best result's. Replaced a hard top-10 <em>rank</em> cutoff, under which a strong match at rank 11 was gated while a weak one at rank 10 was not. Measured on raw scores rather than normalized ones, because normalization deliberately stretches small sets and would split genuine near-ties.</td></tr>
+<tr><td class="k">lift cap</td><td class="k">2 × typical gap</td><td>Adaptive, not fixed. The ceiling is twice the <em>median gap between adjacent results in this query's own set</em>, clamped to 0.02–0.30. A fixed percentage cannot express "comparable": adjacent results sit ~1% apart in a dense semantic set but ~10% apart in a sparse lexical one, so the same 12% deficit is a chasm in one and a near-tie in the other.</td></tr>
+<tr><td class="k">crowding</td><td class="k">1 / n²</td><td>Where <code>n</code> counts eligible results that are also recent. When everything is recent, recency identifies nothing — each rival both dilutes the signal and raises the cost of acting on it.</td></tr>
+</table>
+<div class="note"><strong>The cap and the crowding term solve different problems.</strong> The cap asks <em>how far behind is this note, relative to how tightly this set is packed</em> — which is why it must adapt rather than be a fixed percentage. The crowding term asks <em>how many notes have the same claim</em>: recency cannot single out one note when several are equally recent. Neither substitutes for the other. Without crowding, three recently-opened siblings pushed the correct answer from rank 1 to rank 4 even though each sat within a normal adjacent gap of it.</div>
+<div class="note"><strong>Dead end worth recording.</strong> Scaling the cap to the gap <em>to the leader</em> looks equivalent but cannot work: it is monotonic in relative relevance, while the required outcomes are not. A distractor at 0.8747 must lose while a genuine near-tie at 0.8844 must win — 1.1 points apart, opposite verdicts. Set spread is the signal that separates them.</div>
+<p class="sm" style="margin-top:12px">Notes that fail the gate keep their <code>recent</code> badge but receive no score change — the signal stays visible to the user without distorting the ranking.</p>
+</div>
+
+<h2>5 · Measured behaviour</h2>
+
+<div class="card">
+<table>
+<tr><th>Dimension</th><th>Status</th><th>Evidence</th></tr>
+<tr><td class="k">set size</td><td><span class="tag ok">stable</span></td><td>Identical relative structure at n = 5, 25, 100, 500, 2000 keeps the target at rank 1; top-to-second margin drifts only 4.88% → 4.25% across a 400× range.</td></tr>
+<tr><td class="k">cosine band</td><td><span class="tag ok">stable</span></td><td>Ordering preserved from wide (0.9 / 0.5 / 0.3) to very narrow (0.42 / 0.418 / 0.416). The recency gate reports the same relative relevance in every band.</td></tr>
+<tr><td class="k">note length</td><td><span class="tag ok">bounded</span></td><td>A 0.75-scoring long note can never beat a 0.90-scoring short one; it asymptotes at 0.8625 regardless of chunk count.</td></tr>
+<tr><td class="k">embedding model</td><td><span class="tag ok">stable</span></td><td>qwen3-8b 0.9966, harrier-oss-0.6b 0.9934. A fixed lift cap fitted to qwen's separation scored only 0.9729 on harrier; making the cap adapt to result-set spread recovered it. Measured typical gaps: harrier 0.7%, qwen 0.9%, sparse lexical 10–16%.</td></tr>
+<tr><td class="k">latency</td><td><span class="tag ok">local-bound</span></td><td>About 97% of query time is the embedding call. Local MLX ~28 ms versus remote ~1626 ms; ANN search ~47 ms and lexical ~6 ms are effectively free.</td></tr>
+</table>
+</div>
+
+<div class="card">
+  <div class="ct">Benchmark</div>
+  <div class="cf">bun run test:benchmark</div>
+  <p class="sm">18 graded cases over a deterministic 300-note corpus, scored by nDCG@10 and MRR. Queries deliberately avoid each target note's own wording, so term overlap alone cannot find them. Cases cover near-synonym bridging, lexical distractors, zero-overlap retrieval, very short and multi-chunk targets, alias matches, multi-target queries, near-duplicate discrimination, recency conflicts, and length bias.</p>
+  <p class="sm">The suite ratchets: it fails if the mean drops below the recorded baseline, and prints the new value when it improves.</p>
+  <div class="note"><strong>Length-bias probes come in pairs.</strong> One case where the many-chunk note is <em>wrong</em>, one where it is genuinely right. Without the first, chunk-count inflation is invisible — in every earlier case the many-chunk note also happened to be correct. Without the second, a fix can over-correct into a blanket penalty on long notes.</div>
+</div>
+
+<footer>
+Source: <code>utils/chunkText.ts</code> · <code>utils/fileFiltering.ts</code> · <code>vectorstore/VectorStoreService.ts</code> · <code>vectorstore/chunkAggregation.ts</code> · <code>vectorstore/HNSWVectorStore.ts</code> · <code>vectorstore/MiniSearchService.ts</code> · <code>search/finalSearchRanking.ts</code> · <code>search/recentNotes.ts</code>
+</footer>
+
+</div>
+</body>
+</html>

--- a/integration/README.md
+++ b/integration/README.md
@@ -142,3 +142,63 @@ Notes:
 - `eval` and `dev:cdp` are more fragile and should be used only when DOM queries and screenshots are not enough.
 - Some commands return before the modal/view is fully mounted, so polling for a selector is the safest pattern.
 - There is an upstream Codex Desktop macOS issue where running `obsidian` from inside Codex can sometimes make Obsidian quit unexpectedly. If that starts happening, run the same `obsidian` commands in a normal terminal outside Codex and continue verification there.
+
+## Search relevance benchmark
+
+`search-relevance-benchmark.test.ts` measures *ranking quality* as a number
+(nDCG@10 and MRR) rather than asserting individual orderings. Use it to prove a
+search change improves results instead of merely altering them.
+
+### Running it
+
+```bash
+bun run corpus:generate     # once — writes Corpus/ into the test vault
+bun run build && bun run setup-vault
+# open the vault in Obsidian, configure an embedding provider, let it index
+bun run test:benchmark
+```
+
+The corpus is **generated, not committed** (~300 notes, 1.9 MB). The generator is
+seeded, so it reproduces byte-for-byte; `scripts/generate-search-corpus.ts` is
+the source of truth. Regenerate after changing it, then reindex.
+
+### What it contains
+
+`helpers/relevanceJudgments.ts` holds the judgment set: each query carries graded
+expectations (`2` = answers the query, `1` = related, `0` = a distractor the
+ranker is expected to be tempted by) plus a `probes` string explaining which
+behaviour the case tests. Queries deliberately avoid the target note's own
+wording, so term overlap alone cannot find them.
+
+Cases cover: near-synonym bridging, lexical distractors, zero-overlap
+(semantic-only) retrieval, very short and multi-chunk targets, alias matches,
+multi-target queries, near-duplicate discrimination, and recency-vs-relevance
+conflicts (via the `recentNotes` fixture, which the harness applies and clears
+per query).
+
+### The ratchet
+
+`BASELINE_MEAN_NDCG` / `BASELINE_MEAN_RR` are the current best measured scores.
+The suite fails if the mean drops below them, and **prints the new value when it
+improves — raise the constants at that point** so progress is locked in. Lowering
+them should be deliberate and explained.
+
+Current baseline: **mean nDCG@10 = 0.9966, MRR = 1.0** (18 cases,
+`openrouter:qwen/qwen3-embedding-8b`, 2026-08-16). Seventeen cases score 1.000;
+the multi-target smart-city query sits at 0.938 because a grade-1 note ranks
+between the two grade-2 targets, which reflects grading uncertainty in that case
+rather than a demonstrated ranking defect.
+
+Two of the cases are length-bias probes and must be kept as a pair: one where the
+many-chunk note is the *wrong* answer, and one where it is genuinely right. The
+first catches chunk-count inflation; the second stops a fix for it from turning
+into a blanket penalty on long notes.
+
+### Adding a case
+
+Append to `RELEVANCE_JUDGMENTS`. Prefer cases the ranker currently *fails* —
+those are what justify a change. If one is a known failure, set `knownFailure`
+with the measured evidence; the suite reports it separately instead of going red,
+and tells you when it starts passing.
+
+Skips cleanly when no embedding provider is configured, so CI stays green.

--- a/integration/Smart2Brain Test Vault/.gitignore
+++ b/integration/Smart2Brain Test Vault/.gitignore
@@ -15,3 +15,8 @@
 # Obsidian cache
 .obsidian/plugins/.obsidian/
 .trash/
+
+# Generated search-relevance corpus (~300 notes, 1.9MB).
+# Deterministic: `bun run corpus:generate` reproduces it byte-for-byte from a
+# seeded script, so the generator is the source of truth rather than the output.
+Corpus/

--- a/integration/helpers/relevanceJudgments.ts
+++ b/integration/helpers/relevanceJudgments.ts
@@ -1,0 +1,269 @@
+/**
+ * Graded relevance judgments for the search ranking benchmark.
+ *
+ * Each entry pairs a natural-language query with graded expectations over the
+ * generated corpus (`scripts/generate-search-corpus.ts`). Grades follow the usual
+ * nDCG convention:
+ *
+ *   2 = highly relevant — this note answers the query
+ *   1 = relevant        — related and reasonable to surface
+ *   0 = irrelevant      — listed explicitly when it is a *distractor* we expect the
+ *                         ranker to be tempted by, so a regression is legible
+ *
+ * The queries deliberately avoid the target note's own phrasing: the corpus states
+ * each answer using a near-synonym, so term overlap alone cannot find it. Any note
+ * not listed is treated as grade 0.
+ */
+
+export interface RelevanceJudgment {
+	/** The query as a user would type it. */
+	query: string;
+	/** Vault-relative paths → grade. */
+	grades: Record<string, 0 | 1 | 2>;
+	/** What ranking behaviour this case is probing (shown in benchmark output). */
+	probes: string;
+	/**
+	 * Notes to mark as recently opened before running this query, most-recent first.
+	 *
+	 * Recency is a real ranking input (`getRecentNotes` → `buildRecentBoostMap` →
+	 * `rankSearchResults`), and it is the single largest source of untested behaviour:
+	 * a recently-opened note receives a multiplicative lift of up to 1.6x. Cases that
+	 * set this deliberately put recency *in conflict* with relevance.
+	 *
+	 * The harness clears the recent list before every query, so a case without this
+	 * field runs with no recency signal at all.
+	 */
+	recentNotes?: string[];
+	/**
+	 * Set when the current ranker is known to fail this case.
+	 *
+	 * These are the cases that justify the ranking rework: they are measured, not
+	 * hypothetical. The benchmark reports them separately rather than failing the
+	 * suite, so the file records "what is still wrong" instead of going red on a
+	 * known-open issue.
+	 */
+	knownFailure?: string;
+}
+
+const C = "Corpus";
+
+export const RELEVANCE_JUDGMENTS: readonly RelevanceJudgment[] = [
+	{
+		query: "how much output do solar panels lose to wear at sea",
+		probes: "near-synonym bridging (query 'solar panel' vs note 'photovoltaic array') against a lexical distractor that owns the words 'solar panel'",
+		grades: {
+			[`${C}/Marine Biology/photovoltaic-array-degradation.md`]: 2,
+			[`${C}/Typography/solar-panel-metaphors-in-design.md`]: 0,
+		},
+	},
+	{
+		query: "can an octopus learn to open a sealed jar",
+		probes: "distractor with identical query-term overlap ('octopus', 'open'); only meaning separates them",
+		grades: {
+			[`${C}/Marine Biology/cephalopod-problem-solving.md`]: 2,
+			[`${C}/Fermentation/octopus-recipes.md`]: 0,
+		},
+	},
+	{
+		query: "how long before a rate change reaches borrowers",
+		probes: "long multi-chunk target (~2400 words) vs a distractor using 'rate' and 'interest' in a non-monetary sense",
+		grades: {
+			[`${C}/Monetary Policy/policy-rate-transmission-lag.md`]: 2,
+			[`${C}/Typography/interest-in-typography-history.md`]: 0,
+		},
+	},
+	{
+		query: "what makes very small text readable",
+		probes: "zero lexical overlap with the target — semantic-only retrieval; distractor shares the phrase 'small sizes'",
+		grades: {
+			[`${C}/Typography/legibility-at-small-sizes.md`]: 2,
+			[`${C}/Fermentation/small-sizes-of-fermentation-vessels.md`]: 0,
+		},
+	},
+	{
+		query: "when do prices rise so fast people stop using the local currency",
+		probes: "very short note (~45 words) as the correct answer — length normalization must not bury it under long notes",
+		grades: {
+			[`${C}/Monetary Policy/hyperinflation-episodes.md`]: 2,
+		},
+	},
+	{
+		query: "how long does a wet sourdough starter take to double",
+		probes: "multi-chunk target where the answer is repeated late in the note — aggregate vs best-chunk scoring",
+		grades: {
+			[`${C}/Fermentation/starter-hydration-and-rise.md`]: 2,
+		},
+	},
+	{
+		query: "Octopus Intelligence",
+		probes: "alias match: the title does not contain these words, only the frontmatter alias does",
+		grades: {
+			[`${C}/Marine Biology/cephalopod-problem-solving.md`]: 2,
+		},
+	},
+	{
+		query: "Levain Timing",
+		probes: "alias match on a long note, competing against its own domain's filler",
+		grades: {
+			[`${C}/Fermentation/starter-hydration-and-rise.md`]: 2,
+		},
+	},
+
+	// ── recency vs relevance ────────────────────────────────────────────────
+	// These cases drove the ranking rework. Recency used to be a multiplicative
+	// lift gated by a hard top-10 *rank* cutoff, so whether a recently-opened note
+	// could hijack a query depended on which side of an arbitrary line it landed.
+	// It is now gated by *relative relevance*, capped, and attenuated when several
+	// results are equally recent — keep these cases as the regression guard.
+
+	{
+		query: "can an octopus learn to open a sealed jar",
+		probes: "recency vs relevance: the WRONG note (a recipe) is the most recently opened. It must not overtake the correct answer — the failure that motivated capping the recency lift.",
+		recentNotes: [`${C}/Fermentation/octopus-recipes.md`],
+		grades: {
+			[`${C}/Marine Biology/cephalopod-problem-solving.md`]: 2,
+			[`${C}/Fermentation/octopus-recipes.md`]: 0,
+		},
+	},
+	{
+		query: "what makes very small text readable",
+		probes: "the same conflict with a distractor that is a much weaker match, so the relative-relevance gate suppresses its recency lift entirely",
+		recentNotes: [`${C}/Fermentation/small-sizes-of-fermentation-vessels.md`],
+		grades: {
+			[`${C}/Typography/legibility-at-small-sizes.md`]: 2,
+			[`${C}/Fermentation/small-sizes-of-fermentation-vessels.md`]: 0,
+		},
+	},
+	{
+		query: "how long does a wet sourdough starter take to double",
+		probes: "recency piled onto near-duplicates: three sibling filler notes that already crowd this query are marked recent, testing whether the true answer survives a coordinated lift",
+		recentNotes: [
+			`${C}/Fermentation/sourdough-starter-maintenance-4.md`,
+			`${C}/Fermentation/sourdough-starter-maintenance-3.md`,
+			`${C}/Fermentation/sourdough-starter-maintenance-8.md`,
+		],
+		grades: {
+			[`${C}/Fermentation/starter-hydration-and-rise.md`]: 2,
+			// Graded explicitly so the recency lift they receive is actually scored:
+			// these are generic maintenance notes, not the hydration/timing answer.
+			[`${C}/Fermentation/sourdough-starter-maintenance-4.md`]: 0,
+			[`${C}/Fermentation/sourdough-starter-maintenance-3.md`]: 0,
+			[`${C}/Fermentation/sourdough-starter-maintenance-8.md`]: 0,
+		},
+	},
+	{
+		query: "Octopus Intelligence",
+		probes: "recency must not override an exact alias match — the strongest possible identity signal",
+		recentNotes: [`${C}/Fermentation/octopus-recipes.md`],
+		grades: {
+			[`${C}/Marine Biology/cephalopod-problem-solving.md`]: 2,
+			[`${C}/Fermentation/octopus-recipes.md`]: 0,
+		},
+	},
+
+	// ── multi-target queries ────────────────────────────────────────────────
+	// Every case above has exactly one right answer, so nDCG only ever measures
+	// "is the winner on top". These grade a whole result *set*, which is what
+	// catches a ranker that finds the best note but orders the rest badly.
+
+	{
+		query: "smart city sensors and data platforms",
+		probes: "multi-target: two notes are directly on point, several siblings are related. Measures the ordering of the whole set, not just rank 1.",
+		grades: {
+			"Topics/Smart Cities/IoT Sensors.md": 2,
+			"Topics/Smart Cities/Urban Data Platforms.md": 2,
+			"Topics/Smart Cities/Digital Twins.md": 1,
+			"Topics/Smart Cities/Smart City Overview.md": 1,
+			"Topics/Smart Cities/Smart Street Lighting.md": 1,
+		},
+	},
+	{
+		query: "how do cities cut energy use in buildings and street lighting",
+		probes: "multi-target spanning two folders (Smart Cities + Renewable Energy) — a query no single note fully answers",
+		grades: {
+			"Topics/Smart Cities/Smart Buildings.md": 2,
+			"Topics/Smart Cities/Smart Street Lighting.md": 2,
+			"Topics/Renewable Energy/Energy Storage.md": 1,
+			"Topics/Smart Cities/Smart City Overview.md": 1,
+		},
+	},
+
+	// ── near-duplicate discrimination ───────────────────────────────────────
+	// The corpus contains ~8 near-identical filler notes per subject. A ranker
+	// that cannot tell the specific answer from its siblings still scores well on
+	// single-target queries as long as the right note edges ahead; these make the
+	// siblings explicitly wrong so crowding is penalised.
+
+	{
+		query: "what hydration level makes a starter rise fastest",
+		probes: "the answer must beat ~8 sibling 'sourdough starter maintenance' notes that share nearly all vocabulary; siblings graded 0 so crowding costs score",
+		grades: {
+			[`${C}/Fermentation/starter-hydration-and-rise.md`]: 2,
+			[`${C}/Fermentation/sourdough-starter-maintenance.md`]: 0,
+			[`${C}/Fermentation/sourdough-starter-maintenance-2.md`]: 0,
+			[`${C}/Fermentation/sourdough-starter-maintenance-3.md`]: 0,
+			[`${C}/Fermentation/sourdough-starter-maintenance-4.md`]: 0,
+		},
+	},
+	// ── length bias ─────────────────────────────────────────────────────────
+	// Long notes are split into many chunks (a 66KB note yields ~33 vs ~3 for a
+	// short one), so they get systematically more chances to appear in the
+	// candidate set. Chunk-support aggregation must not turn that into score: a
+	// long note whose sections are all mediocre should lose to a short note that
+	// actually answers the query. Without a converging support term the 33-chunk
+	// note was inflated from a 0.662 best chunk to 0.909 and won on length alone.
+
+	{
+		query: "at what monthly inflation rate do people switch to foreign currency",
+		probes: "short single-chunk note (513 bytes) as the answer, against 66KB many-chunk notes that share economic vocabulary — pure length-bias probe",
+		grades: {
+			[`${C}/Monetary Policy/hyperinflation-episodes.md`]: 2,
+			"Large Notes/Distributed Systems Deep Dive.md": 0,
+			"Large Notes/Storage Engines and Indexing.md": 0,
+		},
+	},
+	{
+		query: "which borrowers feel a policy rate change first",
+		probes: "the many-chunk note (17KB, ~20 chunks) is genuinely correct here — guards against over-correcting the length-bias fix into a penalty on long notes",
+		grades: {
+			[`${C}/Monetary Policy/policy-rate-transmission-lag.md`]: 2,
+		},
+	},
+	{
+		query: "why do offshore panels lose efficiency over the years",
+		probes: "restates the solar case with no shared content words at all ('offshore panels' vs 'photovoltaic arrays', 'lose efficiency' vs 'lose rated output')",
+		grades: {
+			[`${C}/Marine Biology/photovoltaic-array-degradation.md`]: 2,
+			[`${C}/Typography/solar-panel-metaphors-in-design.md`]: 0,
+		},
+	},
+];
+
+// ── metrics ──────────────────────────────────────────────────────────────────
+
+/** Discounted cumulative gain over the ranked paths. */
+function dcg(gains: number[]): number {
+	return gains.reduce((sum, gain, i) => sum + (2 ** gain - 1) / Math.log2(i + 2), 0);
+}
+
+/**
+ * nDCG@k for one query. Ideal ordering is the judged grades sorted descending,
+ * so a query whose target the ranker misses entirely scores 0.
+ */
+export function ndcgAt(rankedPaths: string[], grades: Record<string, number>, k: number): number {
+	const actual = rankedPaths.slice(0, k).map((p) => grades[p] ?? 0);
+	const ideal = Object.values(grades)
+		.filter((g) => g > 0)
+		.sort((a, b) => b - a)
+		.slice(0, k);
+	const idealDcg = dcg(ideal);
+	return idealDcg === 0 ? 0 : dcg(actual) / idealDcg;
+}
+
+/** Reciprocal rank of the first highly-relevant (grade 2) result; 0 if absent. */
+export function reciprocalRank(rankedPaths: string[], grades: Record<string, number>): number {
+	for (const [i, path] of rankedPaths.entries()) {
+		if ((grades[path] ?? 0) === 2) return 1 / (i + 1);
+	}
+	return 0;
+}

--- a/integration/search-relevance-benchmark.test.ts
+++ b/integration/search-relevance-benchmark.test.ts
@@ -1,0 +1,282 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+	PLUGIN,
+	clearBuffers,
+	isProviderConfigured,
+	obsidianEval,
+	pollEval,
+	sleep,
+	waitForStandaloneMiniSearch,
+} from "./helpers/cli.ts";
+import { RELEVANCE_JUDGMENTS, ndcgAt, reciprocalRank } from "./helpers/relevanceJudgments.ts";
+
+/*
+ * Graded relevance benchmark for the hybrid search ranking.
+ *
+ * Unlike the assertion-style tests in `semantic-search.test.ts` ("query X returns
+ * note Y"), this measures ranking *quality* as a number, so a change to the ranking
+ * algorithm can be shown to improve rather than merely alter results.
+ *
+ * Run it once before a ranking change to capture a baseline, then again after:
+ *
+ *   bunx vitest run --config vitest.integration.config.ts \
+ *     integration/search-relevance-benchmark.test.ts
+ *
+ * Requires the generated corpus (`bun run scripts/generate-search-corpus.ts`) to be
+ * present in the vault and indexed. Semantic cases need a configured embedding
+ * provider; they skip cleanly without one so CI stays green.
+ */
+
+const NDCG_K = 10;
+/** Query enough results that a target sitting outside the top-10 is still visible in the debug output. */
+const RESULT_LIMIT = 25;
+
+/**
+ * Current best measured scores — the ratchet the suite defends.
+ *
+ * Recorded 2026-08-16 on the 300-note generated corpus, 18 cases. Now stable
+ * across embedding models, since the recency lift cap adapts to result-set
+ * spread rather than being a fixed percentage:
+ *   - `openrouter:qwen/qwen3-embedding-8b`  mean nDCG@10 = 0.9966, MRR = 1.0
+ *   - `omlx:harrier-oss-v1-0.6b-MLX-8bit`   mean nDCG@10 = 0.9934, MRR = 1.0
+ * The baseline below is set to clear both.
+ *
+ * **Raise these whenever a change improves the mean** — the test prints the new
+ * value when it clears the bar. Lowering them is a deliberate act that should
+ * come with an explanation of why the regression is acceptable.
+ */
+const BASELINE_MEAN_NDCG = 0.99;
+const BASELINE_MEAN_RR = 1.0;
+
+/**
+ * Absorbs embedding-provider jitter only. Repeated runs against the same index
+ * reproduce the mean exactly, so this is headroom for a model or provider whose
+ * scores differ slightly — not licence for a real regression to pass.
+ */
+const BASELINE_TOLERANCE = 0.02;
+
+const providerAvailable = (() => {
+	try {
+		return isProviderConfigured();
+	} catch {
+		return false;
+	}
+})();
+
+const searchIndexAvailable = (() => {
+	try {
+		return obsidianEval(`${PLUGIN}.pluginData.searchEmbedIndex !== null`).includes("true");
+	} catch {
+		return false;
+	}
+})();
+
+const corpusIndexed = (() => {
+	try {
+		const raw = obsidianEval(
+			`${PLUGIN}.app.vault.getFiles().filter(function(f){ return f.path.indexOf("Corpus/") === 0; }).length`,
+		);
+		const value = raw.startsWith("=> ") ? raw.slice(3) : raw;
+		return Number.parseInt(value, 10) > 0;
+	} catch {
+		return false;
+	}
+})();
+
+interface QueryOutcome {
+	query: string;
+	probes: string;
+	ndcg: number;
+	rr: number;
+	targetRank: number | null;
+	topPaths: string[];
+	knownFailure?: string;
+}
+
+/**
+ * Reset the recent-notes list, then mark this case's fixtures as opened.
+ *
+ * Recency is real ranking input, and it leaks between queries — without an
+ * explicit reset a case would inherit whatever the previous one opened, making
+ * results order-dependent. `recordRecentlyOpenedNote` prepends, so the array is
+ * applied in reverse to leave `recentNotes[0]` as the most recent.
+ */
+async function applyRecentNotes(paths: readonly string[]): Promise<void> {
+	const ordered = [...paths].reverse();
+	obsidianEval(
+		`(function(){ var d = ${PLUGIN}.pluginData; d.clearRecentNotes(); ${ordered
+			.map((p) => `d.recordRecentlyOpenedNote(${JSON.stringify(p)});`)
+			.join(" ")} return "ok"; })()`,
+	);
+	// The setter persists asynchronously; give it a beat before querying.
+	await sleep(500);
+}
+
+/** Run one query through the real search stack and score the returned ordering. */
+async function scoreQuery(
+	globalKey: string,
+	algorithm: "hybrid" | "lexical",
+	judgment: (typeof RELEVANCE_JUDGMENTS)[number],
+): Promise<QueryOutcome> {
+	await applyRecentNotes(judgment.recentNotes ?? []);
+
+	const raw = await pollEval(
+		`(function(){ window.${globalKey} = "pending"; ${PLUGIN}.searchNotesForBenchmark(${JSON.stringify(judgment.query)}, ${JSON.stringify(algorithm)}, ${RESULT_LIMIT}).then(function(r){ window.${globalKey} = JSON.stringify(r.map(function(d){ return d.path; })); }).catch(function(e){ window.${globalKey} = JSON.stringify({error: String(e && e.message || e)}); }); return "started"; })()`,
+		globalKey,
+		{ timeoutMs: 60_000 },
+	);
+
+	const parsed = JSON.parse(raw);
+	if (parsed.error) throw new Error(`search failed for "${judgment.query}": ${parsed.error}`);
+	const paths: string[] = parsed;
+
+	// Multi-target cases have several grade-2 notes; report the best-placed one so
+	// the "rank" column stays meaningful for them too.
+	const targets = Object.entries(judgment.grades)
+		.filter(([, grade]) => grade === 2)
+		.map(([path]) => path);
+	const targetIndex = targets
+		.map((path) => paths.indexOf(path))
+		.filter((index) => index >= 0)
+		.reduce((best, index) => (best < 0 ? index : Math.min(best, index)), -1);
+
+	return {
+		query: judgment.query,
+		probes: judgment.probes,
+		ndcg: ndcgAt(paths, judgment.grades, NDCG_K),
+		rr: reciprocalRank(paths, judgment.grades),
+		targetRank: targetIndex >= 0 ? targetIndex + 1 : null,
+		topPaths: paths.slice(0, 5),
+		knownFailure: judgment.knownFailure,
+	};
+}
+
+const mean = (xs: number[]) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+function report(label: string, outcomes: QueryOutcome[]): void {
+	const lines: string[] = [
+		"",
+		`──────── ${label} ────────`,
+		`${"nDCG".padStart(6)} ${"RR".padStart(5)} ${"rank".padStart(5)}  query`,
+	];
+	for (const o of outcomes) {
+		const flag = o.knownFailure ? " ⚠" : "";
+		lines.push(
+			`${o.ndcg.toFixed(3).padStart(6)} ${o.rr.toFixed(2).padStart(5)} ${String(o.targetRank ?? "—").padStart(5)}${flag}  ${o.query}`,
+		);
+		// The imperfect cases are the interesting ones — show what beat the target.
+		if (o.ndcg < 1) {
+			lines.push(`${" ".repeat(19)}probes: ${o.probes}`);
+			lines.push(`${" ".repeat(19)}top: ${o.topPaths.join(", ") || "(none)"}`);
+		}
+	}
+
+	// Split the aggregate: the known-failure cases are exactly the ones a ranking
+	// rework is meant to move, so averaging them in would hide progress on the rest.
+	const known = outcomes.filter((o) => o.knownFailure);
+	const rest = outcomes.filter((o) => !o.knownFailure);
+	lines.push(
+		`${" ".repeat(19)}ALL      nDCG@${NDCG_K}=${mean(outcomes.map((o) => o.ndcg)).toFixed(4)} MRR=${mean(outcomes.map((o) => o.rr)).toFixed(4)} (n=${outcomes.length})`,
+	);
+	if (known.length > 0) {
+		lines.push(
+			`${" ".repeat(19)}EXPECTED nDCG@${NDCG_K}=${mean(rest.map((o) => o.ndcg)).toFixed(4)} MRR=${mean(rest.map((o) => o.rr)).toFixed(4)} (n=${rest.length}, excludes ${known.length} known failure(s))`,
+			`${" ".repeat(19)}KNOWN FAILURES:`,
+		);
+		for (const o of known) {
+			lines.push(`${" ".repeat(21)}⚠ ${o.query}`);
+			lines.push(`${" ".repeat(23)}${o.knownFailure}`);
+		}
+	}
+	lines.push("");
+	console.log(lines.join("\n"));
+}
+
+describe("search relevance benchmark", () => {
+	beforeAll(async () => {
+		clearBuffers();
+		await waitForStandaloneMiniSearch();
+	});
+
+	afterAll(async () => {
+		// Recency is persisted plugin state; leaving fixtures behind would skew any
+		// later search in this vault (including a subsequent benchmark run).
+		await applyRecentNotes([]);
+		clearBuffers();
+	});
+
+	it("has the generated corpus present in the vault", () => {
+		expect(
+			corpusIndexed,
+			"Corpus/ not found in the vault — run: bun run scripts/generate-search-corpus.ts",
+		).toBe(true);
+	});
+
+	describe.skipIf(!corpusIndexed)("lexical baseline", () => {
+		it("measures nDCG@10 and MRR for lexical-only ranking", async () => {
+			const outcomes: QueryOutcome[] = [];
+			for (const [i, judgment] of RELEVANCE_JUDGMENTS.entries()) {
+				outcomes.push(await scoreQuery(`__s2bBenchLex${i}`, "lexical", judgment));
+			}
+			report(`LEXICAL  (n=${outcomes.length})`, outcomes);
+
+			// Lexical alone cannot bridge the near-synonym cases; this run exists to
+			// quantify the gap the semantic half is supposed to close, so it only
+			// asserts that the harness produced a score for every query.
+			expect(outcomes).toHaveLength(RELEVANCE_JUDGMENTS.length);
+		});
+	});
+
+	describe.skipIf(!corpusIndexed || !providerAvailable || !searchIndexAvailable)("hybrid ranking", () => {
+		it("measures nDCG@10 and MRR for hybrid ranking", async () => {
+			const outcomes: QueryOutcome[] = [];
+			for (const [i, judgment] of RELEVANCE_JUDGMENTS.entries()) {
+				outcomes.push(await scoreQuery(`__s2bBenchHyb${i}`, "hybrid", judgment));
+			}
+			report(`HYBRID  (n=${outcomes.length})`, outcomes);
+
+			const meanNdcg = mean(outcomes.map((o) => o.ndcg));
+			const meanRr = mean(outcomes.map((o) => o.rr));
+
+			// Ratchet. Raise BASELINE_* whenever a change improves the score, so the
+			// suite locks in progress instead of only catching catastrophes. The
+			// tolerance absorbs embedding-provider jitter, not real regressions —
+			// repeated runs on the same index reproduce the mean exactly.
+			expect(meanNdcg, `mean nDCG@${NDCG_K} regressed`).toBeGreaterThanOrEqual(
+				BASELINE_MEAN_NDCG - BASELINE_TOLERANCE,
+			);
+			expect(meanRr, "MRR regressed").toBeGreaterThanOrEqual(BASELINE_MEAN_RR - BASELINE_TOLERANCE);
+
+			if (meanNdcg > BASELINE_MEAN_NDCG + BASELINE_TOLERANCE) {
+				console.log(
+					`\n  ✅ IMPROVED — raise BASELINE_MEAN_NDCG to ${meanNdcg.toFixed(4)} (was ${BASELINE_MEAN_NDCG})\n`,
+				);
+			}
+
+			// No single case may collapse, even if the mean still clears the bar —
+			// that would hide one query breaking while others improve.
+			for (const outcome of outcomes) {
+				expect(outcome.ndcg, `${outcome.query} — ${outcome.probes}`).toBeGreaterThan(0.5);
+			}
+		});
+
+		it("reports which known failures the current ranker still exhibits", async () => {
+			const known = RELEVANCE_JUDGMENTS.filter((j) => j.knownFailure);
+			if (known.length === 0) return;
+
+			const outcomes: QueryOutcome[] = [];
+			for (const [i, judgment] of known.entries()) {
+				outcomes.push(await scoreQuery(`__s2bBenchKnown${i}`, "hybrid", judgment));
+			}
+
+			// Informational, not a gate: if one of these starts passing, the ranking
+			// change worked and the `knownFailure` annotation should be removed.
+			for (const outcome of outcomes) {
+				if (outcome.ndcg >= 1) {
+					console.log(`\n  ✅ FIXED — remove knownFailure from: "${outcome.query}"\n`);
+				}
+			}
+			expect(outcomes).toHaveLength(known.length);
+		});
+	});
+});

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run --config vitest.integration.config.ts",
-    "setup-vault": "mkdir -p 'integration/Smart2Brain Test Vault/.obsidian/plugins/smart-second-brain' && cd 'integration/Smart2Brain Test Vault/.obsidian/plugins/smart-second-brain' && ln -sf ../../../../../build/smart-second-brain/main.js main.js && ln -sf ../../../../../build/smart-second-brain/styles.css styles.css && ln -sf ../../../../../build/smart-second-brain/manifest.json manifest.json"
+    "setup-vault": "mkdir -p 'integration/Smart2Brain Test Vault/.obsidian/plugins/smart-second-brain' && cd 'integration/Smart2Brain Test Vault/.obsidian/plugins/smart-second-brain' && ln -sf ../../../../../build/smart-second-brain/main.js main.js && ln -sf ../../../../../build/smart-second-brain/styles.css styles.css && ln -sf ../../../../../build/smart-second-brain/manifest.json manifest.json",
+    "corpus:generate": "bun run scripts/generate-search-corpus.ts",
+    "test:benchmark": "vitest run --config vitest.integration.config.ts integration/search-relevance-benchmark.test.ts"
   },
   "type": "module",
   "dependencies": {

--- a/scripts/generate-search-corpus.ts
+++ b/scripts/generate-search-corpus.ts
@@ -1,0 +1,476 @@
+#!/usr/bin/env bun
+/**
+ * Generate the synthetic relevance corpus used by the search ranking benchmark.
+ *
+ * The corpus is *generated* rather than committed as 300 hand-written notes so the
+ * relevance structure stays reviewable: every property the benchmark measures is
+ * declared here, in one place, instead of being implicit in a pile of prose.
+ *
+ * Properties deliberately encoded (each one exists to defeat a specific ranking
+ * failure mode):
+ *
+ *  - **Near-synonyms across domains** — the target note phrases a concept one way
+ *    ("photovoltaic array"), the query another ("solar panel"). Pure lexical search
+ *    cannot bridge these; they measure the semantic half of the hybrid.
+ *  - **Lexical distractors** — notes that share the query's vocabulary while being
+ *    about something else. These punish rankers that reward raw term frequency.
+ *  - **Length spread** — stubs (~40 words) through reference notes (~2500 words),
+ *    replacing the old bimodal fixture (7 tiny + 2 huge). Long notes are the ones
+ *    that win on surface area alone when length normalization is missing.
+ *  - **Multi-chunk targets** — notes long enough to split into several chunks, with
+ *    the answer repeated in separate sections, so "best chunk wins" and "aggregate
+ *    across chunks" produce measurably different rankings.
+ *  - **Alias / tag / path signals** — frontmatter aliases and tags that a query can
+ *    hit without the title matching.
+ *
+ * Deterministic: a fixed-seed PRNG means re-running produces byte-identical output,
+ * so regenerating never shows up as benchmark noise.
+ *
+ * Usage:
+ *   bun run scripts/generate-search-corpus.ts [--out <vault path>] [--clean]
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const DEFAULT_VAULT = "integration/Smart2Brain Test Vault";
+/** Corpus lives in its own folder so it is trivially separable from hand-written fixtures. */
+const CORPUS_DIR = "Corpus";
+
+// ── deterministic PRNG (mulberry32) ──────────────────────────────────────────
+
+function makeRng(seed: number): () => number {
+	let a = seed >>> 0;
+	return () => {
+		a = (a + 0x6d2b79f5) >>> 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+const rng = makeRng(0x5eed_1234);
+
+function pick<T>(items: readonly T[]): T {
+	return items[Math.floor(rng() * items.length)];
+}
+
+function shuffled<T>(items: readonly T[]): T[] {
+	const out = [...items];
+	for (let i = out.length - 1; i > 0; i--) {
+		const j = Math.floor(rng() * (i + 1));
+		[out[i], out[j]] = [out[j], out[i]];
+	}
+	return out;
+}
+
+// ── domain model ─────────────────────────────────────────────────────────────
+
+interface Domain {
+	/** Folder name under Corpus/. */
+	name: string;
+	/** Frontmatter tag applied to every note in the domain. */
+	tag: string;
+	/** Subject nouns used to build note titles and prose. */
+	subjects: readonly string[];
+	/** Domain vocabulary sprinkled into note bodies. */
+	vocabulary: readonly string[];
+}
+
+const DOMAINS: readonly Domain[] = [
+	{
+		name: "Marine Biology",
+		tag: "marine-biology",
+		subjects: [
+			"Coral Reef Bleaching",
+			"Deep Sea Hydrothermal Vents",
+			"Cephalopod Cognition",
+			"Whale Migration Routes",
+			"Plankton Blooms",
+			"Mangrove Nurseries",
+			"Shark Population Decline",
+			"Tidal Zone Ecology",
+			"Bioluminescence",
+			"Ocean Acidification",
+		],
+		vocabulary: [
+			"salinity",
+			"benthic",
+			"pelagic",
+			"symbiosis",
+			"larval dispersal",
+			"trophic cascade",
+			"upwelling",
+			"photic zone",
+		],
+	},
+	{
+		name: "Monetary Policy",
+		tag: "monetary-policy",
+		subjects: [
+			"Interest Rate Corridors",
+			"Quantitative Tightening",
+			"Inflation Expectations",
+			"Yield Curve Inversion",
+			"Reserve Requirements",
+			"Currency Pegs",
+			"Open Market Operations",
+			"Liquidity Traps",
+			"Forward Guidance",
+			"Seigniorage",
+		],
+		vocabulary: [
+			"basis points",
+			"counterparty",
+			"balance sheet",
+			"transmission mechanism",
+			"nominal anchor",
+			"term premium",
+			"repo market",
+			"output gap",
+		],
+	},
+	{
+		name: "Typography",
+		tag: "typography",
+		subjects: [
+			"Optical Sizing",
+			"Kerning Pairs",
+			"Variable Font Axes",
+			"Grotesque Sans Serifs",
+			"Baseline Grids",
+			"Hinting and Rasterization",
+			"Ligature Design",
+			"Type Foundries",
+			"Counters and Apertures",
+			"Reading Cadence",
+		],
+		vocabulary: [
+			"x-height",
+			"tracking",
+			"leading",
+			"serif bracket",
+			"stroke contrast",
+			"em square",
+			"glyph coverage",
+			"diacritics",
+		],
+	},
+	{
+		name: "Fermentation",
+		tag: "fermentation",
+		subjects: [
+			"Sourdough Starter Maintenance",
+			"Lactic Acid Bacteria",
+			"Koji Cultivation",
+			"Kombucha Scoby Health",
+			"Brine Concentration",
+			"Wild Yeast Capture",
+			"Miso Aging",
+			"Vinegar Mother Care",
+			"Kimchi Seasonality",
+			"Temperature Control in Fermentation",
+		],
+		vocabulary: [
+			"anaerobic",
+			"inoculation",
+			"pellicle",
+			"acidity",
+			"substrate",
+			"hydration ratio",
+			"osmotic pressure",
+			"secondary ferment",
+		],
+	},
+];
+
+/**
+ * Query-bearing fixtures: each one pins a specific ranking behaviour the benchmark
+ * asserts on. `answer` is the sentence that makes the note the correct result — it is
+ * phrased with the *near-synonym*, never the query's own wording, so a match requires
+ * semantic understanding rather than term overlap.
+ */
+interface Probe {
+	/** Slug used for the note filename. */
+	slug: string;
+	domain: string;
+	title: string;
+	/** The distinctive sentence that answers the probe query. */
+	answer: string;
+	/** Frontmatter aliases, for alias-signal coverage. */
+	aliases?: string[];
+	/** Extra tags beyond the domain tag. */
+	tags?: string[];
+	/** Approximate body length in words. */
+	words: number;
+	/** Repeat the answer in a late section too, to create a genuine multi-chunk target. */
+	repeatAnswerLate?: boolean;
+}
+
+const PROBES: readonly Probe[] = [
+	{
+		slug: "photovoltaic-array-degradation",
+		domain: "Marine Biology",
+		title: "Photovoltaic Array Degradation Offshore",
+		// Query will say "solar panel wear at sea" — no shared content words.
+		answer:
+			"Offshore photovoltaic arrays lose roughly half a percent of rated output each year, driven mainly by salt-spray corrosion of the cell interconnects rather than by ultraviolet damage.",
+		aliases: ["Offshore Solar Wear"],
+		tags: ["degradation"],
+		words: 1800,
+		repeatAnswerLate: true,
+	},
+	{
+		slug: "cephalopod-problem-solving",
+		domain: "Marine Biology",
+		title: "Cephalopod Problem Solving",
+		answer:
+			"Octopuses open sealed containers by rotating the lid counter-clockwise, and individuals retain the technique for at least three weeks without reinforcement.",
+		aliases: ["Octopus Intelligence"],
+		words: 240,
+	},
+	{
+		slug: "policy-rate-transmission-lag",
+		domain: "Monetary Policy",
+		title: "Policy Rate Transmission Lag",
+		answer:
+			"A change in the overnight target reaches consumer borrowing costs after four to six quarters, with mortgage rates responding faster than small-business credit.",
+		tags: ["transmission"],
+		words: 2400,
+		repeatAnswerLate: true,
+	},
+	{
+		slug: "hyperinflation-episodes",
+		domain: "Monetary Policy",
+		title: "Hyperinflation Episodes",
+		answer:
+			"Once monthly price growth passes fifty percent, households abandon the domestic unit of account within weeks and switch to foreign currency for savings.",
+		aliases: ["Runaway Price Growth"],
+		words: 45,
+	},
+	{
+		slug: "legibility-at-small-sizes",
+		domain: "Typography",
+		title: "Legibility at Small Sizes",
+		answer:
+			"Below nine points, open apertures and a generous x-height preserve character recognition far more effectively than increasing the stroke weight.",
+		tags: ["legibility"],
+		words: 900,
+	},
+	{
+		slug: "starter-hydration-and-rise",
+		domain: "Fermentation",
+		title: "Starter Hydration and Rise Time",
+		answer:
+			"A hundred percent hydration starter doubles in about five hours at twenty-four degrees, while a stiff sixty percent starter takes nearly twice as long.",
+		aliases: ["Levain Timing"],
+		words: 1400,
+		repeatAnswerLate: true,
+	},
+];
+
+/**
+ * Distractors: notes engineered to *look* right lexically for a probe query while
+ * being about something else. Without them a ranker that simply counts query terms
+ * scores as well as one that understands the question.
+ */
+interface Distractor {
+	slug: string;
+	domain: string;
+	title: string;
+	/** Deliberately stuffed with the query's own words, in the wrong context. */
+	decoy: string;
+	words: number;
+}
+
+const DISTRACTORS: readonly Distractor[] = [
+	{
+		slug: "solar-panel-metaphors-in-design",
+		domain: "Typography",
+		title: "Solar Panel Metaphors in Signage Design",
+		decoy:
+			"Wayfinding signage for solar farms borrows the visual language of the panel grid: repeated rectangular modules, high contrast, and a cool blue cast. The panels themselves are only a motif here — this note is about sign layout, not about how any array performs or wears over time.",
+		words: 700,
+	},
+	{
+		slug: "interest-in-typography-history",
+		domain: "Typography",
+		title: "Interest and Rates of Change in Type History",
+		decoy:
+			"Interest in revival faces rose sharply after 1990, and the rate at which foundries released new families climbed with it. The words interest and rate appear throughout this note in their ordinary English sense, with no monetary meaning whatsoever.",
+		words: 650,
+	},
+	{
+		slug: "octopus-recipes",
+		domain: "Fermentation",
+		title: "Fermented Octopus Preparations",
+		decoy:
+			"Octopus is salted and left to ferment briefly before grilling. This note covers brining and texture, not animal behaviour, learning, or any container-opening problem solving.",
+		words: 500,
+	},
+	{
+		slug: "small-sizes-of-fermentation-vessels",
+		domain: "Fermentation",
+		title: "Small Sizes of Fermentation Vessels",
+		decoy:
+			"At small sizes, a vessel loses heat quickly and the ferment stalls. Small batch sizes also make the pH swing faster. Nothing here concerns reading, type, or character recognition.",
+		words: 480,
+	},
+];
+
+// ── prose generation ─────────────────────────────────────────────────────────
+
+const SECTION_TITLES = [
+	"Background",
+	"Mechanism",
+	"Field Observations",
+	"Measurement",
+	"Common Failure Modes",
+	"Practical Notes",
+	"Open Questions",
+	"Further Reading",
+] as const;
+
+/** Build filler prose from a domain's vocabulary — plausible, never accidentally on-topic. */
+function fillerSentence(domain: Domain): string {
+	const a = pick(domain.vocabulary);
+	const b = pick(domain.vocabulary);
+	const subject = pick(domain.subjects);
+	const templates = [
+		`Work on ${subject.toLowerCase()} tends to foreground ${a} while treating ${b} as a secondary effect.`,
+		`Practitioners disagree about how much ${a} explains, particularly where ${b} varies across sites.`,
+		`Any survey of ${subject.toLowerCase()} has to reconcile ${a} with the constraints imposed by ${b}.`,
+		`Reported figures for ${a} vary widely, which complicates comparison against ${b}.`,
+		`The relationship between ${a} and ${b} is not linear, and small shifts compound over a season.`,
+	];
+	return pick(templates);
+}
+
+/** Generate a body of approximately `words` words, split into `##` sections. */
+function buildBody(domain: Domain, words: number, leadPara: string, repeatLate?: string): string {
+	const parts: string[] = [leadPara];
+	let count = leadPara.split(/\s+/).length;
+
+	const sections = shuffled(SECTION_TITLES);
+	let s = 0;
+	while (count < words) {
+		const heading = sections[s % sections.length];
+		s++;
+		parts.push(`\n## ${heading}\n`);
+		count += 2;
+
+		// Each section gets a few sentences; long notes therefore cross chunk
+		// boundaries with real headings, exercising the chunker's breadcrumbs.
+		const sentences: string[] = [];
+		const target = Math.min(words - count, 60 + Math.floor(rng() * 60));
+		let sectionCount = 0;
+		while (sectionCount < target) {
+			const sentence = fillerSentence(domain);
+			sentences.push(sentence);
+			sectionCount += sentence.split(/\s+/).length;
+		}
+		parts.push(sentences.join(" "));
+		count += sectionCount;
+	}
+
+	// Restate the answer far from the top so the note has more than one strong
+	// chunk — this is what separates best-chunk from aggregate scoring.
+	if (repeatLate) {
+		parts.push(`\n## Summary\n`);
+		parts.push(repeatLate);
+	}
+
+	return parts.join("\n");
+}
+
+function frontmatter(tags: string[], aliases?: string[]): string {
+	const lines = ["---"];
+	if (aliases?.length) {
+		lines.push("aliases:");
+		for (const alias of aliases) lines.push(`  - ${alias}`);
+	}
+	lines.push("tags:");
+	for (const tag of tags) lines.push(`  - ${tag}`);
+	lines.push("---", "");
+	return lines.join("\n");
+}
+
+function domainByName(name: string): Domain {
+	const found = DOMAINS.find((d) => d.name === name);
+	if (!found) throw new Error(`Unknown domain: ${name}`);
+	return found;
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+function main(): void {
+	const args = process.argv.slice(2);
+	const outIndex = args.indexOf("--out");
+	const vaultPath = outIndex >= 0 ? args[outIndex + 1] : DEFAULT_VAULT;
+	const corpusRoot = join(vaultPath, CORPUS_DIR);
+
+	if (args.includes("--clean")) {
+		rmSync(corpusRoot, { recursive: true, force: true });
+	}
+
+	const written: Array<{ path: string; words: number }> = [];
+
+	const write = (domain: Domain, filename: string, content: string) => {
+		const dir = join(corpusRoot, domain.name);
+		mkdirSync(dir, { recursive: true });
+		const full = join(dir, `${filename}.md`);
+		writeFileSync(full, content, "utf8");
+		written.push({ path: full, words: content.split(/\s+/).length });
+	};
+
+	// 1. Probe notes — the graded-relevance targets.
+	for (const probe of PROBES) {
+		const domain = domainByName(probe.domain);
+		const body = buildBody(
+			domain,
+			probe.words,
+			probe.answer,
+			probe.repeatAnswerLate ? probe.answer : undefined,
+		);
+		const content = `${frontmatter([domain.tag, ...(probe.tags ?? [])], probe.aliases)}# ${probe.title}\n\n${body}\n`;
+		write(domain, probe.slug, content);
+	}
+
+	// 2. Distractor notes — lexically tempting, semantically wrong.
+	for (const distractor of DISTRACTORS) {
+		const domain = domainByName(distractor.domain);
+		const body = buildBody(domain, distractor.words, distractor.decoy);
+		const content = `${frontmatter([domain.tag, "distractor"])}# ${distractor.title}\n\n${body}\n`;
+		write(domain, distractor.slug, content);
+	}
+
+	// 3. Bulk filler — gives the corpus realistic scale so rank-sensitive behaviour
+	//    (cutoffs, normalization) is exercised rather than trivially satisfied.
+	//    Lengths follow a long-tailed spread instead of the old bimodal fixture.
+	const BULK_TARGET = 300 - written.length;
+	for (let i = 0; i < BULK_TARGET; i++) {
+		const domain = DOMAINS[i % DOMAINS.length];
+		const subject = domain.subjects[Math.floor(i / DOMAINS.length) % domain.subjects.length];
+		const variant = Math.floor(i / (DOMAINS.length * domain.subjects.length)) + 1;
+		const title = variant > 1 ? `${subject} ${variant}` : subject;
+
+		// Long tail: mostly short/medium notes, a few genuinely long ones.
+		const roll = rng();
+		const words = roll < 0.5 ? 60 + Math.floor(rng() * 120) : roll < 0.85 ? 300 + Math.floor(rng() * 500) : 1200 + Math.floor(rng() * 1400);
+
+		const lead = `${title} is a recurring topic in ${domain.name.toLowerCase()}. ${fillerSentence(domain)}`;
+		const body = buildBody(domain, words, lead);
+		const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+		const content = `${frontmatter([domain.tag])}# ${title}\n\n${body}\n`;
+		write(domain, slug, content);
+	}
+
+	const totalWords = written.reduce((sum, w) => sum + w.words, 0);
+	const lengths = written.map((w) => w.words).sort((a, b) => a - b);
+	const median = lengths[Math.floor(lengths.length / 2)];
+	console.log(`Wrote ${written.length} notes to ${corpusRoot}`);
+	console.log(`  probes: ${PROBES.length}, distractors: ${DISTRACTORS.length}`);
+	console.log(`  words: total ${totalWords}, median ${median}, min ${lengths[0]}, max ${lengths[lengths.length - 1]}`);
+}
+
+main();

--- a/src/components/modal/EmbeddingIndexSetupModal.ts
+++ b/src/components/modal/EmbeddingIndexSetupModal.ts
@@ -1,5 +1,6 @@
 import { Modal } from "obsidian";
 import { mount, unmount } from "svelte";
+import ModalProvider from "../../lib/QueryClientProvider.svelte";
 import type SecondBrainPlugin from "../../main";
 import type { SelectedModel } from "./ModelSelectionModal";
 import EmbeddingIndexSetupModalComponent from "./EmbeddingIndexSetupModal.svelte";
@@ -37,15 +38,30 @@ export class EmbeddingIndexSetupModal extends Modal {
 			this.options.purpose === "search" ? "Configure Search Embedding Index" : "Configure Graph Embedding Index",
 		);
 
-		this.component = mount(EmbeddingIndexSetupModalComponent, {
-			target: this.contentEl,
-			props: {
-				modal: this,
-				plugin: this.plugin,
-				currentSelection: this.options.currentSelection,
-				onSave: this.options.onSave,
+		// Wrapped in ModalProvider: the component calls `useAvailableModels()`, which
+		// resolves a QueryClient from Svelte context. Mounting it bare threw
+		// "No QueryClient was found in Svelte context" and left the modal blank.
+		this.component = mount(
+			ModalProvider<{
+				modal: EmbeddingIndexSetupModal;
+				plugin: SecondBrainPlugin;
+				currentSelection: SelectedModel | null;
+				onSave: (selectedModel: SelectedModel, batchSize: number) => void;
+			}>,
+			{
+				target: this.contentEl,
+				props: {
+					plugin: this.plugin,
+					component: EmbeddingIndexSetupModalComponent,
+					componentProps: {
+						modal: this,
+						plugin: this.plugin,
+						currentSelection: this.options.currentSelection,
+						onSave: this.options.onSave,
+					},
+				},
 			},
-		});
+		);
 	}
 
 	onClose() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,8 @@ import { persistStartupRecord, recordStartupEnvironment } from "./utils/startupT
 import "./styles.css";
 import { AgentManager } from "./agent/AgentManager";
 import { PromptFilesService } from "./agent/promptFiles";
+import { performSearch } from "./agent/tools/searchNotes";
+import type { SearchAlgorithm } from "./types/plugin";
 import { inlineDiffPlugin } from "./editor/inlineDiffExtension";
 import { selectionHighlightPlugin } from "./editor/selectionHighlightExtension";
 import { createReadingViewDiffPostProcessor } from "./editor/readingViewDiffProcessor";
@@ -66,6 +68,30 @@ export default class SecondBrainPlugin extends Plugin {
 	private onloadEndAt = -1;
 	/** Mounted status-bar running-agent indicator (unmounted on plugin unload). */
 	private runningIndicator: ReturnType<typeof mount> | null = null;
+
+	/**
+	 * Run the shared search + ranking pipeline and return the ranked paths.
+	 *
+	 * `performSearch` is the single ranking entry point behind both the search modal
+	 * (`SearchModal.ts`) and the `search_notes` agent tool, but it is a module-level
+	 * export and therefore unreachable from the Obsidian CLI's `eval`. Exposing it
+	 * here lets the relevance benchmark
+	 * (`integration/search-relevance-benchmark.test.ts`) measure the real fusion
+	 * ranking rather than re-implementing it. Not part of the plugin's user-facing
+	 * surface.
+	 */
+	async searchNotesForBenchmark(
+		query: string,
+		algorithm: SearchAlgorithm,
+		limit: number,
+	): Promise<Array<{ path: string; name: string; score?: number }>> {
+		const results = await performSearch(this.app, query, algorithm);
+		return results.slice(0, limit).map((result) => ({
+			path: result.path,
+			name: result.name,
+			score: result.score,
+		}));
+	}
 
 	private getAddToChatMenuLabel(selectedCount: number): string {
 		if (selectedCount <= 1) {

--- a/src/search/finalSearchRanking.ts
+++ b/src/search/finalSearchRanking.ts
@@ -363,16 +363,6 @@ export function rankSearchResults({
 	// recently-opened near-duplicates can march past a better answer. (Measured:
 	// three recent siblings pushed the correct note from rank 1 to rank 4.)
 	//
-	// Attenuate quadratically in the number of recent contenders: each rival both
-	// dilutes the signal (1/n, it no longer identifies a single note) and raises
-	// the bar for acting on it (1/n again, since promoting one of n interchangeable
-	// notes is n times more likely to be wrong). A lone recent note in a field of
-	// stale ones keeps full strength.
-	const recentContenders = scored.filter(
-		(entry) => (recentBoostByPath.get(entry.result.path)?.boost ?? 0) > 0,
-	).length;
-	const recentCrowdingFactor = recentContenders > 0 ? 1 / recentContenders ** 2 : 1;
-
 	// Adaptive lift ceiling: scale recency to how tightly *this* result set is
 	// packed. The median adjacent gap is used rather than the mean so a single
 	// outlier (one very strong match, or a long tail of near-zeroes) cannot skew
@@ -404,6 +394,23 @@ export function rankSearchResults({
 		// enough match to earn a recency lift.
 		return 0;
 	};
+
+	// Attenuate quadratically in the number of recent contenders: each rival both
+	// dilutes the signal (1/n, it no longer identifies a single note) and raises
+	// the bar for acting on it (1/n again, since promoting one of n interchangeable
+	// notes is n times more likely to be wrong). A lone recent note in a field of
+	// stale ones keeps full strength.
+	//
+	// Only *eligible* notes count. A recently-opened note that failed the relevance
+	// gate receives no lift at all, so it is not competing for the tiebreaker and
+	// must not dilute it — otherwise opening a few irrelevant notes would silently
+	// suppress recency for the one note it should actually help.
+	const recentContenders = scored.filter(
+		(entry) =>
+			(recentBoostByPath.get(entry.result.path)?.boost ?? 0) > 0 &&
+			rawRelativeRelevance(entry) >= RECENT_RELATIVE_ELIGIBILITY,
+	).length;
+	const recentCrowdingFactor = recentContenders > 0 ? 1 / recentContenders ** 2 : 1;
 
 	return scored
 		.map((entry) => {

--- a/src/search/finalSearchRanking.ts
+++ b/src/search/finalSearchRanking.ts
@@ -4,58 +4,118 @@ import { getRecentRerankScore, type RecentBoostInfo } from "./recentNotes";
 import type { SearchMatchBadge, SearchRankingDebug, SearchResult } from "../vectorstore/types";
 
 /*
- * ROBUSTNESS DEBT (tracked in GitHub issue): this file is a stack of ~9
- * hand-calibrated constants (FUSION_RRF_K, the FUSION_*_BOOST_MAX /
- * SEMANTIC_ONLY_*_BOOST_MAX pairs, RECENT_ALIAS_SCORE_WEIGHT,
- * MAX_RECENT_ALIAS_SCORE_SHARE, RECENT_BOOST_ELIGIBLE_RANK,
- * SEMANTIC_SCORE_BLEND_WEIGHT) that interact multiplicatively and were tuned
- * against a small fixture vault (~88 docs, one embedding model). Two known
- * generalization gaps:
- *   1. RECENT_BOOST_ELIGIBLE_RANK is a hard *rank* cutoff, not a relative
- *      *score* cliff — a strong match at rank 11 is gated while a weak match
- *      at rank 10 is not. A relative-score threshold (cosine >= fraction of
- *      the top match) would scale better across vault sizes / models.
- *   2. SEMANTIC_SCORE_BLEND_WEIGHT (0.3) is a fixed share, not adaptive to the
- *      cosine distribution of the result set.
- * The current values fix an observed bug and regress nothing; treat them as a
- * tuned heuristic, not a general algorithm. Re-validate before scaling to
- * large vaults or new embedding models.
+ * Hybrid fusion ranking.
+ *
+ * Design rule: every signal is normalized *within the current result set*. No
+ * constant is ever compared against a raw BM25 magnitude or a raw cosine, and
+ * there are no hard rank cutoffs — so the algorithm behaves the same shape on a
+ * 40-note vault as on a 40,000-note one, and across embedding models whose score
+ * distributions differ wildly.
+ *
+ * This replaced a stack of hand-calibrated constants tuned against a small
+ * fixture vault. Two gaps that rework fixed, both measured on the graded
+ * relevance benchmark (`integration/search-relevance-benchmark.test.ts`):
+ *
+ *   1. Recency eligibility was a hard *rank* cutoff (top 10), so a strong match
+ *      at rank 11 was gated while a weak one at rank 10 was not — whether a
+ *      recently-opened note could hijack a query depended on which side of an
+ *      arbitrary line it fell. It is now a *relative score* threshold.
+ *   2. The semantic magnitude contribution was a fixed share bolted onto RRF.
+ *      Score magnitude is now a first-class fusion input via per-source
+ *      normalization, with RRF retained only as a rank-stability term.
  */
 
+/**
+ * RRF damping constant. Retained as a *stability* term: rank-based scoring is
+ * robust when one source's magnitudes are degenerate (e.g. every BM25 hit tied),
+ * which pure score normalization handles badly.
+ */
 const FUSION_RRF_K = 60;
-const FUSION_TITLE_BOOST_MAX = 0.03;
-const FUSION_ALIAS_BOOST_MAX = 0.028;
-const SEMANTIC_ONLY_TITLE_BOOST_MAX = 0.12;
-const SEMANTIC_ONLY_ALIAS_BOOST_MAX = 0.12;
+
+/**
+ * Split between normalized-score fusion and rank-based RRF. Score carries the
+ * relevance signal; rank guards against degenerate score distributions.
+ */
+const SCORE_FUSION_WEIGHT = 0.7;
+const RANK_FUSION_WEIGHT = 1 - SCORE_FUSION_WEIGHT;
+
+/**
+ * Relative weight of the semantic vs lexical source once both are normalized to
+ * 0-1. Semantic leads because it is the only source that can bridge vocabulary
+ * gaps; lexical remains a strong tiebreaker and the sole signal for exact terms.
+ */
+const SEMANTIC_SOURCE_WEIGHT = 0.6;
+const LEXICAL_SOURCE_WEIGHT = 1 - SEMANTIC_SOURCE_WEIGHT;
+
+/** Identity boosts, as a fraction of the (0-1) fused score. */
+const FUSION_TITLE_BOOST_MAX = 0.18;
+const FUSION_ALIAS_BOOST_MAX = 0.17;
+const SEMANTIC_ONLY_TITLE_BOOST_MAX = 0.3;
+const SEMANTIC_ONLY_ALIAS_BOOST_MAX = 0.3;
 const RECENT_ALIAS_SCORE_WEIGHT = 1.2;
 const MAX_RECENT_ALIAS_SCORE_SHARE = 0.15;
 
 /**
- * A note only receives the recency boost when it is already a genuine match.
- * When semantic results exist, that means a top-N *semantic* rank (a weak
- * lexical hit on common query words is not relevance); for lexical-only queries
- * it means a top-N lexical rank. This stops a merely-recently-opened note from
- * being lifted over the best-matching result. Recent notes below this rank keep
- * their "recent" badge but contribute no recency score.
+ * A note only receives the recency boost when it is already a genuine match —
+ * its fused relevance must be within this fraction of the best result in the
+ * set. Replaces the old top-10 rank cutoff, which produced an arbitrary cliff:
+ * relevance, not position, now decides eligibility, and the test scales with
+ * vault size and embedding model because it is purely relative.
+ *
+ * Measured motivation: with the rank gate, opening a *recipe* note made it
+ * outrank the correct answer for "can an octopus learn to open a sealed jar",
+ * because the correct note led by only 2.8% while recency multiplied by up to
+ * 1.6x. Notes below the threshold keep their "recent" badge but gain no score.
  */
-const RECENT_BOOST_ELIGIBLE_RANK = 10;
+const RECENT_RELATIVE_ELIGIBILITY = 0.8;
 
 /**
- * Share of the hybrid base score derived from the *magnitude* of the semantic
- * cosine (relative to the best match in the set), with the remainder from
- * rank-based RRF. RRF alone discards score magnitude, so a strong semantic
- * match barely outranks a weak one at a nearby rank; this term restores that
- * signal while keeping RRF as the backbone (so the tuned title/alias boosts
- * stay calibrated).
+ * How much recency may lift a note, expressed as a multiple of the *typical gap
+ * between adjacent results in this query's own result set*.
+ *
+ * Recency is a tiebreaker among comparably relevant notes, not a way to overturn
+ * relevance. "Comparable" only means something relative to how tightly the set is
+ * packed: in a dense semantic result set, adjacent notes sit ~1% apart and a 12%
+ * deficit is a chasm; in a sparse two-result lexical set, adjacent notes sit ~10%
+ * apart and the same 12% is a near-tie. A fixed percentage cannot express that —
+ * it is the reason the previous constant (0.15) was tuned to one embedding model
+ * and broke on another.
+ *
+ * Measured typical gaps: harrier-oss semantic 0.7%, qwen3-8b semantic 0.9%,
+ * two-result lexical 10-16%. Required outcomes are satisfied for any multiplier
+ * from 1.5 to 3.0; 2 sits in the middle of that window.
+ *
+ * This is the ceiling for a *lone* recent note; when several eligible results are
+ * recent, `recentCrowdingFactor` attenuates it further.
  */
-const SEMANTIC_SCORE_BLEND_WEIGHT = 0.3;
+const RECENT_LIFT_GAP_MULTIPLIER = 2;
 
 /**
- * Scales the normalized-semantic blend term onto the same magnitude as the RRF
- * sum, whose max is `2 / (K + 1)` (both sources at rank 1). Keeps the blend
- * comparable to the fusion boosts rather than swamping them.
+ * Absolute floor and ceiling on the adaptive cap, guarding the degenerate ends.
+ *
+ * A result set with identical scores has a typical gap of zero, which would
+ * disable recency entirely; a set with one huge outlier could otherwise licence a
+ * lift big enough to overturn genuine relevance.
  */
-const RRF_MAX_SUM = 2 / (FUSION_RRF_K + 1);
+const MIN_RECENT_LIFT = 0.02;
+const MAX_RECENT_LIFT = 0.3;
+
+/**
+ * How much of the weakest score to subtract when normalizing a source onto 0-1.
+ *
+ * 0 = divide-by-max: preserves ratios exactly, so a 10-vs-9 near-tie stays a
+ * near-tie (1.0 vs 0.9) and identity/recency terms can still reorder it. Its
+ * weakness is narrow bands — cosines clustered in 0.40-0.55 all land near 1.0.
+ * 1 = full min-max: maximum contrast, but stretches *any* spread to fill 0-1, so
+ * on small sets a trivial gap becomes a blowout that no bounded term can close.
+ *
+ * Kept low deliberately: preserving true proportions is what lets the identity
+ * and recency signals do their job, and the rank-fusion term (RRF) already
+ * supplies contrast when magnitudes are bunched. A high share re-introduces the
+ * failure this rework exists to remove — scores that look decisive because of
+ * how few results there were, not because of how different they are.
+ */
+const NORMALIZATION_FLOOR_SHARE = 0.15;
 
 interface RankSearchResultsOptions {
 	query?: string;
@@ -157,21 +217,55 @@ export function rankSearchResults({
 	const hasLexicalSource = lexicalResults.length > 0;
 	const hasSemanticSource = semanticResults.length > 0;
 	const hasHybridSources = hasLexicalSource && hasSemanticSource;
-	const shouldApplyQueryRescue = Boolean(queryPlan) && hasSemanticSource;
+	// Identity boosts apply to any keyword query, including lexical-only ones.
+	// They used to require a semantic source, which left an exact alias match on a
+	// lexical-only query with no credit at all — the old code papered over that
+	// with an outsized recency-alias bonus, coupling two unrelated signals. Title
+	// and alias matches are evidence of relevance regardless of which retriever
+	// found the note.
+	const shouldApplyQueryRescue = Boolean(queryPlan);
 	const titleRescueMax = hasHybridSources
 		? FUSION_TITLE_BOOST_MAX
-		: shouldApplyQueryRescue
+		: hasSemanticSource
 			? SEMANTIC_ONLY_TITLE_BOOST_MAX
-			: 0;
+			: FUSION_TITLE_BOOST_MAX;
 	const aliasRescueMax = hasHybridSources
 		? FUSION_ALIAS_BOOST_MAX
-		: shouldApplyQueryRescue
+		: hasSemanticSource
 			? SEMANTIC_ONLY_ALIAS_BOOST_MAX
-			: 0;
+			: FUSION_ALIAS_BOOST_MAX;
 	const totalResults = Math.max(lexicalResults.length, semanticResults.length);
-	// Best semantic score in the set, for relative (per-query) normalization of
-	// the magnitude blend — avoids any per-model absolute threshold.
-	const maxSemanticScore = semanticResults.reduce((max, r) => Math.max(max, r.score ?? 0), 0);
+
+	// Per-source normalization onto 0-1 *within this result set*. This is what
+	// makes BM25 magnitudes and cosines comparable without any per-model constant.
+	//
+	// Deliberately NOT min-max. Min-max maps the worst result to 0 and the best to
+	// 1 regardless of how close they actually are, so a set of two near-identical
+	// scores (BM25 10 vs 9) is stretched into a total blowout — the tail's score
+	// becomes absorbing, and every proportional term downstream (identity boosts,
+	// the recency cap) multiplies to nothing against it.
+	//
+	// Instead the floor is pulled toward zero by NORMALIZATION_FLOOR_SHARE, so the
+	// mapping preserves *relative* differences: scores 10 and 9 stay close (1.0 vs
+	// ~0.93), while a genuine gap (0.9 vs 0.1) stays wide. Divide-by-max alone
+	// would be the degenerate case of this (share = 1) and compresses narrow cosine
+	// bands too much; a partial share keeps ranking signal in both regimes.
+	const normalizer = (results: SearchResult[]) => {
+		const scores = results.map((r) => r.score ?? 0);
+		const max = scores.length > 0 ? Math.max(...scores) : 0;
+		const min = scores.length > 0 ? Math.min(...scores) : 0;
+		const floor = Math.max(0, min) * NORMALIZATION_FLOOR_SHARE;
+		const range = max - floor;
+		return (score: number | undefined): number => {
+			if (score === undefined) return 0;
+			// All scores identical (or a single result): magnitude carries no
+			// information, so treat every hit as a full match and let rank decide.
+			if (range <= 0) return max > 0 ? 1 : 0;
+			return Math.min(1, Math.max(0, (score - floor) / range));
+		};
+	};
+	const normalizeLexical = normalizer(lexicalResults);
+	const normalizeSemantic = normalizer(semanticResults);
 
 	for (const [index, result] of semanticResults.entries()) {
 		entries.set(result.path, {
@@ -197,68 +291,156 @@ export function rankSearchResults({
 		});
 	}
 
-	return Array.from(entries.values())
+	// Pass 1: relevance only. Recency is deliberately excluded here so the
+	// eligibility threshold below is measured against pure relevance — otherwise a
+	// cluster of recent notes would raise the bar they are themselves judged by.
+	const scored = Array.from(entries.values()).map((entry) => {
+		const normalizedLexical = normalizeLexical(entry.lexicalScore);
+		const normalizedSemantic = normalizeSemantic(entry.semanticScore);
+
+		const lexicalRrfScore = hasHybridSources ? getRankScore(entry.lexicalRank) : 0;
+		const semanticRrfScore = hasHybridSources ? getRankScore(entry.semanticRank) : 0;
+
+		let sourceScore: number;
+		if (hasHybridSources) {
+			// Weighted normalized scores, plus a rank term for stability. Both parts
+			// are already 0-1, so the fused score is 0-1 and the identity boosts
+			// below are meaningful fractions rather than magnitude-specific nudges.
+			const scorePart = SEMANTIC_SOURCE_WEIGHT * normalizedSemantic + LEXICAL_SOURCE_WEIGHT * normalizedLexical;
+			// Normalize the RRF sum by its own maximum (both sources at rank 1) so it
+			// too lands on 0-1 and the split below is a true proportion.
+			const rankPart = (lexicalRrfScore + semanticRrfScore) / (2 / (FUSION_RRF_K + 1));
+			sourceScore = SCORE_FUSION_WEIGHT * scorePart + RANK_FUSION_WEIGHT * Math.min(1, rankPart);
+		} else if (hasSemanticSource || hasLexicalSource) {
+			// Single source: its normalized score already spans 0-1.
+			sourceScore = hasSemanticSource ? normalizedSemantic : normalizedLexical;
+		} else {
+			sourceScore = getFallbackScore(
+				entry.semanticScore ?? entry.lexicalScore,
+				entry.semanticRank ?? entry.lexicalRank,
+				totalResults,
+			);
+		}
+
+		const finalTitleBoost =
+			shouldApplyQueryRescue && queryPlan ? calculateTitleBoost(queryPlan, entry.result.name, titleRescueMax) : 0;
+		const finalAliasBoost =
+			shouldApplyQueryRescue && queryPlan
+				? calculateAliasBoost(queryPlan, entry.result.frontmatter, aliasRescueMax)
+				: 0;
+
+		const baseScore = sourceScore + finalTitleBoost + finalAliasBoost;
+
+		return {
+			...entry,
+			baseScore,
+			normalizedLexical,
+			normalizedSemantic,
+			lexicalRrfScore,
+			semanticRrfScore,
+			finalTitleBoost,
+			finalAliasBoost,
+			originalRank: entry.lexicalRank ?? entry.semanticRank,
+		};
+	});
+
+	// Relative-score recency gate: eligibility is "is this note nearly as relevant
+	// as the best answer", not "did it land in the top N".
+	//
+	// The ratio is taken on each source's *raw* scale, not the normalized one.
+	// Normalization is a within-set rescaling tuned for fusion, and on small result
+	// sets it deliberately stretches whatever spread exists to fill 0-1 — so two
+	// nearly-tied BM25 hits (308 vs 260, a genuine 84% near-tie) would look like a
+	// blowout and be gated apart. Raw ratios answer the question the gate actually
+	// asks: is this note about as good a match as the winner?
+	const bestRawSemantic = semanticResults.reduce((max, r) => Math.max(max, r.score ?? 0), 0);
+	const bestRawLexical = lexicalResults.reduce((max, r) => Math.max(max, r.score ?? 0), 0);
+
+	// Recency is a signal for distinguishing a note from its *non-recent* rivals.
+	// When several eligible results are all recently opened, recency says nothing
+	// about which of them the user wants — it is common to all of them — so
+	// applying it just amplifies whatever noise separates them, and a cluster of
+	// recently-opened near-duplicates can march past a better answer. (Measured:
+	// three recent siblings pushed the correct note from rank 1 to rank 4.)
+	//
+	// Attenuate quadratically in the number of recent contenders: each rival both
+	// dilutes the signal (1/n, it no longer identifies a single note) and raises
+	// the bar for acting on it (1/n again, since promoting one of n interchangeable
+	// notes is n times more likely to be wrong). A lone recent note in a field of
+	// stale ones keeps full strength.
+	const recentContenders = scored.filter(
+		(entry) => (recentBoostByPath.get(entry.result.path)?.boost ?? 0) > 0,
+	).length;
+	const recentCrowdingFactor = recentContenders > 0 ? 1 / recentContenders ** 2 : 1;
+
+	// Adaptive lift ceiling: scale recency to how tightly *this* result set is
+	// packed. The median adjacent gap is used rather than the mean so a single
+	// outlier (one very strong match, or a long tail of near-zeroes) cannot skew
+	// the scale. Measured on base scores, which are already normalized to 0-1.
+	const orderedBaseScores = scored.map((entry) => entry.baseScore).sort((a, b) => b - a);
+	const adjacentGaps: number[] = [];
+	const topBaseScore = orderedBaseScores[0] ?? 0;
+	if (topBaseScore > 0) {
+		for (let i = 1; i < orderedBaseScores.length; i++) {
+			adjacentGaps.push((orderedBaseScores[i - 1] - orderedBaseScores[i]) / topBaseScore);
+		}
+	}
+	const typicalGap =
+		adjacentGaps.length > 0 ? adjacentGaps.sort((a, b) => a - b)[Math.floor(adjacentGaps.length / 2)] : 0;
+	const adaptiveRecentLift = Math.min(
+		MAX_RECENT_LIFT,
+		Math.max(MIN_RECENT_LIFT, RECENT_LIFT_GAP_MULTIPLIER * typicalGap),
+	);
+	const rawRelativeRelevance = (entry: (typeof scored)[number]): number => {
+		// Prefer the semantic view when available: it is the source that actually
+		// measures meaning. Fall back to lexical for lexical-only queries.
+		if (hasSemanticSource && entry.semanticScore !== undefined && bestRawSemantic > 0) {
+			return Math.max(0, entry.semanticScore) / bestRawSemantic;
+		}
+		if (entry.lexicalScore !== undefined && bestRawLexical > 0) {
+			return Math.max(0, entry.lexicalScore) / bestRawLexical;
+		}
+		// Present in neither source's score list (rank-only entry): not a strong
+		// enough match to earn a recency lift.
+		return 0;
+	};
+
+	return scored
 		.map((entry) => {
 			const recentInfo = recentBoostByPath.get(entry.result.path);
 			const recentBoost = recentInfo?.boost ?? 0;
-			// Recency only contributes when the note is already a genuine match.
-			// When semantic results exist they are the relevance signal (a weak
-			// lexical hit on common query words is noise), so require top-N
-			// semantic rank; fall back to lexical rank only for lexical-only
-			// queries. Gated-out notes keep their "recent" badge but no score lift.
-			const recentEligible = hasSemanticSource
-				? entry.semanticRank !== undefined && entry.semanticRank <= RECENT_BOOST_ELIGIBLE_RANK
-				: entry.lexicalRank !== undefined && entry.lexicalRank <= RECENT_BOOST_ELIGIBLE_RANK;
+			const relativeRelevance = rawRelativeRelevance(entry);
+			const recentEligible = relativeRelevance >= RECENT_RELATIVE_ELIGIBILITY;
 			const effectiveRecentBoost = recentEligible ? recentBoost : 0;
 			const recentStrength = effectiveRecentBoost > 0 ? effectiveRecentBoost / 4.5 : 0;
-			const lexicalRrfScore = hasHybridSources ? getRankScore(entry.lexicalRank) : 0;
-			const semanticRrfScore = hasHybridSources ? getRankScore(entry.semanticRank) : 0;
-			const finalTitleBoost =
-				shouldApplyQueryRescue && queryPlan
-					? calculateTitleBoost(queryPlan, entry.result.name, titleRescueMax)
-					: 0;
-			const finalAliasBoost =
-				shouldApplyQueryRescue && queryPlan
-					? calculateAliasBoost(queryPlan, entry.result.frontmatter, aliasRescueMax)
-					: 0;
-			// Magnitude blend: normalize this note's semantic cosine against the
-			// best in the set, scaled onto RRF's magnitude. A rank-1 strong match
-			// gets the full term; a weak match at a nearby rank gets little.
-			const normalizedSemantic =
-				maxSemanticScore > 0 ? Math.max(0, entry.semanticScore ?? 0) / maxSemanticScore : 0;
-			const semanticBlend = SEMANTIC_SCORE_BLEND_WEIGHT * normalizedSemantic * RRF_MAX_SUM;
-			const sourceScore = hasHybridSources
-				? (1 - SEMANTIC_SCORE_BLEND_WEIGHT) * (lexicalRrfScore + semanticRrfScore) + semanticBlend
-				: getFallbackScore(
-						entry.semanticScore ?? entry.lexicalScore,
-						entry.semanticRank ?? entry.lexicalRank,
-						totalResults,
-					);
-			const baseScore = sourceScore + finalTitleBoost + finalAliasBoost;
+
 			const aliasMatchKind = queryPlan ? getAliasMatchKind(queryPlan, entry.result.frontmatter) : undefined;
 			const recentAliasBonusWeight = getRecentAliasBonusWeight(aliasMatchKind);
 			const recentAliasBonus =
 				effectiveRecentBoost > 0 && recentAliasBonusWeight > 0
 					? Math.min(
-							baseScore * recentStrength * RECENT_ALIAS_SCORE_WEIGHT * recentAliasBonusWeight,
-							baseScore * MAX_RECENT_ALIAS_SCORE_SHARE * recentAliasBonusWeight,
+							entry.baseScore * recentStrength * RECENT_ALIAS_SCORE_WEIGHT * recentAliasBonusWeight,
+							entry.baseScore * MAX_RECENT_ALIAS_SCORE_SHARE * recentAliasBonusWeight,
 						)
 					: 0;
-			const finalScore = getRecentRerankScore(baseScore, effectiveRecentBoost) + recentAliasBonus;
-			const originalRank = entry.lexicalRank ?? entry.semanticRank;
+
+			// Cap the total recency contribution, then attenuate for crowding. Without
+			// the cap, three recently-opened near-duplicates displaced the correct
+			// answer from rank 1 to rank 4: recency was multiplicative and effectively
+			// unbounded relative to the gaps it competed against.
+			const uncappedLift =
+				getRecentRerankScore(entry.baseScore, effectiveRecentBoost) - entry.baseScore + recentAliasBonus;
+			const recentLift = Math.min(uncappedLift, entry.baseScore * adaptiveRecentLift) * recentCrowdingFactor;
+			const finalScore = entry.baseScore + recentLift;
 
 			return {
 				...entry,
-				baseScore,
 				finalScore,
-				originalRank,
 				recentBoost,
 				recentRank: recentInfo?.recentRank,
-				lexicalRrfScore,
-				semanticRrfScore,
-				finalTitleBoost,
-				finalAliasBoost,
 				recentAliasBonus,
+				relativeRelevance,
+				recentGated: recentBoost > 0 && !recentEligible,
 			};
 		})
 		.sort(
@@ -274,17 +456,29 @@ export function rankSearchResults({
 					finalScore,
 					finalTitleBoost,
 					lexicalRrfScore,
+					normalizedLexical,
+					normalizedSemantic,
 					originalRank,
 					recentAliasBonus,
 					recentBoost,
+					recentGated,
 					recentRank,
+					relativeRelevance,
 					result,
 					semanticRrfScore,
 					...entry
 				},
 				index,
 			) => {
-				const hasUnifiedDebug = Boolean(result.rankingDebug) || hasSemanticSource || recentBoost > 0;
+				// Identity boosts now apply to lexical-only queries too, so debug must
+				// be emitted for them — otherwise a boost that changed the ordering
+				// would be invisible to the search-debug UI and to tests.
+				const hasUnifiedDebug =
+					Boolean(result.rankingDebug) ||
+					hasSemanticSource ||
+					recentBoost > 0 ||
+					finalTitleBoost > 0 ||
+					finalAliasBoost > 0;
 
 				return {
 					...result,
@@ -299,9 +493,14 @@ export function rankSearchResults({
 								finalScore,
 								recentBoost: recentBoost > 0 ? recentBoost : undefined,
 								recentRank,
+								recentGated: recentGated ? true : undefined,
+								adaptiveRecentLift,
+								relativeRelevance,
 								lexicalRank: entry.lexicalRank,
 								semanticRank: entry.semanticRank,
 								semanticScore: entry.semanticScore,
+								normalizedLexical: normalizedLexical > 0 ? normalizedLexical : undefined,
+								normalizedSemantic: normalizedSemantic > 0 ? normalizedSemantic : undefined,
 								lexicalRrfScore: lexicalRrfScore > 0 ? lexicalRrfScore : undefined,
 								semanticRrfScore: semanticRrfScore > 0 ? semanticRrfScore : undefined,
 								finalTitleBoost: finalTitleBoost > 0 ? finalTitleBoost : undefined,

--- a/src/utils/chunkText.ts
+++ b/src/utils/chunkText.ts
@@ -26,6 +26,57 @@ interface HeadingFrame {
 	text: string;
 }
 
+/** Matches a fenced code block delimiter (``` or ~~~), with optional indent. */
+const FENCE_RE = /^\s*(```|~~~)/;
+
+/**
+ * Count the markdown sections in a note body.
+ *
+ * Used to decide whether a note that fits the embedding budget should still be
+ * split: more than one section means more than one topic averaged into a single
+ * vector. Heading lines inside fenced code blocks don't open a section — a shell
+ * comment or a Python `#` line would otherwise fragment a note spuriously.
+ *
+ * Returns the number of top-level-ish sections: any leading prose before the
+ * first heading counts as one.
+ */
+function countSections(content: string): number {
+	let sections = 0;
+	let inFence = false;
+	let sawLeadingProse = false;
+	let seenHeading = false;
+
+	for (const line of content.split("\n")) {
+		if (FENCE_RE.test(line)) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) continue;
+
+		if (HEADING_RE.test(line)) {
+			seenHeading = true;
+			sections++;
+		} else if (!seenHeading && line.trim()) {
+			sawLeadingProse = true;
+		}
+	}
+
+	return sections + (sawLeadingProse ? 1 : 0);
+}
+
+/**
+ * Render the note title for a chunk prefix.
+ *
+ * Deliberately NOT `# <title>`. A level-one heading is ordinary note content, so
+ * a note containing `# Appendix` would yield a chunk with two sibling H1s and
+ * nothing marking which one is the document's identity — the title becomes
+ * indistinguishable from a section. A `Note:` label keeps the title unambiguous
+ * and reads naturally to an embedding model.
+ */
+function formatTitleLine(title: string): string {
+	return `Note: ${title}`;
+}
+
 /**
  * Build the prefix string (title + active heading breadcrumb) for a chunk.
  * Guards against a pathologically deep/long breadcrumb by dropping the
@@ -33,7 +84,7 @@ interface HeadingFrame {
  * prefix can never consume the entire budget.
  */
 function buildPrefix(title: string, headings: HeadingFrame[], maxPrefixChars: number): string {
-	const titleLine = `# ${title}`;
+	const titleLine = formatTitleLine(title);
 	if (headings.length === 0) return titleLine;
 
 	let frames = headings;
@@ -133,12 +184,29 @@ function splitOversizedUnit(unit: string, maxBodyChars: number): string[] {
  * @param maxChars Hard upper bound on the full chunk length (prefix + body).
  */
 export function chunkText(content: string, title: string, maxChars: number): TextChunk[] {
-	const titleLine = `# ${title}`;
+	const titleLine = formatTitleLine(title);
 	const trimmed = content.trim();
 
-	// Fast path: whole note (with title) fits in one chunk — one vector, as before.
+	// Fast path: a note that fits the budget AND covers a single topic becomes one
+	// vector, as before.
+	//
+	// Size alone is the wrong test. An embedding averages everything it is given, so
+	// a note holding several unrelated sections yields a vector near the centroid of
+	// all of them and close to none. Measured on "Cooking Mediterranean Recipes"
+	// (1234 chars — comfortably inside a ~32k budget, so previously one chunk): the
+	// query "griechenland" scores 0.492 against its Greek-salad section in isolation
+	// but only 0.200 against the whole note, because shakshuka, hummus and grilled
+	// fish are averaged in. The note ranked 286/337 and never surfaced.
+	//
+	// So split on section headings whenever the note has more than one, regardless
+	// of length. Every level counts (H1-H6, see HEADING_RE): a note organised with
+	// top-level `#` sections splits exactly like one using `##`, and deeper levels
+	// nest rather than being flattened — a chunk under `### Install` carries the
+	// `## Setup` breadcrumb above it. The packing loop below already emits one
+	// chunk per heading breadcrumb; it was simply unreachable for notes under the
+	// budget.
 	const single = trimmed ? `${titleLine}\n\n${trimmed}` : titleLine;
-	if (single.length <= maxChars) {
+	if (single.length <= maxChars && countSections(trimmed) <= 1) {
 		return [{ content: single, chunkIndex: 0 }];
 	}
 

--- a/src/utils/chunkText.ts
+++ b/src/utils/chunkText.ts
@@ -26,8 +26,15 @@ interface HeadingFrame {
 	text: string;
 }
 
-/** Matches a fenced code block delimiter, capturing the run and any trailing text. */
-const FENCE_RE = /^\s*(`{3,}|~{3,})(.*)$/;
+/**
+ * Matches a fenced code block delimiter, capturing the run and any trailing text.
+ *
+ * At most three leading spaces: four or more make the line an *indented* code
+ * block, not a fence. Accepting arbitrary indentation let a ``` inside indented
+ * example code open a fence that never closed, swallowing every heading after it
+ * — a note with three sections collapsed into one chunk.
+ */
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
 
 /** The delimiter that opened the current fenced block. */
 interface OpenFence {

--- a/src/utils/chunkText.ts
+++ b/src/utils/chunkText.ts
@@ -26,8 +26,8 @@ interface HeadingFrame {
 	text: string;
 }
 
-/** Matches a fenced code block delimiter, capturing the full run of ` or ~. */
-const FENCE_RE = /^\s*(`{3,}|~{3,})/;
+/** Matches a fenced code block delimiter, capturing the run and any trailing text. */
+const FENCE_RE = /^\s*(`{3,}|~{3,})(.*)$/;
 
 /** The delimiter that opened the current fenced block. */
 interface OpenFence {
@@ -50,6 +50,11 @@ interface OpenFence {
  *     three-backtick line inside a four-backtick block is content too. That is
  *     the ordinary way to show fenced code inside fenced code, so it turns up in
  *     real notes rather than only in edge cases.
+ *   - **Trailing text.** An info string (```` ```text ````) is legal only on the
+ *     *opening* delimiter; a closer permits nothing but whitespace after the run.
+ *     So a ```` ```text ```` line inside an open block is content, and treating
+ *     it as a closer would additionally let the *real* closer re-open a fence and
+ *     swallow every following section.
  *
  * @param line The line to inspect.
  * @param open The fence currently open, or null when outside one.
@@ -60,11 +65,18 @@ function nextFenceState(line: string, open: OpenFence | null): OpenFence | null 
 	if (!match) return open;
 
 	const run = match[1];
-	const fence: OpenFence = { char: run[0], length: run.length };
-	if (open === null) return fence;
+	const trailing = match[2];
+	if (open === null) {
+		// Opening delimiter: an info string is allowed. A backtick fence's info
+		// string may not itself contain a backtick (it would be inline code).
+		if (run[0] === "`" && trailing.includes("`")) return null;
+		return { char: run[0], length: run.length };
+	}
 
-	// Anything shorter, or of the other character, is code content.
-	return fence.char === open.char && fence.length >= open.length ? null : open;
+	// Closing delimiter: same character, at least as long, nothing but whitespace
+	// after it. Anything else is code content inside the open block.
+	const closes = run[0] === open.char && run.length >= open.length && trailing.trim() === "";
+	return closes ? null : open;
 }
 
 /**

--- a/src/utils/chunkText.ts
+++ b/src/utils/chunkText.ts
@@ -105,11 +105,15 @@ function countSections(content: string): number {
 
 	for (const line of content.split("\n")) {
 		const nextFence = nextFenceState(line, openFence);
-		if (nextFence !== openFence) {
+		const insideFence = openFence !== null || nextFence !== openFence;
+		if (insideFence) {
+			// Fenced code before the first heading is still leading content: a note
+			// that opens with a code block and then has one heading holds two
+			// topics, and must not take the single-chunk fast path.
+			if (!seenHeading && line.trim()) sawLeadingProse = true;
 			openFence = nextFence;
 			continue;
 		}
-		if (openFence !== null) continue;
 
 		if (HEADING_RE.test(line)) {
 			seenHeading = true;

--- a/src/utils/chunkText.ts
+++ b/src/utils/chunkText.ts
@@ -26,31 +26,45 @@ interface HeadingFrame {
 	text: string;
 }
 
-/** Matches a fenced code block delimiter (``` or ~~~), capturing the marker. */
-const FENCE_RE = /^\s*(```|~~~)/;
+/** Matches a fenced code block delimiter, capturing the full run of ` or ~. */
+const FENCE_RE = /^\s*(`{3,}|~{3,})/;
+
+/** The delimiter that opened the current fenced block. */
+interface OpenFence {
+	/** "`" or "~". */
+	char: string;
+	/** How many delimiter characters opened the block. */
+	length: number;
+}
 
 /**
- * Track fenced-code state across lines, remembering *which* marker opened the
- * block.
+ * Track fenced-code state across lines, remembering *how* the block was opened.
  *
- * A naive boolean toggle is wrong: CommonMark only closes a fence with the same
- * marker that opened it, so a `~~~` line inside a ```` ```markdown ```` block is
- * content, not a delimiter. Toggling on it would end the fence early and leave a
- * following `# comment` looking like a real heading — which then becomes a
- * breadcrumb ancestor of every later section.
+ * Both parts of the delimiter matter, and getting either wrong lets a `#` line
+ * inside code be read as a real heading — which then becomes a breadcrumb
+ * ancestor of every later section:
+ *
+ *   - **Character.** CommonMark closes a fence only with the same character, so
+ *     a `~~~` line inside a ```` ```markdown ```` block is content.
+ *   - **Length.** A closing fence must be *at least as long* as the opener, so a
+ *     three-backtick line inside a four-backtick block is content too. That is
+ *     the ordinary way to show fenced code inside fenced code, so it turns up in
+ *     real notes rather than only in edge cases.
  *
  * @param line The line to inspect.
- * @param openMarker The marker that opened the current fence, or null when outside one.
- * @returns The new open marker (null when the line closed the fence).
+ * @param open The fence currently open, or null when outside one.
+ * @returns The fence still open after this line (null when the line closed it).
  */
-function nextFenceState(line: string, openMarker: string | null): string | null {
+function nextFenceState(line: string, open: OpenFence | null): OpenFence | null {
 	const match = line.match(FENCE_RE);
-	if (!match) return openMarker;
+	if (!match) return open;
 
-	const marker = match[1];
-	if (openMarker === null) return marker;
-	// Only the matching marker closes the block; anything else is code content.
-	return marker === openMarker ? null : openMarker;
+	const run = match[1];
+	const fence: OpenFence = { char: run[0], length: run.length };
+	if (open === null) return fence;
+
+	// Anything shorter, or of the other character, is code content.
+	return fence.char === open.char && fence.length >= open.length ? null : open;
 }
 
 /**
@@ -66,17 +80,17 @@ function nextFenceState(line: string, openMarker: string | null): string | null 
  */
 function countSections(content: string): number {
 	let sections = 0;
-	let fenceMarker: string | null = null;
+	let openFence: OpenFence | null = null;
 	let sawLeadingProse = false;
 	let seenHeading = false;
 
 	for (const line of content.split("\n")) {
-		const nextMarker = nextFenceState(line, fenceMarker);
-		if (nextMarker !== fenceMarker) {
-			fenceMarker = nextMarker;
+		const nextFence = nextFenceState(line, openFence);
+		if (nextFence !== openFence) {
+			openFence = nextFence;
 			continue;
 		}
-		if (fenceMarker !== null) continue;
+		if (openFence !== null) continue;
 
 		if (HEADING_RE.test(line)) {
 			seenHeading = true;
@@ -262,17 +276,17 @@ export function chunkText(content: string, title: string, maxChars: number): Tex
 	// shell comment onto the breadcrumb stack, where it becomes a permanent
 	// ancestor of every following real section, and would split the fence markers
 	// across separate chunks.
-	let fenceMarker: string | null = null;
+	let openFence: OpenFence | null = null;
 
 	for (const line of lines) {
-		const nextMarker = nextFenceState(line, fenceMarker);
-		if (nextMarker !== fenceMarker) {
-			fenceMarker = nextMarker;
+		const nextFence = nextFenceState(line, openFence);
+		if (nextFence !== openFence) {
+			openFence = nextFence;
 			buffer.push(line);
 			continue;
 		}
 
-		const m = fenceMarker !== null ? null : line.match(HEADING_RE);
+		const m = openFence !== null ? null : line.match(HEADING_RE);
 		if (m) {
 			flushBuffer();
 			const level = m[1].length;

--- a/src/utils/chunkText.ts
+++ b/src/utils/chunkText.ts
@@ -232,8 +232,21 @@ export function chunkText(content: string, title: string, maxChars: number): Tex
 		}
 	};
 
+	// Fence state must be tracked here as well as in `countSections`. A `#` line
+	// inside a fenced block is code, not a heading: treating it as one would push a
+	// shell comment onto the breadcrumb stack, where it becomes a permanent
+	// ancestor of every following real section, and would split the fence markers
+	// across separate chunks.
+	let inFence = false;
+
 	for (const line of lines) {
-		const m = line.match(HEADING_RE);
+		if (FENCE_RE.test(line)) {
+			inFence = !inFence;
+			buffer.push(line);
+			continue;
+		}
+
+		const m = inFence ? null : line.match(HEADING_RE);
 		if (m) {
 			flushBuffer();
 			const level = m[1].length;

--- a/src/utils/chunkText.ts
+++ b/src/utils/chunkText.ts
@@ -26,8 +26,32 @@ interface HeadingFrame {
 	text: string;
 }
 
-/** Matches a fenced code block delimiter (``` or ~~~), with optional indent. */
+/** Matches a fenced code block delimiter (``` or ~~~), capturing the marker. */
 const FENCE_RE = /^\s*(```|~~~)/;
+
+/**
+ * Track fenced-code state across lines, remembering *which* marker opened the
+ * block.
+ *
+ * A naive boolean toggle is wrong: CommonMark only closes a fence with the same
+ * marker that opened it, so a `~~~` line inside a ```` ```markdown ```` block is
+ * content, not a delimiter. Toggling on it would end the fence early and leave a
+ * following `# comment` looking like a real heading — which then becomes a
+ * breadcrumb ancestor of every later section.
+ *
+ * @param line The line to inspect.
+ * @param openMarker The marker that opened the current fence, or null when outside one.
+ * @returns The new open marker (null when the line closed the fence).
+ */
+function nextFenceState(line: string, openMarker: string | null): string | null {
+	const match = line.match(FENCE_RE);
+	if (!match) return openMarker;
+
+	const marker = match[1];
+	if (openMarker === null) return marker;
+	// Only the matching marker closes the block; anything else is code content.
+	return marker === openMarker ? null : openMarker;
+}
 
 /**
  * Count the markdown sections in a note body.
@@ -42,16 +66,17 @@ const FENCE_RE = /^\s*(```|~~~)/;
  */
 function countSections(content: string): number {
 	let sections = 0;
-	let inFence = false;
+	let fenceMarker: string | null = null;
 	let sawLeadingProse = false;
 	let seenHeading = false;
 
 	for (const line of content.split("\n")) {
-		if (FENCE_RE.test(line)) {
-			inFence = !inFence;
+		const nextMarker = nextFenceState(line, fenceMarker);
+		if (nextMarker !== fenceMarker) {
+			fenceMarker = nextMarker;
 			continue;
 		}
-		if (inFence) continue;
+		if (fenceMarker !== null) continue;
 
 		if (HEADING_RE.test(line)) {
 			seenHeading = true;
@@ -237,16 +262,17 @@ export function chunkText(content: string, title: string, maxChars: number): Tex
 	// shell comment onto the breadcrumb stack, where it becomes a permanent
 	// ancestor of every following real section, and would split the fence markers
 	// across separate chunks.
-	let inFence = false;
+	let fenceMarker: string | null = null;
 
 	for (const line of lines) {
-		if (FENCE_RE.test(line)) {
-			inFence = !inFence;
+		const nextMarker = nextFenceState(line, fenceMarker);
+		if (nextMarker !== fenceMarker) {
+			fenceMarker = nextMarker;
 			buffer.push(line);
 			continue;
 		}
 
-		const m = inFence ? null : line.match(HEADING_RE);
+		const m = fenceMarker !== null ? null : line.match(HEADING_RE);
 		if (m) {
 			flushBuffer();
 			const level = m[1].length;

--- a/src/utils/fileFiltering.ts
+++ b/src/utils/fileFiltering.ts
@@ -158,6 +158,15 @@ async function readTextFile(vault: Vault, file: TFile): Promise<string> {
 /**
  * Extract human and AI message text from a `.chat` file (LangGraph ThreadData JSON).
  * Skips all LangChain serialisation noise, checkpoint metadata, writes, etc.
+ *
+ * Conversation history is a *tree* of checkpoints, and every checkpoint re-contains
+ * the whole message list that preceded it. Concatenating each checkpoint's messages
+ * therefore re-emits the same text once per subsequent turn — measured at ~8x on a
+ * 526-checkpoint thread, which inflates both the embedding cost and the lexical term
+ * frequencies of every chat file. Emit each distinct message exactly once instead,
+ * keyed on the stable LangChain message id (falling back to the message text when a
+ * message carries no id). First-seen order is preserved so the extracted text still
+ * reads as a transcript.
  */
 function extractChatContent(raw: string): string {
 	try {
@@ -172,11 +181,20 @@ function extractChatContent(raw: string): string {
 		// Walk checkpoints → channel_values.messages → kwargs.content / data.content
 		const checkpoints = data.checkpoints;
 		if (checkpoints && typeof checkpoints === "object") {
+			const seen = new Set<string>();
 			for (const entry of Object.values(checkpoints)) {
 				const messages = getNestedMessages(entry);
 				for (const msg of messages) {
 					const content = extractMessageContent(msg);
-					if (content) parts.push(content);
+					if (!content) continue;
+
+					// Prefer the message id: the same logical message can be
+					// re-serialised across checkpoints, and two genuinely distinct
+					// messages may share identical text (e.g. a repeated "yes").
+					const dedupeKey = getMessageId(msg) ?? `content:${content}`;
+					if (seen.has(dedupeKey)) continue;
+					seen.add(dedupeKey);
+					parts.push(content);
 				}
 			}
 		}
@@ -186,6 +204,32 @@ function extractChatContent(raw: string): string {
 		// If parsing fails, fall back to empty (don't index raw JSON)
 		return "";
 	}
+}
+
+/**
+ * Read the stable LangChain message id, which survives re-serialisation across
+ * checkpoints. Returns `null` when the message carries no usable id so the caller
+ * can fall back to content-based deduplication.
+ */
+function getMessageId(msg: unknown): string | null {
+	if (!msg || typeof msg !== "object") return null;
+	const record = msg as Record<string, unknown>;
+
+	const candidates: unknown[] = [];
+	if (record.kwargs && typeof record.kwargs === "object") {
+		candidates.push((record.kwargs as Record<string, unknown>).id);
+	}
+	if (record.data && typeof record.data === "object") {
+		candidates.push((record.data as Record<string, unknown>).id);
+	}
+	candidates.push(record.id);
+
+	for (const candidate of candidates) {
+		if (typeof candidate === "string" && candidate.trim()) {
+			return `id:${candidate.trim()}`;
+		}
+	}
+	return null;
 }
 
 function getNestedMessages(entry: unknown): unknown[] {

--- a/src/vectorstore/HNSWVectorStore.ts
+++ b/src/vectorstore/HNSWVectorStore.ts
@@ -337,8 +337,17 @@ export class HNSWVectorStore implements VectorStore {
 		}
 		await this.ensureHNSWIndex();
 
-		// Remove existing entry if updating
-		const existing = await this.getByPath(doc.path);
+		// Remove the prior version of *this chunk* if updating.
+		//
+		// Must be keyed on the chunk id, not the path: `getByPath` returns only the
+		// first chunk of a note, so on a multi-chunk note re-upserting chunk #2 would
+		// drop chunk #0's mapping while #2's own stale mapping survived. Each such
+		// upsert then assigned a fresh numeric id and orphaned a graph node, leaving
+		// nodes with no `numericToId` entry — which `search()` silently skips,
+		// truncating results. (Observed after section-aware chunking turned
+		// single-chunk notes into multi-chunk ones: 2611 graph nodes vs 2281
+		// mappings, and a 50-result query returning 4.)
+		const existing = await this.getById(doc.id);
 		if (existing) {
 			await this.removeFromHNSW(existing.id);
 			await this.removeIdMapping(existing.id);
@@ -570,7 +579,25 @@ export class HNSWVectorStore implements VectorStore {
 		this.numericToId.clear();
 		this.nextHnswId = 0;
 
-		// Clear HNSW index by recreating
+		// Drop the *persisted* graph, not just the in-memory handle. Recreating the
+		// HNSWWithDB wrapper leaves the serialized graph in its own IndexedDB
+		// database, so the next open() → loadIndex() resurrects every node from
+		// previous indexing runs. Because clear() also resets `nextHnswId` to 0,
+		// those stale nodes then collide with freshly assigned numeric ids: search
+		// resolves a hit through `numericToId`, misses, and silently drops the
+		// result — which manifests as semantic search returning too few results,
+		// or none at all, for perfectly valid queries.
+		if (this.hnswIndex) {
+			try {
+				await this.hnswIndex.deleteIndex();
+			} catch (e) {
+				Logger.error(`${LOG_PREFIX} Failed to delete persisted HNSW graph:`, e);
+			}
+			this.hnswIndex = null;
+		}
+		this.hasPendingIndexSave = false;
+
+		// Recreate an empty graph so subsequent upserts have somewhere to insert.
 		if (this.dimensions) {
 			this.hnswIndex = await HNSWWithDB.create(
 				this.M,

--- a/src/vectorstore/HNSWWorkerProxy.ts
+++ b/src/vectorstore/HNSWWorkerProxy.ts
@@ -125,4 +125,27 @@ export class HNSWWorkerProxy implements VectorStore {
 	async search(queryVector: Float32Array, topK: number, threshold?: number): Promise<ScoredDocument[]> {
 		return (await this.call("search", queryVector, topK, threshold)) as ScoredDocument[];
 	}
+
+	/**
+	 * Inspect HNSW graph health inside the worker.
+	 *
+	 * The graph lives in the worker realm, so reading `hnswIndex` from the main
+	 * thread always shows `undefined` regardless of its true state. A `nodeCount`
+	 * much larger than `mappedIdCount` indicates stale nodes left over from earlier
+	 * indexing runs, which collide with reassigned numeric ids and cause search to
+	 * silently return too few results.
+	 */
+	async getGraphStats(): Promise<{
+		dimensions: number | null;
+		hasIndex: boolean;
+		nodeCount: number | null;
+		mappedIdCount: number;
+	}> {
+		return (await this.call("getGraphStats")) as {
+			dimensions: number | null;
+			hasIndex: boolean;
+			nodeCount: number | null;
+			mappedIdCount: number;
+		};
+	}
 }

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -19,6 +19,7 @@ import { getRegistry } from "../providers/registry";
 import { getProviderDefinition } from "../providers/index";
 import { showSettingsLinkNotice } from "../utils/settingsNotice";
 import { getDefaultEmbeddingBatchSize, normalizeEmbeddingBatchSize } from "./batchSize";
+import { aggregateChunksToNotes } from "./chunkAggregation";
 import { createVectorStore } from "./index";
 import {
 	INDEX_VERSION,
@@ -132,12 +133,18 @@ const MODIFY_DEBOUNCE_MS = 5_000;
 const CHARS_PER_TOKEN = 4;
 
 /**
- * Over-fetch factor for semantic search. A large note is now stored as multiple
- * chunks, so several of a note's chunks can occupy adjacent result slots; we
- * request more raw neighbors than `topK` and dedup to distinct notes afterwards
- * so `topK` still yields `topK` distinct notes.
+ * Over-fetch factor for semantic search. A note is stored as one vector per
+ * section, so several of a note's chunks can occupy adjacent result slots; we
+ * request more raw neighbors than `topK` and aggregate to distinct notes
+ * afterwards so `topK` still yields `topK` distinct notes.
+ *
+ * This also feeds `aggregateChunksToNotes`: a note's *supporting* chunks only
+ * count toward its score if they were actually retrieved, so under-fetching
+ * silently degrades aggregation into first-hit-wins. Section-aware chunking
+ * raised the fixture corpus from 337 chunks to 2611 (~7.7 chunks per note), so
+ * the previous factor of 4 no longer covered a note's own sections.
  */
-const CHUNK_OVERFETCH = 4;
+const CHUNK_OVERFETCH = 10;
 
 let instance: VectorStoreService | null = null;
 let pendingInstance: VectorStoreService | null = null;
@@ -1508,49 +1515,77 @@ export class VectorStoreService {
 			const results = await inst.store.search(queryVectorTyped, searchTopK, threshold);
 
 			const { metadataCache } = this.plugin.app;
-			const filteredResults: VectorSearchResult[] = [];
-			// Collapse multiple chunk-hits of the same note into one result. HNSW
-			// returns results sorted by score, so the first hit per path is its
-			// best-matching chunk.
-			const seenPaths = new Set<string>();
+
+			// Apply filters at the *chunk* level first, so aggregation only ever sees
+			// chunks the caller is allowed to retrieve.
+			const allowedHits: Array<{ path: string; score: number }> = [];
+			const passedFilter = new Set<string>();
+			const rejectedByFilter = new Set<string>();
 
 			for (const r of results) {
-				if (seenPaths.has(r.doc.path)) continue;
+				const path = r.doc.path;
+				if (rejectedByFilter.has(path)) continue;
 
-				if (filter?.pathPrefixes?.length) {
-					const matchesPath = filter.pathPrefixes.some((prefix) => matchesPathPrefix(r.doc.path, prefix));
-					if (!matchesPath) continue;
+				if (!passedFilter.has(path)) {
+					if (filter?.pathPrefixes?.length) {
+						const matchesPath = filter.pathPrefixes.some((prefix) => matchesPathPrefix(path, prefix));
+						if (!matchesPath) {
+							rejectedByFilter.add(path);
+							continue;
+						}
+					}
+
+					if (filter?.tags?.length) {
+						const file = this.plugin.app.vault.getAbstractFileByPath(path);
+						const cache = file instanceof TFile ? metadataCache.getFileCache(file) : null;
+						const docTags = cache ? (getAllTags(cache) ?? []) : [];
+						const normalizedFilterTags = filter.tags.map((t) => (t.startsWith("#") ? t : `#${t}`));
+						const normalizedDocTags = docTags.map((t) => (t.startsWith("#") ? t : `#${t}`));
+						const matchesTag = (filterTag: string) =>
+							normalizedDocTags.some(
+								(docTag) => docTag === filterTag || docTag.startsWith(`${filterTag}/`),
+							);
+
+						const ok = filter.requireAllTags
+							? normalizedFilterTags.every(matchesTag)
+							: normalizedFilterTags.some(matchesTag);
+						if (!ok) {
+							rejectedByFilter.add(path);
+							continue;
+						}
+					}
+
+					passedFilter.add(path);
 				}
 
-				const file = this.plugin.app.vault.getAbstractFileByPath(r.doc.path);
+				allowedHits.push({ path, score: r.score });
+			}
+
+			// Collapse chunk hits into note-level scores. A note matching in several
+			// sections outranks one that got a single lucky chunk — see
+			// `chunkAggregation.ts` for why first-hit-wins was not good enough.
+			const aggregated = aggregateChunksToNotes(allowedHits);
+
+			const filteredResults: VectorSearchResult[] = [];
+			for (const note of aggregated) {
+				if (filteredResults.length >= topK) break;
+
+				const file = this.plugin.app.vault.getAbstractFileByPath(note.path);
 				const cache = file instanceof TFile ? metadataCache.getFileCache(file) : null;
 				const docTags = cache ? (getAllTags(cache) ?? []) : [];
 
-				if (filter?.tags?.length) {
-					const normalizedFilterTags = filter.tags.map((t) => (t.startsWith("#") ? t : `#${t}`));
-					const normalizedDocTags = docTags.map((t) => (t.startsWith("#") ? t : `#${t}`));
-					const matchesTag = (filterTag: string) =>
-						normalizedDocTags.some((docTag) => docTag === filterTag || docTag.startsWith(`${filterTag}/`));
-
-					if (filter.requireAllTags) {
-						if (!normalizedFilterTags.every(matchesTag)) continue;
-					} else if (!normalizedFilterTags.some(matchesTag)) {
-						continue;
-					}
-				}
-
-				seenPaths.add(r.doc.path);
 				filteredResults.push({
-					path: r.doc.path,
-					name:
-						file instanceof TFile ? file.basename : r.doc.path.replace(/.*\//, "").replace(/\.[^.]+$/, ""),
+					path: note.path,
+					name: file instanceof TFile ? file.basename : note.path.replace(/.*\//, "").replace(/\.[^.]+$/, ""),
 					frontmatter: cache?.frontmatter,
 					tags: docTags,
 					matchBadges: ["semantic"],
-					score: r.score,
+					score: note.score,
+					rankingDebug: {
+						bestChunkScore: note.bestChunkScore,
+						matchingChunks: note.matchingChunks,
+					},
 				});
-
-				if (filteredResults.length >= topK) break;
 			}
 
 			return filteredResults;

--- a/src/vectorstore/chunkAggregation.ts
+++ b/src/vectorstore/chunkAggregation.ts
@@ -1,0 +1,120 @@
+/**
+ * Chunk → note score aggregation for semantic search.
+ *
+ * A note is stored as one vector per section, so a single query can hit several
+ * chunks of the same note. Collapsing those hits with "first one wins" throws
+ * away a real relevance signal: a note that matches in three separate sections is
+ * usually a better answer than one that matches in a single lucky paragraph.
+ *
+ * Measured consequence of first-hit-wins, after section-aware chunking split the
+ * fixture corpus: the query "how long does a wet sourdough starter take to
+ * double" put the correct note at rank 3, behind two generic
+ * `sourdough-starter-maintenance-*` siblings whose best chunk edged it out by a
+ * hair — even though the correct note matched in more places.
+ *
+ * Pure module: no Obsidian / DOM dependencies so it is trivially unit-testable.
+ */
+
+/**
+ * Maximum lift a note can gain from supporting chunks, as a fraction of its own
+ * best chunk. The support term *converges* to this — it never exceeds it no
+ * matter how many chunks match.
+ */
+const SUPPORT_WEIGHT = 0.15;
+
+/**
+ * Half-saturation constant: the amount of accumulated support at which a note
+ * receives half the maximum lift. Larger values make support build more slowly.
+ *
+ * Sized so that the shape matches how notes actually chunk. In the fixture vault
+ * a typical note yields 3-8 chunks and a 66KB reference note yields 33, so `3`
+ * puts ordinary multi-section notes on the steep part of the curve (2 supporting
+ * chunks ≈ 6% lift) while a 33-chunk note saturates near the ceiling (≈14%)
+ * rather than running away.
+ */
+const SUPPORT_HALF_SATURATION = 3;
+
+/** A single chunk hit, already sorted best-first by the caller. */
+export interface ChunkHit {
+	path: string;
+	score: number;
+}
+
+export interface AggregatedNote {
+	path: string;
+	/** Final note-level score: best chunk plus a bounded support term. */
+	score: number;
+	/** Score of this note's single best-matching chunk. */
+	bestChunkScore: number;
+	/** How many of this note's chunks were among the retrieved hits. */
+	matchingChunks: number;
+}
+
+/**
+ * Collapse chunk-level hits into note-level scores.
+ *
+ * The aggregate is `best * (1 + SUPPORT_WEIGHT * s / (s + K))`, where `s` is the
+ * summed strength of the supporting chunks (each measured relative to the note's
+ * own best chunk) and `K` is `SUPPORT_HALF_SATURATION`. Properties:
+ *
+ *  - **Best-chunk dominance.** The strongest single match sets the scale, so a
+ *    precise short note is never buried by a sprawling one.
+ *  - **Converging lift.** `s/(s+K)` approaches 1 but never reaches it, so total
+ *    support is hard-bounded by SUPPORT_WEIGHT regardless of chunk count.
+ *  - **Quality over count.** `s` sums *relative* strengths, so two sections that
+ *    nearly match the best chunk outweigh twenty that barely register.
+ *  - **Relative, not absolute.** No constant is compared against a raw cosine, so
+ *    behaviour is unchanged across embedding models and vault sizes.
+ *
+ * The earlier formula summed `1/(i+1)` — a harmonic series, which *diverges*.
+ * Support therefore grew without bound in chunk count: measured lift was +19% at
+ * 5 chunks, +39% at 20, +63% at 100, and a real 33-chunk note was inflated from a
+ * 0.662 best chunk to 0.909. That let a long note beat a genuinely better short
+ * one on length alone — a 33-chunk note scoring 0.55 per chunk outranked a note
+ * scoring 0.72. Long notes get more chunks sub-linearly in their length (100x the
+ * bytes yields only ~11x the chunks), so this bias grows with vault heterogeneity.
+ *
+ * @param hits Chunk hits sorted by score descending (as returned by the store).
+ * @returns Notes sorted by aggregate score descending.
+ */
+export function aggregateChunksToNotes(hits: readonly ChunkHit[]): AggregatedNote[] {
+	const byPath = new Map<string, number[]>();
+	for (const hit of hits) {
+		const scores = byPath.get(hit.path);
+		if (scores) {
+			scores.push(hit.score);
+		} else {
+			byPath.set(hit.path, [hit.score]);
+		}
+	}
+
+	const aggregated: AggregatedNote[] = [];
+	for (const [path, scores] of byPath) {
+		// Caller sorts best-first, but a note's own chunks may arrive interleaved
+		// with other notes' — sort defensively so `best` is genuinely the best.
+		scores.sort((a, b) => b - a);
+		const best = scores[0];
+
+		let support = 0;
+		if (best > 0) {
+			for (let i = 1; i < scores.length; i++) {
+				// Relative to the note's own best chunk, so a note whose sections all
+				// match strongly gains more than one with a single spike.
+				support += Math.max(0, scores[i]) / best;
+			}
+		}
+
+		// Saturating: rises quickly for the first few supporting sections, then
+		// flattens toward SUPPORT_WEIGHT. Chunk count alone can never run away.
+		const supportLift = SUPPORT_WEIGHT * (support / (support + SUPPORT_HALF_SATURATION));
+
+		aggregated.push({
+			path,
+			score: best * (1 + supportLift),
+			bestChunkScore: best,
+			matchingChunks: scores.length,
+		});
+	}
+
+	return aggregated.sort((left, right) => right.score - left.score);
+}

--- a/src/vectorstore/hnswWorker.ts
+++ b/src/vectorstore/hnswWorker.ts
@@ -136,6 +136,24 @@ globalThis.onmessage = async (e: MessageEvent<HNSWWorkerRequest>) => {
 				result = await requireStore().search(qv, topK, threshold);
 				break;
 			}
+			case "getGraphStats": {
+				// Graph health, for diagnosing recall problems. `nodeCount` far
+				// exceeding `mappedIdCount` means the persisted graph has retained
+				// nodes from earlier indexing runs, whose numeric ids now collide
+				// with freshly assigned ones — search then silently drops results.
+				const s = requireStore() as unknown as {
+					dimensions: number | null;
+					hnswIndex: { nodes?: Map<number, unknown> } | null;
+					numericToId: Map<number, string>;
+				};
+				result = {
+					dimensions: s.dimensions,
+					hasIndex: !!s.hnswIndex,
+					nodeCount: s.hnswIndex?.nodes?.size ?? null,
+					mappedIdCount: s.numericToId.size,
+				};
+				break;
+			}
 			default:
 				throw new Error(`Unknown method: ${method}`);
 		}

--- a/src/vectorstore/types.ts
+++ b/src/vectorstore/types.ts
@@ -126,6 +126,20 @@ export interface SearchRankingDebug {
 	finalAliasBoost?: number;
 	recentAliasBonus?: number;
 	lexicalFeatures?: LexicalRankingFeatures;
+	/** Score of the note's single best-matching chunk, before support aggregation. */
+	bestChunkScore?: number;
+	/** How many of the note's chunks were among the retrieved semantic hits. */
+	matchingChunks?: number;
+	/** Normalized (0-1) lexical score within the result set, after fusion rework. */
+	normalizedLexical?: number;
+	/** Normalized (0-1) semantic score within the result set, after fusion rework. */
+	normalizedSemantic?: number;
+	/** Relevance relative to the top result, used to gate the recency boost. */
+	relativeRelevance?: number;
+	/** True when recency was gated away because the note was not a strong enough match. */
+	recentGated?: boolean;
+	/** Adaptive recency-lift ceiling for this query, derived from result-set spread. */
+	adaptiveRecentLift?: number;
 }
 
 export interface SearchMatchExplanation {

--- a/test/agent/searchNotes.test.ts
+++ b/test/agent/searchNotes.test.ts
@@ -135,17 +135,15 @@ describe("performSearch lexical startup behavior", () => {
 		expect(mockGetLexicalSearchService).toHaveBeenCalledTimes(1);
 		expect(mockLexicalSearch).toHaveBeenCalledWith("alpha", 100, undefined);
 		expect(mockWaitForVectorStore).not.toHaveBeenCalled();
-		expect(results).toEqual([
-			{
-				path: "Notes/alpha.md",
-				name: "alpha",
-				frontmatter: undefined,
-				tags: ["#alpha"],
-				matchExplanation: undefined,
-				matchBadges: undefined,
-				score: 12,
-			},
-		]);
+		// Scores are now normalized within the result set rather than passed through
+		// as raw BM25 magnitudes, and rankingDebug is emitted whenever an identity
+		// boost applied — so assert identity and ordering, not the exact numbers.
+		expect(results).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			path: "Notes/alpha.md",
+			name: "alpha",
+			tags: ["#alpha"],
+		});
 	});
 
 	it("boosts recently opened notes higher in typed search results", async () => {
@@ -191,7 +189,15 @@ describe("performSearch lexical startup behavior", () => {
 		expect(parsed.results[1]?.matchBadges).toEqual(["title"]);
 	});
 
-	it("lets the third most recent typed result climb above a non-recent neighbor", async () => {
+	// Behaviour change (deliberate): when several results are *all* recently opened,
+	// recency no longer identifies any one of them, so its influence is divided
+	// among the contenders instead of applied at full strength to each. This test
+	// previously asserted the weakest of three recent notes (lexical score 9 of 13)
+	// should climb over a non-recent neighbour; that is the mechanism by which a
+	// cluster of recently-opened near-duplicates took over the top of the results.
+	// A *lone* recent note still gets full lift — see "gives the fifth recent result
+	// enough lift to overtake the lexical leader", which still passes.
+	it("does not let one of several equally-recent results climb on recency alone", async () => {
 		mockRecentNotes.push(
 			{ path: "Notes/top-recent.md", lastOpenedAt: 3_000 },
 			{ path: "Notes/mid-recent.md", lastOpenedAt: 2_000 },
@@ -242,13 +248,15 @@ describe("performSearch lexical startup behavior", () => {
 		const result = await tool.invoke({ query: "note" });
 		const parsed: SearchToolResultPayload = JSON.parse(String(result));
 
+		// Relevance order is preserved; edge-recent keeps its badge but not a lift
+		// that would jump it past two better lexical matches.
 		expect(parsed.results.map((entry) => entry.name)).toEqual([
 			"control-one",
-			"edge-recent",
 			"control-two",
 			"control-three",
+			"edge-recent",
 		]);
-		expect(parsed.results[1]?.matchBadges).toEqual(["recent"]);
+		expect(parsed.results.find((entry) => entry.name === "edge-recent")?.matchBadges).toContain("recent");
 	});
 
 	it("keeps a much stronger lexical leader ahead of a recent note", async () => {
@@ -502,17 +510,12 @@ describe("performSearch lexical startup behavior", () => {
 
 		expect(mockWaitForLexicalSearch).toHaveBeenCalledTimes(1);
 		expect(mockBrowse).toHaveBeenCalledWith(100, { tags: ["#beta"] });
-		expect(results).toEqual([
-			{
-				path: "Notes/beta.md",
-				name: "beta",
-				frontmatter: undefined,
-				tags: ["#beta"],
-				matchExplanation: undefined,
-				matchBadges: undefined,
-				score: 8,
-			},
-		]);
+		expect(results).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			path: "Notes/beta.md",
+			name: "beta",
+			tags: ["#beta"],
+		});
 	});
 
 	it("returns no lexical results when the search service has not started", async () => {
@@ -664,22 +667,20 @@ describe("performSearch lexical startup behavior", () => {
 		expect(parsed.algorithm).toBe("lexical");
 		expect(parsed.totalResults).toBe(1);
 		expect(parsed.returnedResults).toBe(1);
-		expect(parsed.results).toEqual([
-			{
-				rank: 1,
-				name: "orbital-index",
-				path: "Notes/orbital-index.md",
-				score: 12.345,
-				frontmatter: { aliases: ["Rocket Science"] },
-				tags: ["#space", "#orbital-index"],
-				matchBadges: ["tag", "content"],
-				matchExplanation: {
-					source: "content",
-					heading: "Launch Checklist",
-					text: "Propulsion systems need thermal checks before ignition.",
-				},
+		expect(parsed.results).toHaveLength(1);
+		expect(parsed.results[0]).toMatchObject({
+			rank: 1,
+			name: "orbital-index",
+			path: "Notes/orbital-index.md",
+			frontmatter: { aliases: ["Rocket Science"] },
+			tags: ["#space", "#orbital-index"],
+			matchBadges: ["tag", "content"],
+			matchExplanation: {
+				source: "content",
+				heading: "Launch Checklist",
+				text: "Propulsion systems need thermal checks before ignition.",
 			},
-		]);
+		});
 	});
 
 	it("drops privacy-restricted results entirely instead of exposing their path/name", async () => {
@@ -712,18 +713,13 @@ describe("performSearch lexical startup behavior", () => {
 		expect(parsed.totalResults).toBe(1);
 		expect(parsed.returnedResults).toBe(1);
 		expect(parsed.skippedPrivateFiles).toBe(1);
-		expect(parsed.results).toEqual([
-			{
-				rank: 1,
-				name: "public-plan",
-				path: "Notes/public-plan.md",
-				score: 20,
-				frontmatter: undefined,
-				tags: ["#public"],
-				matchBadges: undefined,
-				matchExplanation: undefined,
-			},
-		]);
+		expect(parsed.results).toHaveLength(1);
+		expect(parsed.results[0]).toMatchObject({
+			rank: 1,
+			name: "public-plan",
+			path: "Notes/public-plan.md",
+			tags: ["#public"],
+		});
 		expect(parsed.results.some((entry) => entry.name === "launch-plan" || entry.path?.includes("Private"))).toBe(
 			false,
 		);
@@ -773,11 +769,16 @@ describe("performSearch lexical startup behavior", () => {
 		const result = await tool.invoke({ query: "propulsion" });
 		const parsed: SearchToolResultPayload = JSON.parse(String(result));
 
-		expect(parsed.results[0]).toEqual({
+		// The point of this test is which fields are *omitted*; the score value is
+		// incidental and is now a normalized fusion score rather than raw BM25.
+		expect(parsed.results[0]).toMatchObject({
 			rank: 1,
 			name: "orbital-index",
-			score: 12.345,
 			frontmatter: { aliases: ["Rocket Science"] },
 		});
+		expect(parsed.results[0]?.path).toBeUndefined();
+		expect(parsed.results[0]?.tags).toBeUndefined();
+		expect(parsed.results[0]?.matchBadges).toBeUndefined();
+		expect(parsed.results[0]?.matchExplanation).toBeUndefined();
 	});
 });

--- a/test/search/finalSearchRanking.test.ts
+++ b/test/search/finalSearchRanking.test.ts
@@ -67,7 +67,13 @@ describe("rankSearchResults", () => {
         expect(results[0]?.rankingDebug?.finalAliasBoost).toBeGreaterThan(0);
     });
 
-    it("keeps an eighth recent alias match ahead when its lexical score is close to a title leader", () => {
+    it("lifts a weakly-recent alias match close to a title leader without overtaking it", () => {
+        // Behaviour change (deliberate): this previously asserted that the *eighth*
+        // most-recent note — the weakest possible recency signal — should overtake an
+        // exact title match. That is the same "recency outranks relevance" failure
+        // that let a recently-opened recipe beat the correct answer on the graded
+        // benchmark. Recency is now a bounded tiebreaker: it pulls a comparable note
+        // level, it does not overturn a stronger identity match.
         const results = rankSearchResults({
             query: "ekx",
             lexicalResults: [
@@ -83,10 +89,18 @@ describe("rankSearchResults", () => {
             recentBoostByPath: new Map([["Notes/sap-ekx.md", { boost: 0.5, recentRank: 8 }]]),
         });
 
-        expect(results[0]?.name).toBe("SAP Workstream");
-        expect(results[0]?.rankingDebug?.recentRank).toBe(8);
-        expect(results[0]?.rankingDebug?.recentAliasBonus).toBeGreaterThan(0);
-        expect(results[0]?.matchBadges).toContain("recent");
+        // The exact title match keeps the top slot.
+        expect(results[0]?.name).toBe("EKX");
+
+        // The recent alias match is still recognised and lifted to just behind it —
+        // the signal is applied, merely bounded.
+        const alias = results.find((r) => r.name === "SAP Workstream");
+        expect(alias?.rankingDebug?.recentRank).toBe(8);
+        expect(alias?.rankingDebug?.recentAliasBonus).toBeGreaterThan(0);
+        expect(alias?.rankingDebug?.finalAliasBoost).toBeGreaterThan(0);
+        expect(alias?.matchBadges).toContain("recent");
+        // Within a few percent of the leader despite a much lower raw BM25 score.
+        expect((alias?.score ?? 0) / (results[0]?.score ?? 1)).toBeGreaterThan(0.95);
     });
 
     it("keeps the best semantic match ahead of a low-relevance recent note (food-query regression)", () => {
@@ -177,5 +191,211 @@ describe("rankSearchResults", () => {
         expect(recentFar?.matchBadges).toContain("recent");
         // Gated out: its recency did not lift it into the top few.
         expect(results.findIndex((r) => r.path === "recent-far.md")).toBeGreaterThan(2);
+    });
+
+    // ── rework: normalized fusion + relative recency gating ──────────────────
+
+    it("gates recency by relative relevance, not by rank position", () => {
+        // The old gate was a hard top-10 *rank* cutoff, so a strong match at rank 11
+        // was ineligible while a weak one at rank 10 was not. Here the recent note is
+        // far down the list but scores close to the leader: it must still qualify.
+        const semanticResults: Parameters<typeof rankSearchResults>[0]["semanticResults"] = [];
+        for (let i = 0; i < 14; i++) {
+            semanticResults.push({ path: `n${i}.md`, name: `Note ${i}`, score: 0.9 - i * 0.002 });
+        }
+
+        const results = rankSearchResults({
+            query: "irrelevantquery",
+            semanticResults,
+            recentBoostByPath: new Map([["n13.md", { boost: 4.5, recentRank: 1 }]]),
+        });
+
+        const lifted = results.find((r) => r.path === "n13.md");
+        // Rank 14 of 14, but 0.874/0.9 = 97% of the best score -> eligible.
+        expect(lifted?.rankingDebug?.recentGated).toBeUndefined();
+        expect(lifted?.rankingDebug?.relativeRelevance ?? 0).toBeGreaterThan(0.8);
+    });
+
+    it("gates recency away for a note that is genuinely a poor match", () => {
+        const results = rankSearchResults({
+            query: "irrelevantquery",
+            semanticResults: [
+                { path: "best.md", name: "Best", score: 0.9 },
+                { path: "poor.md", name: "Poor", score: 0.1 },
+            ],
+            recentBoostByPath: new Map([["poor.md", { boost: 4.5, recentRank: 1 }]]),
+        });
+
+        expect(results[0]?.path).toBe("best.md");
+        const poor = results.find((r) => r.path === "poor.md");
+        expect(poor?.rankingDebug?.recentGated).toBe(true);
+        // Badge is retained even when the score contribution is suppressed.
+        expect(poor?.matchBadges).toContain("recent");
+    });
+
+    it("attenuates recency when several results are equally recent", () => {
+        // Reproduces the sourdough failure: three recently-opened siblings sit just
+        // below the correct answer and previously marched past it. Recency cannot
+        // distinguish notes that are *all* recent, so its influence is divided among
+        // them rather than applied at full strength to each.
+        const results = rankSearchResults({
+            query: "starter hydration",
+            semanticResults: [
+                { path: "correct.md", name: "Correct", score: 0.9 },
+                { path: "dup1.md", name: "Dup 1", score: 0.82 },
+                { path: "dup2.md", name: "Dup 2", score: 0.8 },
+                { path: "dup3.md", name: "Dup 3", score: 0.78 },
+            ],
+            recentBoostByPath: new Map([
+                ["dup1.md", { boost: 4.5, recentRank: 1 }],
+                ["dup2.md", { boost: 3.75, recentRank: 2 }],
+                ["dup3.md", { boost: 3.0, recentRank: 3 }],
+            ]),
+        });
+
+        expect(results[0]?.path).toBe("correct.md");
+    });
+
+    it("gives a lone recent note more lift than one competing with other recent notes", () => {
+        const scoresFor = (recent: Array<[string, { boost: number; recentRank: number }]>) =>
+            rankSearchResults({
+                query: "topic",
+                semanticResults: [
+                    { path: "a.md", name: "A", score: 0.9 },
+                    { path: "b.md", name: "B", score: 0.88 },
+                    { path: "c.md", name: "C", score: 0.87 },
+                ],
+                recentBoostByPath: new Map(recent),
+            }).find((r) => r.path === "b.md")?.score ?? 0;
+
+        const alone = scoresFor([["b.md", { boost: 4.5, recentRank: 1 }]]);
+        const crowded = scoresFor([
+            ["b.md", { boost: 4.5, recentRank: 1 }],
+            ["c.md", { boost: 3.75, recentRank: 2 }],
+        ]);
+
+        expect(alone).toBeGreaterThan(crowded);
+    });
+
+    it("normalizes each source so BM25 magnitudes cannot swamp cosines", () => {
+        // Lexical scores are ~300x the cosines. Without per-source normalization the
+        // lexical ordering would dictate the result regardless of semantic evidence.
+        const results = rankSearchResults({
+            query: "topic",
+            semanticResults: [
+                { path: "semantic-winner.md", name: "Semantic Winner", score: 0.95 },
+                { path: "lexical-winner.md", name: "Lexical Winner", score: 0.2 },
+            ],
+            lexicalResults: [
+                { path: "lexical-winner.md", name: "Lexical Winner", score: 300 },
+                { path: "semantic-winner.md", name: "Semantic Winner", score: 250 },
+            ],
+        });
+
+        // Both sources are on a 0-1 scale, so the large cosine gap outweighs the
+        // proportionally much smaller lexical one.
+        expect(results[0]?.path).toBe("semantic-winner.md");
+        expect(results[0]?.rankingDebug?.normalizedSemantic).toBe(1);
+    });
+
+    it("keeps near-tied scores near-tied instead of stretching them apart", () => {
+        const results = rankSearchResults({
+            query: "topic",
+            lexicalResults: [
+                { path: "a.md", name: "A", score: 100 },
+                { path: "b.md", name: "B", score: 99 },
+            ],
+        });
+
+        // A 1% raw difference must not become a blowout just because the result set
+        // is small — that was what made weak-but-real matches unliftable.
+        const ratio = (results[1]?.score ?? 0) / (results[0]?.score ?? 1);
+        expect(ratio).toBeGreaterThan(0.9);
+    });
+
+    it("applies identity boosts on lexical-only queries", () => {
+        // Previously these required a semantic source, leaving an exact alias match
+        // on a keyword-only query with no credit at all.
+        const results = rankSearchResults({
+            query: "Rocket Science",
+            lexicalResults: [
+                { path: "plain.md", name: "Plain Note", score: 100 },
+                {
+                    path: "alias.md",
+                    name: "Unrelated Title",
+                    frontmatter: { aliases: ["Rocket Science"] },
+                    score: 95,
+                },
+            ],
+        });
+
+        const alias = results.find((r) => r.path === "alias.md");
+        expect(alias?.rankingDebug?.finalAliasBoost ?? 0).toBeGreaterThan(0);
+    });
+
+    // ── adaptive recency cap ─────────────────────────────────────────────────
+    // The lift ceiling scales with how tightly the result set is packed. A fixed
+    // percentage cannot: 12% behind is a chasm in a dense semantic set (adjacent
+    // results ~1% apart) but a near-tie in a sparse lexical one (~10% apart).
+    // The previous fixed 0.15 was fitted to one embedding model and broke on
+    // another whose scores separated slightly less.
+
+    it("scales the recency ceiling with the result set's own spread", () => {
+        const dense = rankSearchResults({
+            query: "topic",
+            semanticResults: Array.from({ length: 8 }, (_, i) => ({
+                path: `d${i}.md`,
+                name: `D${i}`,
+                score: 0.71 - i * 0.008,
+            })),
+            recentBoostByPath: new Map([["d1.md", { boost: 4.5, recentRank: 1 }]]),
+        });
+        const sparse = rankSearchResults({
+            query: "topic",
+            semanticResults: [
+                { path: "s0.md", name: "S0", score: 0.9 },
+                { path: "s1.md", name: "S1", score: 0.5 },
+            ],
+            recentBoostByPath: new Map([["s1.md", { boost: 4.5, recentRank: 1 }]]),
+        });
+
+        const denseCap = dense[0]?.rankingDebug?.adaptiveRecentLift ?? 0;
+        const sparseCap = sparse[0]?.rankingDebug?.adaptiveRecentLift ?? 0;
+        expect(sparseCap).toBeGreaterThan(denseCap);
+    });
+
+    it("keeps a dense set's leader ahead of a recent note well behind it", () => {
+        // Dense semantic set: the recent note trails by far more than a typical
+        // adjacent gap, so recency must not close the distance.
+        const results = rankSearchResults({
+            query: "topic",
+            semanticResults: [
+                { path: "best.md", name: "Best", score: 0.71 },
+                ...Array.from({ length: 6 }, (_, i) => ({
+                    path: `f${i}.md`,
+                    name: `F${i}`,
+                    score: 0.68 - i * 0.004,
+                })),
+                { path: "recent.md", name: "Recent", score: 0.62 },
+            ],
+            recentBoostByPath: new Map([["recent.md", { boost: 4.5, recentRank: 1 }]]),
+        });
+
+        expect(results[0]?.path).toBe("best.md");
+    });
+
+    it("never drops the ceiling to zero when every score is identical", () => {
+        // A degenerate set has no adjacent gaps at all; the floor keeps recency
+        // from being silently disabled.
+        const results = rankSearchResults({
+            query: "topic",
+            semanticResults: [
+                { path: "a.md", name: "A", score: 0.5 },
+                { path: "b.md", name: "B", score: 0.5 },
+            ],
+            recentBoostByPath: new Map([["b.md", { boost: 4.5, recentRank: 1 }]]),
+        });
+
+        expect(results[0]?.rankingDebug?.adaptiveRecentLift ?? 0).toBeGreaterThan(0);
     });
 });

--- a/test/search/finalSearchRanking.test.ts
+++ b/test/search/finalSearchRanking.test.ts
@@ -398,4 +398,35 @@ describe("rankSearchResults", () => {
 
         expect(results[0]?.rankingDebug?.adaptiveRecentLift ?? 0).toBeGreaterThan(0);
     });
+    it("does not let recency-gated notes dilute an eligible note's tiebreaker", () => {
+        // Review finding: crowding counted every recently-opened note, including
+        // ones below the relevance gate that receive no lift at all. Opening a few
+        // irrelevant notes therefore suppressed recency for the one note it should
+        // have helped, flipping the winner.
+        const run = (withGatedRecent: boolean) => {
+            const recent = new Map([["near.md", { boost: 4.5, recentRank: 1 }]]);
+            if (withGatedRecent) {
+                recent.set("junk1.md", { boost: 4.0, recentRank: 2 });
+                recent.set("junk2.md", { boost: 3.5, recentRank: 3 });
+            }
+            return rankSearchResults({
+                query: "topic",
+                lexicalResults: [
+                    { path: "lead.md", name: "Lead", score: 100 },
+                    { path: "near.md", name: "Near", score: 96 },
+                    { path: "junk1.md", name: "Junk1", score: 12 },
+                    { path: "junk2.md", name: "Junk2", score: 10 },
+                ],
+                recentBoostByPath: recent,
+            });
+        };
+
+        const scoreOf = (results: ReturnType<typeof run>) =>
+            results.find((r) => r.path === "near.md")?.score ?? 0;
+
+        // The gated notes are far below the eligibility threshold, so they neither
+        // gain a lift nor may they cost one.
+        expect(scoreOf(run(true))).toBeCloseTo(scoreOf(run(false)), 10);
+        expect(run(true)[0]?.path).toBe(run(false)[0]?.path);
+    });
 });

--- a/test/search/relevanceMetrics.test.ts
+++ b/test/search/relevanceMetrics.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+	RELEVANCE_JUDGMENTS,
+	ndcgAt,
+	reciprocalRank,
+} from "../../integration/helpers/relevanceJudgments";
+
+/*
+ * The benchmark decides whether the ranking rework ships, so the metrics
+ * themselves need to be trustworthy before they are used to judge anything.
+ */
+
+describe("ndcgAt", () => {
+	const grades = { "a.md": 2, "b.md": 1 } as const;
+
+	it("scores a perfect ordering as 1", () => {
+		expect(ndcgAt(["a.md", "b.md", "x.md"], grades, 10)).toBeCloseTo(1, 10);
+	});
+
+	it("penalises a swapped ordering without zeroing it", () => {
+		const score = ndcgAt(["b.md", "a.md"], grades, 10);
+		expect(score).toBeLessThan(1);
+		expect(score).toBeGreaterThan(0);
+	});
+
+	it("returns 0 when no judged note is retrieved", () => {
+		expect(ndcgAt(["x.md", "y.md"], grades, 10)).toBe(0);
+	});
+
+	it("ranks the highly-relevant note first as better than the merely relevant one", () => {
+		expect(ndcgAt(["a.md"], grades, 10)).toBeGreaterThan(ndcgAt(["b.md"], grades, 10));
+	});
+
+	it("respects the cutoff k", () => {
+		// The only judged note sits at rank 3, outside k=2.
+		expect(ndcgAt(["x.md", "y.md", "a.md"], grades, 2)).toBe(0);
+		expect(ndcgAt(["x.md", "y.md", "a.md"], grades, 3)).toBeGreaterThan(0);
+	});
+
+	it("returns 0 when nothing is judged relevant", () => {
+		expect(ndcgAt(["a.md"], { "a.md": 0 }, 10)).toBe(0);
+	});
+});
+
+describe("reciprocalRank", () => {
+	const grades = { "a.md": 2, "b.md": 1 } as const;
+
+	it("is 1 when the target is first", () => {
+		expect(reciprocalRank(["a.md", "b.md"], grades)).toBe(1);
+	});
+
+	it("decays with the target's rank", () => {
+		expect(reciprocalRank(["x.md", "x2.md", "a.md"], grades)).toBeCloseTo(1 / 3, 10);
+	});
+
+	it("ignores merely-relevant results", () => {
+		// 'b.md' is grade 1, not the answer — MRR should not credit it.
+		expect(reciprocalRank(["b.md"], grades)).toBe(0);
+	});
+
+	it("is 0 when the target is missing", () => {
+		expect(reciprocalRank(["x.md"], grades)).toBe(0);
+	});
+});
+
+describe("judgment set", () => {
+	it("is non-empty and every query has at least one highly-relevant target", () => {
+		expect(RELEVANCE_JUDGMENTS.length).toBeGreaterThan(0);
+		for (const judgment of RELEVANCE_JUDGMENTS) {
+			const targets = Object.values(judgment.grades).filter((g) => g === 2);
+			expect(targets.length, `query: ${judgment.query}`).toBeGreaterThan(0);
+		}
+	});
+
+	it("documents what each case probes", () => {
+		for (const judgment of RELEVANCE_JUDGMENTS) {
+			expect(judgment.probes.length, `query: ${judgment.query}`).toBeGreaterThan(0);
+		}
+	});
+
+	it("points only at vault-relative note paths", () => {
+		for (const judgment of RELEVANCE_JUDGMENTS) {
+			for (const path of Object.keys(judgment.grades)) {
+				expect(path.endsWith(".md"), path).toBe(true);
+				expect(path.startsWith("/"), path).toBe(false);
+			}
+		}
+	});
+
+	it("only marks notes recent that the same case also grades", () => {
+		// A recency fixture pointing at an ungraded note would silently do nothing
+		// measurable — the conflict it is supposed to create wouldn't be scored.
+		for (const judgment of RELEVANCE_JUDGMENTS) {
+			for (const path of judgment.recentNotes ?? []) {
+				expect(Object.keys(judgment.grades), `query: ${judgment.query}`).toContain(path);
+			}
+		}
+	});
+
+	it("explains every known failure", () => {
+		for (const judgment of RELEVANCE_JUDGMENTS) {
+			if (judgment.knownFailure !== undefined) {
+				expect(judgment.knownFailure.length, `query: ${judgment.query}`).toBeGreaterThan(0);
+			}
+		}
+	});
+
+	it("covers multi-target queries, so nDCG measures set ordering not just rank 1", () => {
+		const multi = RELEVANCE_JUDGMENTS.filter(
+			(j) => Object.values(j.grades).filter((g) => g === 2).length > 1,
+		);
+		expect(multi.length).toBeGreaterThan(0);
+	});
+
+	it("covers recency-vs-relevance conflicts", () => {
+		const withRecency = RELEVANCE_JUDGMENTS.filter((j) => (j.recentNotes ?? []).length > 0);
+		expect(withRecency.length).toBeGreaterThan(0);
+	});
+});

--- a/test/utils/chunkText.test.ts
+++ b/test/utils/chunkText.test.ts
@@ -269,4 +269,58 @@ describe("chunkText heading levels", () => {
 		const usage = chunks.find((c) => c.content.includes("Run it."));
 		expect(usage?.content).not.toContain("not a heading");
 	});
+
+
+	it("only closes a fence with the marker that opened it", () => {
+		// Review finding: a shared boolean toggled on *any* fence marker, so a `~~~`
+		// line inside a ```markdown block ended the fence early and the following
+		// `#` line became a heading — and then a breadcrumb ancestor of every later
+		// section. CommonMark closes a fence only with its own marker.
+		const tildeInsideBacktick = [
+			"## Setup",
+			"Install it.",
+			"",
+			"```markdown",
+			"~~~",
+			"# not a heading",
+			"~~~",
+			"```",
+			"",
+			"## Usage",
+			"Run it.",
+		].join("\n");
+
+		const chunks = chunkText(tildeInsideBacktick, "Nested Fence", 32_764);
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks.find((c) => c.content.includes("Run it."))?.content).not.toContain("not a heading");
+	});
+
+	it("handles a backtick fence nested inside a tilde fence", () => {
+		const backtickInsideTilde = [
+			"## Setup",
+			"Install it.",
+			"",
+			"~~~markdown",
+			"```",
+			"# not a heading",
+			"```",
+			"~~~",
+			"",
+			"## Usage",
+			"Run it.",
+		].join("\n");
+
+		const chunks = chunkText(backtickInsideTilde, "Nested Fence", 32_764);
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks.find((c) => c.content.includes("Run it."))?.content).not.toContain("not a heading");
+	});
+
+	it("treats an unclosed fence as running to the end of the note", () => {
+		// Everything after the opener is code, so no further headings are recognised.
+		const body = ["## Setup", "Install it.", "", "```bash", "# c", "", "## Usage", "Run it."].join("\n");
+
+		expect(chunkText(body, "Unclosed", 32_764)).toHaveLength(1);
+	});
 });

--- a/test/utils/chunkText.test.ts
+++ b/test/utils/chunkText.test.ts
@@ -432,4 +432,24 @@ describe("chunkText heading levels", () => {
 		expect(chunks).toHaveLength(2);
 		expect(chunks.find((c) => c.content.includes("y"))?.content).not.toContain("# c");
 	});
+
+
+	it("splits a note that opens with a fenced block before its first heading", () => {
+		// Review finding: countSections skipped fence lines without recording that
+		// content existed, so a note opening with a code block and then one heading
+		// counted as a single section and took the whole-note fast path — merging the
+		// code block into the headed section, the exact dilution this feature exists
+		// to prevent.
+		const body = ["```bash", "echo hello", "```", "", "## Usage", "How to use it."].join("\n");
+
+		const chunks = chunkText(body, "Leading Fence", 32_764);
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks.find((c) => c.content.includes("echo hello"))?.content).not.toContain("How to use it.");
+	});
+
+	it("keeps a note whose only content is a fenced block in one chunk", () => {
+		// The counterpart: leading code with no heading after it is still one topic.
+		expect(chunkText(["```bash", "echo hello", "```"].join("\n"), "Only Fence", 32_764)).toHaveLength(1);
+	});
 });

--- a/test/utils/chunkText.test.ts
+++ b/test/utils/chunkText.test.ts
@@ -6,13 +6,13 @@ describe("chunkText", () => {
         const chunks = chunkText("Hello world.\n\nSecond paragraph.", "My Note", 1000);
         expect(chunks).toHaveLength(1);
         expect(chunks[0].chunkIndex).toBe(0);
-        expect(chunks[0].content).toBe("# My Note\n\nHello world.\n\nSecond paragraph.");
+        expect(chunks[0].content).toBe("Note: My Note\n\nHello world.\n\nSecond paragraph.");
     });
 
     it("handles empty content as a single title-only chunk", () => {
         const chunks = chunkText("", "Empty", 1000);
         expect(chunks).toHaveLength(1);
-        expect(chunks[0].content).toBe("# Empty");
+        expect(chunks[0].content).toBe("Note: Empty");
     });
 
     it("splits a large note into multiple chunks each within maxChars", () => {
@@ -37,7 +37,7 @@ describe("chunkText", () => {
         const chunks = chunkText(body, "Titled", 200);
         expect(chunks.length).toBeGreaterThan(1);
         for (const c of chunks) {
-            expect(c.content.startsWith("# Titled")).toBe(true);
+            expect(c.content.startsWith("Note: Titled")).toBe(true);
         }
     });
 
@@ -60,9 +60,9 @@ describe("chunkText", () => {
         // At least one chunk should carry the nested breadcrumb.
         const nested = chunks.find((c) => c.content.includes("### Subsection A"));
         expect(nested).toBeDefined();
-        expect(nested?.content).toContain("# Doc");
+        expect(nested?.content).toContain("Note: Doc");
         // The breadcrumb precedes the body (prefix at the top of the chunk).
-        expect(nested?.content.indexOf("# Doc")).toBeLessThan(nested?.content.indexOf("### Subsection A") ?? -1);
+        expect(nested?.content.indexOf("Note: Doc")).toBeLessThan(nested?.content.indexOf("### Subsection A") ?? -1);
     });
 
     it("never splits mid-paragraph when paragraphs fit the budget", () => {
@@ -117,4 +117,128 @@ describe("chunkText", () => {
             expect(joined).toContain(p);
         }
     });
+
+	// ── section-aware splitting ──────────────────────────────────────────────
+	// An embedding averages everything it is given, so a short note covering
+	// several topics collapses to a vector near the centroid of all of them and
+	// close to none. Measured on the real "Cooking Mediterranean Recipes" note
+	// (1234 chars, previously a single chunk): "griechenland" scored 0.492 against
+	// its Greek-salad section alone but only 0.200 against the whole note, and the
+	// note ranked 286/337. Splitting on headings regardless of size fixes that.
+
+	it("splits a small multi-section note so each topic gets its own vector", () => {
+		const body = [
+			"Intro line about the collection.",
+			"",
+			"## Greek Salad",
+			"Tomatoes, cucumber, Kalamata olives and feta.",
+			"",
+			"## Shakshuka",
+			"Poached eggs in a spiced tomato sauce.",
+			"",
+			"## Hummus",
+			"Chickpeas blended with tahini and lemon.",
+		].join("\n");
+
+		// Comfortably inside the budget — the old size-only fast path returned 1.
+		const chunks = chunkText(body, "Recipes", 32_764);
+
+		expect(chunks.length).toBeGreaterThan(1);
+		const greek = chunks.find((c) => c.content.includes("Kalamata"));
+		expect(greek).toBeDefined();
+		// The Greek chunk must not carry the other cuisines, or it is diluted again.
+		expect(greek?.content).not.toContain("Poached eggs");
+		expect(greek?.content).not.toContain("tahini");
+	});
+
+	it("keeps the title breadcrumb on every section chunk", () => {
+		const body = ["## One", "First section body.", "", "## Two", "Second section body."].join("\n");
+
+		const chunks = chunkText(body, "My Note", 32_764);
+
+		for (const chunk of chunks) {
+			expect(chunk.content.startsWith("Note: My Note")).toBe(true);
+		}
+	});
+
+	it("still returns one chunk for a small single-topic note", () => {
+		const body = "Just one topic here, no headings at all, so nothing to split on.";
+
+		expect(chunkText(body, "Simple", 32_764)).toHaveLength(1);
+	});
+
+	it("does not split on headings inside fenced code blocks", () => {
+		// A shell comment or Python `#` line must not fragment the note.
+		const body = [
+			"Some prose about a script.",
+			"",
+			"```bash",
+			"# not a heading",
+			"# also not a heading",
+			"echo hi",
+			"```",
+			"",
+			"More prose in the same section.",
+		].join("\n");
+
+		expect(chunkText(body, "Script Notes", 32_764)).toHaveLength(1);
+	});
+
+	it("assigns sequential chunk indices across sections", () => {
+		const body = ["## A", "Body A.", "", "## B", "Body B.", "", "## C", "Body C."].join("\n");
+
+		const chunks = chunkText(body, "Indexed", 32_764);
+
+		expect(chunks.map((c) => c.chunkIndex)).toEqual(chunks.map((_, i) => i));
+	});
+
+	it("keeps the note title distinguishable from a level-one heading in the body", () => {
+		// `#` is ordinary content syntax. Emitting the title as `# <title>` put two
+		// sibling H1s in the chunk with nothing marking which was the note itself.
+		const body = ["## Setup", "Install it.", "", "# Appendix", "Reference tables."].join("\n");
+
+		const chunks = chunkText(body, "My Guide", 32_764);
+		const appendix = chunks.find((c) => c.content.includes("Reference tables"));
+
+		expect(appendix?.content).toContain("Note: My Guide");
+		// The body's own H1 survives as content, unchanged.
+		expect(appendix?.content).toContain("# Appendix");
+		// ...and the title is not itself rendered as a heading.
+		expect(appendix?.content).not.toContain("# My Guide");
+	});
+});
+
+describe("chunkText heading levels", () => {
+	it("splits on level-one headings, not only level two", () => {
+		const body = ["# Part One", "Body one.", "", "# Part Two", "Body two.", "", "# Part Three", "Body three."].join(
+			"\n",
+		);
+
+		const chunks = chunkText(body, "H1 Note", 32_764);
+
+		expect(chunks).toHaveLength(3);
+		expect(chunks[0].content).toContain("# Part One");
+		expect(chunks[0].content).not.toContain("Body two.");
+	});
+
+	it("splits on deeper levels and keeps the ancestor breadcrumb", () => {
+		const body = [
+			"## Setup",
+			"Intro to setup.",
+			"",
+			"### Install",
+			"Run the installer.",
+			"",
+			"### Configure",
+			"Edit the config file.",
+		].join("\n");
+
+		const chunks = chunkText(body, "Deep Note", 32_764);
+		const install = chunks.find((c) => c.content.includes("Run the installer"));
+
+		// The H3 chunk carries its parent H2 so the fragment stays interpretable.
+		expect(install?.content).toContain("## Setup");
+		expect(install?.content).toContain("### Install");
+		expect(install?.content).not.toContain("Edit the config file");
+	});
 });

--- a/test/utils/chunkText.test.ts
+++ b/test/utils/chunkText.test.ts
@@ -356,4 +356,42 @@ describe("chunkText heading levels", () => {
 
 		expect(chunkText(body, "Longer Close", 32_764)).toHaveLength(2);
 	});
+
+
+	it("does not treat an info-string line inside a fence as a closer", () => {
+		// Review finding: an info string is legal only on the *opening* delimiter, so
+		// a ```text line inside an open block is content. Treating it as a closer also
+		// let the real closer re-open a fence, which swallowed the following section.
+		const body = [
+			"## Setup",
+			"Install it.",
+			"",
+			"```markdown",
+			"```text",
+			"# not a heading",
+			"```",
+			"",
+			"## Usage",
+			"Run it.",
+		].join("\n");
+
+		const chunks = chunkText(body, "Info String", 32_764);
+
+		// `## Usage` must still own a chunk rather than being absorbed into code.
+		const usage = chunks.find((c) => c.content.includes("Run it."));
+		expect(usage?.content).toContain("## Usage");
+		expect(usage?.content).not.toContain("not a heading");
+	});
+
+	it("accepts a closing fence followed only by whitespace", () => {
+		const body = ["## Setup", "x", "", "```bash", "# c", "```   ", "", "## Usage", "y"].join("\n");
+
+		expect(chunkText(body, "Trailing Space", 32_764)).toHaveLength(2);
+	});
+
+	it("does not mistake inline code spans for fences", () => {
+		const body = ["## Setup", "see ```code``` inline", "", "## Usage", "y"].join("\n");
+
+		expect(chunkText(body, "Inline", 32_764)).toHaveLength(2);
+	});
 });

--- a/test/utils/chunkText.test.ts
+++ b/test/utils/chunkText.test.ts
@@ -241,4 +241,32 @@ describe("chunkText heading levels", () => {
 		expect(install?.content).toContain("### Install");
 		expect(install?.content).not.toContain("Edit the config file");
 	});
+	it("does not treat heading-like lines inside code fences as sections", () => {
+		// Review finding: countSections tracked fence state but the splitting loop
+		// did not, so a shell comment became a real breadcrumb frame — a permanent
+		// ancestor of every following section — and split the fence markers apart.
+		const body = [
+			"## Setup",
+			"Install it.",
+			"",
+			"```bash",
+			"# not a heading",
+			"echo hi",
+			"```",
+			"",
+			"## Usage",
+			"Run it.",
+		].join("\n");
+
+		const chunks = chunkText(body, "Script Notes", 32_764);
+
+		expect(chunks).toHaveLength(2);
+		// The fenced block stays whole, inside its own section.
+		const setup = chunks.find((c) => c.content.includes("echo hi"));
+		expect(setup?.content).toContain("## Setup");
+		expect(setup?.content).toContain("```bash");
+		// The later section must not inherit the code comment as an ancestor.
+		const usage = chunks.find((c) => c.content.includes("Run it."));
+		expect(usage?.content).not.toContain("not a heading");
+	});
 });

--- a/test/utils/chunkText.test.ts
+++ b/test/utils/chunkText.test.ts
@@ -323,4 +323,37 @@ describe("chunkText heading levels", () => {
 
 		expect(chunkText(body, "Unclosed", 32_764)).toHaveLength(1);
 	});
+
+
+	it("does not let a shorter delimiter close a longer fence", () => {
+		// Review finding: FENCE_RE captured only three characters, so a ``` line
+		// inside a ````-opened block closed it early and the following `#` line
+		// became a heading. Showing fenced code inside fenced code is the ordinary
+		// way to document markdown, so this occurs in real notes.
+		const body = [
+			"## Setup",
+			"Install it.",
+			"",
+			"````markdown",
+			"```",
+			"# not a heading",
+			"```",
+			"````",
+			"",
+			"## Usage",
+			"Run it.",
+		].join("\n");
+
+		const chunks = chunkText(body, "Long Fence", 32_764);
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks.find((c) => c.content.includes("Run it."))?.content).not.toContain("not a heading");
+	});
+
+	it("closes a fence with a delimiter at least as long as the opener", () => {
+		// CommonMark allows the closing fence to be longer than the opening one.
+		const body = ["## Setup", "x", "", "```bash", "# c", "````", "", "## Usage", "y"].join("\n");
+
+		expect(chunkText(body, "Longer Close", 32_764)).toHaveLength(2);
+	});
 });

--- a/test/utils/chunkText.test.ts
+++ b/test/utils/chunkText.test.ts
@@ -394,4 +394,42 @@ describe("chunkText heading levels", () => {
 
 		expect(chunkText(body, "Inline", 32_764)).toHaveLength(2);
 	});
+
+
+	it("does not open a fence from an indented code block", () => {
+		// Review finding: four or more leading spaces make a line an *indented* code
+		// block, not a fence. Accepting any indentation let a ``` inside indented
+		// example code open a fence that never closed, swallowing every later
+		// heading — three sections collapsed into a single chunk.
+		const body = [
+			"## Setup",
+			"Example of an indented code block:",
+			"",
+			"    ```",
+			"    some code",
+			"",
+			"## Usage",
+			"Run it.",
+			"",
+			"## Notes",
+			"More.",
+		].join("\n");
+
+		const chunks = chunkText(body, "Indented", 32_764);
+
+		expect(chunks).toHaveLength(3);
+		expect(chunks.some((c) => c.content.includes("## Usage"))).toBe(true);
+		expect(chunks.some((c) => c.content.includes("## Notes"))).toBe(true);
+	});
+
+	it("still treats up to three spaces of indentation as a fence", () => {
+		// The boundary is exactly three: this is a real fence and must suppress the
+		// `#` line inside it.
+		const body = ["## Setup", "x", "", "   ```bash", "# c", "   ```", "", "## Usage", "y"].join("\n");
+
+		const chunks = chunkText(body, "Three Spaces", 32_764);
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks.find((c) => c.content.includes("y"))?.content).not.toContain("# c");
+	});
 });

--- a/test/utils/fileFiltering.test.ts
+++ b/test/utils/fileFiltering.test.ts
@@ -9,7 +9,8 @@ vi.mock("../../src/stores/dataStore.svelte", () => ({
 	getData: () => mockGetData(),
 }));
 
-import { isAgentFilePath, isAgentPath, isIndexableFile } from "../../src/utils/fileFiltering";
+import { isAgentFilePath, isAgentPath, isIndexableFile, readIndexableContent } from "../../src/utils/fileFiltering";
+import { gzipString, toArrayBuffer } from "../../src/utils/gzip";
 
 describe("isAgentPath (pure)", () => {
 	it("matches the folder itself and files inside it", () => {
@@ -63,5 +64,101 @@ describe("isAgentFilePath / isIndexableFile (folder from plugin data)", () => {
 		});
 		expect(isAgentFilePath("Agents/Skills/foo/SKILL.md")).toBe(false);
 		mockGetData.mockReturnValue({ agentFolder: "Agents" });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// .chat extraction
+// ---------------------------------------------------------------------------
+
+/** Build a LangChain-serialised message as stored inside a checkpoint. */
+function message(id: string | null, content: string): Record<string, unknown> {
+	const kwargs: Record<string, unknown> = { content };
+	if (id !== null) kwargs.id = id;
+	return { lc: 1, type: "constructor", kwargs };
+}
+
+/**
+ * Build thread JSON whose checkpoints form a growing prefix chain — the shape
+ * LangGraph actually persists, where checkpoint N re-contains messages 1..N.
+ */
+function thread(title: string, messages: Array<Record<string, unknown>>): string {
+	const checkpoints: Record<string, unknown> = {};
+	for (let i = 1; i <= messages.length; i++) {
+		checkpoints[`cp-${i}`] = {
+			checkpoint: { id: `cp-${i}`, channel_values: { messages: messages.slice(0, i) } },
+		};
+	}
+	return JSON.stringify({ title, checkpoints });
+}
+
+/** Minimal vault stub exposing the `adapter.readBinary` path used for .chat files. */
+function vaultReturning(raw: string | Uint8Array) {
+	return {
+		adapter: {
+			readBinary: vi.fn().mockImplementation(async () => {
+				const bytes = typeof raw === "string" ? await gzipString(raw) : raw;
+				return toArrayBuffer(bytes);
+			}),
+		},
+	} as never;
+}
+
+const chatFile = { path: "Chats/Thread.chat", extension: "chat", basename: "Thread" } as never;
+
+describe("readIndexableContent (.chat extraction)", () => {
+	it("emits each message once despite the checkpoint tree repeating it", async () => {
+		const raw = thread("Greeting", [
+			message("m1", "hello there"),
+			message("m2", "general kenobi"),
+			message("m3", "you are a bold one"),
+		]);
+
+		const out = await readIndexableContent(vaultReturning(raw), chatFile);
+
+		// Naive per-checkpoint concatenation would emit m1 three times and m2 twice.
+		expect(out.match(/hello there/g)).toHaveLength(1);
+		expect(out.match(/general kenobi/g)).toHaveLength(1);
+		expect(out.match(/you are a bold one/g)).toHaveLength(1);
+	});
+
+	it("preserves the title and first-seen transcript order", async () => {
+		const raw = thread("Greeting", [message("m1", "first"), message("m2", "second")]);
+
+		const out = await readIndexableContent(vaultReturning(raw), chatFile);
+
+		expect(out).toBe("Greeting\n\nfirst\n\nsecond");
+	});
+
+	it("keeps distinct messages that share identical text", async () => {
+		// Two separate turns can legitimately both be "yes"; ids keep them apart.
+		const raw = thread("Confirmations", [message("m1", "yes"), message("m2", "yes")]);
+
+		const out = await readIndexableContent(vaultReturning(raw), chatFile);
+
+		expect(out.match(/yes/g)).toHaveLength(2);
+	});
+
+	it("falls back to content deduplication when messages carry no id", async () => {
+		const raw = thread("Legacy", [message(null, "alpha"), message(null, "beta")]);
+
+		const out = await readIndexableContent(vaultReturning(raw), chatFile);
+
+		expect(out.match(/alpha/g)).toHaveLength(1);
+		expect(out.match(/beta/g)).toHaveLength(1);
+	});
+
+	it("returns an empty string for corrupt thread JSON", async () => {
+		const out = await readIndexableContent(vaultReturning("not json at all"), chatFile);
+
+		expect(out).toBe("");
+	});
+
+	it("returns an empty string when the file cannot be read", async () => {
+		const vault = {
+			adapter: { readBinary: vi.fn().mockRejectedValue(new Error("unreadable")) },
+		} as never;
+
+		expect(await readIndexableContent(vault, chatFile)).toBe("");
 	});
 });

--- a/test/vectorstore/HNSWVectorStore.clear.test.ts
+++ b/test/vectorstore/HNSWVectorStore.clear.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/*
+ * Regression: `clear()` used to recreate the in-memory HNSWWithDB wrapper without
+ * deleting the *persisted* graph. Because clear() also resets `nextHnswId` to 0,
+ * the next indexing run reassigned numeric ids that were already present in the
+ * resurrected graph. `search()` resolves each hit through `numericToId` and
+ * `continue`s on a miss, so those collisions silently dropped results — semantic
+ * search returned too few results, or none at all, for valid queries.
+ *
+ * Measured in the test vault before the fix: 337 indexed chunks but 10,161 nodes
+ * in the persisted graph, with only 377 surviving id mappings.
+ */
+
+const deleteIndex = vi.fn().mockResolvedValue(undefined);
+const saveIndex = vi.fn().mockResolvedValue(undefined);
+const loadIndex = vi.fn().mockResolvedValue(undefined);
+const create = vi.fn();
+
+vi.mock("hnsw", () => ({
+	HNSWWithDB: {
+		create: (...args: unknown[]) => create(...args),
+	},
+}));
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+
+import { HNSWVectorStore } from "../../src/vectorstore/HNSWVectorStore";
+
+/**
+ * Minimal IndexedDB stand-in. `clearStore` resolves on the *transaction's*
+ * `oncomplete` (not the request's `onsuccess`), and clear() clears three stores in
+ * sequence — so each transaction needs its own object with `oncomplete` fired
+ * asynchronously, after the caller has had a chance to attach the handler.
+ */
+function fakeDb() {
+	const store = {
+		clear: () => ({ onerror: null as null | (() => void) }),
+	};
+	return {
+		transaction: () => {
+			const tx = {
+				objectStore: () => store,
+				oncomplete: null as null | (() => void),
+				onerror: null as null | (() => void),
+			};
+			queueMicrotask(() => tx.oncomplete?.());
+			return tx;
+		},
+		close: vi.fn(),
+	};
+}
+
+function makeStore(): HNSWVectorStore {
+	const store = new HNSWVectorStore("vault-1", "index-1");
+	// Reach past the IndexedDB bootstrap; clear() only needs `db` and `dimensions`.
+	Object.assign(store as unknown as Record<string, unknown>, {
+		db: fakeDb(),
+		dimensions: 4096,
+	});
+	return store;
+}
+
+describe("HNSWVectorStore.clear", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		create.mockResolvedValue({ deleteIndex, saveIndex, loadIndex });
+	});
+
+	it("deletes the persisted graph rather than only dropping the in-memory handle", async () => {
+		const store = makeStore();
+		const index = { deleteIndex, saveIndex, loadIndex };
+		Object.assign(store as unknown as Record<string, unknown>, { hnswIndex: index });
+
+		await store.clear();
+
+		// The whole point: without this the graph survives in its own IndexedDB
+		// database and is reloaded on the next open().
+		expect(deleteIndex).toHaveBeenCalledTimes(1);
+	});
+
+	it("leaves a usable empty graph behind so later upserts can insert", async () => {
+		const store = makeStore();
+		Object.assign(store as unknown as Record<string, unknown>, {
+			hnswIndex: { deleteIndex, saveIndex, loadIndex },
+		});
+
+		await store.clear();
+
+		// Recreated after deletion, so indexing does not have to re-open it lazily.
+		expect(create).toHaveBeenCalledTimes(1);
+		expect((store as unknown as { hnswIndex: unknown }).hnswIndex).not.toBeNull();
+	});
+
+	it("resets the numeric id counter that the deleted graph was keyed on", async () => {
+		const store = makeStore();
+		Object.assign(store as unknown as Record<string, unknown>, {
+			hnswIndex: { deleteIndex, saveIndex, loadIndex },
+			nextHnswId: 10_161,
+		});
+
+		await store.clear();
+
+		expect((store as unknown as { nextHnswId: number }).nextHnswId).toBe(0);
+	});
+
+	it("still clears when the persisted graph cannot be deleted", async () => {
+		const store = makeStore();
+		deleteIndex.mockRejectedValueOnce(new Error("db locked"));
+		Object.assign(store as unknown as Record<string, unknown>, {
+			hnswIndex: { deleteIndex, saveIndex, loadIndex },
+		});
+
+		// A failed delete must not abort clear() and strand the store mid-reset.
+		await expect(store.clear()).resolves.toBeUndefined();
+		expect((store as unknown as { nextHnswId: number }).nextHnswId).toBe(0);
+	});
+
+	it("drops any pending graph save so it cannot rewrite the cleared graph", async () => {
+		const store = makeStore();
+		Object.assign(store as unknown as Record<string, unknown>, {
+			hnswIndex: { deleteIndex, saveIndex, loadIndex },
+			hasPendingIndexSave: true,
+		});
+
+		await store.clear();
+
+		expect((store as unknown as { hasPendingIndexSave: boolean }).hasPendingIndexSave).toBe(false);
+	});
+});

--- a/test/vectorstore/chunkAggregation.test.ts
+++ b/test/vectorstore/chunkAggregation.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { aggregateChunksToNotes } from "../../src/vectorstore/chunkAggregation";
+
+describe("aggregateChunksToNotes", () => {
+	it("ranks a note matching in several sections above one lucky chunk", () => {
+		// The sourdough regression: `weak` edges `strong` on best chunk alone, but
+		// `strong` matches in three places and is the better answer.
+		const result = aggregateChunksToNotes([
+			{ path: "weak.md", score: 0.62 },
+			{ path: "strong.md", score: 0.61 },
+			{ path: "strong.md", score: 0.6 },
+			{ path: "strong.md", score: 0.58 },
+		]);
+
+		expect(result[0].path).toBe("strong.md");
+		expect(result[0].matchingChunks).toBe(3);
+	});
+
+	it("keeps a clearly better single chunk ahead of many weak ones", () => {
+		const result = aggregateChunksToNotes([
+			{ path: "precise.md", score: 0.9 },
+			...Array.from({ length: 20 }, () => ({ path: "sprawling.md", score: 0.3 })),
+		]);
+
+		// Support is bounded and relative, so chunk count cannot overturn a big gap.
+		expect(result[0].path).toBe("precise.md");
+	});
+
+	it("does not let a long note beat a better short one on chunk count alone", () => {
+		// The measured length-bias case: a 33-chunk note whose sections are all
+		// mediocre used to outrank a tiny note with a genuinely better match,
+		// because the old harmonic support term diverged with chunk count.
+		const result = aggregateChunksToNotes([
+			{ path: "tiny.md", score: 0.72 },
+			...Array.from({ length: 33 }, (_, i) => ({ path: "huge.md", score: 0.55 - i * 0.003 })),
+		]);
+
+		expect(result[0].path).toBe("tiny.md");
+	});
+
+	it("bounds total support no matter how many chunks match", () => {
+		const lift = (count: number) => {
+			const hits = Array.from({ length: count }, () => ({ path: "n.md", score: 0.6 }));
+			return aggregateChunksToNotes(hits)[0].score / 0.6 - 1;
+		};
+
+		// Converges: the jump from 50 to 500 chunks is negligible, and the ceiling
+		// holds. The old formula grew without limit (+63% at 100 chunks).
+		expect(lift(500)).toBeLessThanOrEqual(0.15);
+		expect(lift(500) - lift(50)).toBeLessThan(0.01);
+	});
+
+	it("weights support by quality rather than by count", () => {
+		const twoStrong = aggregateChunksToNotes([
+			{ path: "a.md", score: 0.8 },
+			{ path: "a.md", score: 0.79 },
+			{ path: "a.md", score: 0.78 },
+		])[0].score;
+		const manyWeak = aggregateChunksToNotes([
+			{ path: "b.md", score: 0.8 },
+			...Array.from({ length: 15 }, () => ({ path: "b.md", score: 0.08 })),
+		])[0].score;
+
+		expect(twoStrong).toBeGreaterThan(manyWeak);
+	});
+
+	it("reports the best chunk score untouched by the support term", () => {
+		const result = aggregateChunksToNotes([
+			{ path: "a.md", score: 0.8 },
+			{ path: "a.md", score: 0.7 },
+		]);
+
+		expect(result[0].bestChunkScore).toBe(0.8);
+		expect(result[0].score).toBeGreaterThan(0.8);
+	});
+
+	it("leaves a single-chunk note's score exactly at its chunk score", () => {
+		const result = aggregateChunksToNotes([{ path: "solo.md", score: 0.42 }]);
+
+		expect(result[0].score).toBe(0.42);
+		expect(result[0].matchingChunks).toBe(1);
+	});
+
+	it("applies diminishing returns so later chunks add less", () => {
+		const two = aggregateChunksToNotes([
+			{ path: "n.md", score: 0.5 },
+			{ path: "n.md", score: 0.5 },
+		])[0].score;
+		const three = aggregateChunksToNotes([
+			{ path: "n.md", score: 0.5 },
+			{ path: "n.md", score: 0.5 },
+			{ path: "n.md", score: 0.5 },
+		])[0].score;
+
+		const firstGain = two - 0.5;
+		const secondGain = three - two;
+		expect(secondGain).toBeGreaterThan(0);
+		expect(secondGain).toBeLessThan(firstGain);
+	});
+
+	it("weights supporting chunks by how close they are to the note's best", () => {
+		const closeSupport = aggregateChunksToNotes([
+			{ path: "a.md", score: 0.8 },
+			{ path: "a.md", score: 0.79 },
+		])[0].score;
+		const weakSupport = aggregateChunksToNotes([
+			{ path: "b.md", score: 0.8 },
+			{ path: "b.md", score: 0.1 },
+		])[0].score;
+
+		expect(closeSupport).toBeGreaterThan(weakSupport);
+	});
+
+	it("sorts by aggregate score and finds the best chunk regardless of input order", () => {
+		const result = aggregateChunksToNotes([
+			{ path: "a.md", score: 0.2 },
+			{ path: "b.md", score: 0.9 },
+			{ path: "a.md", score: 0.85 },
+		]);
+
+		expect(result.map((r) => r.path)).toEqual(["b.md", "a.md"]);
+		expect(result[1].bestChunkScore).toBe(0.85);
+	});
+
+	it("handles an empty hit list", () => {
+		expect(aggregateChunksToNotes([])).toEqual([]);
+	});
+
+	it("does not divide by zero when every chunk scores zero", () => {
+		const result = aggregateChunksToNotes([
+			{ path: "z.md", score: 0 },
+			{ path: "z.md", score: 0 },
+		]);
+
+		expect(result[0].score).toBe(0);
+		expect(Number.isNaN(result[0].score)).toBe(false);
+	});
+
+	it("ignores negative chunk scores in the support term", () => {
+		// Some metrics can emit negatives; they must not reduce the aggregate below
+		// the note's best chunk.
+		const result = aggregateChunksToNotes([
+			{ path: "n.md", score: 0.5 },
+			{ path: "n.md", score: -0.3 },
+		]);
+
+		expect(result[0].score).toBe(0.5);
+	});
+});


### PR DESCRIPTION
Resolves #338 

## Summary

Four measured retrieval bugs were silently degrading search results, and the ranking algorithm's constants were tuned against a single small fixture vault with one embedding model. This fixes both, and adds a graded benchmark so the next change can be measured rather than guessed.

**Benchmark: 0.9966 (qwen3-8b) and 0.9934 (harrier-oss-0.6b)** — stable across models.

## Retrieval bugs

| Bug | Symptom | Cause |
|---|---|---|
| `clear()` leaked the graph | `semanticSearch` returned 0 results for valid queries; 50-result request returned 4 | Recreated the in-memory wrapper without deleting the persisted graph, while resetting `nextHnswId` to 0. Reused ids collided with stale nodes and `search()` skipped them. **10,161 nodes vs 377 mappings.** |
| `upsert()` orphaned chunks | Same truncation, reappearing after section chunking | Keyed removal on `getByPath()`, which returns only a note's *first* chunk |
| `.chat` duplication | ~9× redundant embedding work | Every checkpoint re-contains prior messages; extraction concatenated them all (12.3M chars across 54 fixture files) |
| Topic dilution | Multi-topic notes unfindable by sub-topic | A 1234-byte note scored **0.200** for a query its own section answered at **0.492**, ranking 286/337 |

## Ranking rework

Every signal is now normalized *within the result set* — no absolute thresholds, no rank cutoffs.

- **Per-source normalization** so BM25 magnitudes and cosines are comparable without per-model constants
- **Relative-score recency gate** replaces a hard top-10 rank cutoff (a strong match at rank 11 was gated while a weak one at rank 10 was not)
- **Adaptive lift ceiling** — 2× the median adjacent gap, rather than a fixed percentage. A 12% deficit is a chasm in a dense semantic set (~1% gaps) and a near-tie in a sparse lexical one (~10% gaps)
- **Crowding attenuation** (1/n²) — recency cannot single out a note when several are equally recent
- **Converging chunk support** — the previous harmonic sum diverged, inflating a 33-chunk note from 0.662 to 0.909
- **Identity boosts on lexical-only queries**, which previously got no credit for an exact alias match

## Verification

- **1070 unit tests pass**; `bun run check` clean (4 pre-existing `GraphCanvas.svelte` errors on `dev`, untouched)
- New graded benchmark: 18 cases over a deterministic 300-note corpus, scored by nDCG@10 and MRR, ratcheting on a recorded baseline
- Generalization verified across set size (n=5→2000, margin drift 4.88%→4.25%), cosine band, note length (bounded), and two embedding models

## Also included

- Fixes a `QueryClientProvider` crash when opening the embedding index setup modal
- [`docs/search-algorithm.html`](docs/search-algorithm.html) — standalone reference; all 20 constants verified against source

## Notes for review

- Two legacy tests changed behaviour deliberately: both asserted a *weakly*-recent note should overtake a stronger identity match — the pattern that caused the recency bug. Comments record the change and why.
- The corpus is generated, not committed (`bun run corpus:generate`), and gitignored; the seeded script is the source of truth.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._