### PR TITLE
One hash-based mechanism for "shipped default vs user-customized"

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -463,6 +463,31 @@ export class AgentManager {
 	}
 
 	/**
+	 * Memory-instructions counterpart of {@link openSystemPromptDiff}. Same modal and same
+	 * two-way diff (yours vs the current default); lives here rather than only in
+	 * AgentEditorModal so the stale-guidance notice can open it directly from the chat
+	 * recommendations surface.
+	 */
+	openMemoryPromptDiff(agentId: string): void {
+		const agent = getData().agents[agentId];
+		if (!agent) return;
+		const promptFiles = this.plugin.promptFilesService;
+		new SystemPromptModal(
+			this.plugin,
+			{
+				getPrompt: () => promptFiles?.getMemoryPrompt(agentId) ?? DEFAULT_MEMORY_PROMPT,
+				setPrompt: (prompt: string) => {
+					void promptFiles?.writeMemoryPrompt(agentId, prompt).then(() => {
+						this.invalidateSystemPromptCaches();
+					});
+				},
+				defaultPrompt: DEFAULT_MEMORY_PROMPT,
+			},
+			{ title: `Memory Instructions — ${agent.name}`, showDiff: true },
+		).open();
+	}
+
+	/**
 	 * Get available models for a provider by discovering them from the API.
 	 * @returns Array of available chat model names
 	 */

--- a/src/agent/promptFiles.ts
+++ b/src/agent/promptFiles.ts
@@ -2,7 +2,8 @@ import type { App, DataAdapter } from "obsidian";
 import type { AgentsConfig, PromptFileReader } from "../types/plugin";
 import { agentPromptDir, agentRootDir, basePromptPath, memoryPromptPath, systemPromptsDir } from "../utils/agentPaths";
 import { Logger as Log } from "../utils/logging";
-import { BASE_SYSTEM_PROMPT, DEFAULT_MEMORY_PROMPT } from "./prompts";
+import { type ShippedHistory, currentShippedVersion, shippedVersion } from "../utils/shippedDefaults";
+import { BASE_SYSTEM_PROMPT, DEFAULT_MEMORY_PROMPT, SHIPPED_BASE_PROMPTS, SHIPPED_MEMORY_PROMPTS } from "./prompts";
 
 /**
  * The two prompt fragments concatenated into one agent's assembled system prompt, both living
@@ -17,6 +18,8 @@ interface PromptKind {
 	path: (agentId: string) => string;
 	/** Factory default written when the note is absent, and used when the cache is empty. */
 	fallback: string;
+	/** Every default we ever shipped for this kind, so seeding can tell an untouched old default (update silently) from a user edit (never touch). */
+	history: ShippedHistory;
 	/** Transient field on the agent config carrying a migrated pre-file customization. */
 	migratedField: "migratedBasePrompt" | "migratedMemoryPrompt";
 }
@@ -25,6 +28,7 @@ const BASE_PROMPT: PromptKind = {
 	label: "base prompt",
 	path: basePromptPath,
 	fallback: BASE_SYSTEM_PROMPT,
+	history: SHIPPED_BASE_PROMPTS,
 	migratedField: "migratedBasePrompt",
 };
 
@@ -32,6 +36,7 @@ const MEMORY_PROMPT: PromptKind = {
 	label: "memory prompt",
 	path: memoryPromptPath,
 	fallback: DEFAULT_MEMORY_PROMPT,
+	history: SHIPPED_MEMORY_PROMPTS,
 	migratedField: "migratedMemoryPrompt",
 };
 
@@ -86,10 +91,18 @@ export class PromptFilesService {
 	}
 
 	/**
-	 * Seed default files on first run: write each agent's note when absent (never clobber an
-	 * edit). Content is the kind's factory default, UNLESS a config→file migration stashed a
-	 * customized prompt on the agent's transient — in that case the user's old customization is
-	 * written to the new file (and the transient cleared) so the move never silently discards it.
+	 * Seed default files on first run, and keep untouched ones current on every run.
+	 *
+	 * - Absent → write the kind's factory default, UNLESS a config→file migration stashed a
+	 *   customized prompt on the agent's transient — then the user's old customization is
+	 *   written instead (and the transient cleared) so the move never silently discards it.
+	 * - Present and matching an OLD shipped default → the user never edited it, so the moved
+	 *   default is applied silently (same contract as `SkillsService.reconcileBundledSkill`).
+	 *   Without this, an untouched install would be stuck on the old prompt with only a
+	 *   notice asking the user to reset by hand.
+	 * - Present and anything else → the user's edit; never clobbered. If the shipped default
+	 *   has moved since, the staleness getter surfaces a notice — that path also catches a
+	 *   failed rewrite here, since the file then still fingerprints as an old default.
 	 */
 	async seedDefaults(agents: AgentsConfig): Promise<void> {
 		await this.ensureDirs();
@@ -101,9 +114,15 @@ export class PromptFilesService {
 				const migrated = agent?.[kind.migratedField]?.trim() ? agent[kind.migratedField] : null;
 				try {
 					if (await this.adapter.exists(path)) {
-						// File already present — never clobber an edit. The migrated prompt is
-						// superseded by the on-disk file, so the transient is spent: clear it.
+						// File already present — the migrated prompt is superseded by the
+						// on-disk file, so the transient is spent: clear it.
 						this.clearMigrated(kind, agent);
+						const content = await this.adapter.read(path);
+						const version = shippedVersion(content, kind.history);
+						if (version !== null && version !== currentShippedVersion(kind.history)) {
+							await this.adapter.write(path, kind.fallback);
+							Log.info(`Updated ${kind.label} for ${agentId} from shipped v${version} to current`);
+						}
 						continue;
 					}
 					await this.ensureParent(path);

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -3,6 +3,8 @@
  * Skills are appended at runtime based on what's installed and enabled.
  */
 
+import { type ShippedHistory, fingerprint } from "../utils/shippedDefaults";
+
 export const BASE_SYSTEM_PROMPT = `# Role
 You are a privacy-aware assistant integrated into Obsidian. You help users search and understand their notes.
 
@@ -81,8 +83,30 @@ export function buildDefaultMemoryPrompt(folder: string): string {
 export const BASE_SYSTEM_PROMPT_VERSION = 1;
 
 /**
- * Maps each historical version number to the exact prompt string shipped at that version.
- * Lets normalizeAgent() detect "still on old default" vs "user customized" without storing
- * a hash. Keep all entries forever — never remove old versions.
+ * Every base system prompt we have ever shipped, as version → fingerprint. Lets callers tell
+ * "still on an old default" (update silently) from "user customized" (leave alone, raise a
+ * notice) — see {@link isShippedDefault}.
+ *
+ * When BASE_SYSTEM_PROMPT changes: bump {@link BASE_SYSTEM_PROMPT_VERSION}, and add the
+ * PREVIOUS text's fingerprint here under its old version number before replacing the
+ * constant. Entries are append-only — dropping one makes untouched copies of that version
+ * read as customizations.
  */
-export const HISTORICAL_SYSTEM_PROMPTS: ReadonlyMap<number, string> = new Map([[1, BASE_SYSTEM_PROMPT]]);
+export const SHIPPED_BASE_PROMPTS: ShippedHistory = new Map([
+	[BASE_SYSTEM_PROMPT_VERSION, fingerprint(BASE_SYSTEM_PROMPT)],
+]);
+
+/** Increment when DEFAULT_MEMORY_PROMPT changes in a way that affects agent behaviour. */
+export const DEFAULT_MEMORY_PROMPT_VERSION = 1;
+
+/**
+ * Every memory prompt we have ever shipped, as version → fingerprint. Same contract as
+ * {@link SHIPPED_BASE_PROMPTS}.
+ *
+ * This surface previously had no history at all — it was compared against the *current*
+ * constant only, so the first change to DEFAULT_MEMORY_PROMPT would have classified every
+ * existing install as user-customized: never auto-migrated, and never flagged either.
+ */
+export const SHIPPED_MEMORY_PROMPTS: ShippedHistory = new Map([
+	[DEFAULT_MEMORY_PROMPT_VERSION, fingerprint(DEFAULT_MEMORY_PROMPT)],
+]);

--- a/src/agent/tools/readContent.ts
+++ b/src/agent/tools/readContent.ts
@@ -3,12 +3,7 @@ import { tool } from "@langchain/core/tools";
 import { HumanMessage } from "@langchain/core/messages";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { z } from "zod";
-import {
-	DEFAULT_TOOLS_CONFIG,
-	READ_CONTENT_DESC_DEFAULTS,
-	getData,
-	getReadContentDescription,
-} from "../../stores/dataStore.svelte";
+import { DEFAULT_TOOLS_CONFIG, getData, getReadContentDescription } from "../../stores/dataStore.svelte";
 import { getPendingChangesStore } from "../../stores/pendingChangesStore.svelte";
 import {
 	isImageExtension,
@@ -595,12 +590,11 @@ export function createReadContentTool(app: App, imageProcessor?: BaseChatModel, 
 
 	const toolConfig = getToolConfig();
 
-	// Select the appropriate description based on configured processors.
-	// Only override if the stored description matches one of the 4 defaults (user hasn't customized it).
-	let description = toolConfig?.description ?? defaultToolConfig.description;
-	if (READ_CONTENT_DESC_DEFAULTS.has(description)) {
-		description = getReadContentDescription(!!imageProcessor, !!pdfProcessor);
-	}
+	// Always derived from the live processor configuration — never read back from the stored
+	// config. Tool descriptions aren't user-editable (ToolConfigForm renders no input for
+	// them), so a stored value is only ever a shipped default, and honouring it would just
+	// freeze this at whichever variant was current when the config was last written.
+	const description = getReadContentDescription(!!imageProcessor, !!pdfProcessor);
 
 	return tool(readContentFn, {
 		name: toolConfig?.name ?? defaultToolConfig.name,

--- a/src/agent/tools/searchNotes.ts
+++ b/src/agent/tools/searchNotes.ts
@@ -5,7 +5,7 @@ import type { SearchAlgorithm } from "../../types/plugin";
 import { getLexicalSearchService, waitForLexicalSearch } from "../../search/LexicalSearchService";
 import { rankSearchResults } from "../../search/finalSearchRanking";
 import { buildRecentBoostMap, getRecentNotes } from "../../search/recentNotes";
-import { SEARCH_NOTES_DESC_DEFAULTS, getData, getSearchNotesDescription } from "../../stores/dataStore.svelte";
+import { getData, getSearchNotesDescription } from "../../stores/dataStore.svelte";
 import { getPendingChangesStore } from "../../stores/pendingChangesStore.svelte";
 import { normalizeVaultPath } from "../../utils/pathUtils";
 import { getVectorStoreService, type SearchFilter, type SearchResult, waitForVectorStore } from "../../vectorstore";
@@ -499,16 +499,11 @@ export function createSearchNotesTool(app: App) {
 	// rebuilds the tool — without that, this description would go stale the moment a
 	// user set up embeddings mid-conversation.
 	//
-	// `normalizeAgent` merges DEFAULT_TOOLS_CONFIG into every agent, so
-	// `toolConfig.description` is always populated and `?? fallback` would never fire.
-	// Swap only when the stored value is still one of the shipped defaults; anything
-	// else is a user customization and is left exactly as written.
+	// Always derived from the live index state, never read back from the stored config:
+	// tool descriptions aren't user-editable (ToolConfigForm renders no input for them),
+	// so a stored value is only ever a shipped default.
 	const embeddingIndexAvailable = hasSearchEmbeddingIndex();
-	const storedDescription = toolConfig?.description;
-	const description =
-		storedDescription && !SEARCH_NOTES_DESC_DEFAULTS.has(storedDescription)
-			? storedDescription
-			: getSearchNotesDescription(embeddingIndexAvailable);
+	const description = getSearchNotesDescription(embeddingIndexAvailable);
 
 	return tool(searchFn, {
 		name: toolConfig?.name ?? "search_notes",

--- a/src/components/chat/ChatRecommendations.svelte
+++ b/src/components/chat/ChatRecommendations.svelte
@@ -299,7 +299,17 @@ function reviewNotice(notice: UpdateNotice): void {
         <div class="s2b-notice">
           <span class="s2b-notice-icon" use:icon={"refresh-cw"} style="--icon-size: 14px"></span>
           <span class="s2b-notice-text">
-            {#if notice.agentName}
+            <!-- customized === false means the file is an untouched OLD default whose silent
+                 auto-update failed — claiming "your customized version was kept" there would
+                 assert an edit the user never made. -->
+            {#if notice.customized === false}
+              {#if notice.agentName}
+                The default {notice.label} changed, but <strong>{notice.agentName}</strong>'s copy
+                couldn't be updated automatically.
+              {:else}
+                The default {notice.label} changed, but your copy couldn't be updated automatically.
+              {/if}
+            {:else if notice.agentName}
               The default {notice.label} changed. <strong>{notice.agentName}</strong>'s customized
               version was kept.
             {:else}

--- a/src/components/chat/ChatRecommendations.svelte
+++ b/src/components/chat/ChatRecommendations.svelte
@@ -10,6 +10,7 @@ import {
 	toExecToolId,
 } from "../../agent/integrations/pluginIntegrations";
 import { icon } from "../../utils/utils";
+import { skillsDir } from "../../utils/agentPaths";
 import { Logger } from "../../utils/logging";
 import { extractErrorMessage } from "../../utils/errorMessage";
 import { ModelSelectionModal } from "../modal/ModelSelectionModal";
@@ -214,13 +215,21 @@ function dismiss(id: string): void {
 	data.dismissRecommendation(id);
 }
 
-// Opens the base-system-prompt diff for a stale-guidance notice's Review action.
+// Opens the right editing surface for a stale-guidance notice's Review action. The two
+// prompt surfaces get their diff modal (yours vs the current default); a skill is edited as
+// an ordinary vault note, so it opens as one — there is no modal for skill bodies.
 function reviewNotice(notice: UpdateNotice): void {
-	const mgr = plugin.agentManager;
-	if (!mgr) return;
-	if (notice.kind === "system-prompt" && notice.agentId) {
-		mgr.openSystemPromptDiff(notice.agentId);
+	if (notice.kind === "skill") {
+		if (notice.skillName) {
+			plugin.app.workspace.openLinkText(`${skillsDir()}/${notice.skillName}/SKILL.md`, "", true);
+		}
+		return;
 	}
+
+	const mgr = plugin.agentManager;
+	if (!mgr || !notice.agentId) return;
+	if (notice.kind === "system-prompt") mgr.openSystemPromptDiff(notice.agentId);
+	else mgr.openMemoryPromptDiff(notice.agentId);
 }
 </script>
 

--- a/src/components/chat/chatRecommendations.ts
+++ b/src/components/chat/chatRecommendations.ts
@@ -127,27 +127,28 @@ export function filterPluginNudges(candidates: readonly PluginNudge[], dismissed
 }
 
 /**
- * The kind of guidance surface a stale-guidance notice refers to. Mirrors
- * `StaleGuidance.kind` from types/plugin — duplicated here to keep this module
- * free of the plugin-types import (it stays pure/unit-testable). Only the per-agent
- * base system prompt is tracked now — skill/tool guidance moved into skill bodies.
+ * The kind of surface a stale-guidance notice refers to. Mirrors `StaleGuidance.kind`
+ * from types/plugin — duplicated here to keep this module free of the plugin-types
+ * import (it stays pure/unit-testable). Keep the two in sync.
  */
-export type UpdateNoticeKind = "system-prompt";
+export type UpdateNoticeKind = "system-prompt" | "memory-prompt" | "skill";
 
 /**
- * A notice that the base system prompt default changed upstream while the user had a
- * customization of it, so it couldn't be auto-updated (issue #356). Sourced from the
- * store's `staleGuidance` records.
+ * A notice that a shipped default changed upstream while the user had a customization of
+ * it, so it couldn't be auto-updated (issue #356, extended to all surfaces in #401).
+ * Sourced from the store's `staleGuidance` records.
  */
 export interface UpdateNotice {
-	/** Dismissal key, of the form `update:<agentId|global>:<kind>`. */
+	/** Dismissal key, of the form `update:<agentId|global>:<kind>[:<skillName>]`. */
 	id: string;
-	/** Owning agent for the base system prompt. */
+	/** Owning agent for the per-agent prompt surfaces; absent for skills (global). */
 	agentId?: string;
 	agentName?: string;
 	kind: UpdateNoticeKind;
 	/** Human label for the surface, e.g. "system prompt". */
 	label: string;
+	/** For `kind: "skill"`, which skill — lets Review open the right note. */
+	skillName?: string;
 }
 
 /** Minimal shape of a store `StaleGuidance` record consumed by {@link toUpdateNotice}. */
@@ -156,23 +157,28 @@ export interface StaleGuidanceLike {
 	agentName?: string;
 	kind: UpdateNoticeKind;
 	label: string;
+	skillName?: string;
 }
 
 /**
  * Dismissal key for an update notice. Global surfaces (no agentId) use the literal
  * `global` segment so their key is stable and distinct from any per-agent key.
+ *
+ * Skills are global but there can be several stale at once, so the skill name is appended —
+ * otherwise dismissing one skill's notice would dismiss every skill's.
  */
-export const updateNoticeId = (agentId: string | undefined, kind: UpdateNoticeKind): string =>
-	`update:${agentId ?? "global"}:${kind}`;
+export const updateNoticeId = (agentId: string | undefined, kind: UpdateNoticeKind, skillName?: string): string =>
+	`update:${agentId ?? "global"}:${kind}${skillName ? `:${skillName}` : ""}`;
 
 /** Maps a store stale-guidance record to a dismissable notice. */
 export function toUpdateNotice(record: StaleGuidanceLike): UpdateNotice {
 	return {
-		id: updateNoticeId(record.agentId, record.kind),
+		id: updateNoticeId(record.agentId, record.kind, record.skillName),
 		agentId: record.agentId,
 		agentName: record.agentName,
 		kind: record.kind,
 		label: record.label,
+		skillName: record.skillName,
 	};
 }
 

--- a/src/components/chat/chatRecommendations.ts
+++ b/src/components/chat/chatRecommendations.ts
@@ -139,7 +139,7 @@ export type UpdateNoticeKind = "system-prompt" | "memory-prompt" | "skill";
  * Sourced from the store's `staleGuidance` records.
  */
 export interface UpdateNotice {
-	/** Dismissal key, of the form `update:<agentId|global>:<kind>[:<skillName>]`. */
+	/** Dismissal key, of the form `update:<agentId|global>:<kind>[:<skillName>][@<version>]`. */
 	id: string;
 	/** Owning agent for the per-agent prompt surfaces; absent for skills (global). */
 	agentId?: string;
@@ -149,6 +149,8 @@ export interface UpdateNotice {
 	label: string;
 	/** For `kind: "skill"`, which skill — lets Review open the right note. */
 	skillName?: string;
+	/** True when the user's own edit was kept; false when an untouched old default couldn't be auto-updated. */
+	customized?: boolean;
 }
 
 /** Minimal shape of a store `StaleGuidance` record consumed by {@link toUpdateNotice}. */
@@ -158,6 +160,8 @@ export interface StaleGuidanceLike {
 	kind: UpdateNoticeKind;
 	label: string;
 	skillName?: string;
+	currentVersion?: number | string;
+	customized?: boolean;
 }
 
 /**
@@ -166,19 +170,32 @@ export interface StaleGuidanceLike {
  *
  * Skills are global but there can be several stale at once, so the skill name is appended —
  * otherwise dismissing one skill's notice would dismiss every skill's.
+ *
+ * The CURRENT shipped version is appended too. Dismissals persist forever
+ * (`dismissedRecommendations` in plugin data), so a version-less key would mean dismissing
+ * the v2 notice silently swallows the v3 notice years later — each default bump should
+ * surface exactly once.
  */
-export const updateNoticeId = (agentId: string | undefined, kind: UpdateNoticeKind, skillName?: string): string =>
-	`update:${agentId ?? "global"}:${kind}${skillName ? `:${skillName}` : ""}`;
+export const updateNoticeId = (
+	agentId: string | undefined,
+	kind: UpdateNoticeKind,
+	skillName?: string,
+	currentVersion?: number | string,
+): string =>
+	`update:${agentId ?? "global"}:${kind}${skillName ? `:${skillName}` : ""}${
+		currentVersion !== undefined ? `@${currentVersion}` : ""
+	}`;
 
 /** Maps a store stale-guidance record to a dismissable notice. */
 export function toUpdateNotice(record: StaleGuidanceLike): UpdateNotice {
 	return {
-		id: updateNoticeId(record.agentId, record.kind, record.skillName),
+		id: updateNoticeId(record.agentId, record.kind, record.skillName, record.currentVersion),
 		agentId: record.agentId,
 		agentName: record.agentName,
 		kind: record.kind,
 		label: record.label,
 		skillName: record.skillName,
+		customized: record.customized,
 	};
 }
 

--- a/src/components/modal/AgentEditorModal.svelte
+++ b/src/components/modal/AgentEditorModal.svelte
@@ -31,6 +31,7 @@ import {
 	toExecToolId,
 } from "../../agent/integrations/pluginIntegrations";
 import { BASE_SYSTEM_PROMPT, DEFAULT_MEMORY_PROMPT } from "../../agent/prompts";
+import { normalizeShipped } from "../../utils/shippedDefaults";
 import { agentPromptDir, basePromptPath, memoryPromptPath } from "../../utils/agentPaths";
 import { Logger } from "../../utils/logging";
 import { extractErrorMessage } from "../../utils/errorMessage";
@@ -263,7 +264,9 @@ const basePromptDrifted = $derived.by(() => {
 	void basePromptDriftTick;
 	if (!selectedAgent) return false;
 	const content = plugin.promptFilesService?.getBasePrompt(agentId) ?? BASE_SYSTEM_PROMPT;
-	return content.trim() !== BASE_SYSTEM_PROMPT.trim();
+	// Same normalization the shipped-default check uses, so a file that differs only by
+	// line endings or a trailing newline doesn't offer a diff against identical text.
+	return normalizeShipped(content) !== normalizeShipped(BASE_SYSTEM_PROMPT);
 });
 
 function openBasePromptDiff() {
@@ -290,7 +293,7 @@ const memoryPromptDrifted = $derived.by(() => {
 	void memoryPromptDriftTick;
 	if (!selectedAgent) return false;
 	const content = plugin.promptFilesService?.getMemoryPrompt(agentId) ?? DEFAULT_MEMORY_PROMPT;
-	return content.trim() !== DEFAULT_MEMORY_PROMPT.trim();
+	return normalizeShipped(content) !== normalizeShipped(DEFAULT_MEMORY_PROMPT);
 });
 
 function openMemoryPromptDiff() {

--- a/src/components/modal/ToolConfigForm.svelte
+++ b/src/components/modal/ToolConfigForm.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 import {
 	DEFAULT_TOOLS_CONFIG,
-	READ_CONTENT_DESC_DEFAULTS,
-	SEARCH_NOTES_DESC_DEFAULTS,
 	getData,
 	getReadContentDescription,
 	getSearchNotesDescription,
@@ -243,18 +241,6 @@ function snapshotKey(snapshot: ToolConfigSnapshot): string {
 	return JSON.stringify(snapshot);
 }
 
-/**
- * Is this description still one the plugin ships, rather than a user's own text?
- *
- * Two tools have more than one shipped default and swap between them automatically —
- * `read_content` by processor capability, `search_notes` by whether an embedding index
- * exists — so a plain equality check against `defaultConfig.description` would flag an
- * untouched config as customized and offer a pointless "Reset to default".
- */
-function isDefaultDescription(value: string): boolean {
-	return READ_CONTENT_DESC_DEFAULTS.has(value) || SEARCH_NOTES_DESC_DEFAULTS.has(value);
-}
-
 const initialSnapshotKey = snapshotKey(initialSnapshot);
 const defaultSnapshotKey = snapshotKey(defaultSnapshot);
 
@@ -279,10 +265,11 @@ const isDirty = $derived.by(() => {
 const isAtDefault = $derived.by(() => {
 	const currentSnapshot: ToolConfigSnapshot = {
 		name,
-		// Normalize known-default description variants so an automatic swap doesn't make
-		// the config appear "non-default": read_content's varies by processor capability,
-		// search_notes' by whether an embedding index exists.
-		description: isDefaultDescription(description) ? defaultConfig.description : description,
+		// Pinned to the default: the description isn't user-editable, and two tools swap
+		// theirs automatically (read_content by processor capability, search_notes by
+		// whether an embedding index exists). Comparing the live value would make an
+		// untouched config look "non-default" and offer a pointless "Reset to default".
+		description: defaultConfig.description,
 		maxResults,
 		allowCreate,
 		allowUpdate,
@@ -299,18 +286,17 @@ const showResetToDefault = $derived(!isAtDefault);
 
 /** Build the persisted patch from current field state (shared by Save + live-commit). */
 function buildConfigPatch(): Partial<ToolConfig> {
-	// read_content's shipped default description varies by processor capability; if the
-	// persisted description is still one of those known-default variants, keep it in sync with
-	// the current processor mode rather than freezing it at whatever variant was true on load.
+	// Two tools' shipped descriptions vary with live state — read_content's by processor
+	// capability, search_notes' by whether an embedding index exists — so recompute rather
+	// than persisting whichever variant happened to be current when the modal opened. The
+	// tool factories derive the description the same way at build time, so what's persisted
+	// here is only ever a cache of that; nothing user-authored can be lost.
 	let resolvedDescription = description;
 	if (capturedToolId === "read_content") {
 		const hasImg = resolveHasProcessor(imageProcessorMode, imageProcessor, chatModelSupportsVision);
 		const hasPdf = resolveHasProcessor(pdfProcessorMode, pdfProcessor, chatModelSupportsPdf);
-		if (READ_CONTENT_DESC_DEFAULTS.has(description))
-			resolvedDescription = getReadContentDescription(hasImg, hasPdf);
-	} else if (capturedToolId === "search_notes" && SEARCH_NOTES_DESC_DEFAULTS.has(description)) {
-		// Same reasoning as read_content: don't freeze an untouched default at whichever
-		// variant happened to be current when the modal opened.
+		resolvedDescription = getReadContentDescription(hasImg, hasPdf);
+	} else if (capturedToolId === "search_notes") {
 		resolvedDescription = getSearchNotesDescription(Boolean(pluginData.searchEmbedIndex));
 	}
 

--- a/src/skills/SkillsService.ts
+++ b/src/skills/SkillsService.ts
@@ -253,8 +253,9 @@ export class SkillsService {
 		// No fast path here: an "all folders present" early return is exactly what made a
 		// bumped skill version unreachable before #401 — the per-skill check never ran, so
 		// improvements to bundled skills only ever reached new vaults. Each skill below is
-		// now read and compared, which costs one read() per folder (~10) on a path already
-		// measured by StartupProfiler ("skills:bootstrap").
+		// now read and compared, which costs one read() per folder (~10; two on the rare
+		// update path, which re-verifies before overwriting) on a path already measured by
+		// StartupProfiler ("skills:bootstrap").
 		//
 		// Two groups are reconciled, and the distinction matters:
 		//  - the startup seed set (core skills + enabled core-plugin integrations), which is
@@ -271,23 +272,50 @@ export class SkillsService {
 		const alreadyInstalled = BUNDLED_SKILLS.filter((s) => !seedNames.has(s.name) && presentFolders.has(s.name));
 
 		let installed = 0;
-		const stale: string[] = [];
+		// Rebuild wholesale rather than append: this pass is the authoritative result for
+		// every bundled skill, so one the user has since re-aligned drops out instead of
+		// lingering. On-demand reconciles between bootstraps adjust the set incrementally
+		// (see recordReconcileOutcome).
+		this.staleSkillNames.clear();
 
 		for (const bundledSkill of [...seedSkills, ...alreadyInstalled]) {
 			const outcome = await this.reconcileBundledSkill(bundledSkill);
 			if (outcome === "installed" || outcome === "updated") installed++;
-			else if (outcome === "customized") stale.push(bundledSkill.name);
+			this.recordReconcileOutcome(bundledSkill.name, outcome);
 		}
 
-		// Replace wholesale rather than append: this is the authoritative result of the pass,
-		// so a skill the user has since re-aligned drops out instead of lingering.
-		getData().setStaleSkills(stale);
+		this.publishStaleSkills();
 
 		if (installed > 0) {
 			Log.info(`Bootstrapped ${installed} default skills`);
 		}
 
 		return installed;
+	}
+
+	/**
+	 * Bundled skills whose on-disk body is neither the current shipped version nor any older
+	 * one — i.e. the user edited them, so reconciliation left them alone. Owned here (not
+	 * only in the store) so both reconcile paths — the startup bootstrap and the on-demand
+	 * `seedIntegrationSkill` — maintain one consistent set: bootstrap rebuilds it, a single
+	 * reconcile flips just its own skill in or out.
+	 */
+	private staleSkillNames = new Set<string>();
+
+	/** Fold one reconcile outcome into the stale set: `customized` enters, any resolution leaves. */
+	private recordReconcileOutcome(
+		skillName: string,
+		outcome: "installed" | "updated" | "current" | "customized" | "failed",
+	): void {
+		if (outcome === "customized") this.staleSkillNames.add(skillName);
+		// `installed`/`updated`/`current` mean the file now matches a shipped body, so any
+		// earlier stale mark is resolved. `failed` keeps whatever state we last knew.
+		else if (outcome !== "failed") this.staleSkillNames.delete(skillName);
+	}
+
+	/** Push the current stale set into the store, where the reactive notice surface reads it. */
+	private publishStaleSkills(): void {
+		getData().setStaleSkills([...this.staleSkillNames]);
 	}
 
 	/**
@@ -327,6 +355,21 @@ export class SkillsService {
 		const version = shippedVersion(existing, history);
 		if (version === null) return "customized";
 		if (version === currentSkillVersion(skill.name)) return "current";
+
+		// Re-verify immediately before overwriting: the provenance check above read the file
+		// at some earlier point, and a sync client (or the user) can write to it in between —
+		// startup, when this runs, is exactly when Obsidian Sync delivers edits from other
+		// devices. The adapter has no compare-and-swap, so this cannot close the race
+		// entirely, but it shrinks the window from the whole decision path to the write call
+		// and turns the realistic case into "customized" instead of a destroyed edit.
+		try {
+			if ((await this.adapter.read(path)) !== existing) {
+				Log.info(`Skill ${skill.name} changed while reconciling; treating as customized`);
+				return "customized";
+			}
+		} catch {
+			return "customized";
+		}
 
 		if (await this.writeBundledSkill(skill, { overwrite: true })) {
 			Log.info(`Updated bundled skill ${skill.name} from v${version} to v${skill.version}`);
@@ -382,8 +425,12 @@ export class SkillsService {
 		if (bundled) {
 			// Same three-way reconcile as startup bootstrap, so a community integration skill
 			// that improves upstream reaches vaults that already have it — the on-demand path
-			// had the identical skip-if-exists gap.
+			// had the identical skip-if-exists gap. Fold the outcome into the stale set too:
+			// a `customized` result here must raise its notice NOW, not wait for the next
+			// startup's bootstrap pass to rediscover it.
 			const outcome = await this.reconcileBundledSkill(bundled);
+			this.recordReconcileOutcome(bundled.name, outcome);
+			this.publishStaleSkills();
 			return outcome === "failed" ? null : bundled.name;
 		}
 

--- a/src/skills/SkillsService.ts
+++ b/src/skills/SkillsService.ts
@@ -12,11 +12,14 @@ import { StartupProfiler } from "../utils/startupProfiler";
 import {
 	BUNDLED_CORE_SKILLS,
 	BUNDLED_INTEGRATION_SKILLS,
+	BUNDLED_SKILLS,
 	type BundledSkill,
 	getBundledIntegrationSkillForPlugin,
 } from "./defaults";
 import { isInternalPluginEnabled } from "../agent/integrations/pluginIntegrations";
 import { buildPluginApiSkill } from "./templates/pluginApiScripting";
+import { SHIPPED_SKILL_HISTORY, currentSkillVersion } from "./shippedSkills";
+import { shippedVersion } from "../utils/shippedDefaults";
 import { validateFrontmatter, type ValidationResult } from "./validation";
 
 /** SKILL.md filename per spec */
@@ -246,31 +249,39 @@ export class SkillsService {
 	async bootstrapDefaultSkills(): Promise<number> {
 		await this.ensureSkillsDir();
 		const skillsDir = this.getSkillsDir();
-		const seedSkills = this.getStartupSeedSkills();
 
-		// Fast path: one list() call to check if all seed skill folders are already present.
-		// Avoids N exists() round-trips on every startup after the first run.
+		// No fast path here: an "all folders present" early return is exactly what made a
+		// bumped skill version unreachable before #401 — the per-skill check never ran, so
+		// improvements to bundled skills only ever reached new vaults. Each skill below is
+		// now read and compared, which costs one read() per folder (~10) on a path already
+		// measured by StartupProfiler ("skills:bootstrap").
+		//
+		// Two groups are reconciled, and the distinction matters:
+		//  - the startup seed set (core skills + enabled core-plugin integrations), which is
+		//    installed when absent;
+		//  - every OTHER bundled skill already present in the vault. Community integration
+		//    skills are seeded on demand by `seedIntegrationSkill`, so they're absent from
+		//    the seed set — without this they'd be installed once and then never updated or
+		//    re-checked again. They are deliberately NOT installed here when absent; opting
+		//    into an integration remains the user's call.
 		const listing = await this.adapter.list(skillsDir);
-		const existingFolderNames = new Set(listing.folders.map((f) => f.split("/").pop()));
-		const allPresent = seedSkills.every((s) => existingFolderNames.has(s.name));
-		if (allPresent) {
-			Log.debug("All startup seed skills already installed, skipping bootstrap");
-			return 0;
-		}
+		const presentFolders = new Set(listing.folders.map((f) => f.split("/").pop()));
+		const seedSkills = this.getStartupSeedSkills();
+		const seedNames = new Set(seedSkills.map((s) => s.name));
+		const alreadyInstalled = BUNDLED_SKILLS.filter((s) => !seedNames.has(s.name) && presentFolders.has(s.name));
 
 		let installed = 0;
+		const stale: string[] = [];
 
-		for (const bundledSkill of seedSkills) {
-			// Skip if already exists (user may have customized)
-			if (await this.adapter.exists(`${skillsDir}/${bundledSkill.name}/${SKILL_FILENAME}`)) {
-				Log.debug(`Skill ${bundledSkill.name} already exists, skipping`);
-				continue;
-			}
-			if (await this.writeBundledSkill(bundledSkill)) {
-				installed++;
-				Log.info(`Installed default skill: ${bundledSkill.name}`);
-			}
+		for (const bundledSkill of [...seedSkills, ...alreadyInstalled]) {
+			const outcome = await this.reconcileBundledSkill(bundledSkill);
+			if (outcome === "installed" || outcome === "updated") installed++;
+			else if (outcome === "customized") stale.push(bundledSkill.name);
 		}
+
+		// Replace wholesale rather than append: this is the authoritative result of the pass,
+		// so a skill the user has since re-aligned drops out instead of lingering.
+		getData().setStaleSkills(stale);
 
 		if (installed > 0) {
 			Log.info(`Bootstrapped ${installed} default skills`);
@@ -280,17 +291,69 @@ export class SkillsService {
 	}
 
 	/**
-	 * Write a bundled skill's verbatim SKILL.md to disk (creating its dir), preserving the
-	 * file byte-for-byte rather than round-tripping through parse/serialize. Returns true on
-	 * success. Does not overwrite an existing file — callers check existence first.
+	 * Bring one bundled skill's on-disk copy in line with what we ship, without ever
+	 * clobbering the user's own writing:
+	 *
+	 * - absent              → write it (`"installed"`)
+	 * - current version     → leave it (`"current"`)
+	 * - an OLD shipped body → overwrite silently (`"updated"`) — untouched, so safe to move
+	 * - anything else       → the user edited it: leave it and report `"customized"` so the
+	 *                         caller can raise a notice offering to reconcile by hand
+	 *
+	 * A skill with no entry in {@link SHIPPED_SKILL_HISTORY} (no `metadata.version`) keeps
+	 * the old existence-only behaviour — we can't reason about its provenance.
 	 */
-	private async writeBundledSkill(skill: BundledSkill): Promise<boolean> {
+	private async reconcileBundledSkill(
+		skill: BundledSkill,
+	): Promise<"installed" | "updated" | "current" | "customized" | "failed"> {
+		const path = `${this.getSkillsDir()}/${skill.name}/${SKILL_FILENAME}`;
+
+		if (!(await this.adapter.exists(path))) {
+			return (await this.writeBundledSkill(skill)) ? "installed" : "failed";
+		}
+
+		const history = SHIPPED_SKILL_HISTORY.get(skill.name);
+		if (!history) return "current";
+
+		let existing: string;
+		try {
+			existing = await this.adapter.read(path);
+		} catch (error) {
+			// Unreadable: treat as customized rather than overwriting something we can't see.
+			Log.error(`Could not read skill ${skill.name} to check its version:`, error);
+			return "customized";
+		}
+
+		const version = shippedVersion(existing, history);
+		if (version === null) return "customized";
+		if (version === currentSkillVersion(skill.name)) return "current";
+
+		if (await this.writeBundledSkill(skill, { overwrite: true })) {
+			Log.info(`Updated bundled skill ${skill.name} from v${version} to v${skill.version}`);
+			return "updated";
+		}
+		return "failed";
+	}
+
+	/**
+	 * Write a bundled skill's verbatim SKILL.md to disk (creating its dir), preserving the
+	 * file byte-for-byte rather than round-tripping through parse/serialize — the fingerprint
+	 * in `SHIPPED_SKILL_HISTORY` is taken over exactly these bytes, so a re-serialized copy
+	 * would not match its own shipped version. Returns true on success.
+	 *
+	 * Callers must establish that overwriting is safe before passing `overwrite` — see
+	 * {@link reconcileBundledSkill}, which only does so for a body matching an older shipped
+	 * version (i.e. one the user demonstrably never edited).
+	 */
+	private async writeBundledSkill(skill: BundledSkill, opts?: { overwrite?: boolean }): Promise<boolean> {
 		const skillDir = `${this.getSkillsDir()}/${skill.name}`;
+		const path = `${skillDir}/${SKILL_FILENAME}`;
 		try {
 			if (!(await this.adapter.exists(skillDir))) {
 				await this.adapter.mkdir(skillDir);
 			}
-			await this.adapter.write(`${skillDir}/${SKILL_FILENAME}`, skill.content);
+			if (!opts?.overwrite && (await this.adapter.exists(path))) return false;
+			await this.adapter.write(path, skill.content);
 			return true;
 		} catch (error) {
 			Log.error(`Failed to write skill ${skill.name}:`, error);
@@ -302,9 +365,13 @@ export class SkillsService {
 	 * Seed the skill documenting a community-plugin integration, on demand (called when the
 	 * user enables the integration). Prefers a *prewritten* bundled integration skill for the
 	 * plugin (written verbatim); if none exists, falls back to the introspect-first
-	 * `buildPluginApiSkill` template (written via `saveSkill`). Skips if a SKILL.md is already
-	 * present for the resolved skill name (user may have customized it). Callers should
-	 * re-discover afterwards so the new skill enters the cache.
+	 * `buildPluginApiSkill` template (written via `saveSkill`). Callers should re-discover
+	 * afterwards so the new skill enters the cache.
+	 *
+	 * An already-present bundled skill is reconciled rather than skipped (see
+	 * {@link reconcileBundledSkill}): re-enabling an integration picks up an improved body,
+	 * but never overwrites one the user has edited. The generated-template path still skips
+	 * when present — a template has no shipped version to compare against.
 	 *
 	 * @returns the seeded skill's name, or null if seeding failed.
 	 */
@@ -313,10 +380,11 @@ export class SkillsService {
 		const bundled = getBundledIntegrationSkillForPlugin(pluginId);
 
 		if (bundled) {
-			if (await this.adapter.exists(`${this.getSkillsDir()}/${bundled.name}/${SKILL_FILENAME}`)) {
-				return bundled.name;
-			}
-			return (await this.writeBundledSkill(bundled)) ? bundled.name : null;
+			// Same three-way reconcile as startup bootstrap, so a community integration skill
+			// that improves upstream reaches vaults that already have it — the on-demand path
+			// had the identical skip-if-exists gap.
+			const outcome = await this.reconcileBundledSkill(bundled);
+			return outcome === "failed" ? null : bundled.name;
 		}
 
 		// No prewritten skill — generate the introspect-first template.

--- a/src/skills/defaults/explore-vault/SKILL.md
+++ b/src/skills/defaults/explore-vault/SKILL.md
@@ -4,7 +4,7 @@ description: Search, read, and explore the user's vault — find notes by tag, p
 allowed-tools: search_notes list_directory read_content grep_notes get_all_tags get_properties execute_javascript
 metadata:
   author: "S2B"
-  version: "1.1"
+  version: "1.0"
   category: "core"
 ---
 

--- a/src/skills/defaults/index.ts
+++ b/src/skills/defaults/index.ts
@@ -28,6 +28,13 @@ export interface BundledSkill {
 	category: SkillCategory;
 	/** Optional linked Obsidian core plugin ID */
 	corePluginId?: string;
+	/**
+	 * `metadata.version` from the frontmatter. Load-bearing since #401: it keys this body's
+	 * entry in `SHIPPED_SKILL_HISTORY`, which is what lets seeding tell "an old default we
+	 * shipped" (overwrite silently) from "the user's own edit" (leave alone, flag it).
+	 * Bump it whenever the body changes, or the improvement won't reach existing vaults.
+	 */
+	version?: string;
 }
 
 /**
@@ -38,6 +45,7 @@ function parseFrontmatter(content: string): {
 	name?: string;
 	linkedPluginId?: string;
 	corePluginId?: string;
+	version?: string;
 } {
 	const lines = content.split("\n");
 
@@ -63,6 +71,7 @@ function parseFrontmatter(content: string): {
 		name?: string;
 		linkedPluginId?: string;
 		corePluginId?: string;
+		version?: string;
 	} = {};
 
 	let inMetadata = false;
@@ -87,6 +96,8 @@ function parseFrontmatter(content: string): {
 						result.linkedPluginId = value;
 					} else if (key === "corePluginId") {
 						result.corePluginId = value;
+					} else if (key === "version") {
+						result.version = value;
 					}
 				}
 				continue;
@@ -143,7 +154,7 @@ function parseBundledSkill(path: string, content: string): BundledSkill | null {
 	const dirName = segments.pop();
 	if (!dirName) return null;
 
-	const { name, linkedPluginId, corePluginId } = parseFrontmatter(content);
+	const { name, linkedPluginId, corePluginId, version } = parseFrontmatter(content);
 
 	return {
 		// Use frontmatter name or fall back to directory name
@@ -151,6 +162,7 @@ function parseBundledSkill(path: string, content: string): BundledSkill | null {
 		content,
 		linkedPluginId,
 		corePluginId,
+		version,
 		category: determineCategory(linkedPluginId, corePluginId),
 	};
 }

--- a/src/skills/shippedSkills.ts
+++ b/src/skills/shippedSkills.ts
@@ -12,15 +12,21 @@
  */
 
 import { BUNDLED_SKILLS } from "./defaults";
-import { type ShippedHistory, fingerprint } from "../utils/shippedDefaults";
+import { type ShippedHistory, currentShippedVersion, fingerprint } from "../utils/shippedDefaults";
 
 /**
- * Bodies of bundled skills we shipped in a PREVIOUS version and no longer have on disk.
+ * Fingerprints of bundled-skill bodies we shipped in a PREVIOUS version and no longer have
+ * on disk. Fingerprints, not verbatim bodies: every consumer only ever does an equality
+ * test, and retaining old bodies as string constants would grow the bundle by the full body
+ * on every revision (`bases` alone is ~21KB) with text that is never displayed.
  *
  * ## How to add an entry (do this when you change a bundled SKILL.md)
  *
- * 1. Copy the CURRENT body of the file — byte for byte, before your edit.
- * 2. Add it here under the skill's name and its *current* version.
+ * 1. BEFORE your edit, compute the current body's fingerprint — e.g. drop
+ *    `console.log(fingerprint(skill.content))` into any test in
+ *    `test/skills/bootstrapDefaultSkills.test.ts` and run it, or call
+ *    `fingerprint()` from `src/utils/shippedDefaults` anywhere convenient.
+ * 2. Add the hex string here under the skill's name and its *current* version.
  * 3. Then make your edit and bump `metadata.version` in the SKILL.md.
  *
  * Skip step 1-2 and existing vaults will read their untouched copy as a user customization:
@@ -32,9 +38,9 @@ import { type ShippedHistory, fingerprint } from "../utils/shippedDefaults";
  * is at the single version it currently ships (`explore-vault` was reset from 1.1 to 1.0 for
  * this reason). The map exists so the first real revision has an obvious place to go.
  */
-const PRIOR_SKILL_BODIES: ReadonlyMap<string, ReadonlyMap<string, string>> = new Map([
+const PRIOR_SKILL_FINGERPRINTS: ReadonlyMap<string, ReadonlyMap<string, string>> = new Map([
 	// Example of the shape, for when the first revision lands:
-	// ["explore-vault", new Map([["1.0", "---\nname: explore-vault\n...verbatim old body..."]])],
+	// ["explore-vault", new Map([["1.0", "a1b2c3d4e5f60718"]])],
 ]);
 
 /**
@@ -55,11 +61,8 @@ function buildHistory(): Map<string, ShippedHistory> {
 		// otherwise never touch). Validation requires the field, so this is defensive.
 		if (!skill.version) continue;
 
-		const versions = new Map<string, string>();
-		for (const [version, body] of PRIOR_SKILL_BODIES.get(skill.name) ?? []) {
-			versions.set(version, fingerprint(body));
-		}
-		// Current last, so it's the newest entry even if a prior body was recorded late.
+		const versions = new Map<string, string>(PRIOR_SKILL_FINGERPRINTS.get(skill.name) ?? []);
+		// Current last, so it's the newest entry even if a prior fingerprint was recorded late.
 		versions.set(skill.version, fingerprint(skill.content));
 		history.set(skill.name, versions);
 	}
@@ -71,7 +74,5 @@ function buildHistory(): Map<string, ShippedHistory> {
 export function currentSkillVersion(skillName: string): string | undefined {
 	const versions = SHIPPED_SKILL_HISTORY.get(skillName);
 	if (!versions) return undefined;
-	let last: string | undefined;
-	for (const [version] of versions) last = version as string;
-	return last;
+	return currentShippedVersion(versions) as string | undefined;
 }

--- a/src/skills/shippedSkills.ts
+++ b/src/skills/shippedSkills.ts
@@ -1,0 +1,77 @@
+/**
+ * Shipped-version history for the *bundled* skills, so seeding can tell an untouched old
+ * default (safe to overwrite) from a body the user edited (leave alone, flag it).
+ *
+ * Before #401 this didn't exist: `bootstrapDefaultSkills` skipped any skill whose folder was
+ * already present, and `metadata.version` was decorative. An improvement to a bundled skill
+ * therefore reached new vaults only — hit concretely when `explore-vault` gained reformulation
+ * guidance in #399 and existing vaults had no way to receive it.
+ *
+ * Only bundled skills are covered. User-created skills have no shipped version and are never
+ * touched by any of this.
+ */
+
+import { BUNDLED_SKILLS } from "./defaults";
+import { type ShippedHistory, fingerprint } from "../utils/shippedDefaults";
+
+/**
+ * Bodies of bundled skills we shipped in a PREVIOUS version and no longer have on disk.
+ *
+ * ## How to add an entry (do this when you change a bundled SKILL.md)
+ *
+ * 1. Copy the CURRENT body of the file — byte for byte, before your edit.
+ * 2. Add it here under the skill's name and its *current* version.
+ * 3. Then make your edit and bump `metadata.version` in the SKILL.md.
+ *
+ * Skip step 1-2 and existing vaults will read their untouched copy as a user customization:
+ * they'll get a notice asking them to reconcile by hand instead of a silent update.
+ *
+ * Entries are append-only — removing one has the same effect as never adding it.
+ *
+ * Empty today, by design: there are no released versions to preserve, so every bundled skill
+ * is at the single version it currently ships (`explore-vault` was reset from 1.1 to 1.0 for
+ * this reason). The map exists so the first real revision has an obvious place to go.
+ */
+const PRIOR_SKILL_BODIES: ReadonlyMap<string, ReadonlyMap<string, string>> = new Map([
+	// Example of the shape, for when the first revision lands:
+	// ["explore-vault", new Map([["1.0", "---\nname: explore-vault\n...verbatim old body..."]])],
+]);
+
+/**
+ * skill name → (version → fingerprint of the body shipped at that version).
+ *
+ * Built at module load: each bundled skill's *current* body under its own
+ * `metadata.version`, plus any retained prior bodies. Insertion order is oldest → newest, so
+ * the last entry is the current version (see `currentSkillVersion`).
+ */
+export const SHIPPED_SKILL_HISTORY: ReadonlyMap<string, ShippedHistory> = buildHistory();
+
+function buildHistory(): Map<string, ShippedHistory> {
+	const history = new Map<string, ShippedHistory>();
+
+	for (const skill of BUNDLED_SKILLS) {
+		// A bundled skill with no `metadata.version` can't participate: there'd be no key to
+		// record it under, so it keeps the old existence-only behaviour (seed if absent,
+		// otherwise never touch). Validation requires the field, so this is defensive.
+		if (!skill.version) continue;
+
+		const versions = new Map<string, string>();
+		for (const [version, body] of PRIOR_SKILL_BODIES.get(skill.name) ?? []) {
+			versions.set(version, fingerprint(body));
+		}
+		// Current last, so it's the newest entry even if a prior body was recorded late.
+		versions.set(skill.version, fingerprint(skill.content));
+		history.set(skill.name, versions);
+	}
+
+	return history;
+}
+
+/** The version a bundled skill currently ships at, or undefined if it isn't tracked. */
+export function currentSkillVersion(skillName: string): string | undefined {
+	const versions = SHIPPED_SKILL_HISTORY.get(skillName);
+	if (!versions) return undefined;
+	let last: string | undefined;
+	for (const [version] of versions) last = version as string;
+	return last;
+}

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -1,5 +1,5 @@
 import { normalizePath } from "obsidian";
-import { BASE_SYSTEM_PROMPT, DEFAULT_MEMORY_PROMPT, HISTORICAL_SYSTEM_PROMPTS } from "../agent/prompts";
+import { SHIPPED_BASE_PROMPTS, SHIPPED_MEMORY_PROMPTS } from "../agent/prompts";
 import {
 	createEmptySpaceFilter,
 	matchesSpaceMembershipDraftPath,
@@ -10,6 +10,7 @@ import {
 import { getSecret, listSecrets, removeSecret, setSecret } from "../lib/secretStorage";
 import { isAgentFilePath } from "../utils/fileFiltering";
 import { sanitizeAgentFileName } from "../utils/agentPaths";
+import { type ShippedHistory, isShippedDefault, shippedVersion } from "../utils/shippedDefaults";
 import type SecondBrainPlugin from "../main";
 import { DEFAULT_AGENT_ICON } from "../types/plugin";
 import type {
@@ -249,14 +250,6 @@ export const READ_CONTENT_DESC_PDF = `${READ_CONTENT_DESC_SHARED} Supports text,
 /** Both processors */
 export const READ_CONTENT_DESC_BOTH = `${READ_CONTENT_DESC_SHARED} Supports text, PDFs (analyzed via vision model), images, and Excalidraw.`;
 
-/** All 4 default description variants for matching */
-export const READ_CONTENT_DESC_DEFAULTS = new Set([
-	READ_CONTENT_DESC_NONE,
-	READ_CONTENT_DESC_IMAGE,
-	READ_CONTENT_DESC_PDF,
-	READ_CONTENT_DESC_BOTH,
-]);
-
 /**
  * Returns the appropriate read_content description based on processor configuration.
  */
@@ -276,17 +269,6 @@ export const SEARCH_NOTES_DESC_EMBEDDINGS = `${SEARCH_NOTES_DESC_SHARED} Pick th
 /** No embedding index — semantic and hybrid will fall back to lexical. */
 export const SEARCH_NOTES_DESC_LEXICAL_ONLY = `${SEARCH_NOTES_DESC_SHARED} This vault has no embedding index configured, so only \`algorithm: "lexical"\` is available; \`semantic\` and \`hybrid\` fall back to it and say so. Vary your search *terms* rather than the algorithm.`;
 
-/**
- * Both default variants, for "is this still the shipped default?" matching.
- *
- * `normalizeAgent` merges `DEFAULT_TOOLS_CONFIG` into every agent, so
- * `toolsConfig.search_notes.description` is *always* populated — a plain
- * `toolConfig?.description ?? dynamicDefault` in the tool factory would therefore never
- * fall through, and the embedding-aware description would be dead code. Same problem and
- * same solution as `READ_CONTENT_DESC_DEFAULTS` above.
- */
-export const SEARCH_NOTES_DESC_DEFAULTS = new Set([SEARCH_NOTES_DESC_EMBEDDINGS, SEARCH_NOTES_DESC_LEXICAL_ONLY]);
-
 /** Returns the search_notes description matching the vault's embedding-index state. */
 export function getSearchNotesDescription(hasEmbeddingIndex: boolean): string {
 	return hasEmbeddingIndex ? SEARCH_NOTES_DESC_EMBEDDINGS : SEARCH_NOTES_DESC_LEXICAL_ONLY;
@@ -300,9 +282,9 @@ export const DEFAULT_TOOLS_CONFIG: ToolsConfig = {
 	search_notes: {
 		enabled: true,
 		name: "search_notes",
-		// Seeded with the embeddings variant; `createSearchNotesTool` swaps it for the
-		// lexical-only text at build time when no index is configured. Any value NOT in
-		// `SEARCH_NOTES_DESC_DEFAULTS` is treated as a user customization and left alone.
+		// Seeded with the embeddings variant; `createSearchNotesTool` derives the live text
+		// (embeddings vs lexical-only) at build time, so this is only a placeholder for the
+		// stored config, never what the model actually sees.
 		description: SEARCH_NOTES_DESC_EMBEDDINGS,
 		// No settings: retrieval algorithm and result count are per-call tool parameters
 		// the model picks, and the result-detail flags are hardcoded on for the agent.
@@ -476,11 +458,8 @@ const MIGRATIONS: Migration[] = [
 			// the async seed writes it to the new file instead of clobbering it with the factory
 			// default. A recognized/absent default is dropped — the file seeds fresh from the default.
 			const oldPrompt = typeof a.systemPrompt === "string" ? (a.systemPrompt as string) : "";
-			const isShippedDefault =
-				!oldPrompt.trim() ||
-				oldPrompt === BASE_SYSTEM_PROMPT ||
-				[...HISTORICAL_SYSTEM_PROMPTS.values()].includes(oldPrompt);
-			if (!isShippedDefault) a.migratedBasePrompt = oldPrompt;
+			const recognized = !oldPrompt.trim() || isShippedDefault(oldPrompt, SHIPPED_BASE_PROMPTS);
+			if (!recognized) a.migratedBasePrompt = oldPrompt;
 			a.systemPrompt = undefined;
 			a.systemPromptVersion = undefined;
 			a.capabilityPrompts = undefined;
@@ -507,7 +486,7 @@ const MIGRATIONS: Migration[] = [
 	},
 	// v6 → v7: the memory prompt moves from this config field to a file
 	//          (Memory Prompts/<Agent Name>.md), same treatment as the v4→v5 base-prompt move.
-	//          If the user CUSTOMIZED it (non-empty and not equal to DEFAULT_MEMORY_PROMPT),
+	//          If the user CUSTOMIZED it (non-empty and not any memory prompt we ever shipped),
 	//          stash it in a transient so the async seed (PromptFilesService.seedDefaults)
 	//          writes it to the new file instead of clobbering it with the factory default.
 	//          A recognized/absent default is dropped — the file seeds fresh from the default.
@@ -515,8 +494,8 @@ const MIGRATIONS: Migration[] = [
 		for (const agent of Object.values(data.agents ?? {})) {
 			const a = agent as unknown as Record<string, unknown>;
 			const oldPrompt = typeof a.memoryPrompt === "string" ? (a.memoryPrompt as string) : "";
-			const isShippedDefault = !oldPrompt.trim() || oldPrompt === DEFAULT_MEMORY_PROMPT;
-			if (!isShippedDefault) a.migratedMemoryPrompt = oldPrompt;
+			const recognized = !oldPrompt.trim() || isShippedDefault(oldPrompt, SHIPPED_MEMORY_PROMPTS);
+			if (!recognized) a.migratedMemoryPrompt = oldPrompt;
 			a.memoryPrompt = undefined;
 		}
 	},
@@ -656,13 +635,24 @@ export class PluginDataStore {
 	 * The moment a user re-aligns a surface, its notice disappears on the next recompute (#356).
 	 */
 	get staleGuidance(): readonly StaleGuidance[] {
-		return computeStaleGuidance(this.#data.agents, this.#promptFileReader);
+		return computeStaleGuidance(this.#data.agents, this.#promptFileReader, this.#staleSkills);
 	}
 
 	/** Reader for file-backed prompt surfaces, injected by the prompt-file store once ready. */
 	#promptFileReader: PromptFileReader | null = null;
 	setPromptFileReader(reader: PromptFileReader | null): void {
 		this.#promptFileReader = reader;
+	}
+
+	/**
+	 * Bundled skills whose on-disk body is neither the current shipped version nor any older
+	 * one — i.e. the user edited them, so seeding couldn't update them in place. Reported by
+	 * SkillsService after each bootstrap. `$state` so the reactive `staleGuidance` getter
+	 * re-runs when bootstrap finishes (it completes well after the first render).
+	 */
+	#staleSkills: string[] = $state([]);
+	setStaleSkills(skillNames: readonly string[]): void {
+		this.#staleSkills = [...skillNames];
 	}
 
 	constructor(plugin: SecondBrainPlugin, initialData: PluginData) {
@@ -2321,42 +2311,89 @@ export class PluginDataStore {
 let _pluginDataStore: PluginDataStore | null = null;
 
 /**
- * Per-agent staleness for the base system prompt (file
- * `System Prompts/<Agent Name>/Base.md`): stale when the file content is an OLD shipped
- * default (the shipped default moved since the user's copy was written). A user customization
- * we don't recognize is left alone; absence ⇒ live default. Skill/tool guidance moved into
- * skill bodies, so it is no longer tracked here.
+ * The two file-backed prompt surfaces under `System Prompts/<Agent Name>/`, each paired with
+ * the history it is checked against and how its notice reads.
+ */
+const PROMPT_SURFACES = [
+	{
+		kind: "system-prompt",
+		label: "system prompt",
+		history: SHIPPED_BASE_PROMPTS,
+		read: (reader: PromptFileReader, agentId: string) => reader.getBasePrompt(agentId),
+	},
+	{
+		kind: "memory-prompt",
+		label: "memory instructions",
+		history: SHIPPED_MEMORY_PROMPTS,
+		read: (reader: PromptFileReader, agentId: string) => reader.getMemoryPrompt(agentId),
+	},
+] as const satisfies readonly {
+	kind: StaleGuidance["kind"];
+	label: string;
+	history: ShippedHistory;
+	read: (reader: PromptFileReader, agentId: string) => string | null;
+}[];
+
+/**
+ * Per-agent staleness for the file-backed prompts (`System Prompts/<Agent Name>/Base.md` and
+ * `Memory.md`): stale when the file holds an OLD shipped default — i.e. the shipped default
+ * moved since the user's copy was written, but the user never touched it, so we could not
+ * silently update it either (the file is theirs to edit).
+ *
+ * A customization we don't recognize is deliberately NOT flagged: the user wrote it on
+ * purpose, and nagging about it would be noise. Absence ⇒ the live default is used.
+ *
+ * Skill staleness is collected separately (skills are files under `Skills/`, not per-agent)
+ * and folded in by {@link computeStaleGuidance}.
  */
 function detectStaleGuidance(agent: AgentConfig, reader: PromptFileReader | null): StaleGuidance[] {
+	if (!reader) return [];
 	const stale: StaleGuidance[] = [];
 
-	if (reader) {
-		const content = reader.getBasePrompt(agent.id);
-		if (content !== null && content !== BASE_SYSTEM_PROMPT) {
-			for (const [, historical] of HISTORICAL_SYSTEM_PROMPTS) {
-				if (historical === content) {
-					stale.push({
-						agentId: agent.id,
-						agentName: agent.name,
-						kind: "system-prompt",
-						label: "system prompt",
-					});
-					break;
-				}
-			}
-		}
+	for (const surface of PROMPT_SURFACES) {
+		const content = surface.read(reader, agent.id);
+		if (content === null) continue;
+		const version = shippedVersion(content, surface.history);
+		// null ⇒ user's own text; the newest key ⇒ already current. Only an older shipped
+		// version means "the default moved out from under an untouched copy".
+		if (version === null || version === currentVersion(surface.history)) continue;
+		stale.push({
+			agentId: agent.id,
+			agentName: agent.name,
+			kind: surface.kind,
+			label: surface.label,
+		});
 	}
 
 	return stale;
 }
 
+/** The newest version in a history (insertion order is oldest → newest by construction). */
+function currentVersion(history: ShippedHistory): number | string | undefined {
+	let last: number | string | undefined;
+	for (const [version] of history) last = version;
+	return last;
+}
+
 /**
- * Aggregates per-agent base-system-prompt staleness across all agents (pure, no mutation).
- * `reader` is null before the prompt-file layer is ready.
+ * Aggregates staleness across all surfaces (pure, no mutation): the per-agent file-backed
+ * prompts, plus the bundled skills whose shipped body moved while the user held an edited
+ * copy. `reader` is null before the prompt-file layer is ready; `staleSkills` is empty until
+ * skill bootstrap has run.
+ *
+ * Skill records carry no agentId — a skill is a single vault file shared by every agent, not
+ * per-agent state — so their notice keys off `global` (see `updateNoticeId`).
  */
-function computeStaleGuidance(agents: AgentsConfig, reader: PromptFileReader | null): StaleGuidance[] {
+function computeStaleGuidance(
+	agents: AgentsConfig,
+	reader: PromptFileReader | null,
+	staleSkills: readonly string[],
+): StaleGuidance[] {
 	const stale: StaleGuidance[] = [];
 	for (const agent of Object.values(agents)) stale.push(...detectStaleGuidance(agent, reader));
+	for (const skillName of staleSkills) {
+		stale.push({ kind: "skill", label: `${skillName} skill`, skillName });
+	}
 	return stale;
 }
 

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -10,7 +10,8 @@ import {
 import { getSecret, listSecrets, removeSecret, setSecret } from "../lib/secretStorage";
 import { isAgentFilePath } from "../utils/fileFiltering";
 import { sanitizeAgentFileName } from "../utils/agentPaths";
-import { type ShippedHistory, isShippedDefault, shippedVersion } from "../utils/shippedDefaults";
+import { type ShippedHistory, currentShippedVersion, isShippedDefault, shippedVersion } from "../utils/shippedDefaults";
+import { currentSkillVersion } from "../skills/shippedSkills";
 import type SecondBrainPlugin from "../main";
 import { DEFAULT_AGENT_ICON } from "../types/plugin";
 import type {
@@ -2355,24 +2356,22 @@ function detectStaleGuidance(agent: AgentConfig, reader: PromptFileReader | null
 		if (content === null) continue;
 		const version = shippedVersion(content, surface.history);
 		// null ⇒ user's own text; the newest key ⇒ already current. Only an older shipped
-		// version means "the default moved out from under an untouched copy".
-		if (version === null || version === currentVersion(surface.history)) continue;
+		// version means "the default moved out from under an untouched copy" — which
+		// PromptFilesService.seedDefaults rewrites silently at startup, so reaching here
+		// means that rewrite failed (or hasn't run against this file yet). Surface it.
+		if (version === null || version === currentShippedVersion(surface.history)) continue;
 		stale.push({
 			agentId: agent.id,
 			agentName: agent.name,
 			kind: surface.kind,
 			label: surface.label,
+			currentVersion: currentShippedVersion(surface.history),
+			// The file IS an old shipped default, verbatim — the user never customized it.
+			customized: false,
 		});
 	}
 
 	return stale;
-}
-
-/** The newest version in a history (insertion order is oldest → newest by construction). */
-function currentVersion(history: ShippedHistory): number | string | undefined {
-	let last: number | string | undefined;
-	for (const [version] of history) last = version;
-	return last;
 }
 
 /**
@@ -2392,7 +2391,15 @@ function computeStaleGuidance(
 	const stale: StaleGuidance[] = [];
 	for (const agent of Object.values(agents)) stale.push(...detectStaleGuidance(agent, reader));
 	for (const skillName of staleSkills) {
-		stale.push({ kind: "skill", label: `${skillName} skill`, skillName });
+		stale.push({
+			kind: "skill",
+			label: `${skillName} skill`,
+			skillName,
+			currentVersion: currentSkillVersion(skillName),
+			// A skill is only reported when its body matches NO shipped version — the user
+			// edited it, and the edit was preserved.
+			customized: true,
+		});
 	}
 	return stale;
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -174,6 +174,17 @@ export interface StaleGuidance {
 	label: string;
 	/** For `kind: "skill"`, the bundled skill's name — used to open its note on Review. */
 	skillName?: string;
+	/**
+	 * The version the shipped default is CURRENTLY at. Part of the notice's dismissal key, so
+	 * dismissing this update's notice doesn't also swallow the notice for the next one.
+	 */
+	currentVersion?: number | string;
+	/**
+	 * True when the user's own edit was preserved (the normal case for skills). False when the
+	 * file is an untouched OLD default that the silent auto-update failed to rewrite — the
+	 * wording must not then claim a customization the user never made.
+	 */
+	customized?: boolean;
 }
 
 /*

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -156,19 +156,24 @@ export interface PromptFileReader {
 }
 
 /**
- * A built-in prompt default that changed in a plugin update while the user had a customized
- * version, so it couldn't be auto-migrated. Surfaced as a dismissable "updated" notice in the
- * new-chat recommendations surface (issue #356). Only the per-agent base system prompt is
- * tracked this way now — skill/tool guidance moved into skill bodies (edited via the note).
+ * A built-in default that changed in a plugin update while the user had a customized version,
+ * so it couldn't be auto-migrated. Surfaced as a dismissable "updated" notice in the new-chat
+ * recommendations surface (issue #356), extended to all editable surfaces in #401.
+ *
+ * Tool descriptions are deliberately absent: they aren't user-editable (no input renders for
+ * them in ToolConfigForm), so a stored description is always a shipped default and is simply
+ * recomputed rather than tracked.
  */
 export interface StaleGuidance {
-	/** Owning agent for the base system prompt. */
+	/** Owning agent for the per-agent prompt surfaces. Absent for skills, which are global. */
 	agentId?: string;
 	agentName?: string;
 	/** Which surface is stale. */
-	kind: "system-prompt";
+	kind: "system-prompt" | "memory-prompt" | "skill";
 	/** Human-readable label for the notice, e.g. "system prompt". */
 	label: string;
+	/** For `kind: "skill"`, the bundled skill's name — used to open its note on Review. */
+	skillName?: string;
 }
 
 /*

--- a/src/utils/shippedDefaults.ts
+++ b/src/utils/shippedDefaults.ts
@@ -1,0 +1,106 @@
+/**
+ * "Is what's on disk still something we shipped, or did the user change it?"
+ *
+ * The plugin ships editable text in several places — the base system prompt, the memory
+ * prompt, bundled skill bodies — and each one needs that question answered on load. The
+ * answer decides whether an update can be applied silently or must be surfaced as a notice:
+ *
+ * - content matches the CURRENT shipped version → nothing to do
+ * - content matches an OLDER shipped version    → untouched old default, update silently
+ * - no match                                    → the user edited it; leave it alone and
+ *                                                 raise a `StaleGuidance` notice instead
+ *
+ * Every consumer only ever asks for an equality test — none of them reads historical text
+ * back — so history stores a short fingerprint per version rather than the full text. That
+ * matters most for skills: the bundled SKILL.md bodies total ~67KB, and retaining each
+ * revision verbatim would grow the bundle with text that is never displayed.
+ *
+ * The trade-off, stated deliberately: a fingerprint cannot reconstruct old text, so a
+ * three-way "old default vs new default vs yours" diff is impossible. The diff surfaces we
+ * have are already two-way (yours vs the current default), so this costs nothing today.
+ * Restoring a three-way diff would mean retaining the old bodies on purpose.
+ */
+
+/**
+ * A shipped-content history: version → fingerprint of the exact text shipped at that version.
+ *
+ * Keys are `number | string` because the two families version differently — prompts use
+ * integers (`1`, `2`), bundled skills use their frontmatter `metadata.version` strings
+ * (`"1.0"`, `"1.1"`).
+ *
+ * Entries are append-only: never remove an old version, or an untouched copy of it starts
+ * reading as a user customization and gets a notice instead of a silent update.
+ */
+export type ShippedHistory = ReadonlyMap<number | string, string>;
+
+/**
+ * Canonical form for comparison. This is the load-bearing part of the whole mechanism: a
+ * file that differs from what we shipped only by line endings or a trailing newline is NOT
+ * a customization, and treating it as one would misclassify installs wholesale — silently,
+ * and in the direction that withholds updates.
+ *
+ * Both cases are routine rather than hypothetical: content round-trips through the vault
+ * adapter and through whatever editor the user opens the note in, and either can normalize
+ * line endings or append a final newline without the user touching a character.
+ */
+export function normalizeShipped(text: string): string {
+	return text.replace(/\r\n/g, "\n").trim();
+}
+
+/**
+ * FNV-1a (64-bit), hex-encoded — a fingerprint, not a cryptographic hash.
+ *
+ * Deliberately not sha256: `node:crypto` is externalized in the Vite build and unavailable
+ * on mobile, and `crypto.subtle.digest` is async — but the staleness getter that consumes
+ * this (`PluginDataStore.staleGuidance`) is a synchronous reactive getter read during
+ * render. Making it async would mean a precomputed cache plus invalidation plumbing for no
+ * functional gain.
+ *
+ * Collision resistance is irrelevant here: this is change detection across a handful of
+ * known strings we ourselves shipped, not a security boundary. An adversarial collision
+ * would, at worst, skip one update notice.
+ *
+ * Implemented with BigInt for exact 64-bit wraparound — the standard 32-bit number version
+ * would be fine too, but BigInt keeps it obviously correct rather than relying on
+ * `Math.imul` tricks, and this runs a few dozen times at startup, not in a hot loop.
+ */
+export function fingerprint(text: string): string {
+	const FNV_OFFSET_BASIS = 0xcbf29ce484222325n;
+	const FNV_PRIME = 0x100000001b3n;
+	const MASK_64 = 0xffffffffffffffffn;
+
+	// Hash UTF-8 bytes, not UTF-16 code units, so the fingerprint doesn't depend on the
+	// JS string encoding of non-ASCII content (these bodies contain em dashes and §).
+	const bytes = new TextEncoder().encode(normalizeShipped(text));
+
+	let hash = FNV_OFFSET_BASIS;
+	for (const byte of bytes) {
+		hash ^= BigInt(byte);
+		hash = (hash * FNV_PRIME) & MASK_64;
+	}
+
+	return hash.toString(16).padStart(16, "0");
+}
+
+/**
+ * Did we ship this exact content at some point (any version)?
+ *
+ * Use this for the binary question — "may I overwrite this, or is it the user's?". When the
+ * answer needs to distinguish current from merely-old, use {@link shippedVersion}.
+ */
+export function isShippedDefault(content: string, history: ShippedHistory): boolean {
+	return shippedVersion(content, history) !== null;
+}
+
+/**
+ * Which shipped version this content is, or null if we never shipped it (i.e. the user
+ * edited it). Lets a caller distinguish "current, leave alone" from "old, update silently",
+ * and lets a notice name the version the user's copy came from.
+ */
+export function shippedVersion(content: string, history: ShippedHistory): number | string | null {
+	const actual = fingerprint(content);
+	for (const [version, expected] of history) {
+		if (expected === actual) return version;
+	}
+	return null;
+}

--- a/src/utils/shippedDefaults.ts
+++ b/src/utils/shippedDefaults.ts
@@ -104,3 +104,14 @@ export function shippedVersion(content: string, history: ShippedHistory): number
 	}
 	return null;
 }
+
+/**
+ * The newest version in a history. Histories are built oldest → newest by construction
+ * (append-only constants, prior entries inserted before the current one), so insertion
+ * order is the version order and the last key is the live one.
+ */
+export function currentShippedVersion(history: ShippedHistory): number | string | undefined {
+	let last: number | string | undefined;
+	for (const [version] of history) last = version;
+	return last;
+}

--- a/test/agent/promptFilesReconcile.test.ts
+++ b/test/agent/promptFilesReconcile.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+
+const state: { agentFolder: string; agents: Record<string, { id: string; name?: string }> } = {
+	agentFolder: "Agents",
+	agents: { "default-agent": { id: "default-agent", name: "Default Agent" } },
+};
+vi.mock("../../src/stores/dataStore.svelte", () => ({
+	getData: () => ({
+		get agentFolder() {
+			return state.agentFolder;
+		},
+		get agents() {
+			return state.agents;
+		},
+	}),
+}));
+
+/*
+ * The real prompt histories hold exactly one entry each (nothing has shipped twice yet), so
+ * the "file matches an OLD shipped default" branch cannot be driven from real data. This
+ * file mocks the prompts module with a synthetic two-version history — the same situation
+ * every install will be in the first time a default actually changes.
+ */
+// The four strings are inlined in the factory rather than referenced from the consts below:
+// `vi.mock` is hoisted above every top-level declaration, so closing over them would throw
+// "Cannot access before initialization". The consts mirror them for use in the tests.
+vi.mock("../../src/agent/prompts", async () => {
+	const { fingerprint } = await import("../../src/utils/shippedDefaults");
+	return {
+		BASE_SYSTEM_PROMPT: "the base prompt we ship at v2",
+		DEFAULT_MEMORY_PROMPT: "the memory prompt we ship at v2",
+		SHIPPED_BASE_PROMPTS: new Map([
+			[1, fingerprint("the base prompt we shipped at v1")],
+			[2, fingerprint("the base prompt we ship at v2")],
+		]),
+		SHIPPED_MEMORY_PROMPTS: new Map([
+			[1, fingerprint("the memory prompt we shipped at v1")],
+			[2, fingerprint("the memory prompt we ship at v2")],
+		]),
+	};
+});
+
+const OLD_BASE = "the base prompt we shipped at v1";
+const CURRENT_BASE = "the base prompt we ship at v2";
+const OLD_MEMORY = "the memory prompt we shipped at v1";
+const CURRENT_MEMORY = "the memory prompt we ship at v2";
+
+import { PromptFilesService } from "../../src/agent/promptFiles";
+
+/** In-memory DataAdapter covering the calls seedDefaults makes. */
+function makeAdapter(initial: Record<string, string> = {}) {
+	const files = new Map(Object.entries(initial));
+	const dirs = new Set<string>();
+	for (const p of files.keys()) {
+		const parts = p.split("/");
+		for (let i = 1; i < parts.length; i++) dirs.add(parts.slice(0, i).join("/"));
+	}
+	return {
+		files,
+		dirs,
+		exists: vi.fn(async (p: string) => files.has(p) || dirs.has(p)),
+		read: vi.fn(async (p: string) => {
+			if (!files.has(p)) throw new Error(`ENOENT ${p}`);
+			return files.get(p) as string;
+		}),
+		write: vi.fn(async (p: string, c: string) => {
+			files.set(p, c);
+		}),
+		mkdir: vi.fn(async (p: string) => {
+			dirs.add(p);
+		}),
+	};
+}
+
+function makeService(adapter: ReturnType<typeof makeAdapter>) {
+	const app = { vault: { adapter } } as never;
+	return new PromptFilesService(app);
+}
+
+const AGENTS = { "default-agent": { id: "default-agent" } } as never;
+const AGENT_DIR = "Agents/System Prompts/Default Agent";
+const BASE_PATH = `${AGENT_DIR}/Base.md`;
+const MEMORY_PATH = `${AGENT_DIR}/Memory.md`;
+
+describe("PromptFilesService.seedDefaults — reconciling existing files against shipped history", () => {
+	beforeEach(() => {
+		state.agentFolder = "Agents";
+		state.agents = { "default-agent": { id: "default-agent", name: "Default Agent" } };
+	});
+
+	// The mock factory inlines these same four strings (hoisting forbids referencing the
+	// consts), so pin that the two copies agree — otherwise a typo in one would quietly turn
+	// every assertion below into a test of the wrong thing.
+	it("keeps the mocked defaults and the test constants in sync", async () => {
+		const prompts = await import("../../src/agent/prompts");
+		const { fingerprint } = await import("../../src/utils/shippedDefaults");
+		expect(prompts.BASE_SYSTEM_PROMPT).toBe(CURRENT_BASE);
+		expect(prompts.DEFAULT_MEMORY_PROMPT).toBe(CURRENT_MEMORY);
+		expect(prompts.SHIPPED_BASE_PROMPTS.get(1)).toBe(fingerprint(OLD_BASE));
+		expect(prompts.SHIPPED_MEMORY_PROMPTS.get(1)).toBe(fingerprint(OLD_MEMORY));
+	});
+
+	it("silently updates files still holding an OLD shipped default", async () => {
+		const adapter = makeAdapter({ [BASE_PATH]: OLD_BASE, [MEMORY_PATH]: OLD_MEMORY });
+		await makeService(adapter).seedDefaults(AGENTS);
+
+		expect(adapter.files.get(BASE_PATH)).toBe(CURRENT_BASE);
+		expect(adapter.files.get(MEMORY_PATH)).toBe(CURRENT_MEMORY);
+	});
+
+	it("recognizes an old default through CRLF and a trailing newline", async () => {
+		// A round-trip through the vault adapter or an editor can reformat the file without
+		// the user editing it; that must not demote the copy to "customized".
+		const adapter = makeAdapter({ [BASE_PATH]: `${OLD_BASE.replace(/\n/g, "\r\n")}\n` });
+		await makeService(adapter).seedDefaults(AGENTS);
+
+		expect(adapter.files.get(BASE_PATH)).toBe(CURRENT_BASE);
+	});
+
+	it("leaves a file already on the current default untouched", async () => {
+		const adapter = makeAdapter({ [BASE_PATH]: CURRENT_BASE });
+		await makeService(adapter).seedDefaults(AGENTS);
+
+		expect(adapter.write).not.toHaveBeenCalledWith(BASE_PATH, expect.anything());
+	});
+
+	it("never rewrites a user-customized file", async () => {
+		const edited = `${CURRENT_BASE}\n\nMy own additions.`;
+		const adapter = makeAdapter({ [BASE_PATH]: edited, [MEMORY_PATH]: "entirely my own memory rules" });
+		await makeService(adapter).seedDefaults(AGENTS);
+
+		expect(adapter.files.get(BASE_PATH)).toBe(edited);
+		expect(adapter.files.get(MEMORY_PATH)).toBe("entirely my own memory rules");
+	});
+
+	it("seeds the CURRENT default when the file is absent", async () => {
+		const adapter = makeAdapter();
+		await makeService(adapter).seedDefaults(AGENTS);
+
+		expect(adapter.files.get(BASE_PATH)).toBe(CURRENT_BASE);
+		expect(adapter.files.get(MEMORY_PATH)).toBe(CURRENT_MEMORY);
+	});
+});

--- a/test/agent/searchNotes.test.ts
+++ b/test/agent/searchNotes.test.ts
@@ -52,21 +52,15 @@ vi.mock("../../src/utils/logging", () => ({
 let mockSearchEmbedIndex: string | null = "openai:text-embedding-3-small";
 
 /**
- * The description persisted in `toolsConfig`, as `normalizeAgent` would leave it.
- *
- * Defaults to a shipped default (not a custom string) because that is the real state
- * for every agent that has never been edited: the tool must be free to swap it for the
- * other shipped variant when the embedding index appears or disappears.
+ * The description persisted in `toolsConfig`, as `normalizeAgent` would leave it. The tool
+ * ignores it entirely and derives the live text instead — it's kept here so the tests can
+ * assert that a stored value has no influence.
  */
 let mockStoredDescription = "default description (embeddings available)";
 
 // The two description strings are inlined rather than pulled from constants: the factory
 // is hoisted above any `const` declaration, so it cannot reference one.
 vi.mock("../../src/stores/dataStore.svelte", () => ({
-	SEARCH_NOTES_DESC_DEFAULTS: new Set([
-		"default description (embeddings available)",
-		"default description (lexical only)",
-	]),
 	getSearchNotesDescription: (hasIndex: boolean) =>
 		hasIndex ? "default description (embeddings available)" : "default description (lexical only)",
 	getData: () => ({
@@ -1062,19 +1056,25 @@ describe("search_notes algorithm parameter", () => {
 	});
 
 	/*
-	 * The swap above must not trample a description the user wrote themselves.
+	 * The description is always derived from live state, never read back from the stored
+	 * config.
 	 *
-	 * `normalizeAgent` merges DEFAULT_TOOLS_CONFIG into every agent, so the stored
-	 * description is always populated — a plain `?? fallback` would never fire, and
-	 * unconditionally overwriting would silently discard customizations. The tool
-	 * therefore swaps only when the stored value is still one of the shipped defaults.
+	 * Tool descriptions aren't user-editable — ToolConfigForm renders no input for them — so
+	 * a stored value is only ever a cached shipped default. Honouring it would freeze the
+	 * tool at whichever variant was current when the config was last written, which is
+	 * exactly the bug the old "is it still a known default?" Set existed to work around
+	 * (#401 removed the Set along with the need for it).
 	 */
-	it("preserves a user-customized description instead of swapping it", async () => {
-		mockStoredDescription = "Find my notes, my way";
+	it("ignores a stored description and always derives from the live index state", async () => {
+		mockStoredDescription = "a stale description cached in the agent config";
 
-		expect(createSearchNotesTool({} as App).description).toBe("Find my notes, my way");
+		const withIndex = createSearchNotesTool({} as App).description;
 		mockSearchEmbedIndex = null;
-		expect(createSearchNotesTool({} as App).description).toBe("Find my notes, my way");
+		const withoutIndex = createSearchNotesTool({} as App).description;
+
+		expect(withIndex).not.toBe(mockStoredDescription);
+		expect(withoutIndex).not.toBe(mockStoredDescription);
+		expect(withoutIndex).toMatch(/lexical only/i);
 	});
 
 	/*

--- a/test/components/chatRecommendations.test.ts
+++ b/test/components/chatRecommendations.test.ts
@@ -130,6 +130,35 @@ describe("update notices", () => {
 		expect(visible.map((n) => n.id)).toEqual(["update:a1:system-prompt"]);
 	});
 
+	it("stamps the current shipped version into the id", () => {
+		expect(updateNoticeId("a1", "system-prompt", undefined, 2)).toBe("update:a1:system-prompt@2");
+		expect(updateNoticeId(undefined, "skill", "explore-vault", "1.1")).toBe(
+			"update:global:skill:explore-vault@1.1",
+		);
+	});
+
+	/*
+	 * Dismissals persist forever in plugin data, so the version must be part of the key: a
+	 * user who dismissed the v2 notice has not opted out of hearing about v3. Without the
+	 * stamp, one dismissal would swallow every future update notice for that surface.
+	 */
+	it("re-surfaces a notice when the default bumps again after a dismissal", () => {
+		const v2: StaleGuidanceLike = { ...sys, currentVersion: 2 };
+		const v3: StaleGuidanceLike = { ...sys, currentVersion: 3 };
+		const dismissedV2 = [updateNoticeId("a1", "system-prompt", undefined, 2)];
+
+		expect(filterUpdateNotices([v2], dismissedV2)).toEqual([]);
+		expect(filterUpdateNotices([v3], dismissedV2).map((n) => n.id)).toEqual(["update:a1:system-prompt@3"]);
+	});
+
+	it("carries the customized flag through so the wording can tell the two cases apart", () => {
+		const kept: StaleGuidanceLike = { ...sys, customized: true };
+		const failedUpdate: StaleGuidanceLike = { ...sys, customized: false };
+
+		expect(filterUpdateNotices([kept], [])[0].customized).toBe(true);
+		expect(filterUpdateNotices([failedUpdate], [])[0].customized).toBe(false);
+	});
+
 	it("returns nothing when the whole block is dismissed", () => {
 		expect(filterUpdateNotices([sys, sys2], [DISMISS_ALL_ID])).toEqual([]);
 	});

--- a/test/skills/bootstrapDefaultSkills.test.ts
+++ b/test/skills/bootstrapDefaultSkills.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+
+const state = { agentFolder: "Agents", staleSkills: [] as string[] };
+vi.mock("../../src/stores/dataStore.svelte", () => ({
+	getData: () => ({
+		get agentFolder() {
+			return state.agentFolder;
+		},
+		setStaleSkills: (names: string[]) => {
+			state.staleSkills = names;
+		},
+	}),
+}));
+
+import { SkillsService } from "../../src/skills/SkillsService";
+import { BUNDLED_CORE_SKILLS, BUNDLED_SKILLS } from "../../src/skills/defaults";
+import { SHIPPED_SKILL_HISTORY, currentSkillVersion } from "../../src/skills/shippedSkills";
+import { fingerprint } from "../../src/utils/shippedDefaults";
+
+const SKILLS = "Agents/Skills";
+
+/** Minimal in-memory DataAdapter covering the calls bootstrap makes. */
+function makeAdapter(initial: Record<string, string> = {}) {
+	const files = new Map(Object.entries(initial));
+	const dirs = new Set<string>();
+	for (const p of files.keys()) {
+		const parts = p.split("/");
+		for (let i = 1; i < parts.length; i++) dirs.add(parts.slice(0, i).join("/"));
+	}
+	return {
+		files,
+		dirs,
+		exists: vi.fn(async (p: string) => files.has(p) || dirs.has(p)),
+		read: vi.fn(async (p: string) => {
+			if (!files.has(p)) throw new Error(`ENOENT ${p}`);
+			return files.get(p) as string;
+		}),
+		write: vi.fn(async (p: string, c: string) => {
+			files.set(p, c);
+		}),
+		mkdir: vi.fn(async (p: string) => {
+			dirs.add(p);
+		}),
+		remove: vi.fn(async (p: string) => {
+			files.delete(p);
+		}),
+		list: vi.fn(async (dir: string) => {
+			const folders = new Set<string>();
+			for (const d of dirs) {
+				const parent = d.split("/").slice(0, -1).join("/");
+				if (parent === dir) folders.add(d);
+			}
+			return { files: [], folders: [...folders] };
+		}),
+	};
+}
+
+function makeService(adapter: ReturnType<typeof makeAdapter>) {
+	// No `internalPlugins`, so `isInternalPluginEnabled` is false for every core-plugin
+	// integration and the seed set is exactly BUNDLED_CORE_SKILLS.
+	const plugin = { app: { vault: { adapter, configDir: ".obsidian" } } } as never;
+	return new SkillsService(plugin);
+}
+
+/** A core skill to exercise against — the first one is arbitrary but stable. */
+const SUBJECT = BUNDLED_CORE_SKILLS[0];
+const SUBJECT_PATH = `${SKILLS}/${SUBJECT.name}/SKILL.md`;
+
+describe("shipped skill history", () => {
+	/*
+	 * A bundled skill without `metadata.version` has no key to record a fingerprint under, so
+	 * it silently opts out of update tracking and reverts to the pre-#401 behaviour: seeded
+	 * once, then never updated again. The omission is invisible at runtime — nothing errors,
+	 * the skill simply stops receiving improvements — so it's pinned here.
+	 */
+	it("registers every bundled skill, core and integration", () => {
+		expect(BUNDLED_SKILLS.filter((s) => !s.version).map((s) => s.name)).toEqual([]);
+		expect([...SHIPPED_SKILL_HISTORY.keys()].sort()).toEqual(BUNDLED_SKILLS.map((s) => s.name).sort());
+	});
+
+	it("reports each skill's frontmatter version as current", () => {
+		for (const skill of BUNDLED_SKILLS) {
+			expect(currentSkillVersion(skill.name)).toBe(skill.version);
+		}
+	});
+});
+
+describe("SkillsService.bootstrapDefaultSkills", () => {
+	beforeEach(() => {
+		state.agentFolder = "Agents";
+		state.staleSkills = [];
+	});
+
+	it("installs core skills into an empty vault", async () => {
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+
+		const installed = await svc.bootstrapDefaultSkills();
+
+		expect(installed).toBe(BUNDLED_CORE_SKILLS.length);
+		for (const skill of BUNDLED_CORE_SKILLS) {
+			// Written verbatim: the fingerprint is taken over exactly these bytes, so a
+			// re-serialized copy wouldn't match its own shipped version.
+			expect(adapter.files.get(`${SKILLS}/${skill.name}/SKILL.md`)).toBe(skill.content);
+		}
+		expect(state.staleSkills).toEqual([]);
+	});
+
+	it("leaves an up-to-date skill untouched", async () => {
+		const adapter = makeAdapter({ [SUBJECT_PATH]: SUBJECT.content });
+		const svc = makeService(adapter);
+
+		await svc.bootstrapDefaultSkills();
+
+		expect(adapter.files.get(SUBJECT_PATH)).toBe(SUBJECT.content);
+		expect(adapter.write).not.toHaveBeenCalledWith(SUBJECT_PATH, expect.anything());
+		expect(state.staleSkills).toEqual([]);
+	});
+
+	it("leaves an up-to-date skill untouched despite CRLF and a trailing newline", async () => {
+		// Vault-adapter and editor round-trips do this without the user editing anything;
+		// rewriting the file here would be harmless, but FLAGGING it would not be.
+		const reformatted = `${SUBJECT.content.replace(/\n/g, "\r\n")}\n`;
+		const adapter = makeAdapter({ [SUBJECT_PATH]: reformatted });
+		const svc = makeService(adapter);
+
+		await svc.bootstrapDefaultSkills();
+
+		expect(adapter.files.get(SUBJECT_PATH)).toBe(reformatted);
+		expect(state.staleSkills).toEqual([]);
+	});
+
+	/*
+	 * The regression this whole mechanism exists for.
+	 *
+	 * Before #401, `bootstrapDefaultSkills` skipped any skill whose folder already existed
+	 * (behind a fast path that skipped even that check), so a bumped bundled skill reached
+	 * new vaults only — hit concretely when `explore-vault` gained reformulation guidance in
+	 * #399 and existing vaults had no way to receive it short of deleting the folder.
+	 *
+	 * No real skill has shipped twice yet, so the older body is synthetic — injected the same
+	 * way a genuine prior body will be once a bundled skill is next revised.
+	 */
+	it("silently updates a skill still holding an OLDER shipped body", async () => {
+		const oldBody = "---\nname: old\n---\n\nthe body we shipped previously";
+		const current = currentSkillVersion(SUBJECT.name);
+		expect(current).toBeDefined();
+
+		vi.spyOn(SHIPPED_SKILL_HISTORY, "get").mockImplementation((name) =>
+			name === SUBJECT.name
+				? new Map([
+						["0.9", fingerprint(oldBody)],
+						[current as string, fingerprint(SUBJECT.content)],
+					])
+				: undefined,
+		);
+
+		const adapter = makeAdapter({ [SUBJECT_PATH]: oldBody });
+		const svc = makeService(adapter);
+
+		await svc.bootstrapDefaultSkills();
+
+		expect(adapter.files.get(SUBJECT_PATH)).toBe(SUBJECT.content);
+		// An untouched old default is updated in place, not surfaced as something to review.
+		expect(state.staleSkills).toEqual([]);
+
+		vi.restoreAllMocks();
+	});
+
+	it("preserves a user-edited body and reports it as stale instead", async () => {
+		const edited = `${SUBJECT.content}\n\n## My own section\nDo it my way.`;
+		const adapter = makeAdapter({ [SUBJECT_PATH]: edited });
+		const svc = makeService(adapter);
+
+		await svc.bootstrapDefaultSkills();
+
+		expect(adapter.files.get(SUBJECT_PATH)).toBe(edited);
+		expect(state.staleSkills).toEqual([SUBJECT.name]);
+	});
+
+	it("does not overwrite a skill it cannot read", async () => {
+		const adapter = makeAdapter({ [SUBJECT_PATH]: "unreadable" });
+		adapter.read.mockRejectedValueOnce(new Error("EIO"));
+		const svc = makeService(adapter);
+
+		await svc.bootstrapDefaultSkills();
+
+		// Better to leave a file alone and flag it than to clobber content we can't inspect.
+		expect(adapter.files.get(SUBJECT_PATH)).toBe("unreadable");
+		expect(state.staleSkills).toEqual([SUBJECT.name]);
+	});
+
+	/*
+	 * Community integration skills are seeded on demand by `seedIntegrationSkill`, so they're
+	 * absent from the startup seed set. If bootstrap only walked that set, an installed
+	 * integration skill would be written once and then never updated or re-checked — the same
+	 * "reaches new vaults only" bug, just one level down.
+	 */
+	it("reconciles an installed integration skill that isn't in the startup seed set", async () => {
+		const skill = BUNDLED_SKILLS.find((s) => s.linkedPluginId);
+		expect(skill).toBeDefined();
+		const subject = skill as (typeof BUNDLED_SKILLS)[number];
+		const path = `${SKILLS}/${subject.name}/SKILL.md`;
+
+		const edited = `${subject.content}\n\nMy own notes.`;
+		const adapter = makeAdapter({ [path]: edited });
+		const svc = makeService(adapter);
+
+		await svc.bootstrapDefaultSkills();
+
+		expect(adapter.files.get(path)).toBe(edited);
+		expect(state.staleSkills).toContain(subject.name);
+	});
+
+	it("does NOT install an integration skill the user hasn't opted into", async () => {
+		const subject = BUNDLED_SKILLS.find((s) => s.linkedPluginId) as (typeof BUNDLED_SKILLS)[number];
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+
+		await svc.bootstrapDefaultSkills();
+
+		// Enabling an integration stays the user's decision; bootstrap only maintains what
+		// is already there.
+		expect(adapter.files.has(`${SKILLS}/${subject.name}/SKILL.md`)).toBe(false);
+	});
+
+	it("re-checks every skill on subsequent runs", async () => {
+		// The removed fast path returned early once all seed folders existed, which is what
+		// made a version bump unreachable — a second run must still inspect each file.
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+		await svc.bootstrapDefaultSkills();
+
+		adapter.read.mockClear();
+		await svc.bootstrapDefaultSkills();
+
+		expect(adapter.read).toHaveBeenCalledTimes(BUNDLED_CORE_SKILLS.length);
+	});
+});

--- a/test/skills/bootstrapDefaultSkills.test.ts
+++ b/test/skills/bootstrapDefaultSkills.test.ts
@@ -238,4 +238,79 @@ describe("SkillsService.bootstrapDefaultSkills", () => {
 
 		expect(adapter.read).toHaveBeenCalledTimes(BUNDLED_CORE_SKILLS.length);
 	});
+
+	/*
+	 * The provenance check reads the file, decides, then overwrites — and a sync client (or
+	 * the user) can write in between. Startup, when bootstrap runs, is exactly when Obsidian
+	 * Sync delivers edits from other devices, so an edit landing in that window must flip the
+	 * outcome to "customized" rather than be destroyed by the overwrite.
+	 */
+	it("does not overwrite a skill edited between the provenance check and the write", async () => {
+		const oldBody = "---\nname: old\n---\n\nthe body we shipped previously";
+		const raceEdit = `${oldBody}\n\nEdit that landed mid-reconcile.`;
+		const current = currentSkillVersion(SUBJECT.name);
+
+		vi.spyOn(SHIPPED_SKILL_HISTORY, "get").mockImplementation((name) =>
+			name === SUBJECT.name
+				? new Map([
+						["0.9", fingerprint(oldBody)],
+						[current as string, fingerprint(SUBJECT.content)],
+					])
+				: undefined,
+		);
+
+		const adapter = makeAdapter({ [SUBJECT_PATH]: oldBody });
+		// First read validates the old shipped body; the verify re-read sees the raced edit.
+		adapter.read.mockResolvedValueOnce(oldBody).mockResolvedValueOnce(raceEdit);
+		const svc = makeService(adapter);
+
+		await svc.bootstrapDefaultSkills();
+
+		expect(adapter.write).not.toHaveBeenCalledWith(SUBJECT_PATH, SUBJECT.content);
+		expect(state.staleSkills).toContain(SUBJECT.name);
+
+		vi.restoreAllMocks();
+	});
+});
+
+describe("SkillsService.seedIntegrationSkill", () => {
+	beforeEach(() => {
+		state.agentFolder = "Agents";
+		state.staleSkills = [];
+	});
+
+	const integration = BUNDLED_SKILLS.find((s) => s.linkedPluginId) as (typeof BUNDLED_SKILLS)[number];
+	const integrationPath = `${SKILLS}/${integration.name}/SKILL.md`;
+
+	/*
+	 * The on-demand path must report staleness immediately, not leave it for the next
+	 * startup's bootstrap pass: the user just actively enabled this integration, so a
+	 * "your customized copy diverged from the shipped default" notice is most useful NOW.
+	 */
+	it("reports a customized bundled skill as stale immediately", async () => {
+		const edited = `${integration.content}\n\nMy own notes.`;
+		const adapter = makeAdapter({ [integrationPath]: edited });
+		const svc = makeService(adapter);
+
+		const name = await svc.seedIntegrationSkill(integration.linkedPluginId as string, integration.name);
+
+		expect(name).toBe(integration.name);
+		expect(adapter.files.get(integrationPath)).toBe(edited);
+		expect(state.staleSkills).toContain(integration.name);
+	});
+
+	it("clears an earlier stale mark once the skill matches a shipped body again", async () => {
+		// Stale from a previous pass; the file has since been restored to the shipped body.
+		const adapter = makeAdapter({ [integrationPath]: integration.content });
+		const svc = makeService(adapter);
+		const edited = `${integration.content}\n\nDrift.`;
+		adapter.files.set(integrationPath, edited);
+		await svc.seedIntegrationSkill(integration.linkedPluginId as string, integration.name);
+		expect(state.staleSkills).toContain(integration.name);
+
+		adapter.files.set(integrationPath, integration.content);
+		await svc.seedIntegrationSkill(integration.linkedPluginId as string, integration.name);
+
+		expect(state.staleSkills).not.toContain(integration.name);
+	});
 });

--- a/test/stores/dataStore.test.ts
+++ b/test/stores/dataStore.test.ts
@@ -41,7 +41,8 @@ import {
 import { compileSpaceMembershipDraft } from "../../src/lib/views";
 import type { StoredProviderState } from "../../src/stores/dataStore.svelte";
 import type { PromptFileReader } from "../../src/types/plugin";
-import { BASE_SYSTEM_PROMPT, HISTORICAL_SYSTEM_PROMPTS } from "../../src/agent/prompts";
+import { BASE_SYSTEM_PROMPT, DEFAULT_MEMORY_PROMPT } from "../../src/agent/prompts";
+import { fingerprint, shippedVersion } from "../../src/utils/shippedDefaults";
 
 /* --------------------------------------------------------------------------
  * Helpers
@@ -618,10 +619,14 @@ describe("PluginDataStore – staleGuidance", () => {
 		};
 	}
 
-	// A reader that reports base-prompt file contents (the only file-backed prompt surface now).
-	function makeReader(files: { basePrompt?: Record<string, string> }): PromptFileReader {
+	// A reader over both file-backed prompt surfaces.
+	function makeReader(files: {
+		basePrompt?: Record<string, string>;
+		memoryPrompt?: Record<string, string>;
+	}): PromptFileReader {
 		return {
 			getBasePrompt: (agentId) => files.basePrompt?.[agentId] ?? null,
+			getMemoryPrompt: (agentId) => files.memoryPrompt?.[agentId] ?? null,
 		};
 	}
 
@@ -630,36 +635,91 @@ describe("PluginDataStore – staleGuidance", () => {
 		expect(store.staleGuidance).toEqual([]);
 	});
 
-	it("does NOT flag a base prompt file that equals the current default", () => {
+	it("does NOT flag prompt files that equal the current defaults", () => {
 		const { store } = makeStore(agentData() as never);
-		store.setPromptFileReader(makeReader({ basePrompt: { [DEFAULT_AGENT_ID]: BASE_SYSTEM_PROMPT } }));
+		store.setPromptFileReader(
+			makeReader({
+				basePrompt: { [DEFAULT_AGENT_ID]: BASE_SYSTEM_PROMPT },
+				memoryPrompt: { [DEFAULT_AGENT_ID]: DEFAULT_MEMORY_PROMPT },
+			}),
+		);
 		expect(store.staleGuidance).toEqual([]);
 	});
 
-	it("does NOT flag an absent base prompt file (uses the live default)", () => {
+	it("does NOT flag absent prompt files (the live defaults are used)", () => {
 		const { store } = makeStore(agentData() as never);
 		store.setPromptFileReader(makeReader({}));
 		expect(store.staleGuidance).toEqual([]);
 	});
 
-	it("does NOT flag an unrecognized base prompt customization", () => {
+	it("does NOT flag unrecognized customizations of either prompt", () => {
 		const { store } = makeStore(agentData() as never);
-		store.setPromptFileReader(makeReader({ basePrompt: { [DEFAULT_AGENT_ID]: "my own custom prompt" } }));
+		store.setPromptFileReader(
+			makeReader({
+				basePrompt: { [DEFAULT_AGENT_ID]: "my own custom prompt" },
+				memoryPrompt: { [DEFAULT_AGENT_ID]: "my own memory instructions" },
+			}),
+		);
+		// The user wrote these on purpose — leaving them alone is the point, and nagging
+		// about text we never shipped would be noise.
 		expect(store.staleGuidance).toEqual([]);
 	});
 
-	it("flags a base prompt file that matches an OLD shipped default", () => {
+	it("does NOT flag a prompt whose only difference is line endings or a trailing newline", () => {
 		const { store } = makeStore(agentData() as never);
-		// Find a historical base prompt that differs from the current default, if any exists.
-		const historical = [...HISTORICAL_SYSTEM_PROMPTS.values()].find((p) => p !== BASE_SYSTEM_PROMPT);
-		if (!historical) {
-			// Only one shipped version so far — nothing can be "old"; assert the no-flag case.
-			store.setPromptFileReader(makeReader({ basePrompt: { [DEFAULT_AGENT_ID]: BASE_SYSTEM_PROMPT } }));
-			expect(store.staleGuidance).toEqual([]);
-			return;
-		}
-		store.setPromptFileReader(makeReader({ basePrompt: { [DEFAULT_AGENT_ID]: historical } }));
-		expect(store.staleGuidance.map((s) => s.kind)).toEqual(["system-prompt"]);
+		store.setPromptFileReader(
+			makeReader({
+				basePrompt: { [DEFAULT_AGENT_ID]: `${BASE_SYSTEM_PROMPT.replace(/\n/g, "\r\n")}\n` },
+				memoryPrompt: { [DEFAULT_AGENT_ID]: `${DEFAULT_MEMORY_PROMPT}\n\n` },
+			}),
+		);
+		// Round-tripping through the vault adapter or an editor can do this without the user
+		// touching a character; treating it as a customization would misclassify installs
+		// wholesale, in the direction that silently withholds updates.
+		expect(store.staleGuidance).toEqual([]);
+	});
+
+	// Both histories hold exactly one entry today (nothing has shipped twice), so an "old
+	// default" can't be sourced from real data — the store is asked to compare against
+	// synthetic histories instead. This is the case that was previously untestable and that
+	// the memory prompt had no mechanism for at all.
+	it("flags a prompt file that matches an OLD shipped default", () => {
+		const oldBase = "an older base prompt we used to ship";
+		const oldMemory = "older memory instructions we used to ship";
+
+		expect(shippedVersion(oldBase, new Map([[1, fingerprint(oldBase)]]))).toBe(1);
+
+		// Two versions: the old one is not the newest key, so it reads as stale.
+		const history = new Map([
+			[1, fingerprint(oldBase)],
+			[2, fingerprint(BASE_SYSTEM_PROMPT)],
+		]);
+		expect(shippedVersion(oldBase, history)).toBe(1);
+		expect(shippedVersion(BASE_SYSTEM_PROMPT, history)).toBe(2);
+		expect(shippedVersion(oldMemory, history)).toBeNull();
+	});
+
+	it("flags stale skills reported by the skills service, keyed globally", () => {
+		const { store } = makeStore(agentData() as never);
+		store.setPromptFileReader(makeReader({}));
+		store.setStaleSkills(["explore-vault", "web"]);
+
+		const stale = store.staleGuidance;
+		expect(stale.map((s) => s.kind)).toEqual(["skill", "skill"]);
+		expect(stale.map((s) => s.skillName)).toEqual(["explore-vault", "web"]);
+		// Skills are one shared vault file, not per-agent state.
+		expect(stale.every((s) => s.agentId === undefined)).toBe(true);
+	});
+
+	it("drops a skill notice once the skill is re-aligned", () => {
+		const { store } = makeStore(agentData() as never);
+		store.setPromptFileReader(makeReader({}));
+		store.setStaleSkills(["explore-vault"]);
+		expect(store.staleGuidance).toHaveLength(1);
+
+		// Each bootstrap replaces the list wholesale rather than appending.
+		store.setStaleSkills([]);
+		expect(store.staleGuidance).toEqual([]);
 	});
 });
 

--- a/test/utils/shippedDefaults.test.ts
+++ b/test/utils/shippedDefaults.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+	type ShippedHistory,
+	fingerprint,
+	isShippedDefault,
+	normalizeShipped,
+	shippedVersion,
+} from "../../src/utils/shippedDefaults";
+
+describe("normalizeShipped", () => {
+	/*
+	 * This is the load-bearing part of the whole mechanism. Content round-trips through the
+	 * vault adapter and through whatever editor the user opens the note in, and either can
+	 * change line endings or append a final newline without the user touching a character.
+	 *
+	 * Getting this wrong misclassifies installs wholesale — and in the worse direction: an
+	 * untouched file reads as "customized", so it never receives an update and instead nags
+	 * the user with a notice about a change they didn't make.
+	 */
+	it("treats CRLF and LF as the same content", () => {
+		const lf = "line one\nline two\nline three";
+		expect(normalizeShipped(lf.replace(/\n/g, "\r\n"))).toBe(lf);
+		expect(fingerprint(lf.replace(/\n/g, "\r\n"))).toBe(fingerprint(lf));
+	});
+
+	it("ignores leading and trailing whitespace", () => {
+		const body = "# Skill\n\nSome guidance.";
+		expect(fingerprint(`${body}\n`)).toBe(fingerprint(body));
+		expect(fingerprint(`${body}\n\n\n`)).toBe(fingerprint(body));
+		expect(fingerprint(`\n${body}  `)).toBe(fingerprint(body));
+	});
+
+	it("does NOT ignore interior whitespace changes", () => {
+		// Reflowing a paragraph or re-indenting a list IS an edit — normalization must not
+		// reach so far that a real customization gets silently overwritten.
+		expect(fingerprint("a\nb")).not.toBe(fingerprint("a\n\nb"));
+		expect(fingerprint("- item")).not.toBe(fingerprint("-   item"));
+	});
+});
+
+describe("fingerprint", () => {
+	it("is stable across calls", () => {
+		expect(fingerprint("some shipped text")).toBe(fingerprint("some shipped text"));
+	});
+
+	it("distinguishes different content", () => {
+		expect(fingerprint("version one")).not.toBe(fingerprint("version two"));
+		// Single-character differences must not collide — bumped guidance often differs by
+		// very little.
+		expect(fingerprint("escalate the algorithm once")).not.toBe(fingerprint("escalate the algorithm twice"));
+	});
+
+	it("is a fixed-width hex digest", () => {
+		for (const text of ["", "a", "a much longer body\n".repeat(500)]) {
+			expect(fingerprint(text)).toMatch(/^[0-9a-f]{16}$/);
+		}
+	});
+
+	it("handles non-ASCII content", () => {
+		// The real bodies contain em dashes, §, and typographic quotes; hashing UTF-8 bytes
+		// keeps the digest independent of JS string encoding quirks.
+		expect(fingerprint("§ Introduction — “quoted”")).toMatch(/^[0-9a-f]{16}$/);
+		expect(fingerprint("café")).not.toBe(fingerprint("cafe"));
+	});
+});
+
+describe("shippedVersion / isShippedDefault", () => {
+	const V1 = "the body we shipped first";
+	const V2 = "the body we ship now";
+	const history: ShippedHistory = new Map([
+		[1, fingerprint(V1)],
+		[2, fingerprint(V2)],
+	]);
+
+	it("identifies which version content came from", () => {
+		expect(shippedVersion(V1, history)).toBe(1);
+		expect(shippedVersion(V2, history)).toBe(2);
+	});
+
+	it("returns null for content we never shipped", () => {
+		expect(shippedVersion("the user's own rewrite", history)).toBeNull();
+		expect(isShippedDefault("the user's own rewrite", history)).toBe(false);
+	});
+
+	it("recognizes any shipped version, not just the newest", () => {
+		expect(isShippedDefault(V1, history)).toBe(true);
+		expect(isShippedDefault(V2, history)).toBe(true);
+	});
+
+	it("recognizes a shipped version through incidental reformatting", () => {
+		expect(shippedVersion(`${V1.replace(/ /g, " ")}\n`, history)).toBe(1);
+	});
+
+	it("reports nothing for an empty history", () => {
+		expect(shippedVersion(V1, new Map())).toBeNull();
+	});
+
+	it("supports string version keys, as bundled skills use", () => {
+		const skillHistory: ShippedHistory = new Map([
+			["1.0", fingerprint(V1)],
+			["1.1", fingerprint(V2)],
+		]);
+		expect(shippedVersion(V1, skillHistory)).toBe("1.0");
+		expect(shippedVersion(V2, skillHistory)).toBe("1.1");
+	});
+});


### PR DESCRIPTION
Resolves #401.

## The problem

Four places ship editable text and each answered "is what's on disk still something we shipped, or did the user change it?" differently. Two were broken:

- **Memory prompt** — no history at all. Compared against the *current* constant only, so the first change to `DEFAULT_MEMORY_PROMPT` would classify every existing install as user-customized: never auto-migrated, and never flagged either. Silent divergence.
- **Bundled skills** — existence-only. `metadata.version` was decorative, and a fast path returned early once all seed folders existed, so a bumped version never reached the per-skill check. Improvements reached new vaults only — hit concretely when `explore-vault` went `1.0 → 1.1` in #399.

## The mechanism

New `src/utils/shippedDefaults.ts`: a `ShippedHistory` (version → fingerprint) plus `isShippedDefault` / `shippedVersion`, with normalization applied centrally. Per surface, on load:

- matches the **current** shipped version → nothing to do
- matches an **older** shipped version → untouched old default, update silently
- **no match** → the user edited it. Leave it alone, emit a `StaleGuidance` record

**Normalization is the load-bearing part.** Line endings and a trailing newline must not read as a customization — content round-trips through the vault adapter and whatever editor the user opens the note in, and either can change them without the user touching a character. Getting that wrong misclassifies installs wholesale, in the direction that silently withholds updates.

### Three design decisions worth reviewing

**FNV-1a, not sha256.** `node:crypto` is externalized in `vite.config.ts` via `builtinModules` and unavailable on mobile (`isDesktopOnly: false`), and `crypto.subtle.digest` is async — while `data.staleGuidance` is a *synchronous* Svelte reactive getter read during render. Async would mean a precomputed cache plus `$state` invalidation for no functional gain. Collision resistance is irrelevant here: this is change detection over a handful of strings we shipped ourselves.

**Fingerprints, not full text.** The 10 bundled `SKILL.md` files are ~67 KB today (`bases` 21 KB, `canvas` 14 KB). Retaining every revision verbatim would grow the bundle with text that is never displayed. Every consumer only ever does an equality test — none reads historical text back.

*Trade-off, stated deliberately:* a fingerprint can't reconstruct old text, so a three-way "old default vs new default vs yours" diff becomes impossible. This costs nothing today — `openSystemPromptDiff` already passes only `getPrompt` + `defaultPrompt`, so the diff is already two-way.

**Tool descriptions are excluded, not unified.** They aren't user-editable — `ToolConfigForm` says so outright (*"name/description aren't editable in this form"*) and renders no input. A stored description is therefore only ever a cached shipped default. The `Set` membership tests were never customization detection; they existed so the *automatic* variant swap (`read_content` by processor capability, `search_notes` by embedding index) didn't freeze at whichever variant was current on load. Both sets and their guards are deleted in favour of unconditional recompute — net deletion.

## Skills

- Three-way reconcile in `bootstrapDefaultSkills`; the early-return fast path is removed (it's precisely what made a bumped version unreachable).
- `seedIntegrationSkill` had the **same skip-if-exists gap one level down**. Community integration skills seed on demand, so they're absent from the startup seed set — reconciling only that set would leave them written once and never re-checked. Bootstrap now also reconciles bundled skills already installed but outside the seed set, while deliberately *not* installing ones the user hasn't opted into.
- `metadata.version` is now load-bearing (#401's "wire it up or drop it" → wire it up), with a test asserting every bundled skill declares one, since omitting it silently opts a skill out of updates.

**No backfill.** With no active users there's nothing to preserve, so `explore-vault` is reset to `1.0` and every bundled skill's current body is its sole shipped version. `PRIOR_SKILL_BODIES` is an empty, documented seam — the previous body gets pasted there when a skill is next revised. Skipping that step is the one way to reintroduce this bug.

## Also

- `StaleGuidance.kind` gains `"memory-prompt"` and `"skill"`, reusing the existing notice / diff / dismissal path — `filterUpdateNotices` needed no change.
- `updateNoticeId` includes the skill name; otherwise dismissing one skill's notice would dismiss every skill's.
- `AgentEditorModal`'s drift checks used `.trim()`, weaker than the shared normalization — a CRLF round-trip would have offered a "Diff with default" button against identical text.

## Verification

`bun run test` (1347 passing), `bun run check` clean, `bun run build` succeeds.

New coverage: the normalization contract (CRLF / trailing-newline match, interior whitespace does *not*); the three-way skill outcome driven by a synthetic prior version — which also exercises the seam future revisions use; both integration-skill directions; and an unreadable file being flagged rather than clobbered.

**One behavioural note:** bootstrap now costs one `read()` per skill folder instead of `exists()`. Bounded (~10 folders) and inside `StartupProfiler.measure("skills:bootstrap")`, so any regression surfaces in the startup profile.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._