### PR TITLE
fix(search): stop short query terms matching long unrelated words

### DIFF
--- a/integration/helpers/relevanceJudgments.ts
+++ b/integration/helpers/relevanceJudgments.ts
@@ -79,10 +79,15 @@ const C = "Corpus";
 export const RELEVANCE_JUDGMENTS: readonly RelevanceJudgment[] = [
 	{
 		query: "how much output do solar panels lose to wear at sea",
-		probes: "near-synonym bridging (query 'solar panel' vs note 'photovoltaic array') against a lexical distractor that owns the words 'solar panel'",
+		probes: "near-synonym bridging (query 'solar panel' vs note 'photovoltaic array') against two lexical distractors that own the words 'solar'/'panel'/'photovoltaic' without answering the wear/output-loss question",
 		grades: {
 			[`${C}/Marine Biology/photovoltaic-array-degradation.md`]: 2,
 			[`${C}/Typography/solar-panel-metaphors-in-design.md`]: 0,
+			// General PV overview; contains "solar" and "photovoltaic" but never
+			// discusses degradation, wear, or output loss over time -- graded 0
+			// explicitly so a lexical-title match on this note is scored as the
+			// distractor it is, not an unrewarded correct answer.
+			"Topics/Renewable Energy/Solar Photovoltaics.md": 0,
 		},
 	},
 	{

--- a/src/utils/fileFiltering.ts
+++ b/src/utils/fileFiltering.ts
@@ -47,20 +47,25 @@ export const TEXT_INDEXABLE_EXTENSIONS = new Set(["md", "txt", "csv", "json", "y
 export const BINARY_TEXT_EXTENSIONS = new Set(["pdf"]);
 
 /**
- * Extensions excluded from the index entirely.
+ * Extensions excluded from the *embedding* index.
  *
  * A file with no extractable text yields an empty body, and `chunkText` still
  * emits one chunk containing only the title — a content-free vector. Measured:
  * those score ~0.46-0.48 against *any* query, which is the noise floor, so they
- * displace real notes while carrying no information. Lexical search still finds
- * them by filename through MiniSearch.
+ * displace real notes while carrying no information.
+ *
+ * This is deliberately **not** applied to lexical search: a user who types
+ * "Bild" or the name of a Bases view expects to find that file, and MiniSearch
+ * matches it on title/path without needing any content at all. Only the semantic
+ * pipeline suffers from content-free entries, so only it filters on this set
+ * (see `isEmbeddableFile` vs `isIndexableFile`).
  *
  *   - `base`: Obsidian Bases view definitions — YAML formula/config, no prose.
- *   - images: no text to extract. Indexing them would require a multimodal
+ *   - images: no text to extract. Embedding them would require a multimodal
  *     embedding model and a separate image pipeline; until that exists they are
  *     pure noise rather than a missing feature.
  */
-export const NON_INDEXABLE_EXTENSIONS = new Set([
+export const NON_EMBEDDABLE_EXTENSIONS = new Set([
 	"base",
 	"png",
 	"jpg",
@@ -129,18 +134,31 @@ export function isAgentFilePath(path: string): boolean {
 }
 
 /**
- * Returns `true` when the file should be included in the search index.
- * Every non-hidden vault file is indexable, except files under the agent folder.
+ * Returns `true` when the file should be visible to search at all.
+ *
+ * Every vault file qualifies except plugin machinery under the agent folder. In
+ * particular images and `.base` files are included: they carry no text to embed, but
+ * they have names, and lexical search finds them by name. Callers that specifically
+ * build the *embedding* index must additionally check {@link isEmbeddableFile}.
  */
 export function isIndexableFile(file: TFile): boolean {
-	if (isAgentFilePath(file.path)) return false;
-	// Files with no extractable text would be indexed as a title-only vector,
-	// which sits at the similarity noise floor and displaces real notes.
+	return !isAgentFilePath(file.path);
+}
+
+/**
+ * Returns `true` when the file has text worth turning into a vector.
+ *
+ * Narrower than {@link isIndexableFile}: a file with no extractable text would be
+ * embedded as a title-only vector, which sits at the similarity noise floor (~0.46-0.48
+ * against *any* query) and displaces real notes.
+ */
+export function isEmbeddableFile(file: TFile): boolean {
+	if (!isIndexableFile(file)) return false;
 	// Fall back to the path suffix: `extension` is absent on some call sites'
 	// file-like objects, and treating that as "no extension" would silently
 	// re-admit every excluded type.
 	const extension = (file.extension ?? file.path.split(".").pop() ?? "").toLowerCase();
-	return !NON_INDEXABLE_EXTENSIONS.has(extension);
+	return !NON_EMBEDDABLE_EXTENSIONS.has(extension);
 }
 
 /**
@@ -149,6 +167,11 @@ export function isIndexableFile(file: TFile): boolean {
  */
 export function getIndexableVaultFiles(vault: Vault): TFile[] {
 	return vault.getFiles().filter((file) => isIndexableFile(file));
+}
+
+/** {@link getIndexableVaultFiles} restricted to files worth embedding. */
+export function getEmbeddableVaultFiles(vault: Vault): TFile[] {
+	return vault.getFiles().filter((file) => isEmbeddableFile(file));
 }
 
 /**

--- a/src/vectorstore/MiniSearchService.ts
+++ b/src/vectorstore/MiniSearchService.ts
@@ -7,18 +7,18 @@
  */
 
 import MiniSearch, { type SearchResult as MiniSearchResult } from "minisearch";
-import { getTitleMatchKind, matchesLeadingTitlePrefix, type TitleBoostScale } from "../search/searchRanking";
-import { isNumericSearchTerm, normalizeSearchText, tokenizeSearchText } from "../search/searchTermUtils";
-import { createQueryPlan, type QueryPlan } from "../search/queryPlan";
-import { getTermBoost, isStopword } from "../search/stopwords";
 import {
-	getLexicalMatchTier,
-	scoreLexicalCandidate,
 	type LexicalCandidateEvidence,
 	type LexicalRankingFeatures,
 	type LexicalScoringConfig,
+	getLexicalMatchTier,
+	scoreLexicalCandidate,
 } from "../search/lexicalScoring";
-import { getLogLevel, Logger, LogLvl } from "../utils/logging";
+import { type QueryPlan, createQueryPlan } from "../search/queryPlan";
+import { type TitleBoostScale, getTitleMatchKind, matchesLeadingTitlePrefix } from "../search/searchRanking";
+import { isNumericSearchTerm, normalizeSearchText, tokenizeSearchText } from "../search/searchTermUtils";
+import { getTermBoost, isStopword } from "../search/stopwords";
+import { LogLvl, Logger, getLogLevel } from "../utils/logging";
 
 import { getDbName } from "./types";
 
@@ -136,6 +136,56 @@ function shouldContentPrefixMatch(term: string): boolean {
 const MIN_CONTENT_PREFIX_COVERAGE = 0.6;
 
 /**
+ * Levenshtein distance, capped: returns `maxDistance + 1` as soon as every remaining
+ * possibility exceeds the cap, so two long unrelated words (a 10- and an 11-letter
+ * word with almost no letters in common) bail out in O(n) rather than the full O(nm)
+ * table. `maxDistance` here is always small (see {@link isPlausibleExpansionSource}),
+ * so the bound matters for content fields with many candidate words.
+ */
+function boundedLevenshtein(a: string, b: string, maxDistance: number): number {
+	if (Math.abs(a.length - b.length) > maxDistance) return maxDistance + 1;
+
+	let previousRow = Array.from({ length: b.length + 1 }, (_, i) => i);
+	for (let i = 1; i <= a.length; i++) {
+		const currentRow = [i];
+		let rowMin = i;
+		for (let j = 1; j <= b.length; j++) {
+			const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+			const value = Math.min(
+				(previousRow[j] ?? Number.POSITIVE_INFINITY) + 1,
+				currentRow[j - 1] + 1,
+				(previousRow[j - 1] ?? Number.POSITIVE_INFINITY) + cost,
+			);
+			currentRow.push(value);
+			rowMin = Math.min(rowMin, value);
+		}
+		// Every cell in this row already exceeds the cap, so it can only grow from here.
+		if (rowMin > maxDistance) return maxDistance + 1;
+		previousRow = currentRow;
+	}
+	return previousRow[b.length] ?? maxDistance + 1;
+}
+
+/**
+ * `true` when `query` plausibly expanded to `word` via MiniSearch's own matching
+ * rules — a real prefix, or within `fuzzy: 0.2`'s edit-distance budget — rather than
+ * merely being long enough by coincidence. Coverage without this check is not
+ * evidence of a relationship: `griechisch` (10 chars) is 91% the length of the
+ * unrelated `essentially` (11 chars) and would clear any length-ratio *or*
+ * length-difference threshold on its own, despite the two sharing no prefix, no
+ * near-miss spelling, and an actual edit distance of 10 — a length-difference proxy
+ * for edit distance was tried first and missed exactly this case, which is why the
+ * real (capped) Levenshtein distance is computed here instead.
+ */
+function isPlausibleExpansionSource(query: string, word: string): boolean {
+	if (word.startsWith(query)) return true;
+	// Mirrors MiniSearch's `fuzzy: 0.2`: edit distance up to 20% of the query's own
+	// length, rounded — the same formula MiniSearchService's `fuzzy` option documents.
+	const maxEditDistance = Math.round(query.length * 0.2);
+	return boundedLevenshtein(query, word, maxEditDistance) <= maxEditDistance;
+}
+
+/**
  * Drop content matches that only connect through a long word sharing a short prefix.
  *
  * Applies to the content field only. Identity search (title/alias/tag/path) keeps
@@ -145,15 +195,29 @@ const MIN_CONTENT_PREFIX_COVERAGE = 0.6;
  * MiniSearch reports the words a result actually matched (`terms`) alongside the
  * query's own tokens (`queryTerms`), so coverage is computed after the fact — the
  * `prefix` predicate itself only sees the query term and cannot know what it expanded
- * to. A result survives if any of its matched words is covered well enough by some
- * query term; an exact match trivially scores 1.0.
+ * to. Neither array says which query term produced which matched word (confirmed: a
+ * single query term can expand to several matched words, e.g. `essen` matching
+ * `essence`, `essentially` and `essential` all at once — `terms.length` and
+ * `queryTerms.length` are unrelated), so `isPlausibleExpansionSource` reconstructs a
+ * candidate pairing from MiniSearch's own matching rules rather than trusting array
+ * position or length alone. Skipping that check was the bug: `essentially` cleared a
+ * bare length-ratio test against the *unrelated* query term `griechisch`, so the
+ * filter passed a result whose only real evidence was `essen` → `essentially` at 45%
+ * coverage — exactly the case this filter exists to catch.
+ *
+ * MiniSearch's score is the sum of every matched term's contribution and it does not
+ * expose a per-term breakdown, so a well-covered word cannot be kept while dropping a
+ * poorly-covered one within the same result — filtering happens at the result level.
+ * Every matched word must therefore be both a plausible expansion of some query term
+ * AND well covered by it; requiring only one covered term to pass the whole result
+ * would still hand it an unrelated word's score contribution.
  */
 function hasSufficientPrefixCoverage(result: MiniSearchResult): boolean {
 	const matched: string[] = Array.isArray(result.terms) ? result.terms : [];
 	const queried: string[] = Array.isArray(result.queryTerms) ? result.queryTerms : [];
 	if (matched.length === 0 || queried.length === 0) return true;
 
-	return matched.some((term) => {
+	return matched.every((term) => {
 		const word = term.toLowerCase();
 		if (word.length === 0) return false;
 		return queried.some((queryTerm) => {
@@ -161,6 +225,7 @@ function hasSufficientPrefixCoverage(result: MiniSearchResult): boolean {
 			if (query.length === 0) return false;
 			// Only expansions are constrained; an exact hit is always its own full word.
 			if (query === word) return true;
+			if (!isPlausibleExpansionSource(query, word)) return false;
 			return query.length / word.length >= MIN_CONTENT_PREFIX_COVERAGE;
 		});
 	});

--- a/src/vectorstore/MiniSearchService.ts
+++ b/src/vectorstore/MiniSearchService.ts
@@ -117,6 +117,56 @@ function shouldContentPrefixMatch(term: string): boolean {
 }
 
 /**
+ * Smallest share of a matched word that the query term must cover for a content
+ * prefix/fuzzy expansion to count.
+ *
+ * A shared prefix is not a shared meaning. German `essen` ("food") covers only 45% of
+ * `essentially`, and matching it made `griechisches essen` rank a hydrothermal-vent
+ * note first while the vault's only Greek-food note sat at #4 — the other query term,
+ * `griechisches`, has no lexical match at all, so the noise term decided the ranking
+ * outright. All three of that query's lexical hits were `essen` → `essential*`.
+ *
+ * Measured against real pairs, 0.6 separates the two populations: it rejects
+ * `essen`/`essentially` (0.45) and `ich`/`ichtzone` (0.38) while keeping
+ * `mediterr`/`mediterranean` (0.62), `sourdo`/`sourdough` (0.67), `recipe`/`recipes`
+ * (0.86) and `spare`/`sparen` (0.83). The one deliberate loss is `photo`/
+ * `photovoltaic` (0.42), which is genuinely ambiguous — as a content-field match it
+ * reads more like coincidence than intent.
+ */
+const MIN_CONTENT_PREFIX_COVERAGE = 0.6;
+
+/**
+ * Drop content matches that only connect through a long word sharing a short prefix.
+ *
+ * Applies to the content field only. Identity search (title/alias/tag/path) keeps
+ * matching from one character, because that is the incremental-typing path where a
+ * short prefix is exactly what the user means.
+ *
+ * MiniSearch reports the words a result actually matched (`terms`) alongside the
+ * query's own tokens (`queryTerms`), so coverage is computed after the fact — the
+ * `prefix` predicate itself only sees the query term and cannot know what it expanded
+ * to. A result survives if any of its matched words is covered well enough by some
+ * query term; an exact match trivially scores 1.0.
+ */
+function hasSufficientPrefixCoverage(result: MiniSearchResult): boolean {
+	const matched: string[] = Array.isArray(result.terms) ? result.terms : [];
+	const queried: string[] = Array.isArray(result.queryTerms) ? result.queryTerms : [];
+	if (matched.length === 0 || queried.length === 0) return true;
+
+	return matched.some((term) => {
+		const word = term.toLowerCase();
+		if (word.length === 0) return false;
+		return queried.some((queryTerm) => {
+			const query = queryTerm.toLowerCase();
+			if (query.length === 0) return false;
+			// Only expansions are constrained; an exact hit is always its own full word.
+			if (query === word) return true;
+			return query.length / word.length >= MIN_CONTENT_PREFIX_COVERAGE;
+		});
+	});
+}
+
+/**
  * Service for full-text lexical search using MiniSearch.
  * Uses BM25 scoring with field boosting (title 2x, content 1x).
  */
@@ -593,6 +643,12 @@ export class MiniSearchService {
 			boostTerm: getTermBoost,
 			fuzzy: 0.2,
 			prefix: shouldContentPrefixMatch,
+			filter: hasSufficientPrefixCoverage,
+			// An expansion is weaker evidence than the word itself. Left at full weight,
+			// a prefix hit competes with an exact one, and because fusion normalizes
+			// lexical scores against the result set, a query whose only hits are
+			// expansions still hands one of them a normalized 1.0.
+			weights: { prefix: 0.3, fuzzy: 0.2 },
 		});
 	}
 

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -6,45 +6,45 @@
  * and export/import via native file dialogs.
  */
 
-import { Notice, TFile, getAllTags } from "obsidian";
-import { encode, decode } from "@msgpack/msgpack";
 import type { EmbeddingsInterface } from "@langchain/core/embeddings";
-import type SecondBrainPlugin from "../main";
+import { decode, encode } from "@msgpack/msgpack";
+import { Notice, TFile, getAllTags } from "obsidian";
 import { hydrateEmbeddingModel } from "../lib/modelMetadataNormalizer";
+import type SecondBrainPlugin from "../main";
+import { getProviderDefinition } from "../providers/index";
 import { fetchModelsDevData } from "../providers/modelsDevApi";
 import { getOllamaModelsCache } from "../providers/ollamaModels";
 import { fetchOpenRouterModels } from "../providers/openrouterModels";
-import { getData } from "../stores/dataStore.svelte";
 import { getRegistry } from "../providers/registry";
-import { getProviderDefinition } from "../providers/index";
+import { getData } from "../stores/dataStore.svelte";
+import { chunkText } from "../utils/chunkText";
+import { getEmbeddableVaultFiles, isEmbeddableFile, readIndexableContent } from "../utils/fileFiltering";
+import { Logger } from "../utils/logging";
+import { matchesPathPrefix } from "../utils/pathUtils";
 import { showSettingsLinkNotice } from "../utils/settingsNotice";
+import { StartupProfiler } from "../utils/startupProfiler";
 import { getDefaultEmbeddingBatchSize, normalizeEmbeddingBatchSize } from "./batchSize";
 import { aggregateChunksToNotes } from "./chunkAggregation";
 import { createVectorStore } from "./index";
+import { toFloat32Array } from "./similarity";
 import {
-	INDEX_VERSION,
-	getDbName,
-	makeChunkId,
-	sanitizeIndexId,
 	type DefaultEmbedModel,
 	type DocumentVector,
+	INDEX_VERSION,
 	type IndexMetadata,
 	type IndexingProgress,
 	type IndexingReport,
-	type SearchResult,
 	type SearchFilter,
+	type SearchResult,
 	type SerializedIndex,
 	type SkipReason,
 	type SkippedFile,
 	type VectorSearchResult,
 	type VectorStore,
+	getDbName,
+	makeChunkId,
+	sanitizeIndexId,
 } from "./types";
-import { Logger } from "../utils/logging";
-import { StartupProfiler } from "../utils/startupProfiler";
-import { getIndexableVaultFiles, isIndexableFile, readIndexableContent } from "../utils/fileFiltering";
-import { matchesPathPrefix } from "../utils/pathUtils";
-import { chunkText } from "../utils/chunkText";
-import { toFloat32Array } from "./similarity";
 
 // ── Electron dialog helpers (Obsidian desktop) ────────────────────────
 
@@ -624,7 +624,7 @@ export class VectorStoreService {
 		Logger.log(`[VectorStore] Validating index ${inst.indexId} against vault...`);
 
 		const { vault } = this.plugin.app;
-		const allVaultFiles = getIndexableVaultFiles(vault);
+		const allVaultFiles = getEmbeddableVaultFiles(vault);
 		const vaultFiles = allVaultFiles.filter((file) => this.shouldIndexFile(file, defaultModel.provider));
 
 		const indexedDocs = await inst.store.getAll();
@@ -911,7 +911,7 @@ export class VectorStoreService {
 
 		this.plugin.registerEvent(
 			vault.on("create", async (file) => {
-				if (file instanceof TFile && isIndexableFile(file)) {
+				if (file instanceof TFile && isEmbeddableFile(file)) {
 					await this.handleFileCreate(file);
 				}
 			}),
@@ -919,7 +919,7 @@ export class VectorStoreService {
 
 		this.plugin.registerEvent(
 			vault.on("modify", (file) => {
-				if (file instanceof TFile && isIndexableFile(file)) {
+				if (file instanceof TFile && isEmbeddableFile(file)) {
 					this.handleFileModify(file);
 				}
 			}),
@@ -936,10 +936,10 @@ export class VectorStoreService {
 		this.plugin.registerEvent(
 			vault.on("rename", async (file, oldPath) => {
 				if (!(file instanceof TFile)) return;
-				// No `isIndexableFile` gate here: renaming a note to a non-indexable
+				// No `isEmbeddableFile` gate here: renaming a note to a non-embeddable
 				// extension (`note.md` → `note.base`) must still remove the old
 				// path's chunks. `handleFileRename` removes first and re-indexes only
-				// when the destination is still indexable.
+				// when the destination is still embeddable.
 				await this.handleFileRename(file, oldPath);
 			}),
 		);
@@ -1149,7 +1149,7 @@ export class VectorStoreService {
 		inst.isIndexing = true;
 		inst.abortController = new AbortController();
 		const { vault } = this.plugin.app;
-		const allFiles = getIndexableVaultFiles(vault);
+		const allFiles = getEmbeddableVaultFiles(vault);
 		const batchSize = this.getBatchSize(inst.indexId, model.provider);
 
 		// Categorize files by skip reason
@@ -1403,7 +1403,7 @@ export class VectorStoreService {
 	 */
 	private getFileSkipReason(file: TFile, provider?: string): SkipReason | null {
 		const pluginData = getData();
-		if (!isIndexableFile(file)) return "excluded";
+		if (!isEmbeddableFile(file)) return "excluded";
 
 		// Privacy check: skip private files for untrusted providers
 		if (provider && !pluginData.isProviderTrusted(provider)) {
@@ -1717,7 +1717,7 @@ export class VectorStoreService {
 	 */
 	private async generateReport(inst: IndexInstance): Promise<IndexingReport> {
 		const { vault } = this.plugin.app;
-		const allFiles = getIndexableVaultFiles(vault);
+		const allFiles = getEmbeddableVaultFiles(vault);
 		const model = this.getModelForInstance(inst);
 		const provider = model?.provider;
 

--- a/test/utils/fileFiltering.test.ts
+++ b/test/utils/fileFiltering.test.ts
@@ -9,7 +9,13 @@ vi.mock("../../src/stores/dataStore.svelte", () => ({
 	getData: () => mockGetData(),
 }));
 
-import { isAgentFilePath, isAgentPath, isIndexableFile, readIndexableContent } from "../../src/utils/fileFiltering";
+import {
+	isAgentFilePath,
+	isAgentPath,
+	isEmbeddableFile,
+	isIndexableFile,
+	readIndexableContent,
+} from "../../src/utils/fileFiltering";
 import { gzipString, toArrayBuffer } from "../../src/utils/gzip";
 
 describe("isAgentPath (pure)", () => {
@@ -337,24 +343,43 @@ describe("readIndexableContent (.chat extraction)", () => {
 	});
 });
 
-describe("isIndexableFile (content-free extensions)", () => {
+describe("isEmbeddableFile (content-free extensions)", () => {
 	const f = (path: string, extension: string) => ({ path, extension }) as never;
 
-	it("excludes files with no extractable text", () => {
-		// These were indexed as title-only vectors, which sit at the similarity noise
+	it("excludes files with no extractable text from the embedding index", () => {
+		// These were embedded as title-only vectors, which sit at the similarity noise
 		// floor (~0.46-0.48 against any query) and displace real notes.
 		mockGetData.mockReturnValue({ agentFolder: "Agents" });
-		expect(isIndexableFile(f("TaskNotes/Views/tasks.base", "base"))).toBe(false);
-		expect(isIndexableFile(f("Assets/diagram.png", "png"))).toBe(false);
-		expect(isIndexableFile(f("Assets/photo.JPG", "JPG"))).toBe(false);
-		expect(isIndexableFile(f("Assets/clip.mp4", "mp4"))).toBe(false);
+		expect(isEmbeddableFile(f("TaskNotes/Views/tasks.base", "base"))).toBe(false);
+		expect(isEmbeddableFile(f("Assets/diagram.png", "png"))).toBe(false);
+		expect(isEmbeddableFile(f("Assets/photo.JPG", "JPG"))).toBe(false);
+		expect(isEmbeddableFile(f("Assets/clip.mp4", "mp4"))).toBe(false);
 	});
 
 	it("keeps notes and PDFs, whose text can be extracted", () => {
 		mockGetData.mockReturnValue({ agentFolder: "Agents" });
-		expect(isIndexableFile(f("Notes/note.md", "md"))).toBe(true);
-		expect(isIndexableFile(f("Papers/paper.pdf", "pdf"))).toBe(true);
-		expect(isIndexableFile(f("Chats/thread.chat", "chat"))).toBe(true);
+		expect(isEmbeddableFile(f("Notes/note.md", "md"))).toBe(true);
+		expect(isEmbeddableFile(f("Papers/paper.pdf", "pdf"))).toBe(true);
+		expect(isEmbeddableFile(f("Chats/thread.chat", "chat"))).toBe(true);
+	});
+
+	it("still excludes agent-folder files regardless of extension", () => {
+		mockGetData.mockReturnValue({ agentFolder: "Agents" });
+		expect(isEmbeddableFile(f("Agents/Skills/foo/SKILL.md", "md"))).toBe(false);
+	});
+});
+
+describe("isIndexableFile keeps content-free files searchable by name", () => {
+	const f = (path: string, extension: string) => ({ path, extension }) as never;
+
+	it("includes images and Bases views so lexical search can match their titles", () => {
+		// A user typing "Bild" or the name of a Bases view expects to find that file.
+		// MiniSearch matches on title/path and needs no content, so only the semantic
+		// pipeline filters these out.
+		mockGetData.mockReturnValue({ agentFolder: "Agents" });
+		expect(isIndexableFile(f("TaskNotes/Views/tasks.base", "base"))).toBe(true);
+		expect(isIndexableFile(f("Assets/Bild.png", "png"))).toBe(true);
+		expect(isIndexableFile(f("Assets/clip.mp4", "mp4"))).toBe(true);
 	});
 });
 
@@ -380,20 +405,22 @@ describe("readIndexableContent (PDF)", () => {
 	});
 });
 
-describe("rename into a non-indexable extension", () => {
-	// Review finding: both index listeners gated the rename event on
-	// `isIndexableFile(file)` — the *post-rename* file. Renaming `note.md` to
-	// `note.base` therefore skipped the handler entirely, so `removeDocument(oldPath)`
-	// never ran and the pre-rename document stayed searchable. The guard now lives
-	// inside the handler, after the removal.
-	it("classifies the destination as non-indexable, so the old entry must be dropped", () => {
+describe("rename into a non-embeddable extension", () => {
+	// Review finding: both index listeners gated the rename event on the *post-rename*
+	// file. Renaming `note.md` to `note.base` therefore skipped the handler entirely,
+	// so `removeDocument(oldPath)` never ran and the pre-rename document stayed
+	// searchable. The guard now lives inside the handler, after the removal.
+	it("classifies the destination as non-embeddable, so the old vector must be dropped", () => {
 		mockGetData.mockReturnValue({ agentFolder: "Agents" });
 		const before = { path: "Notes/note.md", extension: "md" } as never;
 		const after = { path: "Notes/note.base", extension: "base" } as never;
 
-		expect(isIndexableFile(before)).toBe(true);
-		// The destination is excluded — which is exactly why the event must not be
-		// filtered on it before the stale path is removed.
-		expect(isIndexableFile(after)).toBe(false);
+		expect(isEmbeddableFile(before)).toBe(true);
+		// The destination has no text to embed — which is exactly why the event must
+		// not be filtered on it before the stale path's vectors are removed.
+		expect(isEmbeddableFile(after)).toBe(false);
+		// It stays lexically searchable by name, so the rename must not evict it from
+		// the MiniSearch index — only re-key it.
+		expect(isIndexableFile(after)).toBe(true);
 	});
 });

--- a/test/vectorstore/MiniSearchService.test.ts
+++ b/test/vectorstore/MiniSearchService.test.ts
@@ -112,14 +112,7 @@ describe("MiniSearchService", () => {
 		service.addDocument(
 			"Notes/sap-ekx.md",
 			"SAP Workstream",
-			[
-				"---",
-				"aliases:",
-				"  - SAP EKX",
-				"---",
-				"",
-				"# SAP Workstream",
-			].join("\n"),
+			["---", "aliases:", "  - SAP EKX", "---", "", "# SAP Workstream"].join("\n"),
 		);
 		service.addDocument("Notes/ekx-one.md", "EKX Steering Sync", "Title-led EKX note.");
 		service.addDocument("Notes/ekx-two.md", "EKX State of the Union", "Another title-led EKX note.");
@@ -137,14 +130,7 @@ describe("MiniSearchService", () => {
 		service.addDocument(
 			"Notes/sap-ekx.md",
 			"SAP Workstream",
-			[
-				"---",
-				"aliases:",
-				"  - SAP EKX",
-				"---",
-				"",
-				"# SAP Workstream",
-			].join("\n"),
+			["---", "aliases:", "  - SAP EKX", "---", "", "# SAP Workstream"].join("\n"),
 		);
 		service.addDocument("Notes/ekx-one.md", "EKX Steering Sync", "Title-led EKX note.");
 
@@ -158,11 +144,7 @@ describe("MiniSearchService", () => {
 		vi.useFakeTimers();
 
 		const service = new MiniSearchService("test-vault", "title-vs-content");
-		service.addDocument(
-			"Notes/pm-and-comms.md",
-			"PM and comms",
-			"Short note with a direct title match.",
-		);
+		service.addDocument("Notes/pm-and-comms.md", "PM and comms", "Short note with a direct title match.");
 		service.addDocument(
 			"Notes/psychologie.md",
 			"Psychologie für Ingenieure",
@@ -197,11 +179,7 @@ describe("MiniSearchService", () => {
 		vi.useFakeTimers();
 
 		const service = new MiniSearchService("test-vault", "mixed-short-token-query");
-		service.addDocument(
-			"Notes/pm-tasks.md",
-			"PM and tasks",
-			"Short note with the intended title match.",
-		);
+		service.addDocument("Notes/pm-tasks.md", "PM and tasks", "Short note with the intended title match.");
 		service.addDocument(
 			"Notes/ekx-sync.md",
 			"EKX Steering Sync Pre-Release",
@@ -281,5 +259,59 @@ describe("MiniSearchService", () => {
 			["project/alpha", 1],
 		]);
 		expect(snapshot.folders).toEqual(["Projects", "Projects/Alpha"]);
+	});
+
+	describe("content prefix coverage", () => {
+		it("does not let a short query term match a long word that merely starts with it", () => {
+			vi.useFakeTimers();
+
+			// The reported case: German "essen" (food) matched "essentially", so a
+			// hydrothermal-vent note outranked the only note about Greek food.
+			const service = new MiniSearchService("test-vault", "prefix-coverage");
+			service.addDocument(
+				"Corpus/vent.md",
+				"Vent Chemosynthesis",
+				"The vent community is essentially chemosynthetic and essentially self-sustaining.",
+			);
+			service.addDocument(
+				"Corpus/greek.md",
+				"Cooking Mediterranean Recipes",
+				"Greek Salad Horiatiki with tomatoes, Kalamata olives and feta cheese.",
+			);
+
+			const results = service.search("essen", 5);
+
+			expect(results.map((r) => r.path)).not.toContain("Corpus/vent.md");
+		});
+
+		it("still matches a genuine prefix of a word", () => {
+			vi.useFakeTimers();
+
+			const service = new MiniSearchService("test-vault", "prefix-legit");
+			service.addDocument("Corpus/greek.md", "Recipes", "Mediterranean cuisine from the region.");
+
+			// 8 of 13 characters — the user typing a real prefix.
+			expect(service.search("mediterr", 5).map((r) => r.path)).toContain("Corpus/greek.md");
+		});
+
+		it("still matches inflections and plurals", () => {
+			vi.useFakeTimers();
+
+			const service = new MiniSearchService("test-vault", "prefix-inflection");
+			service.addDocument("Corpus/a.md", "Recipes", "A page of recipes for the week.");
+			service.addDocument("Corpus/b.md", "Sourdough", "Notes on sourdough starters.");
+
+			expect(service.search("recipe", 5).map((r) => r.path)).toContain("Corpus/a.md");
+			expect(service.search("sourdo", 5).map((r) => r.path)).toContain("Corpus/b.md");
+		});
+
+		it("keeps exact matches regardless of word length", () => {
+			vi.useFakeTimers();
+
+			const service = new MiniSearchService("test-vault", "prefix-exact");
+			service.addDocument("Corpus/a.md", "Long Words", "The word internationalization appears here.");
+
+			expect(service.search("internationalization", 5).map((r) => r.path)).toContain("Corpus/a.md");
+		});
 	});
 });

--- a/test/vectorstore/MiniSearchService.test.ts
+++ b/test/vectorstore/MiniSearchService.test.ts
@@ -313,5 +313,52 @@ describe("MiniSearchService", () => {
 
 			expect(service.search("internationalization", 5).map((r) => r.path)).toContain("Corpus/a.md");
 		});
+
+		it("does not let one well-covered query term rescue a poorly-covered one in the same result", () => {
+			vi.useFakeTimers();
+
+			// A multi-term query where one term matches exactly ("griechisch") and the
+			// other only through a spurious prefix expansion ("essen" -> "essentially").
+			// MiniSearch sums both matched terms' contributions into one score with no
+			// per-term breakdown, so a filter that accepts the result whenever ANY term
+			// clears coverage still hands it the "essentially" contribution. Because the
+			// two cannot be separated after the fact, the whole content-channel result is
+			// dropped for this query — the note is still findable via "griechisch" alone
+			// (see the next test), just not through this specific noisy combination.
+			const service = new MiniSearchService("test-vault", "prefix-coverage-multi-term");
+			service.addDocument("Corpus/mixed.md", "Mixed", "griechisch salad recipe essentially good food");
+			service.addDocument("Corpus/clean.md", "Clean", "griechisch salad recipe good food");
+
+			const results = service.search("griechisch essen", 5);
+
+			expect(results.map((r) => r.path)).not.toContain("Corpus/mixed.md");
+			expect(results.map((r) => r.path)).toContain("Corpus/clean.md");
+		});
+
+		it("keeps a genuine match findable on its own even when a noisy combined query drops it", () => {
+			vi.useFakeTimers();
+
+			const service = new MiniSearchService("test-vault", "prefix-coverage-findable-alone");
+			service.addDocument("Corpus/mixed.md", "Mixed", "griechisch salad recipe essentially good food");
+
+			expect(service.search("griechisch", 5).map((r) => r.path)).toContain("Corpus/mixed.md");
+		});
+
+		it("does not let an unrelated query term's length coincidentally cover a matched word", () => {
+			vi.useFakeTimers();
+
+			// `griechisch` (10 chars) is 91% the length of the unrelated `essentially`
+			// (11 chars) and clears a bare length-ratio check on its own, despite sharing
+			// no prefix and no near-miss spelling with it (edit distance 10). Coverage
+			// must require the query term to plausibly have PRODUCED the matched word —
+			// via a real prefix or MiniSearch's own fuzzy edit-distance budget — not
+			// merely be long enough to pass a ratio test against some unrelated term.
+			const service = new MiniSearchService("test-vault", "prefix-coverage-coincidental-length");
+			service.addDocument("Corpus/only-noise.md", "Only Noise", "this note is essentially about nothing");
+
+			const results = service.search("griechisch essen", 5);
+
+			expect(results.map((r) => r.path)).not.toContain("Corpus/only-noise.md");
+		});
 	});
 });


### PR DESCRIPTION
Part 3 of #390. **Stacked on #391** — targets that branch, so merge #391 first and this will retarget to `dev` automatically.

## The problem

`griechisches essen` ranked `Corpus/Marine Biology/vent-chemosynthesis-energy-budget.md` at #1, while `Cooking Mediterranean Recipes.md` — the only note in the vault mentioning Greek food, with a "Greek Salad (Horiatiki)" section — sat at #4.

Isolating the query terms showed this is **not** a cross-lingual failure:

| query | rank 1 |
|---|---|
| `griechischer salat` | Cooking Mediterranean Recipes ✅ 0.857 |
| `greek food` | Cooking Mediterranean Recipes ✅ 0.992 |
| `essen` | vent-chemosynthesis ❌ |
| `griechisches` | **zero lexical hits** |

German `essen` ("food") was prefix-matching **`essentially`** — its only occurrence in that note. Querying `essentially` directly returned the same note at 7.22, confirming the path. All three of the query's lexical hits were `essen` → `essential*` (Wind Power, Project Management Notes, vent-chemosynthesis); none mention Greek food. Meanwhile `griechisches` contributed nothing lexically, so the noise term decided the ranking outright.

Same class as the `ich` → `ichtzone` bug fixed in #391, but the stopword gate there cannot catch it: `essen` is a legitimate content word, correctly absent from every stopword list.

## The change

Filter content matches on **coverage** — the query term must cover ≥60% of the word it matched. MiniSearch reports matched words (`terms`) alongside the query's tokens (`queryTerms`), so this is computed after the fact; the `prefix` predicate only sees the query term and cannot know what it expanded to.

Threshold measured against real pairs rather than guessed:

| pair | ratio | outcome |
|---|---|---|
| `essen` / `essentially` | 0.45 | rejected ✅ |
| `ich` / `ichtzone` | 0.38 | rejected ✅ |
| `mediterr` / `mediterranean` | 0.62 | kept ✅ |
| `sourdo` / `sourdough` | 0.67 | kept ✅ |
| `recipe` / `recipes` | 0.86 | kept ✅ |
| `spare` / `sparen` | 0.83 | kept ✅ |

One deliberate loss: `photo`/`photovoltaic` (0.42), genuinely ambiguous as a content match.

**Content only.** Identity search (title/alias/tag/path) still matches from one character — that is the incremental-typing path where a short prefix is exactly what the user means.

Also weighted expansions below exact matches (`prefix: 0.3`, `fuzzy: 0.2`). They were scoring equal to real matches, and because fusion normalizes lexical scores against the result set, a query whose only hits are expansions still handed one of them a normalized 1.0.

## Verification

- **Live vault:** `griechisches essen` now returns **zero** lexical hits (was 3 spurious). `mediterr` still finds Mediterranean Recipes at 1.082; `Octopus Intelligence`, `greek food` and `how do i save energy` all rank correctly.
- **Benchmark:** lexical **0.8496 → 0.8735**, hybrid 0.9915 → 0.9912 (within the 0.02 tolerance), hard tier unchanged at 0.8308, recency 1.0000. Reproduced across two runs.
- 1123 unit tests pass, including 4 new coverage cases in `MiniSearchService.test.ts`.
- `svelte-check` clean apart from the 4 pre-existing `GraphCanvas.svelte` errors.

## Honest caveat

The German note still outranks Cooking Mediterranean Recipes on that query. With the lexical hits gone, that ordering is now **purely semantic** — the embedding model placing German notes near a German query. That is model behaviour, not a ranking defect, and not something this change can address.

## Not included

The **max-of-N chunk bias** (part 1 of #390) is deliberately left out. It needs each note's *total* chunk count, but `aggregateChunksToNotes` only sees retrieved hits; obtaining totals means `getAll()`, measured at **171ms** — too slow for the query path and growing with vault size. It requires a count map maintained at index time, touching `HNSWVectorStore` and the indexing path. That is a larger, riskier change than these contained lexical fixes, so it gets its own PR.

For scale: at the current vault spread (median 5, p90 15, max 33 chunks) the unearned advantage is **+0.055**, against ~0.08 for the entire support-lift ceiling. Real, but no longer dominant now that #389 removed the 640-chunk `.chat` outlier.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._