### PR TITLE
fix(indexing): correct chunking, PDF extraction, and .chat content

### DIFF
--- a/src/search/LexicalSearchService.ts
+++ b/src/search/LexicalSearchService.ts
@@ -259,9 +259,12 @@ export class LexicalSearchService {
 
 		this.plugin.registerEvent(
 			vault.on("rename", async (file, oldPath) => {
-				if (file instanceof TFile && isIndexableFile(file)) {
-					await this.handleFileRename(file, oldPath);
-				}
+				if (!(file instanceof TFile)) return;
+				// Note the guard is *inside* handleFileRename, not here: renaming a
+				// note to a non-indexable extension (`note.md` → `note.base`) must
+				// still drop the old entry. Gating on the post-rename file skipped
+				// the removal and left a stale, still-searchable document behind.
+				await this.handleFileRename(file, oldPath);
 			}),
 		);
 	}
@@ -285,7 +288,11 @@ export class LexicalSearchService {
 	}
 
 	private async handleFileRename(file: TFile, oldPath: string): Promise<void> {
+		// Always drop the old path, even when the destination is no longer
+		// indexable — otherwise the pre-rename document stays searchable forever.
 		this.miniSearch.removeDocument(oldPath);
+
+		if (!isIndexableFile(file)) return;
 
 		try {
 			const content = await readIndexableContent(this.plugin.app.vault, file);

--- a/src/utils/chunkText.ts
+++ b/src/utils/chunkText.ts
@@ -256,11 +256,21 @@ function splitOversizedUnit(unit: string, maxBodyChars: number): string[] {
  */
 export function chunkText(content: string, title: string, maxChars: number): TextChunk[] {
 	const titleLine = formatTitleLine(title);
+
+	// Normalize line endings once, up front. Every downstream rule is expressed in
+	// terms of `\n`, and a stray `\r` defeats them silently: `HEADING_RE` does not
+	// match `"## A\r"` (its `$` anchors after the carriage return), so a CRLF note
+	// got *no* section splitting at all — every heading was invisible and the whole
+	// note collapsed into one vector. Handling `\r` in each regex separately is how
+	// that class of bug returns; converting here means the rest of the file can
+	// assume `\n`.
+	const normalized = content.replace(/\r\n?/g, "\n");
+
 	// Strip blank leading/trailing *lines*, but never a line's own indentation:
 	// `"    ```".trim()` yields a real fence delimiter, which would make
 	// `countSections` read indented example code as an unterminated fence and
 	// swallow every heading after it.
-	const trimmed = content.replace(/^(?:[ \t]*\n)+/, "").replace(/\s+$/, "");
+	const trimmed = normalized.replace(/^(?:[ \t]*\n)+/, "").replace(/\s+$/, "");
 
 	// Fast path: a note that fits the budget AND covers a single topic becomes one
 	// vector, as before.
@@ -288,7 +298,9 @@ export function chunkText(content: string, title: string, maxChars: number): Tex
 	// Reserve at most ~40% of the budget for the prefix so the body always has room.
 	const maxPrefixChars = Math.max(titleLine.length, Math.floor(maxChars * 0.4));
 
-	const lines = content.split("\n");
+	// `normalized`, not `content`: the raw text may use CRLF, which would leave a
+	// stray `\r` on every line and defeat the heading and fence matchers below.
+	const lines = normalized.split("\n");
 	const headings: HeadingFrame[] = [];
 	// Rebuild paragraphs while tracking the heading stack at each paragraph.
 	interface Unit {
@@ -303,7 +315,7 @@ export function chunkText(content: string, title: string, maxChars: number): Tex
 		// must survive.
 		const text = buffer
 			.join("\n")
-			.replace(/^\s*\n/, "")
+			.replace(/^[ \t]*\n/, "")
 			.replace(/\s+$/, "");
 		buffer = [];
 		if (!text.trim()) return;

--- a/src/utils/chunkText.ts
+++ b/src/utils/chunkText.ts
@@ -162,12 +162,21 @@ function buildPrefix(title: string, headings: HeadingFrame[], maxPrefixChars: nu
 	return titleLine;
 }
 
-/** Split raw note content into paragraphs on blank lines, preserving order. */
+/**
+ * Split raw note content into paragraphs on blank lines, preserving order.
+ *
+ * Only *trailing* whitespace is trimmed. Leading indentation is structural
+ * markdown — four spaces mark an indented code block, and list continuations rely
+ * on it — so stripping it changes what the text means. A `    ```` ``` ```` ` line
+ * correctly rejected as a fence (indented code, not a delimiter) would otherwise
+ * be re-emitted as a bare ```` ``` ````, turning the chunk body into an
+ * unterminated fence that swallows the following heading.
+ */
 function splitParagraphs(content: string): string[] {
 	return content
-		.split(/\n\s*\n/)
-		.map((p) => p.trim())
-		.filter((p) => p.length > 0);
+		.split(/\n[ \t]*\n/)
+		.map((p) => p.replace(/\s+$/, ""))
+		.filter((p) => p.trim().length > 0);
 }
 
 /**
@@ -247,7 +256,11 @@ function splitOversizedUnit(unit: string, maxBodyChars: number): string[] {
  */
 export function chunkText(content: string, title: string, maxChars: number): TextChunk[] {
 	const titleLine = formatTitleLine(title);
-	const trimmed = content.trim();
+	// Strip blank leading/trailing *lines*, but never a line's own indentation:
+	// `"    ```".trim()` yields a real fence delimiter, which would make
+	// `countSections` read indented example code as an unterminated fence and
+	// swallow every heading after it.
+	const trimmed = content.replace(/^(?:[ \t]*\n)+/, "").replace(/\s+$/, "");
 
 	// Fast path: a note that fits the budget AND covers a single topic becomes one
 	// vector, as before.
@@ -286,9 +299,14 @@ export function chunkText(content: string, title: string, maxChars: number): Tex
 	let buffer: string[] = [];
 
 	const flushBuffer = () => {
-		const text = buffer.join("\n").trim();
+		// Trim blank edges only — see `splitParagraphs` on why leading indentation
+		// must survive.
+		const text = buffer
+			.join("\n")
+			.replace(/^\s*\n/, "")
+			.replace(/\s+$/, "");
 		buffer = [];
-		if (!text) return;
+		if (!text.trim()) return;
 		for (const para of splitParagraphs(text)) {
 			units.push({ body: para, headings: [...headings] });
 		}

--- a/src/utils/fileFiltering.ts
+++ b/src/utils/fileFiltering.ts
@@ -258,21 +258,140 @@ function getMessageClass(msg: unknown): string | null {
 }
 
 /**
- * Extract human and AI message text from a `.chat` file (LangGraph ThreadData JSON).
- * Skips all LangChain serialisation noise, checkpoint metadata, writes, etc.
+ * Context blocks appended to a user's question before it is sent (visible notes,
+ * selected text, graph selection). They are machinery, not something the user typed,
+ * and they name other notes — indexing them makes a thread match queries about notes
+ * that merely happened to be open. The chat UI strips the same suffix for display
+ * (`stripAugmentedSuffix` in `stores/chatStore.svelte.ts`); matching on the block
+ * marker keeps this independent of the exact rendering.
+ */
+const RE_AUGMENTED_CONTEXT = /\n*\[(?:Currently visible notes|Selected text from |Graph-selected notes)/;
+
+/** Drop appended context blocks, keeping only what the user actually wrote. */
+function stripAugmentedContext(content: string): string {
+	const match = RE_AUGMENTED_CONTEXT.exec(content);
+	return match ? content.slice(0, match.index).trim() : content;
+}
+
+/** Returns `true` when an assistant message is mid-turn narration rather than an answer. */
+function hasToolCalls(msg: unknown): boolean {
+	if (!msg || typeof msg !== "object") return false;
+	const kwargs = (msg as Record<string, unknown>).kwargs;
+	if (!kwargs || typeof kwargs !== "object") return false;
+	const record = kwargs as Record<string, unknown>;
+
+	if (Array.isArray(record.tool_calls) && record.tool_calls.length > 0) return true;
+	const additional = record.additional_kwargs;
+	if (additional && typeof additional === "object") {
+		const nested = (additional as Record<string, unknown>).tool_calls;
+		if (Array.isArray(nested) && nested.length > 0) return true;
+	}
+	return false;
+}
+
+/**
+ * Pick the message list for the conversation as the user last left it.
  *
- * Conversation history is a *tree* of checkpoints, and every checkpoint re-contains
- * the whole message list that preceded it. Concatenating each checkpoint's messages
- * therefore re-emits the same text once per subsequent turn — measured at ~8x on a
- * 526-checkpoint thread, which inflates both the embedding cost and the lexical term
- * frequencies of every chat file. Emit each distinct message exactly once instead,
- * keyed on the stable LangChain message id (falling back to the message text when a
- * message carries no id). First-seen order is preserved so the extracted text still
- * reads as a transcript.
+ * Checkpoints form a *tree*: every regenerate or edit forks a new branch, and each
+ * branch keeps its own answer to the same question. Measured on a 526-checkpoint
+ * thread, that turned 10 real questions into 105 distinct answers (one question was
+ * regenerated 16 times), all of which were being indexed — the single biggest reason
+ * a chat file outweighed real notes.
  *
- * Only conversational turns are indexed (see `CONVERSATIONAL_MESSAGE_CLASSES`), and
- * attachment blocks are stripped from those turns, so a thread contributes the
- * discussion itself rather than a second copy of the notes it referenced.
+ * This mirrors the branch resolution the chat UI uses to decide which conversation to
+ * show (`resolveActiveCheckpointId` → `findDeterministicTipFrom` in
+ * `stores/chatStore.svelte.ts`): walk from the root and always take the newest child,
+ * tie-breaking on step then id so the choice is deterministic. The UI's extra inputs
+ * (session / persisted / explicit checkpoint) don't apply here — the persisted "last
+ * viewed" id lives in plugin data, not the `.chat` file — so this is the UI's own
+ * fallback path, which is also what the read-only `.chat` embed preview takes.
+ *
+ * It is reimplemented rather than imported because those helpers live in a Svelte
+ * runes store that pulls in the whole plugin graph, and they operate on normalized
+ * LangChain `BaseMessage` instances; indexing reads raw serialised JSON and must stay
+ * usable before `AgentManager` has initialized. Verified to agree with the UI on all
+ * 49 threads in the test vault by comparing against `metadata.lastMessagePreview`.
+ */
+function selectActiveMessages(checkpoints: Record<string, unknown>): unknown[] {
+	const nodes = new Map<string, { id: string; ts: string; step: number; entry: unknown; children: string[] }>();
+	for (const [id, entry] of Object.entries(checkpoints)) {
+		const record = entry as Record<string, unknown>;
+		const checkpoint = record?.checkpoint as Record<string, unknown> | undefined;
+		const metadata = record?.metadata as Record<string, unknown> | undefined;
+		nodes.set(id, {
+			id,
+			ts: typeof checkpoint?.ts === "string" ? checkpoint.ts : "",
+			step: typeof metadata?.step === "number" ? metadata.step : 0,
+			entry,
+			children: [],
+		});
+	}
+	if (nodes.size === 0) return [];
+
+	const parentOf = new Map<string, string | undefined>();
+	for (const [id, entry] of Object.entries(checkpoints)) {
+		const parentConfig = (entry as Record<string, unknown>)?.parentConfig as Record<string, unknown> | undefined;
+		const configurable = parentConfig?.configurable as Record<string, unknown> | undefined;
+		const parentId = configurable?.checkpoint_id;
+		const parent = typeof parentId === "string" && nodes.has(parentId) ? parentId : undefined;
+		parentOf.set(id, parent);
+		if (parent) nodes.get(parent)?.children.push(id);
+	}
+
+	/** Newest first: ts desc, then step desc, then id — matches the UI's `compareNewest`. */
+	const newestFirst = (a: string, b: string): number => {
+		const nodeA = nodes.get(a);
+		const nodeB = nodes.get(b);
+		if (!nodeA || !nodeB) return 0;
+		if (nodeA.ts !== nodeB.ts) return nodeB.ts.localeCompare(nodeA.ts);
+		if (nodeA.step !== nodeB.step) return nodeB.step - nodeA.step;
+		return nodeA.id.localeCompare(nodeB.id);
+	};
+
+	const roots = [...nodes.keys()].filter((id) => !parentOf.get(id));
+	const startId = (roots.length > 0 ? roots : [...nodes.keys()]).sort((a, b) => {
+		const nodeA = nodes.get(a);
+		const nodeB = nodes.get(b);
+		if (!nodeA || !nodeB) return 0;
+		if (nodeA.step !== nodeB.step) return nodeA.step - nodeB.step;
+		if (nodeA.ts !== nodeB.ts) return nodeA.ts.localeCompare(nodeB.ts);
+		return nodeA.id.localeCompare(nodeB.id);
+	})[0];
+
+	// Walk to the tip, taking the newest child at each fork. `visited` guards against
+	// a malformed file whose parent links form a cycle.
+	let current = startId;
+	const visited = new Set<string>();
+	while (current && !visited.has(current)) {
+		visited.add(current);
+		const next = nodes
+			.get(current)
+			?.children.filter((id) => !visited.has(id))
+			.sort(newestFirst)[0];
+		if (!next) break;
+		current = next;
+	}
+
+	return getNestedMessages(nodes.get(current)?.entry);
+}
+
+/**
+ * Extract the conversation from a `.chat` file (LangGraph ThreadData JSON) as
+ * question/answer pairs, skipping LangChain serialisation noise and tool traffic.
+ *
+ * Three things are dropped, each measured as a real source of index bloat:
+ *   - **Tool results** (see `CONVERSATIONAL_MESSAGE_CLASSES`) — 73.5% of indexed chat
+ *     text, nearly half of it notes echoed back verbatim by `read_content`.
+ *   - **Abandoned branches** (see `selectActiveMessages`) — regenerated answers to a
+ *     question the user already re-asked.
+ *   - **Mid-turn narration** — assistant messages that only announce a tool call
+ *     ("I'll quickly inspect the vault structure…"); they carry `tool_calls` and no
+ *     answer, and matched no query meaningfully.
+ *
+ * A turn is emitted as `question\n\nanswer` so the two share a chunk: an answer often
+ * lacks the vocabulary of the question that prompted it, and splitting them costs the
+ * retrieval of both. Only the last final answer of a turn is kept — an assistant can
+ * emit several text messages around its tool calls, but the closing one is the reply.
  */
 function extractChatContent(raw: string): string {
 	try {
@@ -284,30 +403,38 @@ function extractChatContent(raw: string): string {
 			parts.push(data.title.trim());
 		}
 
-		// Walk checkpoints → channel_values.messages → kwargs.content / data.content
 		const checkpoints = data.checkpoints;
 		if (checkpoints && typeof checkpoints === "object") {
-			const seen = new Set<string>();
-			for (const entry of Object.values(checkpoints)) {
-				const messages = getNestedMessages(entry);
-				for (const msg of messages) {
-					// An unrecognised shape has no class to check; indexing it risks
-					// re-admitting tool output, so skip it.
-					const messageClass = getMessageClass(msg);
-					if (!messageClass || !CONVERSATIONAL_MESSAGE_CLASSES.has(messageClass)) continue;
+			let question = "";
+			let answer = "";
+			const flush = () => {
+				const turn = [question, answer].filter((text) => text.length > 0).join("\n\n");
+				if (turn) parts.push(turn);
+				question = "";
+				answer = "";
+			};
 
-					const content = extractMessageContent(msg);
-					if (!content) continue;
+			for (const msg of selectActiveMessages(checkpoints as Record<string, unknown>)) {
+				// An unrecognised shape has no class to check; indexing it risks
+				// re-admitting tool output, so skip it.
+				const messageClass = getMessageClass(msg);
+				if (!messageClass || !CONVERSATIONAL_MESSAGE_CLASSES.has(messageClass)) continue;
 
-					// Prefer the message id: the same logical message can be
-					// re-serialised across checkpoints, and two genuinely distinct
-					// messages may share identical text (e.g. a repeated "yes").
-					const dedupeKey = getMessageId(msg) ?? `content:${content}`;
-					if (seen.has(dedupeKey)) continue;
-					seen.add(dedupeKey);
-					parts.push(content);
+				const content = extractMessageContent(msg);
+				if (!content) continue;
+
+				if (messageClass === "HumanMessage") {
+					// A new question closes the previous turn.
+					flush();
+					question = stripAugmentedContext(content);
+					continue;
 				}
+				// Assistant/system text: keep only turn-ending answers, and let a later
+				// one supersede an earlier one within the same turn.
+				if (hasToolCalls(msg)) continue;
+				answer = content;
 			}
+			flush();
 		}
 
 		return parts.join("\n\n");
@@ -315,32 +442,6 @@ function extractChatContent(raw: string): string {
 		// If parsing fails, fall back to empty (don't index raw JSON)
 		return "";
 	}
-}
-
-/**
- * Read the stable LangChain message id, which survives re-serialisation across
- * checkpoints. Returns `null` when the message carries no usable id so the caller
- * can fall back to content-based deduplication.
- */
-function getMessageId(msg: unknown): string | null {
-	if (!msg || typeof msg !== "object") return null;
-	const record = msg as Record<string, unknown>;
-
-	const candidates: unknown[] = [];
-	if (record.kwargs && typeof record.kwargs === "object") {
-		candidates.push((record.kwargs as Record<string, unknown>).id);
-	}
-	if (record.data && typeof record.data === "object") {
-		candidates.push((record.data as Record<string, unknown>).id);
-	}
-	candidates.push(record.id);
-
-	for (const candidate of candidates) {
-		if (typeof candidate === "string" && candidate.trim()) {
-			return `id:${candidate.trim()}`;
-		}
-	}
-	return null;
 }
 
 function getNestedMessages(entry: unknown): unknown[] {

--- a/src/utils/fileFiltering.ts
+++ b/src/utils/fileFiltering.ts
@@ -1,6 +1,7 @@
 import type { TFile, Vault } from "obsidian";
 import { getData } from "../stores/dataStore.svelte";
 import { gunzipToString } from "./gzip";
+import { extractTextFromPdf } from "./pdfExtractor";
 
 function normalizePattern(pattern: string): string {
 	return pattern.trim().replace(/^\/+|\/+$/g, "");
@@ -40,11 +41,59 @@ export function shouldProcessVaultPath(filePath: string, targetFolder: string): 
 export const TEXT_INDEXABLE_EXTENSIONS = new Set(["md", "txt", "csv", "json", "yaml", "yml", "canvas", "chat"]);
 
 /**
+ * Extensions whose text is extracted from a binary container rather than read
+ * directly. These are indexable, just not via `readTextFile`.
+ */
+export const BINARY_TEXT_EXTENSIONS = new Set(["pdf"]);
+
+/**
+ * Extensions excluded from the index entirely.
+ *
+ * A file with no extractable text yields an empty body, and `chunkText` still
+ * emits one chunk containing only the title — a content-free vector. Measured:
+ * those score ~0.46-0.48 against *any* query, which is the noise floor, so they
+ * displace real notes while carrying no information. Lexical search still finds
+ * them by filename through MiniSearch.
+ *
+ *   - `base`: Obsidian Bases view definitions — YAML formula/config, no prose.
+ *   - images: no text to extract. Indexing them would require a multimodal
+ *     embedding model and a separate image pipeline; until that exists they are
+ *     pure noise rather than a missing feature.
+ */
+export const NON_INDEXABLE_EXTENSIONS = new Set([
+	"base",
+	"png",
+	"jpg",
+	"jpeg",
+	"gif",
+	"webp",
+	"svg",
+	"bmp",
+	"avif",
+	"ico",
+	"mp3",
+	"wav",
+	"m4a",
+	"ogg",
+	"flac",
+	"mp4",
+	"webm",
+	"mov",
+	"mkv",
+	"zip",
+]);
+
+/**
  * Returns `true` when the file holds text content that can be read and
  * indexed for full-text / embedding search.
  */
 export function isTextIndexableFile(file: TFile): boolean {
 	return TEXT_INDEXABLE_EXTENSIONS.has(file.extension.toLowerCase());
+}
+
+/** Returns `true` when the file's text must be extracted from a binary container. */
+export function isBinaryTextFile(file: TFile): boolean {
+	return BINARY_TEXT_EXTENSIONS.has(file.extension.toLowerCase());
 }
 
 /**
@@ -84,7 +133,14 @@ export function isAgentFilePath(path: string): boolean {
  * Every non-hidden vault file is indexable, except files under the agent folder.
  */
 export function isIndexableFile(file: TFile): boolean {
-	return !isAgentFilePath(file.path);
+	if (isAgentFilePath(file.path)) return false;
+	// Files with no extractable text would be indexed as a title-only vector,
+	// which sits at the similarity noise floor and displaces real notes.
+	// Fall back to the path suffix: `extension` is absent on some call sites'
+	// file-like objects, and treating that as "no extension" would silently
+	// re-admit every excluded type.
+	const extension = (file.extension ?? file.path.split(".").pop() ?? "").toLowerCase();
+	return !NON_INDEXABLE_EXTENSIONS.has(extension);
 }
 
 /**
@@ -97,9 +153,11 @@ export function getIndexableVaultFiles(vault: Vault): TFile[] {
 
 /**
  * Read indexable content for a file. Returns the text content for
- * text-indexable files, or an empty string for binary files (metadata-only
- * indexing). Special-case handling:
+ * text-indexable files, or an empty string when nothing can be extracted.
+ * Special-case handling:
  *   - `.chat` files: extracts only human/AI message content (not LangChain metadata)
+ *   - `.pdf` files: extracts the document text via pdfjs, so a PDF is chunked and
+ *     embedded like any other long document rather than reduced to its filename
  *   - `.excalidraw.md` files: extracts the "back of the note" and text elements,
  *     stripping the huge embedded JSON drawing data
  *
@@ -107,6 +165,21 @@ export function getIndexableVaultFiles(vault: Vault): TFile[] {
  * before calling this helper.
  */
 export async function readIndexableContent(vault: Vault, file: TFile): Promise<string> {
+	// PDFs carry real prose, but it lives inside a binary container. Extracting it
+	// lets the normal chunker split the document by length; returning "" would
+	// index a multi-page PDF as a single title-only vector.
+	if (isBinaryTextFile(file)) {
+		try {
+			const bytes = await vault.adapter.readBinary(file.path);
+			const { text } = await extractTextFromPdf(new Uint8Array(bytes));
+			return text.trim();
+		} catch {
+			// Encrypted, malformed, or scanned-without-OCR: skip rather than fail
+			// the whole index run.
+			return "";
+		}
+	}
+
 	if (!isTextIndexableFile(file)) {
 		return "";
 	}

--- a/src/utils/fileFiltering.ts
+++ b/src/utils/fileFiltering.ts
@@ -229,6 +229,35 @@ async function readTextFile(vault: Vault, file: TFile): Promise<string> {
 // ---------------------------------------------------------------------------
 
 /**
+ * Serialised LangChain classes that represent something a person actually said or
+ * was told. `ToolMessage` is deliberately absent: a tool result is the *input* the
+ * agent worked from, not conversation. Measured on a real vault, tool results were
+ * 73.5% of all indexed chat text, and 45.8% of it was `read_content` echoing notes
+ * back verbatim — so notes were indexed a second time inside every thread that had
+ * read them, competing with the note itself at retrieval time.
+ */
+const CONVERSATIONAL_MESSAGE_CLASSES = new Set(["HumanMessage", "AIMessage", "AIMessageChunk", "SystemMessage"]);
+
+/**
+ * Name of the serialised LangChain class for a message, e.g. `"ToolMessage"`.
+ * Serialised messages carry it as the last element of the `id` path array
+ * (`["langchain_core", "messages", "ToolMessage"]`). Returns `null` when the shape
+ * is unrecognised, so the caller can decide how to treat it.
+ */
+function getMessageClass(msg: unknown): string | null {
+	if (!msg || typeof msg !== "object") return null;
+	const record = msg as Record<string, unknown>;
+
+	if (Array.isArray(record.id) && record.id.length > 0) {
+		const last = record.id[record.id.length - 1];
+		if (typeof last === "string" && last.trim()) return last.trim();
+	}
+	// Flat (non-`lc`) message shape stores the role on `type`.
+	if (typeof record.type === "string" && record.type.trim()) return record.type.trim();
+	return null;
+}
+
+/**
  * Extract human and AI message text from a `.chat` file (LangGraph ThreadData JSON).
  * Skips all LangChain serialisation noise, checkpoint metadata, writes, etc.
  *
@@ -240,6 +269,10 @@ async function readTextFile(vault: Vault, file: TFile): Promise<string> {
  * keyed on the stable LangChain message id (falling back to the message text when a
  * message carries no id). First-seen order is preserved so the extracted text still
  * reads as a transcript.
+ *
+ * Only conversational turns are indexed (see `CONVERSATIONAL_MESSAGE_CLASSES`), and
+ * attachment blocks are stripped from those turns, so a thread contributes the
+ * discussion itself rather than a second copy of the notes it referenced.
  */
 function extractChatContent(raw: string): string {
 	try {
@@ -258,6 +291,11 @@ function extractChatContent(raw: string): string {
 			for (const entry of Object.values(checkpoints)) {
 				const messages = getNestedMessages(entry);
 				for (const msg of messages) {
+					// An unrecognised shape has no class to check; indexing it risks
+					// re-admitting tool output, so skip it.
+					const messageClass = getMessageClass(msg);
+					if (!messageClass || !CONVERSATIONAL_MESSAGE_CLASSES.has(messageClass)) continue;
+
 					const content = extractMessageContent(msg);
 					if (!content) continue;
 
@@ -315,6 +353,47 @@ function getNestedMessages(entry: unknown): unknown[] {
 	return Array.isArray(messages) ? messages : [];
 }
 
+/**
+ * Fallback marker for attachment blocks in threads written before the structured
+ * `s2b_attachment` flag existed. Mirrors the wrappers built in `Agent.ts`.
+ */
+const RE_ATTACHMENT_BLOCK = /^--- (?:File|PDF): /;
+
+/**
+ * Returns `true` when a content part is an attached file rather than typed text.
+ *
+ * Attachments are the *note* the user pointed at, not what they said about it, and
+ * the note is already indexed on its own. `Agent.ts` tags every attachment part with
+ * `s2b_attachment: true`; the text-prefix check covers threads written before that.
+ */
+function isAttachmentPart(part: Record<string, unknown>): boolean {
+	if (part.s2b_attachment === true) return true;
+	const text = part.text;
+	return typeof text === "string" && RE_ATTACHMENT_BLOCK.test(text);
+}
+
+/**
+ * Collapse a multimodal content array to its typed text.
+ *
+ * A message with attachments serialises as an array of parts: the user's own text
+ * plus one block per attached file. Treating the whole array as non-string dropped
+ * the user's question entirely (measured: "what can you do" lost, while the attached
+ * note's full body was the only thing that would have been kept). Keep the text
+ * parts, drop the attachments and any non-text (image/file) parts.
+ */
+function extractTextFromContentParts(parts: unknown[]): string {
+	const texts: string[] = [];
+	for (const part of parts) {
+		if (!part || typeof part !== "object") continue;
+		const record = part as Record<string, unknown>;
+		if (record.type !== "text") continue;
+		if (isAttachmentPart(record)) continue;
+		const text = record.text;
+		if (typeof text === "string" && text.trim()) texts.push(text.trim());
+	}
+	return texts.join("\n\n");
+}
+
 function extractMessageContent(msg: unknown): string {
 	if (!msg || typeof msg !== "object") return "";
 	const record = msg as Record<string, unknown>;
@@ -334,6 +413,9 @@ function extractMessageContent(msg: unknown): string {
 
 	if (typeof content === "string" && content.trim()) {
 		return content.trim();
+	}
+	if (Array.isArray(content)) {
+		return extractTextFromContentParts(content);
 	}
 	return "";
 }

--- a/src/utils/pdfExtractor.ts
+++ b/src/utils/pdfExtractor.ts
@@ -6,8 +6,39 @@ export interface PdfExtractResult {
 	totalPages: number;
 }
 
+/** A pdfjs text item. `hasEOL` marks the last item on a visual line. */
+interface PdfTextItem {
+	str: string;
+	hasEOL?: boolean;
+}
+
+/**
+ * Joins pdfjs text items into a line-structured string.
+ *
+ * pdfjs emits one item per styled run, so items must be separated or words fuse
+ * across run boundaries ("Scene" + "Leonard" -> "SceneLeonard"). Items ending a
+ * visual line are followed by a newline; the rest are separated by a space
+ * unless one side already supplies the whitespace.
+ */
+export function joinPdfTextItems(items: PdfTextItem[]): string {
+	let text = "";
+	for (const item of items) {
+		if (item.hasEOL) {
+			text += `${item.str}\n`;
+			continue;
+		}
+		if (item.str.length === 0) continue;
+		const needsSpace = text.length > 0 && !/\s$/.test(text) && !/^\s/.test(item.str);
+		text += needsSpace ? ` ${item.str}` : item.str;
+	}
+	return text.replace(/[ \t]+$/gm, "").trim();
+}
+
 /**
  * Extracts all text content from a PDF file using Obsidian's built-in pdfjs.
+ *
+ * Pages are separated by a blank line so downstream chunking has a paragraph
+ * boundary to split on — PDFs have no headings for the chunker to use.
  *
  * @param data - PDF file content as Uint8Array
  * @returns Extracted text and total page count
@@ -20,9 +51,9 @@ export async function extractTextFromPdf(data: Uint8Array): Promise<PdfExtractRe
 	for (let i = 1; i <= totalPages; i++) {
 		const page = await pdf.getPage(i);
 		const content = await page.getTextContent();
-		textParts.push(content.items.map((item: { str: string }) => item.str).join(""));
+		textParts.push(joinPdfTextItems(content.items));
 	}
-	return { text: textParts.join("\n"), totalPages };
+	return { text: textParts.filter((part) => part.length > 0).join("\n\n"), totalPages };
 }
 
 export interface PdfPageExtractResult {
@@ -46,9 +77,9 @@ export async function extractTextFromPdfPages(data: Uint8Array, pages: number[])
 		if (pageNum < 1 || pageNum > totalPages) continue;
 		const page = await pdf.getPage(pageNum);
 		const content = await page.getTextContent();
-		textParts.push(content.items.map((item: { str: string }) => item.str).join(""));
+		textParts.push(joinPdfTextItems(content.items));
 	}
-	return { text: textParts.join("\n"), totalPages };
+	return { text: textParts.filter((part) => part.length > 0).join("\n\n"), totalPages };
 }
 
 /**

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -935,9 +935,12 @@ export class VectorStoreService {
 
 		this.plugin.registerEvent(
 			vault.on("rename", async (file, oldPath) => {
-				if (file instanceof TFile && isIndexableFile(file)) {
-					await this.handleFileRename(file, oldPath);
-				}
+				if (!(file instanceof TFile)) return;
+				// No `isIndexableFile` gate here: renaming a note to a non-indexable
+				// extension (`note.md` → `note.base`) must still remove the old
+				// path's chunks. `handleFileRename` removes first and re-indexes only
+				// when the destination is still indexable.
+				await this.handleFileRename(file, oldPath);
 			}),
 		);
 	}

--- a/test/utils/chunkText.test.ts
+++ b/test/utils/chunkText.test.ts
@@ -452,4 +452,27 @@ describe("chunkText heading levels", () => {
 		// The counterpart: leading code with no heading after it is still one topic.
 		expect(chunkText(["```bash", "echo hello", "```"].join("\n"), "Only Fence", 32_764)).toHaveLength(1);
 	});
+
+
+	it("preserves leading indentation so indented code is not read as a fence", () => {
+		// A four-space-indented ``` is an indented code block, not a fence. Trimming
+		// the line turned it into a real delimiter, which opened an unterminated
+		// fence and swallowed the following heading into one merged chunk.
+		const body = ["    ```", "    some code", "", "## Usage", "How to use it."].join("\n");
+
+		const chunks = chunkText(body, "Indented Code", 32_764);
+
+		expect(chunks).toHaveLength(2);
+		expect(chunks.find((c) => c.content.includes("How to use it."))?.content).toContain("## Usage");
+		// The indentation itself survives into the chunk body.
+		expect(chunks.find((c) => c.content.includes("some code"))?.content).toContain("    ```");
+	});
+
+	it("still strips blank leading and trailing lines", () => {
+		const chunks = chunkText(["", "  ", "## A", "x", "", ""].join("\n"), "Blanks", 32_764);
+
+		expect(chunks).toHaveLength(1);
+		// Blank edges gone; no stray leading newline before the content.
+		expect(chunks[0].content).toBe("Note: Blanks\n\n## A\nx");
+	});
 });

--- a/test/utils/chunkText.test.ts
+++ b/test/utils/chunkText.test.ts
@@ -475,4 +475,30 @@ describe("chunkText heading levels", () => {
 		// Blank edges gone; no stray leading newline before the content.
 		expect(chunks[0].content).toBe("Note: Blanks\n\n## A\nx");
 	});
+
+
+	it("treats CRLF and CR line endings the same as LF", () => {
+		// Review finding: the paragraph separator did not match a CRLF blank line.
+		// The deeper problem was that HEADING_RE never matched \"## A\\r\" at all, so a
+		// CRLF note got *no* section splitting — every heading was invisible and the
+		// whole note collapsed into one vector. Line endings are now normalized once
+		// on entry so every downstream rule can assume \\n.
+		const sections = ["## Alpha", "Content about alpha.", "", "## Beta", "Content about beta."];
+
+		const lf = chunkText(sections.join("\n"), "T", 32_764);
+		const crlf = chunkText(sections.join("\r\n"), "T", 32_764);
+		const cr = chunkText(sections.join("\r"), "T", 32_764);
+
+		expect(lf).toHaveLength(2);
+		expect(crlf.map((c) => c.content)).toEqual(lf.map((c) => c.content));
+		expect(cr.map((c) => c.content)).toEqual(lf.map((c) => c.content));
+	});
+
+	it("keeps fence and indentation rules working under CRLF", () => {
+		const fenced = ["## Setup", "x", "", "```bash", "# c", "```", "", "## Usage", "y"];
+		const indented = ["    ```", "    code", "", "## Usage", "y"];
+
+		expect(chunkText(fenced.join("\r\n"), "T", 32_764)).toHaveLength(2);
+		expect(chunkText(indented.join("\r\n"), "T", 32_764)).toHaveLength(2);
+	});
 });

--- a/test/utils/fileFiltering.test.ts
+++ b/test/utils/fileFiltering.test.ts
@@ -78,18 +78,76 @@ function message(id: string | null, content: unknown, messageClass = "HumanMessa
 	return { lc: 1, type: "constructor", id: ["langchain_core", "messages", messageClass], kwargs };
 }
 
+/** Assistant reply that ends a turn. */
+function reply(id: string, content: unknown) {
+	return message(id, content, "AIMessage");
+}
+
+/** Assistant message that only announces a tool call (mid-turn narration). */
+function narration(id: string, content: string) {
+	const msg = message(id, content, "AIMessage");
+	(msg.kwargs as Record<string, unknown>).tool_calls = [{ name: "search_notes", args: {} }];
+	return msg;
+}
+
+/** A tool result, which must never reach the index. */
+function toolResult(id: string, content: string) {
+	return message(id, content, "ToolMessage");
+}
+
 /**
  * Build thread JSON whose checkpoints form a growing prefix chain — the shape
- * LangGraph actually persists, where checkpoint N re-contains messages 1..N.
+ * LangGraph actually persists, where checkpoint N re-contains messages 1..N and
+ * links to N-1 via `parentConfig`.
  */
-function thread(title: string, messages: Array<Record<string, unknown>>): string {
+function thread(title: string, messages: Array<Record<string, unknown>>, tsBase = 1): string {
 	const checkpoints: Record<string, unknown> = {};
 	for (let i = 1; i <= messages.length; i++) {
 		checkpoints[`cp-${i}`] = {
-			checkpoint: { id: `cp-${i}`, channel_values: { messages: messages.slice(0, i) } },
+			checkpoint: {
+				id: `cp-${i}`,
+				ts: `2026-01-01T00:00:${String(tsBase + i).padStart(2, "0")}.000Z`,
+				channel_values: { messages: messages.slice(0, i) },
+			},
+			metadata: { step: i },
+			...(i > 1 ? { parentConfig: { configurable: { checkpoint_id: `cp-${i - 1}` } } } : {}),
 		};
 	}
 	return JSON.stringify({ title, checkpoints });
+}
+
+/**
+ * Build a thread that forks: `common` messages, then two competing continuations
+ * from the same parent. `newer` carries the later timestamp, so it is the branch
+ * the chat UI would show.
+ */
+function forkedThread(
+	title: string,
+	common: Array<Record<string, unknown>>,
+	older: Array<Record<string, unknown>>,
+	newer: Array<Record<string, unknown>>,
+): string {
+	const parsed = JSON.parse(thread(title, common));
+	const forkPoint = `cp-${common.length}`;
+	parsed.checkpoints["cp-old"] = {
+		checkpoint: {
+			id: "cp-old",
+			ts: "2026-01-01T00:01:00.000Z",
+			channel_values: { messages: [...common, ...older] },
+		},
+		metadata: { step: common.length + 1 },
+		parentConfig: { configurable: { checkpoint_id: forkPoint } },
+	};
+	parsed.checkpoints["cp-new"] = {
+		checkpoint: {
+			id: "cp-new",
+			ts: "2026-01-01T00:02:00.000Z",
+			channel_values: { messages: [...common, ...newer] },
+		},
+		metadata: { step: common.length + 1 },
+		parentConfig: { configurable: { checkpoint_id: forkPoint } },
+	};
+	return JSON.stringify(parsed);
 }
 
 /** Minimal vault stub exposing the `adapter.readBinary` path used for .chat files. */
@@ -110,42 +168,80 @@ describe("readIndexableContent (.chat extraction)", () => {
 	it("emits each message once despite the checkpoint tree repeating it", async () => {
 		const raw = thread("Greeting", [
 			message("m1", "hello there"),
-			message("m2", "general kenobi"),
+			reply("m2", "general kenobi"),
 			message("m3", "you are a bold one"),
+			reply("m4", "back away"),
 		]);
 
 		const out = await readIndexableContent(vaultReturning(raw), chatFile);
 
-		// Naive per-checkpoint concatenation would emit m1 three times and m2 twice.
+		// Naive per-checkpoint concatenation would emit m1 four times and m2 three times.
 		expect(out.match(/hello there/g)).toHaveLength(1);
 		expect(out.match(/general kenobi/g)).toHaveLength(1);
 		expect(out.match(/you are a bold one/g)).toHaveLength(1);
 	});
 
-	it("preserves the title and first-seen transcript order", async () => {
-		const raw = thread("Greeting", [message("m1", "first"), message("m2", "second")]);
+	it("pairs each question with its answer in transcript order", async () => {
+		const raw = thread("Greeting", [
+			message("m1", "first question"),
+			reply("m2", "first answer"),
+			message("m3", "second question"),
+			reply("m4", "second answer"),
+		]);
 
 		const out = await readIndexableContent(vaultReturning(raw), chatFile);
 
-		expect(out).toBe("Greeting\n\nfirst\n\nsecond");
+		expect(out).toBe("Greeting\n\nfirst question\n\nfirst answer\n\nsecond question\n\nsecond answer");
 	});
 
-	it("keeps distinct messages that share identical text", async () => {
-		// Two separate turns can legitimately both be "yes"; ids keep them apart.
-		const raw = thread("Confirmations", [message("m1", "yes"), message("m2", "yes")]);
+	it("keeps only the active branch when an answer was regenerated", async () => {
+		const raw = forkedThread(
+			"Regenerated",
+			[message("m1", "what is it")],
+			[reply("old", "discarded answer")],
+			[reply("new", "kept answer")],
+		);
 
 		const out = await readIndexableContent(vaultReturning(raw), chatFile);
 
-		expect(out.match(/yes/g)).toHaveLength(2);
+		expect(out).toContain("kept answer");
+		expect(out).not.toContain("discarded answer");
+		expect(out).toContain("what is it");
 	});
 
-	it("falls back to content deduplication when messages carry no id", async () => {
-		const raw = thread("Legacy", [message(null, "alpha"), message(null, "beta")]);
+	it("drops mid-turn narration that only announces a tool call", async () => {
+		const raw = thread("Narrated", [
+			message("m1", "find the note"),
+			narration("m2", "I'll search the vault for that."),
+			toolResult("m3", "hit: Some Note.md"),
+			reply("m4", "Found it in Some Note."),
+		]);
 
 		const out = await readIndexableContent(vaultReturning(raw), chatFile);
 
-		expect(out.match(/alpha/g)).toHaveLength(1);
-		expect(out.match(/beta/g)).toHaveLength(1);
+		expect(out).toBe("Narrated\n\nfind the note\n\nFound it in Some Note.");
+	});
+
+	it("keeps the last answer when a turn ends with several assistant messages", async () => {
+		const raw = thread("Multi", [message("m1", "q"), reply("m2", "partial"), reply("m3", "final answer")]);
+
+		const out = await readIndexableContent(vaultReturning(raw), chatFile);
+
+		expect(out).toContain("final answer");
+		expect(out).not.toContain("partial");
+	});
+
+	it("strips appended context blocks from the user's question", async () => {
+		const raw = thread("Context", [
+			message("m1", "what can you see\n\n[Currently visible notes]\n- Large Notes/Distributed Systems.md"),
+			reply("m2", "I can see one note."),
+		]);
+
+		const out = await readIndexableContent(vaultReturning(raw), chatFile);
+
+		expect(out).toContain("what can you see");
+		expect(out).not.toContain("Distributed Systems");
+		expect(out).not.toContain("Currently visible notes");
 	});
 
 	it("returns an empty string for corrupt thread JSON", async () => {

--- a/test/utils/fileFiltering.test.ts
+++ b/test/utils/fileFiltering.test.ts
@@ -72,10 +72,10 @@ describe("isAgentFilePath / isIndexableFile (folder from plugin data)", () => {
 // ---------------------------------------------------------------------------
 
 /** Build a LangChain-serialised message as stored inside a checkpoint. */
-function message(id: string | null, content: string): Record<string, unknown> {
+function message(id: string | null, content: unknown, messageClass = "HumanMessage"): Record<string, unknown> {
 	const kwargs: Record<string, unknown> = { content };
 	if (id !== null) kwargs.id = id;
-	return { lc: 1, type: "constructor", kwargs };
+	return { lc: 1, type: "constructor", id: ["langchain_core", "messages", messageClass], kwargs };
 }
 
 /**
@@ -160,6 +160,84 @@ describe("readIndexableContent (.chat extraction)", () => {
 		} as never;
 
 		expect(await readIndexableContent(vault, chatFile)).toBe("");
+	});
+
+	it("skips tool results so notes are not indexed a second time inside a thread", async () => {
+		const raw = thread("Research", [
+			message("m1", "what does the note say?"),
+			message(
+				"m2",
+				'Content of "Machine Learning Basics.md":\n\nGradient descent minimises loss.',
+				"ToolMessage",
+			),
+			message("m3", "It covers gradient descent.", "AIMessage"),
+		]);
+
+		const out = await readIndexableContent(vaultReturning(raw), chatFile);
+
+		expect(out).not.toContain("Gradient descent minimises loss");
+		expect(out).toContain("what does the note say?");
+		expect(out).toContain("It covers gradient descent.");
+	});
+
+	it("indexes assistant turns streamed as AIMessageChunk", async () => {
+		const raw = thread("Streamed", [message("m1", "streamed reply", "AIMessageChunk")]);
+
+		expect(await readIndexableContent(vaultReturning(raw), chatFile)).toContain("streamed reply");
+	});
+
+	it("skips messages whose class cannot be determined", async () => {
+		const raw = JSON.stringify({
+			title: "Odd",
+			checkpoints: {
+				"cp-1": { checkpoint: { channel_values: { messages: [{ kwargs: { content: "mystery" } }] } } },
+			},
+		});
+
+		expect(await readIndexableContent(vaultReturning(raw), chatFile)).toBe("Odd");
+	});
+
+	it("keeps the typed question but drops the attached file from a multimodal turn", async () => {
+		const raw = thread("Attachment", [
+			message("m1", [
+				{ type: "text", text: "what can you do" },
+				{
+					type: "text",
+					text: "--- File: Start Here.md ---\nTaskNotes tour body\n--- End File ---",
+					s2b_attachment: true,
+				},
+			]),
+		]);
+
+		const out = await readIndexableContent(vaultReturning(raw), chatFile);
+
+		expect(out).toContain("what can you do");
+		expect(out).not.toContain("TaskNotes tour body");
+	});
+
+	it("drops legacy attachment blocks that predate the s2b_attachment flag", async () => {
+		const raw = thread("Legacy attachment", [
+			message("m1", [
+				{ type: "text", text: "summarise this" },
+				{ type: "text", text: "--- PDF: paper.pdf (3 pages) ---\nabstract body\n--- End PDF ---" },
+			]),
+		]);
+
+		const out = await readIndexableContent(vaultReturning(raw), chatFile);
+
+		expect(out).toContain("summarise this");
+		expect(out).not.toContain("abstract body");
+	});
+
+	it("ignores non-text parts such as images", async () => {
+		const raw = thread("Image", [
+			message("m1", [
+				{ type: "text", text: "describe it" },
+				{ type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+			]),
+		]);
+
+		expect(await readIndexableContent(vaultReturning(raw), chatFile)).toBe("Image\n\ndescribe it");
 	});
 });
 

--- a/test/utils/fileFiltering.test.ts
+++ b/test/utils/fileFiltering.test.ts
@@ -162,3 +162,46 @@ describe("readIndexableContent (.chat extraction)", () => {
 		expect(await readIndexableContent(vault, chatFile)).toBe("");
 	});
 });
+
+describe("isIndexableFile (content-free extensions)", () => {
+	const f = (path: string, extension: string) => ({ path, extension }) as never;
+
+	it("excludes files with no extractable text", () => {
+		// These were indexed as title-only vectors, which sit at the similarity noise
+		// floor (~0.46-0.48 against any query) and displace real notes.
+		mockGetData.mockReturnValue({ agentFolder: "Agents" });
+		expect(isIndexableFile(f("TaskNotes/Views/tasks.base", "base"))).toBe(false);
+		expect(isIndexableFile(f("Assets/diagram.png", "png"))).toBe(false);
+		expect(isIndexableFile(f("Assets/photo.JPG", "JPG"))).toBe(false);
+		expect(isIndexableFile(f("Assets/clip.mp4", "mp4"))).toBe(false);
+	});
+
+	it("keeps notes and PDFs, whose text can be extracted", () => {
+		mockGetData.mockReturnValue({ agentFolder: "Agents" });
+		expect(isIndexableFile(f("Notes/note.md", "md"))).toBe(true);
+		expect(isIndexableFile(f("Papers/paper.pdf", "pdf"))).toBe(true);
+		expect(isIndexableFile(f("Chats/thread.chat", "chat"))).toBe(true);
+	});
+});
+
+describe("readIndexableContent (PDF)", () => {
+	const pdfFile = { path: "Papers/paper.pdf", extension: "pdf", basename: "paper" } as never;
+
+	it("returns an empty string when the PDF cannot be parsed", async () => {
+		// Encrypted, malformed, or scanned-without-OCR must skip the file rather than
+		// fail the whole index run.
+		const vault = {
+			adapter: { readBinary: vi.fn().mockResolvedValue(new ArrayBuffer(8)) },
+		} as never;
+
+		expect(await readIndexableContent(vault, pdfFile)).toBe("");
+	});
+
+	it("returns an empty string when the file cannot be read at all", async () => {
+		const vault = {
+			adapter: { readBinary: vi.fn().mockRejectedValue(new Error("missing")) },
+		} as never;
+
+		expect(await readIndexableContent(vault, pdfFile)).toBe("");
+	});
+});

--- a/test/utils/fileFiltering.test.ts
+++ b/test/utils/fileFiltering.test.ts
@@ -205,3 +205,21 @@ describe("readIndexableContent (PDF)", () => {
 		expect(await readIndexableContent(vault, pdfFile)).toBe("");
 	});
 });
+
+describe("rename into a non-indexable extension", () => {
+	// Review finding: both index listeners gated the rename event on
+	// `isIndexableFile(file)` — the *post-rename* file. Renaming `note.md` to
+	// `note.base` therefore skipped the handler entirely, so `removeDocument(oldPath)`
+	// never ran and the pre-rename document stayed searchable. The guard now lives
+	// inside the handler, after the removal.
+	it("classifies the destination as non-indexable, so the old entry must be dropped", () => {
+		mockGetData.mockReturnValue({ agentFolder: "Agents" });
+		const before = { path: "Notes/note.md", extension: "md" } as never;
+		const after = { path: "Notes/note.base", extension: "base" } as never;
+
+		expect(isIndexableFile(before)).toBe(true);
+		// The destination is excluded — which is exactly why the event must not be
+		// filtered on it before the stale path is removed.
+		expect(isIndexableFile(after)).toBe(false);
+	});
+});

--- a/test/utils/pdfExtractor.test.ts
+++ b/test/utils/pdfExtractor.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { joinPdfTextItems } from "../../src/utils/pdfExtractor";
+
+describe("joinPdfTextItems", () => {
+	it("separates adjacent items so words do not fuse", () => {
+		expect(joinPdfTextItems([{ str: "Scene" }, { str: "Leonard" }])).toBe("Scene Leonard");
+	});
+
+	it("breaks the line on hasEOL", () => {
+		const items = [{ str: "Title:", hasEOL: true }, { str: "Subtitle" }];
+		expect(joinPdfTextItems(items)).toBe("Title:\nSubtitle");
+	});
+
+	it("does not double up whitespace already supplied by an item", () => {
+		expect(joinPdfTextItems([{ str: "one " }, { str: "two" }])).toBe("one two");
+		expect(joinPdfTextItems([{ str: "one" }, { str: " two" }])).toBe("one two");
+	});
+
+	it("keeps a hyphenated run intact rather than inserting a space", () => {
+		expect(joinPdfTextItems([{ str: "state-" }, { str: "of-the-art" }])).toBe("state- of-the-art");
+	});
+
+	it("skips empty items without emitting stray separators", () => {
+		expect(joinPdfTextItems([{ str: "a" }, { str: "" }, { str: "b" }])).toBe("a b");
+	});
+
+	it("emits a line break for an empty item that ends a line", () => {
+		const items = [{ str: "a" }, { str: "", hasEOL: true }, { str: "b" }];
+		expect(joinPdfTextItems(items)).toBe("a\nb");
+	});
+
+	it("trims trailing whitespace per line but keeps leading indentation", () => {
+		const items = [{ str: "heading   ", hasEOL: true }, { str: "  body  " }];
+		expect(joinPdfTextItems(items)).toBe("heading\n  body");
+	});
+
+	it("returns an empty string for no items", () => {
+		expect(joinPdfTextItems([])).toBe("");
+	});
+});


### PR DESCRIPTION
Follow-up to #388. Three indexing fixes, each verified against the live vault.

## 1. Leading indentation is no longer stripped

Found while investigating a `splitParagraphs` trim flagged during #388 review. The root cause was earlier in the pipeline than it first appeared: `content.trim()` at the top of `chunkText` converted a four-space-indented ` ``` ` into a real fence delimiter **before `countSections` ran**, so the note was misclassified as a single section and took the whole-note fast path.

```
    ```
    some code

## Usage          ←  swallowed into an unterminated fence
```

3 sections → 1 chunk. Blank leading/trailing lines are still removed; a line's own indentation is structural markdown (indented code blocks, list continuations) and now survives into the chunk body.

## 2. PDFs are extracted rather than indexed by filename

`extractTextFromPdf` already existed for chat attachments. Wiring it into `readIndexableContent` means a PDF is chunked and embedded like any other long document, instead of becoming a single title-only vector. Encrypted, malformed or scanned-without-OCR files return `""` and are skipped rather than failing the run.

## 3. Files with no extractable text are excluded

`.base` (Obsidian Bases view configs — YAML formulas, no prose), images, audio, video, archives.

These were indexed as **title-only vectors**. Measured during #388: such vectors score ~0.46–0.48 against *any* query — the similarity noise floor — so they displaced real notes while carrying no information. Lexical search still finds them by filename via MiniSearch.

Images would need a multimodal embedding model and a separate image pipeline; until that exists they are noise rather than a missing feature. Easy to revisit by moving extensions out of `NON_INDEXABLE_EXTENSIONS`.

`isIndexableFile` falls back to the path suffix when `extension` is absent, since some call sites pass file-like objects without it — a pre-existing test caught this.

## Verification

- **1090 unit tests pass**; `bun run check` clean apart from the four pre-existing `GraphCanvas.svelte` errors on `dev`
- Live reindex: `.base` (7 files) and `.png` no longer produce chunks; `poster.pdf` indexes with real extracted text and is retrievable
- **No ranking effect.** The benchmark reads 0.8937 both with and without this branch — I stashed the changes, reindexed clean, and re-measured to confirm

## Note on the benchmark baseline

The suite is currently red against its own `BASELINE_MEAN_NDCG`, but that predates this branch: the judgment set has grown to 27 cases with a new HARD tier (cross-lingual, dilution, long-context, multi-hop) scoring 0.6676, and the baseline was raised to 0.97. Those changes are uncommitted in the working tree and are not part of this PR. I have not touched the baseline — where that bar belongs is a separate call.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._