### PR TITLE
perf(graph): render on demand, HNSW semantic edges, and scale-bound costs

### DIFF
--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -2512,6 +2512,23 @@ export function panToClusters(clusters: Set<number>) {
     outline: none;
     cursor: grab;
     touch-action: none; /* Required for pointer capture to work */
+    /* The container is a <button> only so it can take keyboard focus for the
+       graph's shortcuts — it is a canvas surface, not a control. Suppress the
+       tap feedback a real button gets: WebKit's grey flash on touch, and the
+       box-shadow Obsidian's mobile theme puts on :active/:focus buttons. */
+    -webkit-tap-highlight-color: transparent;
+    box-shadow: none;
+  }
+
+  /* Obsidian's button rules set a background on these states; the canvas must
+     stay transparent so the graph shows through unchanged when tapped. */
+  .graph-canvas-container:active,
+  .graph-canvas-container:hover,
+  .graph-canvas-container:focus,
+  .graph-canvas-container:focus-visible {
+    background: transparent;
+    box-shadow: none;
+    outline: none;
   }
 
   .graph-canvas-container:active {

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -37,7 +37,6 @@ interface Props {
 	clusterLabels?: Record<number, string>;
 	/** When false, the cluster/topic label pills are not drawn over the graph. */
 	showClusterLabels?: boolean;
-	isLabeling?: boolean;
 	/**
 	 * Strength of the cluster cohesion force (0 = off, default 0.15).
 	 * Pulls nodes toward their cluster centroid each simulation tick.
@@ -87,7 +86,6 @@ let {
 	focusedClusters = new Set<number>(),
 	clusterLabels = {},
 	showClusterLabels = true,
-	isLabeling = false,
 	clusterCohesionStrength = 0.15,
 	onNodeClick,
 	onSetTopicCollapsed,
@@ -291,7 +289,6 @@ const HULL_OUTLIER_FACTOR = 2.2;
 // Smooth hover highlighting: per-node alpha lerps toward target on each frame.
 // 0 = fully dimmed, 1 = fully visible. Drives node, edge, and label opacity.
 let hoverAlphas: Map<string, number> = new Map();
-let hoverAnimFrameId: number | null = null;
 
 /**
  * Hull cross-fade state.
@@ -303,7 +300,6 @@ let hoverAnimFrameId: number | null = null;
  */
 let outgoingHulls: Array<{ cluster: number; color: string; path: Array<{ x: number; y: number }> }> = [];
 let hullFadeProgress = 1;
-let hullAnimFrameId: number | null = null;
 /** Releases the sustained alpha after a collapse/expand transition. */
 let retargetTimer: ReturnType<typeof setTimeout> | null = null;
 /** Fires the corrective fit once post-settle drift has stopped. */
@@ -337,30 +333,53 @@ function isOverClusterPill(x: number, y: number): boolean {
 	return clusterPillAt(x, y) !== undefined;
 }
 
-// Labeling animation loop
-let labelAnimFrameId: number | null = null;
+// ── On-demand render scheduling ─────────────────────────────
+//
+// Every render trigger funnels through requestRender, which coalesces any
+// number of same-frame requests (sim tick + camera animation + hover fade…)
+// into one render pass per animation frame. The Pixi application ticker is
+// disabled, so the GPU draws exactly once per pass and a settled, untouched
+// graph costs nothing at idle.
+//
+// The mode bounds how much of the scene is rebuilt:
+//   world   — content changed (positions, data, hover/fade state): rebuild
+//             everything.
+//   zoom    — only the camera scale changed: counter-scaled strokes and label
+//             visibility need refreshing, but edge tessellation waits until
+//             the scale drifts past EDGE_REDRAW_SCALE_STEP.
+//   overlay — the camera panned: world-space layers move with the viewport
+//             transform for free; only screen-space content (labels, pills,
+//             tooltip) refreshes.
+type RenderMode = "overlay" | "zoom" | "world";
+const RENDER_MODE_RANK: Record<RenderMode, number> = { overlay: 0, zoom: 1, world: 2 };
+let renderRafId: number | null = null;
+let pendingRenderMode: RenderMode | null = null;
 
-function stopLabelAnimation() {
-	if (labelAnimFrameId != null) {
-		cancelAnimationFrame(labelAnimFrameId);
-		labelAnimFrameId = null;
+function requestRender(mode: RenderMode) {
+	if (pendingRenderMode === null || RENDER_MODE_RANK[mode] > RENDER_MODE_RANK[pendingRenderMode]) {
+		pendingRenderMode = mode;
 	}
+	if (renderRafId != null) return;
+	renderRafId = requestAnimationFrame(() => {
+		renderRafId = null;
+		const nextMode = pendingRenderMode ?? "world";
+		pendingRenderMode = null;
+		render(nextMode);
+	});
 }
 
-$effect(() => {
-	if (isLabeling) {
-		function tick() {
-			render();
-			labelAnimFrameId = requestAnimationFrame(tick);
-		}
-		labelAnimFrameId = requestAnimationFrame(tick);
-		return () => {
-			stopLabelAnimation();
-			// One final render to clear the animated border
-			render();
-		};
-	}
-});
+/**
+ * Scale drift (as a fraction) a zoom must accumulate before edges are
+ * re-tessellated. Edge widths counter-scale with the camera (`1.2 / scale`),
+ * so skipping a rebuild leaves them up to this much too thick or thin —
+ * invisible at 5%, while smooth-wheel zooming stops paying the full O(E)
+ * tessellation on every frame.
+ */
+const EDGE_REDRAW_SCALE_STEP = 0.05;
+/** Camera scale at which edges were last tessellated. */
+let lastEdgeDrawScale = 1;
+/** Camera scale at the last viewport-move callback — distinguishes zoom from pan. */
+let lastViewportScale = 1;
 
 function handleKeyDown(e: KeyboardEvent) {
 	const tag = (e.target as HTMLElement | null)?.tagName;
@@ -389,7 +408,7 @@ function handleKeyDown(e: KeyboardEvent) {
 				isLassoing = false;
 				lassoPoints = [];
 				pixi?.resumeViewport();
-				render();
+				requestRender("world");
 			} else if (selectedNodes.size > 0) {
 				clearSelection();
 			} else if (immersed) {
@@ -534,7 +553,7 @@ function pointInPolygon(px: number, py: number, poly: Array<{ x: number; y: numb
 export function clearSelection() {
 	selectedNodes = new Set();
 	onSelectionChange?.([]);
-	render();
+	requestRender("world");
 }
 
 /**
@@ -554,7 +573,7 @@ export function selectNodesByPaths(paths: string[]) {
 	// Match collapsed topics too: a topic node is selected when any note it
 	// stands for is in the set, so a selection survives folding and unfolding.
 	selectedNodes = new Set(simNodes.filter((n) => resolveNodePaths(n).some((p) => pathSet.has(p))).map((n) => n.id));
-	render();
+	requestRender("world");
 }
 
 /**
@@ -585,21 +604,6 @@ function findNodeAt(screenX: number, screenY: number): GraphNode | null {
 		}
 	}
 	return null;
-}
-
-/**
- * Ask for another frame while the hull cross-fade is still running.
- *
- * The force simulation drives most redraws, but it can already be at rest when a
- * grouping changes (e.g. changing granularity with a settled layout), so the fade needs its
- * own frame source to finish.
- */
-function scheduleFrame() {
-	if (hullAnimFrameId != null) return;
-	hullAnimFrameId = requestAnimationFrame(() => {
-		hullAnimFrameId = null;
-		render();
-	});
 }
 
 /**
@@ -750,10 +754,14 @@ function getNodeRadius(node: GraphNode): number {
 }
 
 /**
- * Update the Pixi renderer with current state.
- * Replaces the old Canvas 2D render() function.
+ * Update the Pixi renderer with current state and draw one frame.
+ *
+ * See {@link requestRender} for how calls are scheduled and what each mode
+ * skips. Everything after the world-space section runs in every mode: labels,
+ * pills and the tooltip are placed in screen space, so a camera move changes
+ * their layout even when no node moved.
  */
-function render() {
+function render(mode: RenderMode) {
 	if (!pixi || !pixi.ready) return;
 	// Narrowed once here so the nested helpers below (which close over it) don't
 	// each have to re-check a field the early return already guaranteed.
@@ -763,11 +771,15 @@ function render() {
 	const height = renderer.height;
 	const scale = renderer.scale;
 	const c = renderer.theme;
-	const nodeClusterMap = getNodeClusterMap();
+	const isWorld = mode === "world";
 
-	// Advance edge fade-in (smooth crossfade on mode / data changes)
-	if (edgeFadeAlpha < 1) {
+	// Advance edge fade-in (smooth crossfade on mode / data changes).
+	// Fades advance only on world frames, and an unfinished fade requests the
+	// next world frame below — so a concurrent zoom or pan can't stall it, and
+	// it needs no frame source of its own once the simulation is at rest.
+	if (isWorld && edgeFadeAlpha < 1) {
 		edgeFadeAlpha = Math.min(1, edgeFadeAlpha + EDGE_FADE_RATE);
+		if (edgeFadeAlpha < 1) requestRender("world");
 	}
 
 	// ── Smooth hover alpha interpolation ──────────────────────
@@ -775,11 +787,12 @@ function render() {
 	// If it matches the previous frame and alphas have fully settled, skip the
 	// O(n) lerp loop — nothing would change anyway (e.g. during viewport pan).
 	const hoverFingerprint = `${hoveredNode?.id ?? ""}|${draggedNode?.id ?? ""}|${selectedNodes.size}|${focusedClusters.size}|${simNodesVersion}`;
-	const skipHoverLoop = hoverAlphasSettled && hoverFingerprint === lastHoverFingerprint;
-	lastHoverFingerprint = hoverFingerprint;
+	const skipHoverLoop = !isWorld || (hoverAlphasSettled && hoverFingerprint === lastHoverFingerprint);
+	if (isWorld) lastHoverFingerprint = hoverFingerprint;
 
-	let hoverSettled = true;
+	let hoverSettled = hoverAlphasSettled;
 	if (!skipHoverLoop) {
+		hoverSettled = true;
 		const hasSelection = selectedNodes.size > 0;
 		for (const node of simNodes) {
 			let target: number;
@@ -809,73 +822,85 @@ function render() {
 	}
 	hoverAlphasSettled = hoverSettled;
 
-	// Schedule another frame if alphas haven't settled yet
-	if (!hoverSettled && hoverAnimFrameId == null) {
-		hoverAnimFrameId = requestAnimationFrame(() => {
-			hoverAnimFrameId = null;
-			render();
-		});
-	}
+	// Ask for another world frame while alphas are still converging.
+	if (isWorld && !hoverSettled) requestRender("world");
 
-	// ── Topic regions ──────────────────────────────────────────
-	if (showTopicHulls) {
-		const hulls = computeTopicHulls();
-		// Advance the cross-fade toward the new grouping. Eased so the dissolve
-		// starts quickly and settles gently, matching the camera animations.
-		if (hullFadeProgress < 1) {
-			hullFadeProgress = Math.min(1, hullFadeProgress + HULL_FADE_RATE);
-			if (hullFadeProgress >= 1) outgoingHulls = [];
-			scheduleFrame();
+	// ── World-space layers ─────────────────────────────────────
+	// Skipped entirely on pure pans: hulls, edges and nodes live inside the
+	// viewport container, so the camera transform moves them for free.
+	if (mode !== "overlay") {
+		const nodeClusterMap = getNodeClusterMap();
+
+		// ── Topic regions ──────────────────────────────────────
+		if (showTopicHulls) {
+			const hulls = computeTopicHulls();
+			// Advance the cross-fade toward the new grouping. Eased so the dissolve
+			// starts quickly and settles gently, matching the camera animations.
+			// World frames only, and an unfinished fade requests the next one — the
+			// force simulation can already be at rest when a grouping changes (e.g.
+			// changing granularity on a settled layout), so the fade sustains itself.
+			if (isWorld && hullFadeProgress < 1) {
+				hullFadeProgress = Math.min(1, hullFadeProgress + HULL_FADE_RATE);
+				if (hullFadeProgress >= 1) outgoingHulls = [];
+				else requestRender("world");
+			}
+			renderer.drawHulls(hulls, {
+				focusedClusters,
+				fadeAlpha: edgeFadeAlpha,
+				outgoing: outgoingHulls,
+				outgoingAlpha: outgoingHulls.length > 0 ? 1 - easeOutCubic(hullFadeProgress) : 0,
+			});
+		} else {
+			// Regions are hidden — drop any in-flight fade so re-enabling them starts
+			// clean rather than dissolving from a grouping that's since gone stale.
+			outgoingHulls = [];
+			lastHullPaths = [];
+			lastHullSignature = "";
+			hullFadeProgress = 1;
+			renderer.drawHulls([], { focusedClusters, fadeAlpha: edgeFadeAlpha });
 		}
-		renderer.drawHulls(hulls, {
-			focusedClusters,
-			fadeAlpha: edgeFadeAlpha,
-			outgoing: outgoingHulls,
-			outgoingAlpha: outgoingHulls.length > 0 ? 1 - easeOutCubic(hullFadeProgress) : 0,
-		});
-	} else {
-		// Regions are hidden — drop any in-flight fade so re-enabling them starts
-		// clean rather than dissolving from a grouping that's since gone stale.
-		outgoingHulls = [];
-		lastHullPaths = [];
-		lastHullSignature = "";
-		hullFadeProgress = 1;
-		renderer.drawHulls([], { focusedClusters, fadeAlpha: edgeFadeAlpha });
-	}
 
-	// ── Edges ──────────────────────────────────────────────────
-	renderer.drawEdges(
-		renderableSimLinks as unknown as Array<{
-			source: { id: string; x: number; y: number; kind?: string };
-			target: { id: string; x: number; y: number; kind?: string };
-			type: string;
-			weight?: number;
-		}>,
-		{
-			showWikiLinks,
-			showSemanticLinks,
-			directedWikiEdges,
-			hoveredNodeId: hoveredNode?.id ?? null,
-			adjacency,
-			focusedClusters,
+		// ── Edges ──────────────────────────────────────────────
+		// Re-tessellating every edge is the priciest CPU step of a frame, so
+		// zoom-only frames skip it until the scale has drifted enough for the
+		// counter-scaled widths to be visibly off (see EDGE_REDRAW_SCALE_STEP).
+		const scaleDrift = Math.abs(scale - lastEdgeDrawScale) / (lastEdgeDrawScale || 1);
+		if (isWorld || scaleDrift > EDGE_REDRAW_SCALE_STEP) {
+			renderer.drawEdges(
+				renderableSimLinks as unknown as Array<{
+					source: { id: string; x: number; y: number; kind?: string };
+					target: { id: string; x: number; y: number; kind?: string };
+					type: string;
+					weight?: number;
+				}>,
+				{
+					showWikiLinks,
+					showSemanticLinks,
+					directedWikiEdges,
+					hoveredNodeId: hoveredNode?.id ?? null,
+					adjacency,
+					focusedClusters,
+					selectedNodes,
+					hoverAlphas,
+					edgeFadeAlpha,
+					baseEdgeAlpha,
+					nodeClusterMap,
+				},
+			);
+			lastEdgeDrawScale = scale;
+		}
+
+		// ── Nodes ──────────────────────────────────────────────
+		renderer.syncNodes(simNodes, nodeSize, {
 			selectedNodes,
+			hoveredNodeId: hoveredNode?.id ?? null,
+			draggedNodeId: draggedNode?.id ?? null,
+			focusedClusters,
+			isForceMode: true,
 			hoverAlphas,
-			edgeFadeAlpha,
-			baseEdgeAlpha,
 			nodeClusterMap,
-		},
-	);
-
-	// ── Nodes ──────────────────────────────────────────────────
-	renderer.syncNodes(simNodes, nodeSize, {
-		selectedNodes,
-		hoveredNodeId: hoveredNode?.id ?? null,
-		draggedNodeId: draggedNode?.id ?? null,
-		focusedClusters,
-		isForceMode: true,
-		hoverAlphas,
-		nodeClusterMap,
-	});
+		});
+	}
 
 	// ── Labels ─────────────────────────────────────────────────
 	// Labels appear automatically when a node's screen-space radius reaches a
@@ -1178,6 +1203,9 @@ function render() {
 	} else {
 		renderer.hideTooltip();
 	}
+
+	// One GPU draw per pass — the application ticker is disabled.
+	renderer.renderFrame();
 }
 
 // ============================================================================
@@ -1222,7 +1250,7 @@ function handleMouseDown(e: PointerEvent) {
 			selectedNodes = next;
 			onSelectionChange?.(simNodes.filter((n) => next.has(n.id)).flatMap(resolveNodePaths));
 			lassoJustFinished = true;
-			render();
+			requestRender("world");
 			return;
 		}
 		isLassoing = true;
@@ -1244,7 +1272,7 @@ function handleMouseDown(e: PointerEvent) {
 		if (e.pointerType === "touch" || e.pointerType === "pen") {
 			if (hoveredNode !== node) {
 				hoveredNode = node;
-				render();
+				requestRender("world");
 			}
 			longPressFired = false;
 			cancelLongPress();
@@ -1294,7 +1322,7 @@ function handleMouseMove(e: PointerEvent) {
 			if (dist < 3) return;
 		}
 		lassoPoints = [...lassoPoints, graphPos];
-		render();
+		requestRender("world");
 		return;
 	}
 
@@ -1305,14 +1333,14 @@ function handleMouseMove(e: PointerEvent) {
 		const graphPos = screenToGraph(x, y);
 		dragSimNode.fx = graphPos.x;
 		dragSimNode.fy = graphPos.y;
-		render();
+		requestRender("world");
 	} else {
 		// Hover detection: check cluster legend first, then nodes
 		if (isOverClusterPill(x, y)) {
 			canvas.style.cursor = "pointer";
 			if (hoveredNode) {
 				hoveredNode = null;
-				render();
+				requestRender("world");
 			}
 			return;
 		}
@@ -1322,7 +1350,7 @@ function handleMouseMove(e: PointerEvent) {
 			hoveredNode = node;
 			previewTriggeredForNode = null;
 			canvas.style.cursor = node ? "pointer" : lassoMode ? "crosshair" : "grab";
-			render();
+			requestRender("world");
 		}
 		// Cmd/Ctrl+hover triggers note preview (fire once per node)
 		if (node && (e.metaKey || e.ctrlKey) && onHoverPreview && previewTriggeredForNode !== node.id) {
@@ -1351,7 +1379,7 @@ function handleMouseUp(_e: PointerEvent) {
 			}
 		}
 		lassoPoints = [];
-		render();
+		requestRender("world");
 		return;
 	}
 	if (dragSimNode) {
@@ -1399,7 +1427,7 @@ function handleClick(e: MouseEvent) {
 		// the noun the selection bar's verbs (Immerse, Open all, Collapse…) act on,
 		// so the label stays one consistent gesture and collapsing moves there.
 		onFocusCluster?.(pill.cluster, false, e.shiftKey || e.metaKey || e.ctrlKey);
-		render();
+		requestRender("world");
 		return;
 	}
 	const node = findNodeAt(x, y);
@@ -1463,7 +1491,7 @@ function handleMouseLeave() {
 	cancelLongPress();
 	hoveredNode = null;
 	previewTriggeredForNode = null;
-	render();
+	requestRender("world");
 }
 
 function handleContextMenu(e: MouseEvent) {
@@ -1876,7 +1904,7 @@ function setupForceSimulation(
 					}, SETTLE_FIT_DELAY_MS);
 				}
 			}
-			render();
+			requestRender("world");
 		})
 		.alphaDecay(isFreshLayout ? 0.04 : 0.02)
 		.velocityDecay(isFreshLayout ? 0.5 : 0.3);
@@ -1990,7 +2018,7 @@ function setupGraph(data: GraphData) {
 			forceTickCount = 0;
 		}
 
-		if (pixi) render();
+		if (pixi) requestRender("world");
 		return;
 	}
 
@@ -2012,7 +2040,10 @@ $effect(() => {
 	untrack(() => setupGraph(graphData));
 });
 
-// Re-render when appearance settings change (nodeSize, showWikiLinks, …)
+// Re-render when appearance settings or prop-driven overlay content change
+// (nodeSize, link toggles, topic names arriving from the AI labeling pass, a
+// focus selection made in the Topics panel, …). Nothing else re-renders on
+// prop changes, so every prop render() reads belongs in this list.
 $effect(() => {
 	void nodeSize;
 	void showWikiLinks;
@@ -2021,7 +2052,9 @@ $effect(() => {
 	void alwaysRefitOnDataChange;
 	void directedWikiEdges;
 	void showClusterLabels;
-	if (pixi) render();
+	void clusterLabels;
+	void focusedClusters;
+	if (pixi) requestRender("world");
 });
 
 // Hot-update force parameters without full rebuild.
@@ -2085,9 +2118,18 @@ onMount(() => {
 	pixi = renderer;
 
 	renderer.init(containerEl, theme).then(() => {
-		// Re-render overlays (cluster pills, legends, labels) when viewport moves
+		lastViewportScale = renderer.scale;
+		// Re-render when the viewport moves. A zoom must refresh counter-scaled
+		// strokes and label visibility; a pure pan only needs the screen-space
+		// overlay (labels, pills, tooltip) re-laid-out.
 		renderer.onViewportMoved(() => {
-			render();
+			const scale = renderer.scale;
+			if (scale !== lastViewportScale) {
+				lastViewportScale = scale;
+				requestRender("zoom");
+			} else {
+				requestRender("overlay");
+			}
 			if (pendingUserViewportMove || pendingUserViewportZoom) {
 				pendingUserViewportMove = false;
 				pendingUserViewportZoom = false;
@@ -2120,13 +2162,13 @@ onMount(() => {
 				needsInitialFit = true;
 				forceTickCount = 0;
 			}
-			render();
+			requestRender("world");
 		}
 
 		const resizeObserver = new ResizeObserver(() => {
 			const rect = containerEl.getBoundingClientRect();
 			renderer.resize(rect.width, rect.height);
-			render();
+			requestRender("world");
 		});
 		resizeObserver.observe(containerEl);
 
@@ -2135,7 +2177,7 @@ onMount(() => {
 		const handleCssChange = () => {
 			const newTheme = readThemeColors(containerEl);
 			renderer.updateTheme(newTheme);
-			render();
+			requestRender("world");
 		};
 		document.body.addEventListener("css-change", handleCssChange);
 
@@ -2162,8 +2204,10 @@ onMount(() => {
 
 	return () => {
 		(containerEl as any).__graphCleanup?.();
-		if (hoverAnimFrameId != null) cancelAnimationFrame(hoverAnimFrameId);
-		if (hullAnimFrameId != null) cancelAnimationFrame(hullAnimFrameId);
+		if (renderRafId != null) {
+			cancelAnimationFrame(renderRafId);
+			renderRafId = null;
+		}
 		if (retargetTimer != null) clearTimeout(retargetTimer);
 		if (settleFitTimer != null) clearTimeout(settleFitTimer);
 		if (canvasRevealTimer != null) clearTimeout(canvasRevealTimer);
@@ -2171,7 +2215,6 @@ onMount(() => {
 			simulation.stop();
 			simulation = null;
 		}
-		stopLabelAnimation();
 		renderer.destroy();
 		pixi = null;
 	};
@@ -2243,7 +2286,7 @@ function zoomByFactor(factor: number) {
 	const center = renderer.screenToWorld(renderer.width / 2, renderer.height / 2);
 	renderer.moveCenter(center.x, center.y, newScale);
 	onUserViewportChange?.();
-	render();
+	requestRender("zoom");
 }
 
 /**

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -55,7 +55,8 @@ interface Props {
 	onSelectionChange?: (paths: string[]) => void;
 	onClearFocusedClusters?: () => void;
 	onHoverPreview?: (event: MouseEvent, path: string, targetEl: HTMLElement) => void;
-	onSkeletonToggle?: () => void;
+	/** Collapse or expand all topics at once (the atom button / S shortcut). */
+	onToggleCollapseAll?: () => void;
 	immersed?: boolean;
 	onExitImmerse?: () => void;
 	// Selection-bar verbs, mirrored as keyboard shortcuts so a selection made on
@@ -95,7 +96,7 @@ let {
 	onSelectionChange,
 	onClearFocusedClusters,
 	onHoverPreview,
-	onSkeletonToggle,
+	onToggleCollapseAll,
 	immersed = false,
 	onExitImmerse,
 	onCollapseSelectedTopics,
@@ -470,7 +471,7 @@ function handleKeyDown(e: KeyboardEvent) {
 			}
 			break;
 		case "s":
-			onSkeletonToggle?.();
+			onToggleCollapseAll?.();
 			break;
 		// Selection-bar verbs. All no-op without a selection, so they stay inert
 		// while panning an unselected graph.
@@ -857,23 +858,17 @@ function weightedLinkDistance(link: SimLink): number {
 }
 
 /**
- * Get the draw radius for a node based on its degree, centrality, and the user-configurable nodeSize.
+ * Get the draw radius for a node from its degree and the auto-tuned nodeSize.
  *
- * When betweenness centrality is available (Leiden mode), it is blended with degree:
- * - degree gives a +log bonus for highly-connected hubs
- * - centrality gives a larger bonus for bridge nodes whose removal would fragment the graph
- * The two signals are additive so a hub that is also a bridge gets the largest radius.
+ * Size encodes exactly one thing — connectedness — so it stays unambiguous.
+ * Bridge nodes are surfaced by the highlight toggle's color, not by size.
+ * Must match the renderer's sprite radius (`syncNodes`), since this value
+ * also drives hit-testing, collision spacing, and label offsets.
  */
 function getNodeRadius(node: GraphNode): number {
 	const base = Math.max(1, nodeSize);
 	const degree = node.degree ?? 0;
-	const degreeBonus = Math.min(Math.log1p(degree) * 2.5, base * 5);
-	if (node.centrality != null && node.centrality > 0) {
-		// centrality is 0–1; scale it to the same ceiling as the degree bonus
-		const centralityBonus = Math.min(node.centrality * base * 8, base * 8);
-		return base + Math.max(degreeBonus, centralityBonus * 0.6 + degreeBonus * 0.4);
-	}
-	return base + degreeBonus;
+	return base + Math.min(Math.log1p(degree) * 2.5, base * 5);
 }
 
 /**
@@ -2135,7 +2130,6 @@ function setupGraph(data: GraphData) {
 				sn.color = node.color;
 				sn.cluster = node.cluster;
 				sn.highlighted = node.highlighted;
-				sn.centrality = node.centrality;
 			}
 		}
 		// Sync the cohesion force strength to the current prop value.
@@ -2144,8 +2138,6 @@ function setupGraph(data: GraphData) {
 		// Re-derive cluster metadata so pills on the canvas reflect the new segmentation.
 		// (buildInternalData is not called in this path, so we update it explicitly.)
 		refreshClusterMetadata(data);
-		// Centrality feeds node radii, so hit-test geometry may have changed.
-		hitGridDirty = true;
 
 		// New topics mean new cluster centroids, so the nodes have to move there.
 		// The cohesion force alone can't do it once alpha has decayed — it would be

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -203,6 +203,11 @@ let isReclustering = false;
 let baseAlphaDecay = 0.02;
 let baseVelocityDecay = 0.3;
 
+/** False while the graph's leaf is hidden (background tab, collapsed sidebar). */
+let leafVisible = true;
+/** True when the simulation was stopped mid-settle because the leaf went hidden. */
+let simPausedWhileHidden = false;
+
 // D3-compatible node/link types
 type SimNode = GraphNode & SimulationNodeDatum;
 type SimLink = SimulationLinkDatum<SimNode> & { weight: number; type: EdgeType };
@@ -319,6 +324,21 @@ let adjacency: Map<string, Set<string>> = new Map();
 let hoverAlphasSettled = false;
 let lastHoverFingerprint = "";
 
+// Identity ids for the selection sets in the hover fingerprint. Both sets are
+// replaced wholesale on change, so instance identity is the reliable signal —
+// their *size* is not: swapping one same-sized set for another would read as
+// unchanged and leave the fade stale.
+const objectIdentityIds = new WeakMap<object, number>();
+let nextObjectIdentityId = 1;
+function identityOf(value: object): number {
+	let id = objectIdentityIds.get(value);
+	if (id === undefined) {
+		id = nextObjectIdentityId++;
+		objectIdentityIds.set(value, id);
+	}
+	return id;
+}
+
 // Cluster legend hit areas for click detection (screen space)
 let clusterAnchorHitAreas: ClusterPillHit[] = [];
 
@@ -380,6 +400,31 @@ const EDGE_REDRAW_SCALE_STEP = 0.05;
 let lastEdgeDrawScale = 1;
 /** Camera scale at the last viewport-move callback — distinguishes zoom from pan. */
 let lastViewportScale = 1;
+
+/**
+ * Margin (fraction of the view size per side) kept tessellated around the view
+ * when culling offscreen edges. Wide enough that ordinary panning stays inside
+ * it; a pan past it forces a re-tessellation before the gap scrolls into view.
+ */
+const EDGE_CULL_MARGIN = 0.35;
+type WorldRect = { minX: number; minY: number; maxX: number; maxY: number };
+/** Cull rect used at the last edge tessellation — null when nothing was culled. */
+let lastEdgeCullRect: WorldRect | null = null;
+/** Set when a pan left the culled margin; forces an edge redraw next render. */
+let edgesViewportStale = false;
+
+/** The camera's visible world rect, padded by `marginFactor` of its size per side. */
+function viewWorldRect(renderer: PixiRenderer, marginFactor: number): WorldRect {
+	const tl = renderer.screenToWorld(0, 0);
+	const br = renderer.screenToWorld(renderer.width, renderer.height);
+	const mx = (br.x - tl.x) * marginFactor;
+	const my = (br.y - tl.y) * marginFactor;
+	return { minX: tl.x - mx, minY: tl.y - my, maxX: br.x + mx, maxY: br.y + my };
+}
+
+function rectContains(outer: WorldRect, inner: WorldRect): boolean {
+	return inner.minX >= outer.minX && inner.maxX <= outer.maxX && inner.minY >= outer.minY && inner.maxY <= outer.maxY;
+}
 
 function handleKeyDown(e: KeyboardEvent) {
 	const tag = (e.target as HTMLElement | null)?.tagName;
@@ -584,26 +629,104 @@ function screenToGraph(screenX: number, screenY: number): { x: number; y: number
 	return pixi.screenToWorld(screenX, screenY);
 }
 
+// ── Spatial hit grid ────────────────────────────────────────
+// findNodeAt runs on every mousemove, and a linear scan over a large vault's
+// nodes is measurable input-latency work. A uniform hash grid answers the same
+// query from a few cells instead. Positions move every tick while the layout
+// settles, so the grid is only (re)built once the simulation is near rest —
+// while it's moving, the plain scan runs, since rebuilding per query would
+// cost more than the scan it replaces.
+let hitGrid: Map<number, Array<{ node: SimNode; order: number }>> | null = null;
+let hitGridCellSize = 1;
+let hitGridDirty = true;
+let hitGridMaxRadius = 0;
+
+/** Cell coordinates support ±32k cells from the origin. */
+const HIT_GRID_KEY_OFFSET = 32768;
+function hitGridKey(cx: number, cy: number): number {
+	return (cx + HIT_GRID_KEY_OFFSET) * 65536 + (cy + HIT_GRID_KEY_OFFSET);
+}
+
+function buildHitGrid() {
+	hitGridMaxRadius = 0;
+	for (const node of simNodes) {
+		const radius = getNodeRadius(node);
+		if (radius > hitGridMaxRadius) hitGridMaxRadius = radius;
+	}
+	hitGridCellSize = Math.max(64, hitGridMaxRadius * 2);
+	hitGrid = new Map();
+	for (let i = 0; i < simNodes.length; i++) {
+		const node = simNodes[i];
+		if (node.x == null || node.y == null) continue;
+		const key = hitGridKey(Math.floor(node.x / hitGridCellSize), Math.floor(node.y / hitGridCellSize));
+		let cell = hitGrid.get(key);
+		if (!cell) {
+			cell = [];
+			hitGrid.set(key, cell);
+		}
+		cell.push({ node, order: i });
+	}
+	hitGridDirty = false;
+}
+
+/** The original linear scan — still used while the layout is in motion. */
+function findNodeLinear(x: number, y: number, hitRadius: number): GraphNode | null {
+	// Search in reverse order (top-most nodes first)
+	for (let i = simNodes.length - 1; i >= 0; i--) {
+		const node = simNodes[i];
+		const dx = (node.x ?? 0) - x;
+		const dy = (node.y ?? 0) - y;
+		const reach = getNodeRadius(node) + hitRadius;
+		if (dx * dx + dy * dy <= reach * reach) {
+			return node;
+		}
+	}
+	return null;
+}
+
 /**
  * Find the node at the given screen coordinates.
+ *
+ * Picks the top-most match (highest index in `simNodes`), matching the
+ * original reverse-scan semantics in both paths.
  */
 function findNodeAt(screenX: number, screenY: number): GraphNode | null {
 	const { x, y } = screenToGraph(screenX, screenY);
 	const scale = pixi?.scale ?? 1;
 	const hitRadius = (Math.max(1, nodeSize) + 4) / scale;
 
-	// Search in reverse order (top-most nodes first)
-	for (let i = simNodes.length - 1; i >= 0; i--) {
-		const node = simNodes[i];
-		const dx = (node.x ?? 0) - x;
-		const dy = (node.y ?? 0) - y;
-		const dist = Math.sqrt(dx * dx + dy * dy);
-		const radius = getNodeRadius(node);
-		if (dist <= radius + hitRadius) {
-			return node;
+	// While ticking, positions change under the grid every frame — scan instead.
+	if (hitGridDirty && simulation && simulation.alpha() > 0.03) {
+		return findNodeLinear(x, y, hitRadius);
+	}
+	if (hitGridDirty || !hitGrid) buildHitGrid();
+
+	// The zoomed-out hit slack can exceed one cell, so widen the neighbourhood
+	// to however many cells the search radius spans.
+	const searchRadius = hitGridMaxRadius + hitRadius;
+	const span = Math.ceil(searchRadius / hitGridCellSize);
+	const cx = Math.floor(x / hitGridCellSize);
+	const cy = Math.floor(y / hitGridCellSize);
+
+	let best: SimNode | null = null;
+	let bestOrder = -1;
+	for (let gx = cx - span; gx <= cx + span; gx++) {
+		for (let gy = cy - span; gy <= cy + span; gy++) {
+			const cell = hitGrid?.get(hitGridKey(gx, gy));
+			if (!cell) continue;
+			for (const { node, order } of cell) {
+				if (order <= bestOrder) continue;
+				const dx = (node.x ?? 0) - x;
+				const dy = (node.y ?? 0) - y;
+				const reach = getNodeRadius(node) + hitRadius;
+				if (dx * dx + dy * dy <= reach * reach) {
+					best = node;
+					bestOrder = order;
+				}
+			}
 		}
 	}
-	return null;
+	return best;
 }
 
 /**
@@ -786,7 +909,7 @@ function render(mode: RenderMode) {
 	// Build a fingerprint of everything that determines alpha targets.
 	// If it matches the previous frame and alphas have fully settled, skip the
 	// O(n) lerp loop — nothing would change anyway (e.g. during viewport pan).
-	const hoverFingerprint = `${hoveredNode?.id ?? ""}|${draggedNode?.id ?? ""}|${selectedNodes.size}|${focusedClusters.size}|${simNodesVersion}`;
+	const hoverFingerprint = `${hoveredNode?.id ?? ""}|${draggedNode?.id ?? ""}|${identityOf(selectedNodes)}|${identityOf(focusedClusters)}|${simNodesVersion}`;
 	const skipHoverLoop = !isWorld || (hoverAlphasSettled && hoverFingerprint === lastHoverFingerprint);
 	if (isWorld) lastHoverFingerprint = hoverFingerprint;
 
@@ -863,9 +986,11 @@ function render(mode: RenderMode) {
 		// ── Edges ──────────────────────────────────────────────
 		// Re-tessellating every edge is the priciest CPU step of a frame, so
 		// zoom-only frames skip it until the scale has drifted enough for the
-		// counter-scaled widths to be visibly off (see EDGE_REDRAW_SCALE_STEP).
+		// counter-scaled widths to be visibly off (see EDGE_REDRAW_SCALE_STEP),
+		// and edges outside the margined view are culled entirely.
 		const scaleDrift = Math.abs(scale - lastEdgeDrawScale) / (lastEdgeDrawScale || 1);
-		if (isWorld || scaleDrift > EDGE_REDRAW_SCALE_STEP) {
+		if (isWorld || scaleDrift > EDGE_REDRAW_SCALE_STEP || edgesViewportStale) {
+			const cullRect = viewWorldRect(renderer, EDGE_CULL_MARGIN);
 			renderer.drawEdges(
 				renderableSimLinks as unknown as Array<{
 					source: { id: string; x: number; y: number; kind?: string };
@@ -885,9 +1010,16 @@ function render(mode: RenderMode) {
 					edgeFadeAlpha,
 					baseEdgeAlpha,
 					nodeClusterMap,
+					cullRect,
 				},
 			);
 			lastEdgeDrawScale = scale;
+			edgesViewportStale = false;
+			// Pan-staleness tracking only matters if the rect actually excluded
+			// part of the graph — when everything fit inside it, no pan can
+			// reveal a missing edge, so the moved handler can skip the check.
+			const bounds = computeNodeBounds(simNodes);
+			lastEdgeCullRect = bounds && rectContains(cullRect, bounds) ? null : cullRect;
 		}
 
 		// ── Nodes ──────────────────────────────────────────────
@@ -1756,6 +1888,7 @@ function buildInternalData(data: GraphData): {
 	const isFreshLayout = oldPositions.size === 0 && persistentPositionCache.size === 0;
 	simNodesVersion++;
 	hoverAlphasSettled = false;
+	hitGridDirty = true;
 	const hasAnyKnown = oldPositions.size > 0 || persistentPositionCache.size > 0;
 	const unknownCount = data.nodes.filter((n) => !oldPositions.has(n.id) && !persistentPositionCache.has(n.id)).length;
 	// Spread radius for circle pre-layout: scale with node count so the graph fills
@@ -1859,6 +1992,8 @@ function setupForceSimulation(
 			forceCollide<SimNode>().radius((d) => getNodeRadius(d) + 2),
 		)
 		.on("tick", () => {
+			// Positions moved — the spatial hit grid no longer matches them.
+			hitGridDirty = true;
 			// A finished re-cluster transition hands its slower decay back, so the
 			// next drag or retarget feels normal instead of inheriting the drift.
 			if (isReclustering && simulation && simulation.alpha() < 0.02) {
@@ -1946,6 +2081,14 @@ function setupForceSimulation(
 		needsInitialFit = true;
 		forceTickCount = 0;
 	}
+
+	// A graph rebuilt while its leaf is hidden (e.g. data arriving into a
+	// background tab) shouldn't burn CPU settling a layout nobody can see —
+	// the visibility observer resumes it on reveal.
+	if (!leafVisible) {
+		simPausedWhileHidden = true;
+		simulation.stop();
+	}
 }
 
 // ============================================================================
@@ -2001,6 +2144,8 @@ function setupGraph(data: GraphData) {
 		// Re-derive cluster metadata so pills on the canvas reflect the new segmentation.
 		// (buildInternalData is not called in this path, so we update it explicitly.)
 		refreshClusterMetadata(data);
+		// Centrality feeds node radii, so hit-test geometry may have changed.
+		hitGridDirty = true;
 
 		// New topics mean new cluster centroids, so the nodes have to move there.
 		// The cohesion force alone can't do it once alpha has decayed — it would be
@@ -2054,6 +2199,8 @@ $effect(() => {
 	void showClusterLabels;
 	void clusterLabels;
 	void focusedClusters;
+	// nodeSize feeds node radii, which the hit grid bakes in at build time.
+	hitGridDirty = true;
 	if (pixi) requestRender("world");
 });
 
@@ -2112,6 +2259,27 @@ $effect(() => {
 });
 
 onMount(() => {
+	// Stop the simulation while this leaf is hidden — a background tab or a
+	// collapsed sidebar hides via display:none, which IntersectionObserver
+	// reports as non-intersecting. A layout nobody can see shouldn't tick
+	// d3-force at 60fps; it resumes from its current alpha on reveal.
+	const visibilityObserver = new IntersectionObserver((entries) => {
+		const visible = entries[entries.length - 1]?.isIntersecting ?? true;
+		if (visible === leafVisible) return;
+		leafVisible = visible;
+		if (!visible) {
+			if (simulation && simulation.alpha() > 0.02) simPausedWhileHidden = true;
+			simulation?.stop();
+		} else {
+			if (simPausedWhileHidden) {
+				simPausedWhileHidden = false;
+				simulation?.restart();
+			}
+			requestRender("world");
+		}
+	});
+	visibilityObserver.observe(containerEl);
+
 	// Initialize Pixi renderer
 	const theme = readThemeColors(containerEl);
 	const renderer = new PixiRenderer();
@@ -2129,6 +2297,12 @@ onMount(() => {
 				requestRender("zoom");
 			} else {
 				requestRender("overlay");
+			}
+			// A pan can carry the view outside the margin edges were culled to —
+			// re-tessellate before the missing region scrolls fully into view.
+			if (lastEdgeCullRect && !rectContains(lastEdgeCullRect, viewWorldRect(renderer, 0))) {
+				edgesViewportStale = true;
+				requestRender("zoom");
 			}
 			if (pendingUserViewportMove || pendingUserViewportZoom) {
 				pendingUserViewportMove = false;
@@ -2204,6 +2378,7 @@ onMount(() => {
 
 	return () => {
 		(containerEl as any).__graphCleanup?.();
+		visibilityObserver.disconnect();
 		if (renderRafId != null) {
 			cancelAnimationFrame(renderRafId);
 			renderRafId = null;

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -49,11 +49,8 @@ interface Props {
 	onFocusSegment?: (id: string, multi: boolean) => void;
 	/** True when topics are collapsed into single nodes. */
 	isTopicsCollapsed?: boolean;
-	// Skeleton view
-	skeletonDetail?: number;
-	onSkeletonDetailChange?: (value: number) => void;
-	onSkeletonDetailCommit?: (value: number) => void;
-	onSkeletonToggle?: () => void;
+	/** Collapse or expand all topics at once (the atom button / S shortcut). */
+	onToggleCollapseAll?: () => void;
 }
 
 let {
@@ -81,10 +78,7 @@ let {
 	focusedSegmentIds = new Set<string>(),
 	onFocusSegment,
 	isTopicsCollapsed = false,
-	skeletonDetail = 100,
-	onSkeletonDetailChange,
-	onSkeletonDetailCommit,
-	onSkeletonToggle,
+	onToggleCollapseAll,
 }: Props = $props();
 
 let isCollapsed = $state(true);
@@ -194,7 +188,7 @@ const lassoTooltip = onMobile ? "Lasso selection" : "Lasso selection (or hold Sh
       : isTopicsCollapsed
         ? "Expand all topics back into notes (S)"
         : "Collapse all topics into single nodes (S) — or select topics and use Collapse"}
-    onClick={() => onSkeletonToggle?.()}
+    onClick={() => onToggleCollapseAll?.()}
     disabled={isLeidenRunning}
     styles={isTopicsCollapsed ? "is-active" : ""}
   />
@@ -410,17 +404,6 @@ const lassoTooltip = onMobile ? "Lasso selection" : "Lasso selection (or hold Sh
           <SettingContainer name="Cluster cohesion" desc="How strongly nodes are pulled toward their cluster center" compact>
             <RangeSlider value={Math.round((settings.clusterCohesionStrength ?? 0.15) * 100)} min={0} max={100} step={1} showValue={true} oncommit={handleClusterCohesionStrengthChange} />
           </SettingContainer>
-          <SettingContainer name="Detail" desc="Nodes per topic — lower keeps only the top hubs and bridges" compact>
-            <RangeSlider
-              value={skeletonDetail}
-              min={0}
-              max={100}
-              step={1}
-              showValue={true}
-              onchange={onSkeletonDetailChange}
-              oncommit={onSkeletonDetailCommit}
-            />
-          </SettingContainer>
         {/if}
 
         <button
@@ -477,9 +460,6 @@ const lassoTooltip = onMobile ? "Lasso selection" : "Lasso selection (or hold Sh
           </SettingContainer>
           <SettingContainer name="Bridge threshold" desc="Min fraction of foreign-topic neighbors to qualify as a bridge" compact>
             <RangeSlider value={Math.round((settings.bridgeThreshold ?? 0.4) * 100)} min={0} max={100} step={5} showValue={true} oncommit={(v) => { onSettingsChange({ bridgeThreshold: v / 100 }); onReapplySegments?.(); }} />
-          </SettingContainer>
-          <SettingContainer name="Detail bridge centrality" desc="Min betweenness centrality for bridges to survive at low Detail" compact>
-            <RangeSlider value={Math.round((settings.skeletonBridgeCentralityThreshold ?? 0.05) * 1000)} min={0} max={200} step={1} showValue={true} oncommit={(v) => onSettingsChange({ skeletonBridgeCentralityThreshold: v / 1000 })} />
           </SettingContainer>
         {/if}
 

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -104,14 +104,12 @@ let refitAfterTopicsSettle = false;
 
 // Leiden community state — computed async in worker, cleared on graph rebuild
 let leidenCommunities: Record<string, number> = $state({});
-// Betweenness centrality per node — computed alongside Leiden, cleared on rebuild
-let leidenCentrality: Record<string, number> = $state({});
 
 /**
- * Cache of Leiden results keyed by `${seed}:${resolution}`. Leiden is expensive (seconds on
+ * Cache of Leiden partitions keyed by `${seed}:${resolution}`. Leiden is expensive (seconds on
  * large graphs) but pure over (seed, resolution, graph). We invalidate on every graph rebuild.
  */
-let leidenCache = new Map<string, { communities: Record<string, number>; centrality: Record<string, number> }>();
+let leidenCache = new Map<string, Record<string, number>>();
 
 // Filter state
 let selectedFolders: string[] = $state([]);
@@ -190,9 +188,6 @@ const SEMANTIC_LEIDEN_WEIGHT = 0.7;
  * leftovers rather than as another topic competing for attention.
  */
 const UNSORTED_NODE_COLOR = "hsl(0, 0%, 55%)";
-
-// Detail level 0–100: 100 = full graph, <100 = skeleton backbone (fewer nodes per topic)
-let skeletonDetail = $state(100);
 
 // Topics are always segmented by Leiden community; there is no other mode.
 let segments: SpaceSegment[] = $state([]);
@@ -295,67 +290,10 @@ let selectedTopicsCollapseAction: "collapse" | "expand" | null = $derived.by(() 
 	return allCollapsed ? "expand" : "collapse";
 });
 
-/**
- * Detail view: shows only the top hubs and bridges per cluster, parameterised by skeletonDetail (0–100).
- *
- * detail=0   → 1 hub per cluster + only bridges above the skeletonBridgeCentralityThreshold
- * detail=100 → full graph (all nodes)
- *
- * All clusters are always shown; detail only controls how many nodes represent each one.
- * The bridge centrality threshold is a dev setting — a lower value keeps more bridges visible at low detail.
- * Edges: only wiki edges whose both endpoints survived the node filter.
- */
-let skeletonGraphData: GraphData = $derived.by(() => {
-	if (skeletonDetail >= 100 || graphData.nodes.length === 0) return graphData;
-
-	const t = skeletonDetail / 100; // 0–1
-
-	// Hubs per cluster: lerp from 1 at t=0 to 10 at t=1
-	const hubsPerCluster = Math.max(1, Math.round(1 + t * 9));
-
-	// Bridge centrality cutoff: at t=0 only nodes above the configured threshold qualify;
-	// at t=1 any non-zero centrality qualifies (i.e. all bridges)
-	const centralityThreshold = (settings.skeletonBridgeCentralityThreshold ?? 0.05) * (1 - t);
-
-	// For each cluster, collect nodes sorted by degree descending
-	const clusterNodes = new Map<number, typeof graphData.nodes>();
-	for (const node of graphData.nodes) {
-		if (node.cluster == null) continue;
-		const list = clusterNodes.get(node.cluster) ?? [];
-		list.push(node);
-		clusterNodes.set(node.cluster, list);
-	}
-	for (const list of clusterNodes.values()) {
-		list.sort((a, b) => (b.degree ?? 0) - (a.degree ?? 0));
-	}
-
-	const keptPaths = new Set<string>();
-	for (const nodes of clusterNodes.values()) {
-		for (let i = 0; i < Math.min(hubsPerCluster, nodes.length); i++) {
-			keptPaths.add(nodes[i].path);
-		}
-		for (const node of nodes) {
-			if ((node.centrality ?? 0) > centralityThreshold) keptPaths.add(node.path);
-		}
-	}
-
-	const nodes = graphData.nodes.filter((n) => keptPaths.has(n.path));
-	const edges = graphData.edges.filter((e) => keptPaths.has(e.source) && keptPaths.has(e.target));
-	return { nodes, edges };
-});
-
-/** The graph actually rendered: rolled up, thinned by Detail, or as-is. */
-/**
- * The graph as rendered: topics collapsed to single nodes, thinned by Detail, or
- * as-is.
- *
- * Collapse is applied *after* the Detail filter so the two remain independent —
- * collapsing is about altitude, thinning is about density.
- */
+/** The graph as rendered: topics collapsed to single nodes, or as-is. */
 let displayGraphData: GraphData = $derived.by(() => {
-	const base = skeletonDetail < 100 ? skeletonGraphData : graphData;
-	if (effectiveCollapsedTopics.size === 0) return base;
-	return buildCollapsedGraph(base, {
+	if (effectiveCollapsedTopics.size === 0) return graphData;
+	return buildCollapsedGraph(graphData, {
 		collapsedTopics: effectiveCollapsedTopics,
 		topicLabels: effectiveClusterLabels,
 		collapseUnsorted: true,
@@ -683,7 +621,6 @@ function handleFitToView() {
 function handleRefresh() {
 	loadFilterOptions();
 	leidenCommunities = {};
-	leidenCentrality = {};
 	void buildGraph();
 }
 
@@ -918,7 +855,6 @@ async function runLeidenSegmentation() {
 		// the graph honestly shows "nothing is linked" instead of the fused result.
 		if (settings.linkOnlyTopics) {
 			leidenCommunities = {};
-			leidenCentrality = {};
 			resolveAndApplySegments(graphData);
 		}
 		return;
@@ -928,8 +864,7 @@ async function runLeidenSegmentation() {
 	const cached = leidenCache.get(cacheKey);
 	if (cached) {
 		Logger.info(`[SmartGraph] Leiden cache hit (γ=${settings.leidenResolution.toFixed(2)})`);
-		leidenCommunities = cached.communities;
-		leidenCentrality = cached.centrality;
+		leidenCommunities = cached;
 		resolveAndApplySegments(graphData);
 		// The hierarchy and the granularity ladder describe the *graph*, not the current γ,
 		// so they're computed once per build. Re-running them here would fire on
@@ -946,7 +881,7 @@ async function runLeidenSegmentation() {
 	isLeidenRunning = true;
 	let result: Awaited<ReturnType<typeof leidenAsync>>;
 	try {
-		result = await leidenAsync(sources, targets, weights, true, settings.leidenSeed, settings.leidenResolution);
+		result = await leidenAsync(sources, targets, weights, settings.leidenSeed, settings.leidenResolution);
 	} finally {
 		isLeidenRunning = false;
 	}
@@ -959,7 +894,7 @@ async function runLeidenSegmentation() {
 	);
 	// Always worth caching — the result is correct for the settings it ran under,
 	// even if those are no longer the ones on screen.
-	leidenCache.set(cacheKey, { communities: result.communities, centrality: result.centrality });
+	leidenCache.set(cacheKey, result);
 	// …but only *apply* it if those settings are still current. `buildVersion`
 	// alone can't tell: it tracks graph rebuilds, while γ, seed and link-mode all
 	// change the partition without touching the graph. A slow run started at one γ
@@ -970,8 +905,7 @@ async function runLeidenSegmentation() {
 		Logger.info("[SmartGraph] Discarding a Leiden result the settings have moved past");
 		return;
 	}
-	leidenCommunities = result.communities;
-	leidenCentrality = result.centrality;
+	leidenCommunities = result;
 	resolveAndApplySegments(graphData);
 	void computeTopicHierarchy(topicEdges);
 	void deriveGranularityLevels(topicEdges);
@@ -1011,13 +945,13 @@ async function deriveGranularityLevels(topicEdges: GraphEdge[]) {
 			if (localBuildVersion !== buildVersion) return;
 
 			const cacheKey = partitionKey(resolution, linkOnly, seed);
-			let communities = leidenCache.get(cacheKey)?.communities;
+			let communities = leidenCache.get(cacheKey);
 			if (!communities) {
 				try {
-					const result = await leidenAsync(sources, targets, weights, false, seed, resolution);
+					const result = await leidenAsync(sources, targets, weights, seed, resolution);
 					if (localBuildVersion !== buildVersion) return;
-					leidenCache.set(cacheKey, { communities: result.communities, centrality: result.centrality });
-					communities = result.communities;
+					leidenCache.set(cacheKey, result);
+					communities = result;
 				} catch (error) {
 					// A failed probe just means one fewer candidate rung.
 					Logger.error(`[SmartGraph] Granularity probe failed at γ=${resolution}:`, error);
@@ -1085,20 +1019,19 @@ async function computeTopicHierarchy(topicEdges: GraphEdge[]) {
 	let communities: Record<string, number>;
 	const cached = leidenCache.get(cacheKey);
 	if (cached) {
-		communities = cached.communities;
+		communities = cached;
 	} else {
 		try {
 			const result = await leidenAsync(
 				topicEdges.map((e) => e.source),
 				topicEdges.map((e) => e.target),
 				topicEdges.map(leidenWeight),
-				false,
 				settings.leidenSeed,
 				coarseResolution,
 			);
 			if (localBuildVersion !== buildVersion) return;
-			leidenCache.set(cacheKey, { communities: result.communities, centrality: result.centrality });
-			communities = result.communities;
+			leidenCache.set(cacheKey, result);
+			communities = result;
 		} catch (error) {
 			Logger.error("[SmartGraph] Coarse Leiden failed; hierarchy unavailable:", error);
 			return;
@@ -1181,7 +1114,7 @@ function handleFocusSegment(segmentId: string, multi: boolean) {
 }
 
 /**
- * Resolve Leiden community segments from current graphData and apply coloring + centrality.
+ * Resolve Leiden community segments from current graphData and apply coloring + highlights.
  */
 function resolveAndApplySegments(gd: GraphData) {
 	const themeColors = resolveThemeColors();
@@ -1193,7 +1126,7 @@ function resolveAndApplySegments(gd: GraphData) {
 	});
 	segments = resolved;
 	// Build path → segment lookup once so the single node-map pass below can do everything:
-	// strip stale color/cluster/centrality, apply betweenness centrality (leiden), apply segment color.
+	// strip stale color/cluster, apply bridge/isolated highlights, apply segment color.
 	const pathInfo = new Map<string, { color: string; cluster: number }>();
 	for (let i = 0; i < resolved.length; i++) {
 		for (const path of resolved[i].paths) {
@@ -1202,7 +1135,7 @@ function resolveAndApplySegments(gd: GraphData) {
 			}
 		}
 	}
-	const isLeiden = Object.keys(leidenCentrality).length > 0;
+	const isLeiden = Object.keys(leidenCommunities).length > 0;
 	// Paths touched by at least one authored wiki link — drives the isolated highlight.
 	const linkedPaths = new Set<string>();
 	for (const edge of gd.edges) {
@@ -1257,11 +1190,7 @@ function resolveAndApplySegments(gd: GraphData) {
 			...gd,
 			nodes: gd.nodes.map((n) => {
 				const info = pathInfo.get(n.path);
-				const rawCentrality = isLeiden ? leidenCentrality[n.id] : undefined;
-				// Only record centrality on nodes that structurally span communities — these are the
-				// "bridges" surfaced by the Highlight bridges toggle and consumed by the Detail filter.
-				const centrality = rawCentrality !== undefined && bridgeNodes?.has(n.id) ? rawCentrality : undefined;
-				const isBridge = centrality !== undefined;
+				const isBridge = bridgeNodes?.has(n.id) ?? false;
 				// "Isolated" means the user never linked this note — a note pulled into a
 				// topic purely by semantic similarity is still unlinked, and that's exactly
 				// the gap worth surfacing. So this counts authored links only, not `degree`
@@ -1273,7 +1202,6 @@ function resolveAndApplySegments(gd: GraphData) {
 					...n,
 					color: info?.color ?? undefined,
 					cluster: info?.cluster ?? undefined,
-					centrality,
 					highlighted,
 				};
 			}),
@@ -1303,8 +1231,8 @@ function resolveAndApplySegments(gd: GraphData) {
 		graphData = {
 			...gd,
 			nodes: gd.nodes.map((n) =>
-				n.color !== undefined || n.cluster !== undefined || n.centrality !== undefined || n.highlighted
-					? { ...n, color: undefined, cluster: undefined, centrality: undefined, highlighted: false }
+				n.color !== undefined || n.cluster !== undefined || n.highlighted
+					? { ...n, color: undefined, cluster: undefined, highlighted: false }
 					: n,
 			),
 		};
@@ -1372,13 +1300,11 @@ function handleClearFocusedClusters() {
 }
 
 /**
- * Jump between the broadest topic level and wherever the user last was.
- *
- * This is a shortcut for dragging the Granularity slider to its left end —
- * pressing it again returns to the previous level. Every note stays on screen
- * either way; coarser grouping merges topics rather than hiding notes.
+ * Collapse every topic into a single node, or expand them all back — the atom
+ * button and the S shortcut. Every note stays represented either way; folding
+ * merges topics into stand-in nodes rather than hiding notes.
  */
-async function handleSkeletonToggle() {
+async function handleToggleCollapseAll() {
 	// Guard against re-entry while a fresh Leiden run is in flight — otherwise rapid clicks
 	// race on state writes and can leave the view stuck between modes.
 	if (isLeidenRunning) return;
@@ -1512,8 +1438,7 @@ function handleGranularityChange(level: number) {
 	if (!cached) return;
 
 	handleSettingsChange({ leidenResolution: resolution });
-	leidenCommunities = cached.communities;
-	leidenCentrality = cached.centrality;
+	leidenCommunities = cached;
 	resolveAndApplySegments(graphData);
 }
 
@@ -1560,7 +1485,7 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
       onSelectionChange={handleSelectionChange}
       onClearFocusedClusters={handleClearFocusedClusters}
       onHoverPreview={handleHoverPreview}
-      onSkeletonToggle={handleSkeletonToggle}
+      onToggleCollapseAll={handleToggleCollapseAll}
       immersed={isImmersed}
       onExitImmerse={handleExitImmerse}
       onCollapseSelectedTopics={() => void handleCollapseSelectedTopics()}
@@ -1646,10 +1571,7 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
     {isTopicsCollapsed}
     focusedSegmentIds={focusedSegmentIds}
     onFocusSegment={handleFocusSegment}
-    {skeletonDetail}
-    onSkeletonDetailChange={(v) => (skeletonDetail = v)}
-    onSkeletonDetailCommit={() => canvasComponent?.fitToView()}
-    onSkeletonToggle={handleSkeletonToggle}
+    onToggleCollapseAll={handleToggleCollapseAll}
   />
 </div>
 

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -169,13 +169,14 @@ onDestroy(() => {
 /**
  * Upper bound on notes for semantic edge building.
  *
- * The scan runs in the compute worker, so the UI stays responsive regardless —
- * but the work is still O(n²) in notes. Measured at 1024 dimensions it costs
- * ~0.5s at 1k notes, ~2s at 2k, and ~8s at 4k; past this the wait stops being
- * worth it and the graph stays wiki-only. Raising this is safe for
- * responsiveness, only for patience.
+ * Neighbour search is HNSW-accelerated past ~2k chunks (see
+ * `computeSemanticPairs`), so the old O(n²) time wall is gone. What remains is
+ * memory: every chunk vector is copied into the compute worker, roughly
+ * notes × chunks-per-note × dim × 4 bytes — on the order of 150 MB at this cap
+ * with dim 1024. Past it the transfer itself becomes the problem and the graph
+ * stays wiki-only.
  */
-const SEMANTIC_EDGE_MAX_NOTES = 5000;
+const SEMANTIC_EDGE_MAX_NOTES = 20000;
 
 /**
  * Scales cosine similarity into the same range as authored-link weights for

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -1,3 +1,46 @@
+<script module lang="ts">
+import type { GraphEdge as CachedGraphEdge } from "../../types/graph";
+
+// ── Topic-derivation caches ─────────────────────────────────
+//
+// Module-scoped so they survive closing and reopening the graph view — the
+// expensive derivations (Leiden partitions, granularity probing, semantic
+// edges, AI topic labels) are pure over the graph plus the keys embedded in
+// each entry, so staleness is handled by keying, not by component lifecycle.
+// Shared by every graph leaf (they all describe the same vault); dropped only
+// when the plugin reloads.
+
+/**
+ * Leiden partitions keyed by `${seed}:${resolution}:${edge mode}`, valid for
+ * the graph whose topology signature is {@link leidenGraphSignature}.
+ */
+let leidenCache = new Map<string, Record<string, number>>();
+
+/**
+ * Signature of the graph the Leiden cache and granularity ladder were derived
+ * from. A rebuild that produces an identical graph — reopening the view, a
+ * Refresh over an unchanged vault, a filter round-trip — keeps them all, so
+ * topics reappear from cache instead of re-spending seconds of worker time.
+ */
+let leidenGraphSignature = "";
+
+/** The derived granularity ladder for that same graph, restored on reopen. */
+let savedGranularityLadder: number[] | null = null;
+
+/**
+ * The last semantic edge set, keyed by wiki-graph signature + semantic
+ * settings + the embedding index's `lastUpdated` stamp — so a reopen skips
+ * the HNSW neighbour search entirely unless notes or embeddings changed.
+ */
+let cachedSemanticEdges: { key: string; edges: CachedGraphEdge[] } | null = null;
+
+/**
+ * Cache of membership-signature → generated topic label, so re-running Leiden
+ * at the same grouping (or reopening the view) doesn't re-spend API calls.
+ */
+let topicLabelCache = new Map<string, string>();
+</script>
+
 <script lang="ts">
 import { untrack, tick, onDestroy } from "svelte";
 import { getAllTags, Notice, type WorkspaceLeaf } from "obsidian";
@@ -39,7 +82,7 @@ import {
 	granularityToResolution,
 	type TopicHierarchy,
 } from "../../utils/topicHierarchy";
-import { edgeKey } from "../../utils/graphUtils";
+import { edgeKey, graphTopologySignature } from "../../utils/graphUtils";
 import { buildCollapsedGraph, UNSORTED_CLUSTER } from "../../utils/mergeNodes";
 import { leidenAsync } from "../../utils/computeWorkerManager";
 import { VIEW_TYPE_CHAT } from "../../views/chat/Chat";
@@ -105,11 +148,8 @@ let refitAfterTopicsSettle = false;
 // Leiden community state — computed async in worker, cleared on graph rebuild
 let leidenCommunities: Record<string, number> = $state({});
 
-/**
- * Cache of Leiden partitions keyed by `${seed}:${resolution}`. Leiden is expensive (seconds on
- * large graphs) but pure over (seed, resolution, graph). We invalidate on every graph rebuild.
- */
-let leidenCache = new Map<string, Record<string, number>>();
+// (The Leiden cache, graph signature, semantic edge cache and topic label
+// cache live in the module script above, so they survive view reopen.)
 
 // Filter state
 let selectedFolders: string[] = $state([]);
@@ -197,11 +237,6 @@ let focusedSegmentIds: Set<string> = $state(new Set());
 let generatedClusterLabels: Record<number, string> = $state({});
 /** True while topic labels are being generated. */
 let isLabeling = $state(false);
-/**
- * Cache of membership-signature → generated label, so re-running Leiden at the
- * same grouping (or toggling outline back and forth) doesn't re-spend API calls.
- */
-let topicLabelCache = new Map<string, string>();
 /** Aborts an in-flight labeling pass when the graph changes underneath it. */
 let labelingAbort: AbortController | null = null;
 
@@ -397,6 +432,24 @@ async function loadSemanticEdges(wikiData: GraphData, localBuildVersion: number)
 	const indexReady = await waitForVectorStoreIndex(data.graphEmbedIndex);
 	if (!indexReady || localBuildVersion !== buildVersion) return [];
 
+	// The search is pure over (wiki graph, semantic settings, embeddings). The
+	// index's lastUpdated stamp bumps on every vector write, so together these
+	// fully key the result — a reopen or no-change Refresh skips loading every
+	// vector and re-running the HNSW neighbour search.
+	const metadata = await getVectorStoreService()
+		.getOrCreateInstance(data.graphEmbedIndex)
+		.then((inst) => inst.store.getMetadata())
+		.catch(() => null);
+	if (localBuildVersion !== buildVersion) return [];
+	const cacheKey = [
+		graphTopologySignature(wikiData),
+		data.graphEmbedIndex,
+		metadata?.lastUpdated ?? "no-metadata",
+		settings.semanticNeighborCount,
+		settings.semanticThreshold,
+	].join("|");
+	if (cachedSemanticEdges?.key === cacheKey) return cachedSemanticEdges.edges;
+
 	const documents = await getVectorStoreService().getAllDocumentVectors();
 	if (localBuildVersion !== buildVersion || documents.length === 0) return [];
 
@@ -405,11 +458,13 @@ async function loadSemanticEdges(wikiData: GraphData, localBuildVersion: number)
 	const includePaths = new Set(wikiData.nodes.map((node) => node.path));
 	const wikiEdgeKeys = new Set(wikiData.edges.map((edge) => edgeKey(edge.source, edge.target)));
 
-	return buildSemanticEdges(documents, includePaths, {
+	const edges = await buildSemanticEdges(documents, includePaths, {
 		neighborCount: settings.semanticNeighborCount,
 		threshold: settings.semanticThreshold,
 		excludeEdgeKeys: wikiEdgeKeys,
 	});
+	cachedSemanticEdges = { key: cacheKey, edges };
+	return edges;
 }
 
 /**
@@ -436,13 +491,8 @@ async function buildGraph() {
 		graphData = wikiData;
 		isLoading = false;
 
-		// Graph structure changed — previous Leiden runs are no longer valid.
-		leidenCache.clear();
-		topicHierarchy = null;
-		granularityLadder = [...GRANULARITY_LEVEL_RESOLUTIONS];
-		// The ladder describes the old graph; hide the slider until it's re-derived.
-		hasDerivedGranularityLadder = false;
-		// A pending refit belongs to the build being replaced.
+		// A pending refit belongs to the build being replaced. (Topic-state
+		// invalidation waits until the fused graph is known — see below.)
 		refitAfterTopicsSettle = false;
 
 		// Paint the authored graph right away so the view isn't blank while
@@ -472,6 +522,28 @@ async function buildGraph() {
 				nodes: fused.nodes.map((node) => ({ ...node, degree: degreeMap.get(node.path) ?? 0 })),
 			};
 			resolveAndApplySegments(graphData);
+		}
+
+		// Invalidate derived topic state only when the graph actually changed.
+		// Leiden, the hierarchy and the ladder are pure over (graph, seed, γ) —
+		// a rebuild that lands on an identical graph (Refresh with no vault
+		// changes, a filter round-trip) keeps them all, so the topics reappear
+		// from cache instantly instead of re-spending seconds of worker time.
+		const signature = graphTopologySignature(graphData);
+		if (signature !== leidenGraphSignature) {
+			leidenGraphSignature = signature;
+			leidenCache.clear();
+			topicHierarchy = null;
+			granularityLadder = [...GRANULARITY_LEVEL_RESOLUTIONS];
+			// The ladder describes the old graph; hide the slider until it's re-derived.
+			hasDerivedGranularityLadder = false;
+			savedGranularityLadder = null;
+		} else if (savedGranularityLadder) {
+			// A fresh view instance starts on the fallback ladder even though this
+			// graph has already been probed — restore the derived ladder so the
+			// slider appears immediately instead of hiding through a re-probe.
+			granularityLadder = savedGranularityLadder;
+			hasDerivedGranularityLadder = true;
 		}
 
 		void runLeidenSegmentation();
@@ -620,7 +692,9 @@ function handleFitToView() {
 
 function handleRefresh() {
 	loadFilterOptions();
-	leidenCommunities = {};
+	// Keep the current communities while the rebuild runs: they repaint the
+	// interim graph, and if the vault is unchanged the cache confirms them
+	// instantly — clearing here would just flash the topics away and back.
 	void buildGraph();
 }
 
@@ -991,6 +1065,9 @@ async function deriveGranularityLevels(topicEdges: GraphEdge[]) {
 			Logger.info("[SmartGraph] Granularity ladder: too few distinct groupings, keeping the default");
 		}
 		hasDerivedGranularityLadder = true;
+		// Remember the outcome for this graph, so reopening the view restores the
+		// ladder instead of re-probing.
+		savedGranularityLadder = granularityLadder;
 	} finally {
 		isDerivingGranularityLadder = false;
 	}

--- a/src/components/graph/pixiRenderer.ts
+++ b/src/components/graph/pixiRenderer.ts
@@ -9,14 +9,15 @@
 
 import {
 	Application,
+	CanvasSource,
 	Container,
 	Graphics,
 	Sprite,
 	Text,
 	TextStyle,
+	Texture,
 	Ticker,
 	type PointData,
-	type Texture,
 } from "pixi.js";
 import { Viewport } from "pixi-viewport";
 
@@ -180,8 +181,32 @@ export function readThemeColors(el: HTMLElement): ThemeColors {
 
 // ── Types ────────────────────────────────────────────────────
 
-/** World-space radius of the shared node disc texture (see init). */
-const NODE_TEXTURE_RADIUS = 64;
+/**
+ * Backing size of the shared node disc texture. A power of two, so mipmap
+ * generation works on every WebGL context — without mipmaps, a 128px disc
+ * sampled down to a handful of screen pixels aliases into visibly rough edges
+ * on every zoomed-out node.
+ */
+const NODE_TEXTURE_SIZE = 128;
+/**
+ * Radius of the disc drawn into that texture. The margin to the texture edge
+ * keeps the clamped border pixels transparent, so downsampled mip levels don't
+ * pick up edge bleed.
+ */
+const NODE_TEXTURE_RADIUS = 60;
+
+/**
+ * Above this many visible semantic edges, dashes fall back to solid strokes.
+ *
+ * A dashed edge costs path segments proportional to its screen length (~one
+ * per 9px), so a dense zoomed-out graph turns the dash pass into the largest
+ * remaining tessellation cost — at exactly the density where the pattern
+ * reads as shimmer rather than as dashes. Alpha is reduced to match the ink
+ * of the ~55% dash duty cycle, so the fallback carries the same visual
+ * weight.
+ */
+const SEMANTIC_DASH_EDGE_LIMIT = 500;
+const SEMANTIC_SOLID_ALPHA_SCALE = 0.6;
 
 /** Hit area info for screen-space cluster pills (stored for click/hover). */
 export interface ClusterPillHit {
@@ -375,13 +400,25 @@ export class PixiRenderer {
 		this.viewport.addChild(this.lassoLayer);
 
 		// Shared node texture: one antialiased white disc every node sprite
-		// scales and tints. Sized so typical screen radii are a downscale
-		// (crisp); only extreme zoom-ins upscale past it, where the vector
-		// stroke ring on the hovered node carries the sharp edge anyway.
-		const disc = new Graphics();
-		disc.circle(NODE_TEXTURE_RADIUS, NODE_TEXTURE_RADIUS, NODE_TEXTURE_RADIUS).fill({ color: 0xffffff });
-		this.nodeTexture = this.app.renderer.generateTexture({ target: disc, antialias: true, resolution: 2 });
-		disc.destroy();
+		// scales and tints. Drawn on a 2D canvas rather than via generateTexture:
+		// the canvas upload path generates mipmaps (autoGenerateMipmaps), which
+		// is what keeps far-zoomed-out nodes reading as smooth circles instead
+		// of aliased blobs — render textures only mipmap on explicit request.
+		// Extreme zoom-ins upscale past the texture, where the vector stroke
+		// ring on the hovered node carries the sharp edge anyway.
+		const disc = document.createElement("canvas");
+		disc.width = NODE_TEXTURE_SIZE;
+		disc.height = NODE_TEXTURE_SIZE;
+		const discCtx = disc.getContext("2d");
+		if (discCtx) {
+			discCtx.fillStyle = "#ffffff";
+			discCtx.beginPath();
+			discCtx.arc(NODE_TEXTURE_SIZE / 2, NODE_TEXTURE_SIZE / 2, NODE_TEXTURE_RADIUS, 0, Math.PI * 2);
+			discCtx.fill();
+		}
+		this.nodeTexture = new Texture({
+			source: new CanvasSource({ resource: disc, autoGenerateMipmaps: true }),
+		});
 
 		// Hull graphics (single batched)
 		this.hullGraphics = new Graphics();
@@ -585,7 +622,6 @@ export class PixiRenderer {
 			color?: string;
 			degree?: number;
 			highlighted?: boolean;
-			centrality?: number;
 		}>,
 		nodeSize: number,
 		opts: {
@@ -994,10 +1030,26 @@ export class PixiRenderer {
 		};
 
 		const drawDashedBuckets = (buckets: Map<string, Array<{ sx: number; sy: number; tx: number; ty: number }>>) => {
+			// Past the limit, dashes cost more than they communicate — draw the
+			// whole inferred layer as quieter solid strokes instead (see
+			// SEMANTIC_DASH_EDGE_LIMIT).
+			let totalEdges = 0;
+			for (const segments of buckets.values()) totalEdges += segments.length;
+			const asSolid = totalEdges > SEMANTIC_DASH_EDGE_LIMIT;
+
 			for (const [key, segments] of buckets) {
 				const [color, widthStr, alphaStr] = key.split("|");
 				const width = Number(widthStr);
 				const alpha = Number(alphaStr);
+
+				if (asSolid) {
+					for (const seg of segments) {
+						g.moveTo(seg.sx, seg.sy);
+						g.lineTo(seg.tx, seg.ty);
+					}
+					g.stroke({ color, width, alpha: alpha * SEMANTIC_SOLID_ALPHA_SCALE });
+					continue;
+				}
 
 				for (const seg of segments) {
 					drawDashedLine(g, seg.sx, seg.sy, seg.tx, seg.ty, dash, dashGap);

--- a/src/components/graph/pixiRenderer.ts
+++ b/src/components/graph/pixiRenderer.ts
@@ -7,7 +7,17 @@
  * (d3-force / UMAP) and reactive state.
  */
 
-import { Application, Container, Graphics, Text, TextStyle, Ticker, type PointData } from "pixi.js";
+import {
+	Application,
+	Container,
+	Graphics,
+	Sprite,
+	Text,
+	TextStyle,
+	Ticker,
+	type PointData,
+	type Texture,
+} from "pixi.js";
 import { Viewport } from "pixi-viewport";
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -170,6 +180,9 @@ export function readThemeColors(el: HTMLElement): ThemeColors {
 
 // ── Types ────────────────────────────────────────────────────
 
+/** World-space radius of the shared node disc texture (see init). */
+const NODE_TEXTURE_RADIUS = 64;
+
 /** Hit area info for screen-space cluster pills (stored for click/hover). */
 export interface ClusterPillHit {
 	x: number;
@@ -203,21 +216,19 @@ export class PixiRenderer {
 	private hullGraphics!: Graphics;
 	private edgeGraphics!: Graphics;
 	private lassoGraphics!: Graphics;
-	private nodeGraphicsMap: Map<string, Graphics> = new Map();
 
-	// Cached visual state per node — skip geometry rebuild when unchanged.
-	// Unstroked nodes keep constant white geometry and recolor via tint, so
-	// only radius changes and stroke transitions ever rebuild them.
-	private nodeVisualCache: Map<
-		string,
-		{
-			radius: number;
-			stroked: boolean;
-			fillColor: string;
-			strokeColor: string | null;
-			strokeWidth: number;
-		}
-	> = new Map();
+	// Nodes are Sprites sharing one white circle texture, recolored via tint —
+	// position, scale, and tint are all uniform updates, so per-frame node sync
+	// never tessellates geometry and the whole layer batches into one draw call.
+	private nodeTexture!: Texture;
+	private nodeSpriteMap: Map<string, Sprite> = new Map();
+
+	// Stroke rings (hover / selection / highlight — a handful of nodes) stay
+	// vector Graphics in their own layer above the sprites, so they render
+	// crisply at any zoom. Cached per ring to skip rebuilds when unchanged.
+	private nodeStrokeLayer!: Container;
+	private strokeRingMap: Map<string, Graphics> = new Map();
+	private strokeRingCache: Map<string, { radius: number; color: string; width: number }> = new Map();
 
 	// Label pool
 	private labelPool: Text[] = [];
@@ -239,6 +250,11 @@ export class PixiRenderer {
 	private tooltipContainer!: Container;
 	private tooltipGraphics!: Graphics;
 	private tooltipTexts: Text[] = [];
+	// Tooltip layout cache — text rasterization and box measurement rerun only
+	// when the content changes; per-frame calls just move the container.
+	private _tooltipLayoutKey = "";
+	private _tooltipBoxW = 0;
+	private _tooltipBoxH = 0;
 
 	// State
 	private _theme!: ThemeColors;
@@ -348,13 +364,24 @@ export class PixiRenderer {
 		this.hullLayer = new Container();
 		this.edgeLayer = new Container();
 		this.nodeLayer = new Container();
+		this.nodeStrokeLayer = new Container();
 		this.labelLayer = new Container();
 		this.lassoLayer = new Container();
 		this.viewport.addChild(this.hullLayer);
 		this.viewport.addChild(this.edgeLayer);
 		this.viewport.addChild(this.nodeLayer);
+		this.viewport.addChild(this.nodeStrokeLayer);
 		this.viewport.addChild(this.labelLayer);
 		this.viewport.addChild(this.lassoLayer);
+
+		// Shared node texture: one antialiased white disc every node sprite
+		// scales and tints. Sized so typical screen radii are a downscale
+		// (crisp); only extreme zoom-ins upscale past it, where the vector
+		// stroke ring on the hovered node carries the sharp edge anyway.
+		const disc = new Graphics();
+		disc.circle(NODE_TEXTURE_RADIUS, NODE_TEXTURE_RADIUS, NODE_TEXTURE_RADIUS).fill({ color: 0xffffff });
+		this.nodeTexture = this.app.renderer.generateTexture({ target: disc, antialias: true, resolution: 2 });
+		disc.destroy();
 
 		// Hull graphics (single batched)
 		this.hullGraphics = new Graphics();
@@ -427,6 +454,9 @@ export class PixiRenderer {
 			Ticker.shared.remove(this._viewportDirtyFn);
 			this._viewportDirtyFn = null;
 		}
+		// Sprites share this render texture, so it isn't covered by the
+		// children-destroy below.
+		this.nodeTexture?.destroy(true);
 		this.app.destroy(true, { children: true });
 	}
 
@@ -461,6 +491,8 @@ export class PixiRenderer {
 		this._theme = theme;
 		// Invalidate label cache so font/color changes are picked up on the next draw
 		this.labelPoolCache.fill(null);
+		// Tooltip box and text colors are baked into its cached layout
+		this._tooltipLayoutKey = "";
 		// Update tooltip text styles
 		for (let i = 0; i < this.tooltipTexts.length; i++) {
 			this.tooltipTexts[i].style.fontFamily = theme.font;
@@ -570,13 +602,20 @@ export class PixiRenderer {
 		const c = this._theme;
 		const scale = this.viewport.scaled || 1;
 
-		// Remove stale nodes
-		for (const [id, gfx] of this.nodeGraphicsMap) {
+		// Remove stale nodes and rings
+		for (const [id, sprite] of this.nodeSpriteMap) {
 			if (!nodeIds.has(id)) {
-				this.nodeLayer.removeChild(gfx);
-				gfx.destroy();
-				this.nodeGraphicsMap.delete(id);
-				this.nodeVisualCache.delete(id);
+				this.nodeLayer.removeChild(sprite);
+				sprite.destroy();
+				this.nodeSpriteMap.delete(id);
+			}
+		}
+		for (const [id, ring] of this.strokeRingMap) {
+			if (!nodeIds.has(id)) {
+				this.nodeStrokeLayer.removeChild(ring);
+				ring.destroy();
+				this.strokeRingMap.delete(id);
+				this.strokeRingCache.delete(id);
 			}
 		}
 
@@ -584,30 +623,33 @@ export class PixiRenderer {
 
 		// Create or update nodes
 		for (const node of nodes) {
-			let gfx = this.nodeGraphicsMap.get(node.id);
-			let isNew = false;
-			if (!gfx) {
-				gfx = new Graphics();
+			let sprite = this.nodeSpriteMap.get(node.id);
+			if (!sprite) {
+				sprite = new Sprite(this.nodeTexture);
+				sprite.anchor.set(0.5);
 				// Hit-testing happens in GraphCanvas (findNodeAt), not in Pixi's
 				// event system — keeping nodes out of it avoids making every node
 				// a hit candidate on every pointer event the viewport processes.
-				gfx.eventMode = "none";
-				this.nodeLayer.addChild(gfx);
-				this.nodeGraphicsMap.set(node.id, gfx);
-				isNew = true;
+				sprite.eventMode = "none";
+				this.nodeLayer.addChild(sprite);
+				this.nodeSpriteMap.set(node.id, sprite);
 			}
 
-			// Always update position (cheap)
-			gfx.position.set(node.x, node.y);
 			const alpha = opts.hoverAlphas.get(node.id) ?? 0.85;
-
-			// Compute visual state
 			const base = Math.max(1, nodeSize);
 			const degree = node.degree ?? 0;
 			const radius = base + Math.min(Math.log1p(degree) * 2.5, base * 5);
 			const rawFill = node.highlighted ? c.accent : (node.color ?? c.graphNode);
 			// Resolve hsl()/calc() colors to hex so Pixi.js can parse them
 			const resolvedFillColor = rawFill.startsWith("#") ? rawFill : resolveColor(rawFill, c.graphNode);
+
+			// Position, size and color are all uniform updates on the sprite.
+			// Blending the tint toward the background rather than using real
+			// alpha keeps nodes opaque, so overlapping nodes and the edges
+			// underneath don't show through during hover fades.
+			sprite.position.set(node.x, node.y);
+			sprite.scale.set(radius / NODE_TEXTURE_RADIUS);
+			sprite.tint = blendTint(resolvedFillColor, bgChannels, alpha);
 
 			const isSelected = opts.selectedNodes.has(node.id);
 			const isHovered = opts.hoveredNodeId === node.id;
@@ -620,50 +662,38 @@ export class PixiRenderer {
 				strokeColor = isHovered ? c.textNormal : c.accent;
 				strokeWidth = 2 / scale;
 			}
-			const stroked = strokeColor !== null;
 
-			// Unstroked nodes (the vast majority) draw a constant white circle and
-			// recolor via tint, so the per-frame hover fade never rebuilds their
-			// geometry — tint is a cheap uniform, clear()+fill() is tessellation.
-			// Stroked nodes (hover / selection / highlight — a handful) bake the
-			// blended colors into the geometry instead, since tint would multiply
-			// fill and stroke by the same color. Blending toward the background
-			// rather than using real alpha keeps nodes opaque, so overlapping
-			// nodes and edges underneath don't show through.
-			const fillColor = stroked ? blendColor(resolvedFillColor, c.bgPrimary, alpha) : "#ffffff";
-			const blendedStrokeColor =
-				strokeColor !== null && alpha < 1 ? blendColor(strokeColor, c.bgPrimary, alpha) : strokeColor;
-
-			// Check cache — skip geometry rebuild if nothing visual changed
-			const cached = this.nodeVisualCache.get(node.id);
-			const geometryDirty =
-				isNew ||
-				!cached ||
-				cached.radius !== radius ||
-				cached.stroked !== stroked ||
-				cached.fillColor !== fillColor ||
-				cached.strokeColor !== blendedStrokeColor ||
-				cached.strokeWidth !== strokeWidth;
-
-			if (geometryDirty) {
-				gfx.clear();
-
-				gfx.circle(0, 0, radius).fill({ color: fillColor });
-
-				if (blendedStrokeColor) {
-					gfx.circle(0, 0, radius).stroke({ color: blendedStrokeColor, width: strokeWidth });
+			let ring = this.strokeRingMap.get(node.id);
+			if (strokeColor === null) {
+				if (ring) {
+					this.nodeStrokeLayer.removeChild(ring);
+					ring.destroy();
+					this.strokeRingMap.delete(node.id);
+					this.strokeRingCache.delete(node.id);
 				}
-
-				this.nodeVisualCache.set(node.id, {
-					radius,
-					stroked,
-					fillColor,
-					strokeColor: blendedStrokeColor,
-					strokeWidth,
-				});
+				continue;
 			}
 
-			gfx.tint = stroked ? 0xffffff : blendTint(resolvedFillColor, bgChannels, alpha);
+			const blendedStrokeColor = alpha < 1 ? blendColor(strokeColor, c.bgPrimary, alpha) : strokeColor;
+			if (!ring) {
+				ring = new Graphics();
+				ring.eventMode = "none";
+				this.nodeStrokeLayer.addChild(ring);
+				this.strokeRingMap.set(node.id, ring);
+			}
+			ring.position.set(node.x, node.y);
+
+			const cached = this.strokeRingCache.get(node.id);
+			if (
+				!cached ||
+				cached.radius !== radius ||
+				cached.color !== blendedStrokeColor ||
+				cached.width !== strokeWidth
+			) {
+				ring.clear();
+				ring.circle(0, 0, radius).stroke({ color: blendedStrokeColor, width: strokeWidth });
+				this.strokeRingCache.set(node.id, { radius, color: blendedStrokeColor, width: strokeWidth });
+			}
 		}
 	}
 
@@ -761,6 +791,14 @@ export class PixiRenderer {
 			edgeFadeAlpha: number;
 			baseEdgeAlpha: number;
 			nodeClusterMap: Map<string, number | undefined>;
+			/**
+			 * World-space rect (view + margin) outside which edges are skipped.
+			 * Tessellation is the priciest CPU step of a frame, and when zoomed
+			 * into a corner of a large graph most edges land nowhere near the
+			 * screen. The caller re-triggers a draw when panning leaves the
+			 * margin, so culled edges reappear before scrolling into view.
+			 */
+			cullRect?: { minX: number; minY: number; maxX: number; maxY: number } | null;
 		},
 	): void {
 		const g = this.edgeGraphics;
@@ -806,6 +844,20 @@ export class PixiRenderer {
 			const tx = edge.target.x;
 			const ty = edge.target.y;
 			if (sx == null || sy == null || tx == null || ty == null) continue;
+
+			// Conservative AABB rejection: only skip when the whole segment is
+			// on one far side of the rect, so nothing that could touch the view
+			// is ever dropped.
+			const cull = opts.cullRect;
+			if (
+				cull &&
+				((sx < cull.minX && tx < cull.minX) ||
+					(sx > cull.maxX && tx > cull.maxX) ||
+					(sy < cull.minY && ty < cull.minY) ||
+					(sy > cull.maxY && ty > cull.maxY))
+			) {
+				continue;
+			}
 
 			const sourceCluster = opts.nodeClusterMap.get(edge.source.id);
 			const targetCluster = opts.nodeClusterMap.get(edge.target.id);
@@ -1170,8 +1222,7 @@ export class PixiRenderer {
 		isForceMode: boolean,
 	): void {
 		const c = this._theme;
-		const sx = this.viewport.toScreen(node.x, node.y).x;
-		const sy = this.viewport.toScreen(node.x, node.y).y;
+		const screen = this.viewport.toScreen(node.x, node.y);
 
 		const lines: string[] = [node.label];
 		if (node.cluster != null) {
@@ -1189,39 +1240,43 @@ export class PixiRenderer {
 		const padX = 10;
 		const padY = 8;
 
-		// Measure widths
-		let maxW = 0;
-		for (let i = 0; i < lines.length && i < this.tooltipTexts.length; i++) {
-			this.tooltipTexts[i].text = lines[i];
-			this.tooltipTexts[i].style.fontSize = fontSize;
-			this.tooltipTexts[i].style.fontWeight = i === 0 ? "bold" : "normal";
-			this.tooltipTexts[i].style.fill = i === 0 ? c.textNormal : c.textMuted;
-			this.tooltipTexts[i].visible = true;
-			const w = this.tooltipTexts[i].width;
-			if (w > maxW) maxW = w;
-		}
-		// Hide unused lines
-		for (let i = lines.length; i < this.tooltipTexts.length; i++) {
-			this.tooltipTexts[i].visible = false;
-		}
+		// Re-rasterize text and remeasure the box only when the content changed.
+		// While hovering, this runs every frame with identical lines, so the
+		// steady-state cost is just moving the container. Contents are drawn at
+		// the container's origin so position updates never touch the layout.
+		const layoutKey = lines.join("\n");
+		if (layoutKey !== this._tooltipLayoutKey) {
+			this._tooltipLayoutKey = layoutKey;
 
-		const boxW = maxW + padX * 2;
-		const boxH = lines.length * lineH + padY * 2;
+			let maxW = 0;
+			for (let i = 0; i < lines.length && i < this.tooltipTexts.length; i++) {
+				this.tooltipTexts[i].text = lines[i];
+				this.tooltipTexts[i].style.fontSize = fontSize;
+				this.tooltipTexts[i].style.fontWeight = i === 0 ? "bold" : "normal";
+				this.tooltipTexts[i].style.fill = i === 0 ? c.textNormal : c.textMuted;
+				this.tooltipTexts[i].visible = true;
+				this.tooltipTexts[i].position.set(padX, padY + i * lineH);
+				const w = this.tooltipTexts[i].width;
+				if (w > maxW) maxW = w;
+			}
+			// Hide unused lines
+			for (let i = lines.length; i < this.tooltipTexts.length; i++) {
+				this.tooltipTexts[i].visible = false;
+			}
+
+			this._tooltipBoxW = maxW + padX * 2;
+			this._tooltipBoxH = lines.length * lineH + padY * 2;
+
+			this.tooltipGraphics.clear();
+			this.tooltipGraphics.roundRect(0, 0, this._tooltipBoxW, this._tooltipBoxH, 6);
+			this.tooltipGraphics.fill({ color: c.bgPrimary, alpha: 0.92 });
+			this.tooltipGraphics.stroke({ color: c.textFaint, width: 0.5 });
+		}
 
 		// Position: right of node, flip if near edge
-		let bx = sx + 14;
-		if (bx + boxW > this._width - 8) bx = sx - boxW - 14;
-		const by = sy - boxH / 2;
-
-		this.tooltipGraphics.clear();
-		this.tooltipGraphics.roundRect(bx, by, boxW, boxH, 6);
-		this.tooltipGraphics.fill({ color: c.bgPrimary, alpha: 0.92 });
-		this.tooltipGraphics.stroke({ color: c.textFaint, width: 0.5 });
-
-		for (let i = 0; i < lines.length && i < this.tooltipTexts.length; i++) {
-			this.tooltipTexts[i].position.set(bx + padX, by + padY + i * lineH);
-		}
-
+		let bx = screen.x + 14;
+		if (bx + this._tooltipBoxW > this._width - 8) bx = screen.x - this._tooltipBoxW - 14;
+		this.tooltipContainer.position.set(bx, screen.y - this._tooltipBoxH / 2);
 		this.tooltipContainer.visible = true;
 	}
 

--- a/src/components/graph/pixiRenderer.ts
+++ b/src/components/graph/pixiRenderer.ts
@@ -7,7 +7,7 @@
  * (d3-force / UMAP) and reactive state.
  */
 
-import { Application, Container, Graphics, Text, TextStyle, type PointData } from "pixi.js";
+import { Application, Container, Graphics, Text, TextStyle, Ticker, type PointData } from "pixi.js";
 import { Viewport } from "pixi-viewport";
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -41,10 +41,22 @@ function drawDashedLine(g: Graphics, x1: number, y1: number, x2: number, y2: num
  * to let the browser resolve the value.
  */
 let _colorCtx: CanvasRenderingContext2D | null = null;
+// Memo for resolved colors: cluster palettes are hsl() strings and node fills
+// resolve on the per-frame hot path, so each unique value should hit the canvas
+// context exactly once. Only successful resolutions are cached — a failure's
+// result depends on the caller's fallback.
+const _resolvedColorCache = new Map<string, string>();
+function rememberResolvedColor(raw: string, hex: string): string {
+	if (_resolvedColorCache.size > 1024) _resolvedColorCache.clear();
+	_resolvedColorCache.set(raw, hex);
+	return hex;
+}
 function resolveColor(raw: string, fallback: string): string {
 	if (!raw || raw === "none" || raw === "transparent") return fallback;
 	// Already a hex color — fast path
 	if (raw.startsWith("#")) return raw;
+	const cached = _resolvedColorCache.get(raw);
+	if (cached !== undefined) return cached;
 
 	try {
 		if (!_colorCtx) {
@@ -57,14 +69,14 @@ function resolveColor(raw: string, fallback: string): string {
 		_colorCtx.fillStyle = raw;
 		const resolved = _colorCtx.fillStyle; // browser-resolved hex or rgb()
 		// fillStyle returns a hex string like "#rrggbb" or "rgba(r,g,b,a)"
-		if (resolved.startsWith("#")) return resolved;
+		if (resolved.startsWith("#")) return rememberResolvedColor(raw, resolved);
 		// Parse rgb/rgba → hex
 		const m = resolved.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
 		if (m) {
 			const r = Number(m[1]).toString(16).padStart(2, "0");
 			const g = Number(m[2]).toString(16).padStart(2, "0");
 			const b = Number(m[3]).toString(16).padStart(2, "0");
-			return `#${r}${g}${b}`;
+			return rememberResolvedColor(raw, `#${r}${g}${b}`);
 		}
 		return fallback;
 	} catch {
@@ -97,6 +109,28 @@ function blendColor(fg: string, bg: string, alpha: number): string {
 	const g = Math.round(bg_ + (pg - bg_) * safeAlpha);
 	const b = Math.round(bb + (pb - bb) * safeAlpha);
 	return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+}
+
+// Parsed-channel memo backing the per-node-per-frame tint path.
+const _channelCache = new Map<string, [number, number, number]>();
+function hexChannels(color: string): [number, number, number] {
+	let channels = _channelCache.get(color);
+	if (!channels) {
+		channels = parseHexColorChannels(color, [255, 255, 255]);
+		if (_channelCache.size > 1024) _channelCache.clear();
+		_channelCache.set(color, channels);
+	}
+	return channels;
+}
+
+/** Same blend as {@link blendColor}, returned as a Pixi tint number — no string building. */
+function blendTint(fg: string, bg: [number, number, number], alpha: number): number {
+	const safeAlpha = clampUnitInterval(alpha, 1);
+	const [pr, pg, pb] = hexChannels(fg);
+	const r = Math.round(bg[0] + (pr - bg[0]) * safeAlpha);
+	const g = Math.round(bg[1] + (pg - bg[1]) * safeAlpha);
+	const b = Math.round(bg[2] + (pb - bg[2]) * safeAlpha);
+	return (r << 16) | (g << 8) | b;
 }
 
 function clampUnitInterval(value: number, fallback: number): number {
@@ -171,15 +205,16 @@ export class PixiRenderer {
 	private lassoGraphics!: Graphics;
 	private nodeGraphicsMap: Map<string, Graphics> = new Map();
 
-	// Cached visual state per node — skip geometry rebuild when unchanged
+	// Cached visual state per node — skip geometry rebuild when unchanged.
+	// Unstroked nodes keep constant white geometry and recolor via tint, so
+	// only radius changes and stroke transitions ever rebuild them.
 	private nodeVisualCache: Map<
 		string,
 		{
 			radius: number;
+			stroked: boolean;
 			fillColor: string;
-			fillAlpha: number;
 			strokeColor: string | null;
-			strokeAlpha: number;
 			strokeWidth: number;
 		}
 	> = new Map();
@@ -214,6 +249,8 @@ export class PixiRenderer {
 
 	// Callback fired whenever the viewport moves (pan/zoom/pinch)
 	private _onViewportMoved: (() => void) | null = null;
+	// Shared-ticker callback that polls viewport.dirty (removed on destroy)
+	private _viewportDirtyFn: (() => void) | null = null;
 
 	// Public accessors
 	get theme(): ThemeColors {
@@ -255,6 +292,9 @@ export class PixiRenderer {
 			resolution: window.devicePixelRatio || 1,
 			autoDensity: true,
 			preference: "webgl",
+			// Rendering is on demand: the owner calls renderFrame() when something
+			// actually changed, so a settled graph costs no GPU work at idle.
+			autoStart: false,
 		});
 
 		// Style the canvas
@@ -289,10 +329,19 @@ export class PixiRenderer {
 				maxScale: 10,
 			});
 
-		// Fire callback when viewport moves (pan/zoom/pinch/decelerate)
-		this.viewport.on("moved", () => {
-			this._onViewportMoved?.();
-		});
+		// The viewport updates its plugins (wheel smoothing, decelerate, animate)
+		// on the shared ticker, so the camera can move without any pointer event
+		// firing. Its `dirty` flag is set by that update loop for every movement
+		// source — polling it here is the one signal that catches them all. The
+		// viewport's own update runs first on the same ticker (it registered
+		// earlier), so a movement is observed the tick it happens.
+		this._viewportDirtyFn = () => {
+			if (this.viewport.dirty) {
+				this.viewport.dirty = false;
+				this._onViewportMoved?.();
+			}
+		};
+		Ticker.shared.add(this._viewportDirtyFn);
 
 		// World-space layers (inside viewport). Hulls sit at the bottom so topic
 		// regions read as background, never over edges or nodes.
@@ -374,7 +423,21 @@ export class PixiRenderer {
 		if (this._destroyed) return;
 		this._destroyed = true;
 		this._ready = false;
+		if (this._viewportDirtyFn) {
+			Ticker.shared.remove(this._viewportDirtyFn);
+			this._viewportDirtyFn = null;
+		}
 		this.app.destroy(true, { children: true });
+	}
+
+	/**
+	 * Render one frame to the canvas. The application ticker is disabled
+	 * (`autoStart: false`), so nothing draws unless the owner asks for it —
+	 * GraphCanvas calls this once at the end of each coalesced render pass.
+	 */
+	renderFrame(): void {
+		if (this._destroyed || !this._ready) return;
+		this.app.renderer.render(this.app.stage);
 	}
 
 	// ── Canvas access ──────────────────────────────────────
@@ -517,23 +580,26 @@ export class PixiRenderer {
 			}
 		}
 
+		const bgChannels = hexChannels(c.bgPrimary);
+
 		// Create or update nodes
 		for (const node of nodes) {
 			let gfx = this.nodeGraphicsMap.get(node.id);
 			let isNew = false;
 			if (!gfx) {
 				gfx = new Graphics();
-				gfx.eventMode = "static";
-				gfx.cursor = "pointer";
+				// Hit-testing happens in GraphCanvas (findNodeAt), not in Pixi's
+				// event system — keeping nodes out of it avoids making every node
+				// a hit candidate on every pointer event the viewport processes.
+				gfx.eventMode = "none";
 				this.nodeLayer.addChild(gfx);
 				this.nodeGraphicsMap.set(node.id, gfx);
 				isNew = true;
 			}
 
-			// Always update position + alpha (cheap)
+			// Always update position (cheap)
 			gfx.position.set(node.x, node.y);
 			const alpha = opts.hoverAlphas.get(node.id) ?? 0.85;
-			gfx.alpha = 1;
 
 			// Compute visual state
 			const base = Math.max(1, nodeSize);
@@ -542,7 +608,6 @@ export class PixiRenderer {
 			const rawFill = node.highlighted ? c.accent : (node.color ?? c.graphNode);
 			// Resolve hsl()/calc() colors to hex so Pixi.js can parse them
 			const resolvedFillColor = rawFill.startsWith("#") ? rawFill : resolveColor(rawFill, c.graphNode);
-			const fillColor = alpha < 1 ? blendColor(resolvedFillColor, c.bgPrimary, alpha) : resolvedFillColor;
 
 			const isSelected = opts.selectedNodes.has(node.id);
 			const isHovered = opts.hoveredNodeId === node.id;
@@ -555,9 +620,19 @@ export class PixiRenderer {
 				strokeColor = isHovered ? c.textNormal : c.accent;
 				strokeWidth = 2 / scale;
 			}
-			const strokeAlpha = strokeColor ? alpha : 1;
+			const stroked = strokeColor !== null;
+
+			// Unstroked nodes (the vast majority) draw a constant white circle and
+			// recolor via tint, so the per-frame hover fade never rebuilds their
+			// geometry — tint is a cheap uniform, clear()+fill() is tessellation.
+			// Stroked nodes (hover / selection / highlight — a handful) bake the
+			// blended colors into the geometry instead, since tint would multiply
+			// fill and stroke by the same color. Blending toward the background
+			// rather than using real alpha keeps nodes opaque, so overlapping
+			// nodes and edges underneath don't show through.
+			const fillColor = stroked ? blendColor(resolvedFillColor, c.bgPrimary, alpha) : "#ffffff";
 			const blendedStrokeColor =
-				strokeColor && strokeAlpha < 1 ? blendColor(strokeColor, c.bgPrimary, strokeAlpha) : strokeColor;
+				strokeColor !== null && alpha < 1 ? blendColor(strokeColor, c.bgPrimary, alpha) : strokeColor;
 
 			// Check cache — skip geometry rebuild if nothing visual changed
 			const cached = this.nodeVisualCache.get(node.id);
@@ -565,10 +640,9 @@ export class PixiRenderer {
 				isNew ||
 				!cached ||
 				cached.radius !== radius ||
+				cached.stroked !== stroked ||
 				cached.fillColor !== fillColor ||
-				cached.fillAlpha !== alpha ||
 				cached.strokeColor !== blendedStrokeColor ||
-				cached.strokeAlpha !== strokeAlpha ||
 				cached.strokeWidth !== strokeWidth;
 
 			if (geometryDirty) {
@@ -580,25 +654,17 @@ export class PixiRenderer {
 					gfx.circle(0, 0, radius).stroke({ color: blendedStrokeColor, width: strokeWidth });
 				}
 
-				gfx.hitArea = {
-					contains: (px: number, py: number) => px * px + py * py <= (radius + 4 / scale) ** 2,
-				};
-
 				this.nodeVisualCache.set(node.id, {
 					radius,
+					stroked,
 					fillColor,
-					fillAlpha: alpha,
 					strokeColor: blendedStrokeColor,
-					strokeAlpha,
 					strokeWidth,
 				});
 			}
-		}
-	}
 
-	/** Get the Graphics object for a node ID. */
-	getNodeGfx(id: string): Graphics | undefined {
-		return this.nodeGraphicsMap.get(id);
+			gfx.tint = stroked ? 0xffffff : blendTint(resolvedFillColor, bgChannels, alpha);
+		}
 	}
 
 	// ── Hull rendering ─────────────────────────────────────

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -124,12 +124,6 @@ export interface GraphNode {
 	kind?: "note" | "topic";
 	/** For `kind: "topic"` — the vault paths this node stands for. */
 	memberPaths?: string[];
-	/**
-	 * Normalized betweenness centrality (0–1).
-	 * High values indicate "bridge" nodes that connect otherwise distant parts of the graph.
-	 * Set when Leiden community detection is active.
-	 */
-	centrality?: number;
 }
 
 /**
@@ -208,8 +202,6 @@ export interface SmartGraphSettings {
 	leidenResolution: number;
 	/** Bridge node threshold: fraction of foreign-community neighbors required to show the bridge ring (0–1) */
 	bridgeThreshold: number;
-	/** Skeleton bridge centrality threshold: min betweenness centrality for a node to survive in the outline view (0–1) */
-	skeletonBridgeCentralityThreshold: number;
 	/** Highlight isolated notes (degree 0) in the graph */
 	highlightIsolated: boolean;
 	/** Highlight bridge notes (nodes spanning multiple communities) in the graph */
@@ -254,7 +246,6 @@ export const DEFAULT_SMART_GRAPH_SETTINGS: SmartGraphSettings = {
 	// the slider doesn't silently shift γ the first time it's touched.
 	leidenResolution: 1.0,
 	bridgeThreshold: 0.4,
-	skeletonBridgeCentralityThreshold: 0.05,
 	highlightIsolated: false,
 	highlightBridges: false,
 	showClusterLabels: true,

--- a/src/utils/computeWorker.ts
+++ b/src/utils/computeWorker.ts
@@ -8,7 +8,7 @@
 
 import { kMeans, suggestK, hdbscan } from "./clustering";
 import type { HDBSCANResult } from "./clustering";
-import { scanSemanticPairs, type SemanticPair } from "./semanticEdges";
+import { computeSemanticPairs, type SemanticPair } from "./semanticEdges";
 import { project2D, reduceDimensions } from "./projection";
 import type { ProjectionMethod } from "../types/graph";
 import Graph from "graphology";
@@ -267,7 +267,7 @@ workerScope.onmessage = async (e: MessageEvent<ComputeWorkerRequest>) => {
 				break;
 			}
 			case "semanticEdges": {
-				const result = scanSemanticPairs(
+				const result = await computeSemanticPairs(
 					msg.vectors.data,
 					msg.vectors.count,
 					msg.vectors.dim,

--- a/src/utils/computeWorker.ts
+++ b/src/utils/computeWorker.ts
@@ -11,8 +11,6 @@ import type { HDBSCANResult } from "./clustering";
 import { computeSemanticPairs, type SemanticPair } from "./semanticEdges";
 import { project2D, reduceDimensions } from "./projection";
 import type { ProjectionMethod } from "../types/graph";
-import Graph from "graphology";
-import betweennessCentrality from "graphology-metrics/centrality/betweenness";
 import { Graph as LeidenGraph, leiden } from "leiden-ts";
 
 export interface SerializedVectorBatch {
@@ -58,8 +56,6 @@ export type ComputeWorkerRequest =
 			sources: string[];
 			targets: string[];
 			weights: number[];
-			/** If true, also compute betweenness centrality on the same graph */
-			withCentrality?: boolean;
 			/** PRNG seed for reproducibility (default 42) */
 			seed?: number;
 			/** Resolution γ — lower = fewer larger communities (default 1.0) */
@@ -93,11 +89,7 @@ export type ComputeWorkerResponse =
 	| {
 			id: number;
 			type: "leiden";
-			result: {
-				communities: Record<string, number>;
-				/** Normalized betweenness centrality per node (0–1). Only present when withCentrality was true. */
-				centrality?: Record<string, number>;
-			};
+			result: { communities: Record<string, number> };
 	  }
 	| {
 			id: number;
@@ -247,22 +239,10 @@ workerScope.onmessage = async (e: MessageEvent<ComputeWorkerRequest>) => {
 					}
 				}
 
-				// Betweenness centrality still uses graphology (leiden-ts doesn't include it)
-				let centrality: Record<string, number> | undefined;
-				if (msg.withCentrality && Object.keys(communities).length > 0) {
-					const gGraph = new Graph({ type: "undirected", multi: false });
-					for (let i = 0; i < msg.sources.length; i++) {
-						if (msg.sources[i] !== msg.targets[i]) {
-							gGraph.mergeEdge(msg.sources[i], msg.targets[i], { weight: msg.weights[i] });
-						}
-					}
-					centrality = betweennessCentrality(gGraph, { normalized: true, getEdgeWeight: "weight" });
-				}
-
 				workerScope.postMessage({
 					id: msg.id,
 					type: "leiden",
-					result: { communities, centrality },
+					result: { communities },
 				} satisfies ComputeWorkerResponse);
 				break;
 			}

--- a/src/utils/computeWorkerManager.ts
+++ b/src/utils/computeWorkerManager.ts
@@ -11,7 +11,7 @@ import { kMeans, suggestK, hdbscan, type KMeansResult, type HDBSCANResult } from
 import { project2D, reduceDimensions } from "./projection";
 import type { ProjectionMethod } from "../types/graph";
 import type { ComputeWorkerRequest, ComputeWorkerResponse, SerializedVectorBatch } from "./computeWorker";
-import { scanSemanticPairs, type SemanticPair } from "./semanticEdges";
+import { computeSemanticPairs, type SemanticPair } from "./semanticEdges";
 import ComputeWorkerConstructor from "./computeWorker?worker&inline";
 import Graph from "graphology";
 import betweennessCentrality from "graphology-metrics/centrality/betweenness";
@@ -255,7 +255,7 @@ function runOnMainThread(request: ComputeWorkerRequest): ComputeWorkerResponse |
 			return { id: request.id, type: "leiden" as const, result: { communities, centrality } };
 		}
 		case "semanticEdges": {
-			const result = scanSemanticPairs(
+			return computeSemanticPairs(
 				request.vectors.data,
 				request.vectors.count,
 				request.vectors.dim,
@@ -266,8 +266,7 @@ function runOnMainThread(request: ComputeWorkerRequest): ComputeWorkerResponse |
 					threshold: request.threshold,
 					excludePairs: request.excludePairs ? new Set(request.excludePairs) : undefined,
 				},
-			);
-			return { id: request.id, type: "semanticEdges" as const, result };
+			).then((result) => ({ id: request.id, type: "semanticEdges" as const, result }));
 		}
 	}
 }

--- a/src/utils/computeWorkerManager.ts
+++ b/src/utils/computeWorkerManager.ts
@@ -13,8 +13,6 @@ import type { ProjectionMethod } from "../types/graph";
 import type { ComputeWorkerRequest, ComputeWorkerResponse, SerializedVectorBatch } from "./computeWorker";
 import { computeSemanticPairs, type SemanticPair } from "./semanticEdges";
 import ComputeWorkerConstructor from "./computeWorker?worker&inline";
-import Graph from "graphology";
-import betweennessCentrality from "graphology-metrics/centrality/betweenness";
 import { Graph as LeidenGraph, leiden } from "leiden-ts";
 
 let worker: Worker | null = null;
@@ -241,18 +239,7 @@ function runOnMainThread(request: ComputeWorkerRequest): ComputeWorkerResponse |
 					communities[path] = assignments[idx];
 				}
 			}
-
-			let centrality: Record<string, number> | undefined;
-			if (request.withCentrality && Object.keys(communities).length > 0) {
-				const gGraph = new Graph({ type: "undirected", multi: false });
-				for (let i = 0; i < request.sources.length; i++) {
-					if (request.sources[i] !== request.targets[i]) {
-						gGraph.mergeEdge(request.sources[i], request.targets[i], { weight: request.weights[i] });
-					}
-				}
-				centrality = betweennessCentrality(gGraph, { normalized: true, getEdgeWeight: "weight" });
-			}
-			return { id: request.id, type: "leiden" as const, result: { communities, centrality } };
+			return { id: request.id, type: "leiden" as const, result: { communities } };
 		}
 		case "semanticEdges": {
 			return computeSemanticPairs(
@@ -376,10 +363,9 @@ export async function leidenAsync(
 	sources: string[],
 	targets: string[],
 	weights: number[],
-	withCentrality = false,
 	seed = 42,
 	resolution = 1.0,
-): Promise<{ communities: Record<string, number>; centrality: Record<string, number> }> {
+): Promise<Record<string, number>> {
 	const id = ++requestId;
 	const resp = await postRequest<Extract<ComputeWorkerResponse, { type: "leiden" }>>({
 		id,
@@ -387,14 +373,10 @@ export async function leidenAsync(
 		sources,
 		targets,
 		weights,
-		withCentrality,
 		seed,
 		resolution,
 	});
-	return {
-		communities: resp.result.communities,
-		centrality: resp.result.centrality ?? {},
-	};
+	return resp.result.communities;
 }
 
 /**

--- a/src/utils/graphUtils.ts
+++ b/src/utils/graphUtils.ts
@@ -15,3 +15,53 @@ export function splitEdgeKey(key: string): [string, string] {
 	if (separator === -1) return [key, key];
 	return [key.slice(0, separator), key.slice(separator + 1)];
 }
+
+function djb2(text: string): number {
+	let hash = 5381;
+	for (let i = 0; i < text.length; i++) {
+		hash = ((hash * 33) ^ text.charCodeAt(i)) >>> 0;
+	}
+	return hash;
+}
+
+/**
+ * Cheap structural signature of a graph: node identities plus edge
+ * `(source, target, type, weight)`.
+ *
+ * Used to decide whether derived topic state (the Leiden cache, the topic
+ * hierarchy, the granularity ladder) still describes the graph after a
+ * rebuild — a Refresh over an unchanged vault should keep them rather than
+ * recompute seconds of worker time for identical results.
+ *
+ * Per-element hashes are combined order-independently (sum and xor), so two
+ * builds that enumerate the same nodes and edges in different orders produce
+ * the same signature. Counts are included so the accumulators can't be walked
+ * back into a collision by adding and removing offsetting elements.
+ */
+export function graphTopologySignature(graph: {
+	nodes: Array<{ id: string }>;
+	edges: Array<{ source: string; target: string; type: string; weight: number }>;
+}): string {
+	let nodeSum = 0;
+	let nodeXor = 0;
+	for (const node of graph.nodes) {
+		const hash = djb2(node.id);
+		nodeSum = (nodeSum + hash) >>> 0;
+		nodeXor = (nodeXor ^ hash) >>> 0;
+	}
+	let edgeSum = 0;
+	let edgeXor = 0;
+	for (const edge of graph.edges) {
+		const hash = djb2(`${edge.source}\0${edge.target}\0${edge.type}\0${edge.weight}`);
+		edgeSum = (edgeSum + hash) >>> 0;
+		edgeXor = (edgeXor ^ hash) >>> 0;
+	}
+	return [
+		graph.nodes.length,
+		nodeSum.toString(36),
+		nodeXor.toString(36),
+		graph.edges.length,
+		edgeSum.toString(36),
+		edgeXor.toString(36),
+	].join(":");
+}

--- a/src/utils/seededRandom.ts
+++ b/src/utils/seededRandom.ts
@@ -1,0 +1,17 @@
+/**
+ * Deterministic PRNG (mulberry32).
+ *
+ * Used wherever graph derivations need randomness without run-to-run drift —
+ * HNSW level selection and betweenness pivot sampling both feed layouts and
+ * topic structure, which should come out identical when the vault hasn't
+ * changed. Worker-safe, no dependencies.
+ */
+export function mulberry32(seed: number): () => number {
+	let a = seed >>> 0;
+	return () => {
+		a = (a + 0x6d2b79f5) | 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}

--- a/src/utils/semanticEdges.ts
+++ b/src/utils/semanticEdges.ts
@@ -1,14 +1,21 @@
 /**
  * Semantic Edge Scan
  *
- * The pairwise similarity scan behind the smart graph's inferred edges, kept
- * free of Obsidian and vault types so it can run inside the compute worker as
- * well as on the main thread.
+ * The neighbour search behind the smart graph's inferred edges, kept free of
+ * Obsidian and vault types so it can run inside the compute worker as well as
+ * on the main thread.
  *
  * Inputs are a flat vector batch plus a per-vector note index (large notes are
  * embedded as several chunks), which is what survives a structured-clone
  * transfer. Outputs are index pairs; callers map them back to paths.
+ *
+ * Two kernels share one output contract ({@link computeSemanticPairs}): an
+ * exact O(n²) pairwise scan for small graphs, and an HNSW-accelerated
+ * approximate search past {@link SEMANTIC_HNSW_MIN_CHUNKS} chunks, where the
+ * quadratic scan stops being viable.
  */
+
+import { HNSW } from "hnsw";
 
 /**
  * How many semantic neighbours each note may contribute. Kept deliberately low:
@@ -97,7 +104,9 @@ function bestChunkSimilarity(normalized: Float32Array, dim: number, aChunks: num
  * Scan all note pairs and return the top-K neighbours of each, deduped.
  *
  * `chunkOwners[i]` gives the note index owning chunk `i`; `noteCount` is the
- * number of distinct notes. O(n²) in notes — callers cap the input size.
+ * number of distinct notes. Exact but O(chunks²) — use via
+ * {@link computeSemanticPairs}, which switches to the HNSW kernel when the
+ * batch is large enough that this scan would take seconds.
  */
 export function scanSemanticPairs(
 	data: Float32Array,
@@ -138,9 +147,25 @@ export function scanSemanticPairs(
 		}
 	}
 
+	return selectTopPairs(candidates, neighborCount, excludePairs);
+}
+
+/**
+ * Union of every note's top-K candidate neighbours, deduped so an unordered
+ * pair is emitted once.
+ *
+ * Shared by both kernels so their output semantics match exactly — including
+ * the subtlety that a wiki-linked (excluded) pair still *occupies* one of a
+ * note's K slots before being dropped at emission.
+ */
+function selectTopPairs(
+	candidates: Array<Array<{ note: number; score: number }>>,
+	neighborCount: number,
+	excludePairs?: Set<string>,
+): SemanticPair[] {
 	const pairs: SemanticPair[] = [];
 	const seen = new Set<string>();
-	for (let note = 0; note < noteCount; note++) {
+	for (let note = 0; note < candidates.length; note++) {
 		const list = candidates[note];
 		if (list.length === 0) continue;
 		// Ties break on note index so results are stable across runs.
@@ -160,4 +185,152 @@ export function scanSemanticPairs(
 	}
 
 	return pairs;
+}
+
+// ============================================================================
+// HNSW-accelerated kernel
+// ============================================================================
+
+/**
+ * Chunk count above which the exact scan hands over to the HNSW kernel.
+ *
+ * The exact scan's cost is chunks² · dim / 2 — measured around 1–2s at 2k
+ * chunks with dim 1024, and growing quadratically from there. HNSW pays an
+ * n·log n build instead, which loses below this size (the exact scan is
+ * already sub-second and deterministic) and wins increasingly above it.
+ */
+export const SEMANTIC_HNSW_MIN_CHUNKS = 2000;
+
+/** Seed for the HNSW level-selection PRNG — fixed so rebuilds of the same vault produce the same edges. */
+const HNSW_LEVEL_SEED = 42;
+
+/** Deterministic PRNG (mulberry32) for HNSW level selection. */
+function mulberry32(seed: number): () => number {
+	let a = seed >>> 0;
+	return () => {
+		a = (a + 0x6d2b79f5) | 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+/**
+ * Approximate top-K neighbour search over an in-memory HNSW index.
+ *
+ * Builds a transient index over exactly the chunks in this batch (never the
+ * live vault index — that contains notes outside the current graph, whose hits
+ * would crowd out on-screen neighbours) and queries it once per chunk. A note
+ * pair's score is the best hit between any of their chunks, which converges on
+ * the exact scan's best-chunk semantics because every chunk of both notes gets
+ * to propose the pair.
+ *
+ * Two determinism/perf patches are applied to the `hnsw` library instance:
+ * - level selection is re-seeded (the library uses `Math.random`, which would
+ *   make graph edges — and therefore Leiden topics — drift between rebuilds);
+ * - the similarity function is replaced with a plain dot product, since chunks
+ *   are pre-normalized and the library's cosine re-derives both norms on every
+ *   comparison (3× the multiplies for the same result).
+ *
+ * Exported so tests can exercise this kernel directly on small inputs; callers
+ * should go through {@link computeSemanticPairs}.
+ */
+export async function approximateSemanticPairs(
+	data: Float32Array,
+	chunkCount: number,
+	dim: number,
+	chunkOwners: Int32Array,
+	noteCount: number,
+	options: SemanticScanOptions = {},
+): Promise<SemanticPair[]> {
+	const neighborCount = options.neighborCount ?? DEFAULT_SEMANTIC_NEIGHBOR_COUNT;
+	const threshold = options.threshold ?? DEFAULT_SEMANTIC_THRESHOLD;
+	if (neighborCount <= 0 || noteCount < 2 || dim === 0 || chunkCount === 0) return [];
+
+	const normalized = normalizeChunks(data, chunkCount, dim);
+	const chunkVector = (chunk: number) => normalized.subarray(chunk * dim, (chunk + 1) * dim);
+
+	const ownChunkCounts = new Int32Array(noteCount);
+	for (let i = 0; i < chunkCount; i++) {
+		const owner = chunkOwners[i];
+		if (owner >= 0 && owner < noteCount) ownChunkCounts[owner]++;
+	}
+
+	const index = new HNSW(16, 200, dim, "cosine");
+	const internals = index as unknown as {
+		probs: number[];
+		selectLevel: () => number;
+		similarityFunction: (a: number[] | Float32Array, b: number[] | Float32Array) => number;
+	};
+	const rand = mulberry32(HNSW_LEVEL_SEED);
+	// Same walk as the library's selectLevel, with a seeded source.
+	internals.selectLevel = () => {
+		let r = rand();
+		for (let i = 0; i < internals.probs.length; i++) {
+			const p = internals.probs[i];
+			if (r < p) return i;
+			r -= p;
+		}
+		return internals.probs.length - 1;
+	};
+	internals.similarityFunction = (a, b) => {
+		let dot = 0;
+		for (let i = 0; i < a.length; i++) dot += (a[i] as number) * (b[i] as number);
+		return dot;
+	};
+
+	const points: Array<{ id: number; vector: Float32Array }> = new Array(chunkCount);
+	for (let i = 0; i < chunkCount; i++) points[i] = { id: i, vector: chunkVector(i) };
+	await index.buildIndex(points);
+
+	// Best score seen for each unordered note pair, across every chunk query.
+	const pairBest = new Map<string, { a: number; b: number; score: number }>();
+	for (let chunk = 0; chunk < chunkCount; chunk++) {
+		const owner = chunkOwners[chunk];
+		if (owner < 0 || owner >= noteCount) continue;
+		// Over-fetch: hits include this note's own chunks and duplicate chunks of
+		// the same neighbour, none of which count toward its K distinct notes.
+		const k = Math.min(chunkCount, neighborCount * 3 + ownChunkCounts[owner]);
+		const hits = index.searchKNN(chunkVector(chunk), k, { efSearch: Math.max(64, k * 3) });
+		for (const hit of hits) {
+			const other = chunkOwners[hit.id];
+			if (other === owner || other < 0 || other >= noteCount) continue;
+			if (!Number.isFinite(hit.score) || hit.score < threshold) continue;
+			const key = pairKey(owner, other);
+			const existing = pairBest.get(key);
+			if (!existing || hit.score > existing.score) {
+				pairBest.set(key, { a: Math.min(owner, other), b: Math.max(owner, other), score: hit.score });
+			}
+		}
+	}
+
+	const candidates: Array<Array<{ note: number; score: number }>> = Array.from({ length: noteCount }, () => []);
+	for (const { a, b, score } of pairBest.values()) {
+		candidates[a].push({ note: b, score });
+		candidates[b].push({ note: a, score });
+	}
+
+	return selectTopPairs(candidates, neighborCount, options.excludePairs);
+}
+
+/**
+ * Compute semantic neighbour pairs, choosing the kernel by batch size.
+ *
+ * Small batches take the exact O(chunks²) scan — deterministic, exact, and
+ * already sub-second at this size. Larger batches take the approximate HNSW
+ * path, whose n·log n build is what lets vaults far past the old quadratic
+ * wall get semantic edges at all.
+ */
+export async function computeSemanticPairs(
+	data: Float32Array,
+	chunkCount: number,
+	dim: number,
+	chunkOwners: Int32Array,
+	noteCount: number,
+	options: SemanticScanOptions = {},
+): Promise<SemanticPair[]> {
+	if (chunkCount < SEMANTIC_HNSW_MIN_CHUNKS) {
+		return scanSemanticPairs(data, chunkCount, dim, chunkOwners, noteCount, options);
+	}
+	return approximateSemanticPairs(data, chunkCount, dim, chunkOwners, noteCount, options);
 }

--- a/src/utils/semanticEdges.ts
+++ b/src/utils/semanticEdges.ts
@@ -16,6 +16,7 @@
  */
 
 import { HNSW } from "hnsw";
+import { mulberry32 } from "./seededRandom";
 
 /**
  * How many semantic neighbours each note may contribute. Kept deliberately low:
@@ -203,17 +204,6 @@ export const SEMANTIC_HNSW_MIN_CHUNKS = 2000;
 
 /** Seed for the HNSW level-selection PRNG — fixed so rebuilds of the same vault produce the same edges. */
 const HNSW_LEVEL_SEED = 42;
-
-/** Deterministic PRNG (mulberry32) for HNSW level selection. */
-function mulberry32(seed: number): () => number {
-	let a = seed >>> 0;
-	return () => {
-		a = (a + 0x6d2b79f5) | 0;
-		let t = Math.imul(a ^ (a >>> 15), 1 | a);
-		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-	};
-}
 
 /**
  * Approximate top-K neighbour search over an in-memory HNSW index.

--- a/src/views/smart-graph/graphDataBuilder.ts
+++ b/src/views/smart-graph/graphDataBuilder.ts
@@ -190,9 +190,10 @@ function flattenChunksByNote(
  * link is the stronger statement and rendering both would double-count the pair
  * in community detection.
  *
- * The O(n²) scan itself runs in the compute worker (falling back to the main
+ * The search itself runs in the compute worker (falling back to the main
  * thread only when workers are unavailable), so a large vault doesn't stall the
- * UI while the graph builds.
+ * UI while the graph builds. Small batches take an exact pairwise scan; large
+ * ones an approximate HNSW index — see `computeSemanticPairs`.
  */
 export async function buildSemanticEdges(
 	documents: DocumentVector[],

--- a/test/utils/graphUtils.test.ts
+++ b/test/utils/graphUtils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { edgeKey, graphTopologySignature, splitEdgeKey } from "../../src/utils/graphUtils";
+
+describe("edgeKey / splitEdgeKey", () => {
+	it("is order-independent and invertible", () => {
+		expect(edgeKey("a.md", "b.md")).toBe(edgeKey("b.md", "a.md"));
+		expect(splitEdgeKey(edgeKey("a.md", "b.md"))).toEqual(["a.md", "b.md"]);
+	});
+});
+
+describe("graphTopologySignature", () => {
+	const node = (id: string) => ({ id });
+	const wiki = (source: string, target: string, weight = 1) => ({ source, target, type: "wiki", weight });
+
+	const base = () => ({
+		nodes: [node("a.md"), node("b.md"), node("c.md")],
+		edges: [wiki("a.md", "b.md"), wiki("b.md", "c.md", 2)],
+	});
+
+	it("is stable for an identical graph", () => {
+		expect(graphTopologySignature(base())).toBe(graphTopologySignature(base()));
+	});
+
+	it("ignores node and edge enumeration order", () => {
+		const reordered = {
+			nodes: [node("c.md"), node("a.md"), node("b.md")],
+			edges: [wiki("b.md", "c.md", 2), wiki("a.md", "b.md")],
+		};
+		expect(graphTopologySignature(reordered)).toBe(graphTopologySignature(base()));
+	});
+
+	it("changes when a node is added or renamed", () => {
+		const added = base();
+		added.nodes.push(node("d.md"));
+		expect(graphTopologySignature(added)).not.toBe(graphTopologySignature(base()));
+
+		const renamed = base();
+		renamed.nodes[0] = node("a-renamed.md");
+		expect(graphTopologySignature(renamed)).not.toBe(graphTopologySignature(base()));
+	});
+
+	it("changes when an edge is added, rewired, retyped, or reweighted", () => {
+		const reference = graphTopologySignature(base());
+
+		const added = base();
+		added.edges.push(wiki("a.md", "c.md"));
+		expect(graphTopologySignature(added)).not.toBe(reference);
+
+		const rewired = base();
+		rewired.edges[0] = wiki("a.md", "c.md");
+		expect(graphTopologySignature(rewired)).not.toBe(reference);
+
+		const retyped = base();
+		retyped.edges[0] = { ...retyped.edges[0], type: "semantic" };
+		expect(graphTopologySignature(retyped)).not.toBe(reference);
+
+		const reweighted = base();
+		reweighted.edges[0] = wiki("a.md", "b.md", 3);
+		expect(graphTopologySignature(reweighted)).not.toBe(reference);
+	});
+
+	it("distinguishes empty graphs from populated ones", () => {
+		const empty = { nodes: [], edges: [] };
+		expect(graphTopologySignature(empty)).toBe(graphTopologySignature({ nodes: [], edges: [] }));
+		expect(graphTopologySignature(empty)).not.toBe(graphTopologySignature(base()));
+	});
+});

--- a/test/utils/semanticEdges.test.ts
+++ b/test/utils/semanticEdges.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { pairKey, scanSemanticPairs } from "../../src/utils/semanticEdges";
+import {
+	approximateSemanticPairs,
+	computeSemanticPairs,
+	pairKey,
+	scanSemanticPairs,
+} from "../../src/utils/semanticEdges";
 
 /** Flatten note vectors (one chunk each) into the scan's transfer shape. */
 function flatten(notes: number[][]): { data: Float32Array; count: number; dim: number; owners: Int32Array } {
@@ -116,5 +121,132 @@ describe("scanSemanticPairs", () => {
 		for (const pair of pairs) {
 			expect(Number.isNaN(pair.score)).toBe(false);
 		}
+	});
+});
+
+/**
+ * Well-separated synthetic clusters: unit vectors near one of `clusterCount`
+ * orthogonal axes, with small deterministic jitter on the remaining dims.
+ * Within-cluster similarity stays near 1, cross-cluster near 0, so exact and
+ * approximate kernels must find the same neighbourhoods.
+ */
+function clusteredNotes(clusterCount: number, perCluster: number, dim: number): number[][] {
+	const notes: number[][] = [];
+	for (let c = 0; c < clusterCount; c++) {
+		for (let i = 0; i < perCluster; i++) {
+			const vec = new Array(dim).fill(0);
+			vec[c] = 1;
+			// Deterministic jitter, small enough not to bridge clusters.
+			vec[(c + 1 + (i % (dim - clusterCount))) % dim] += 0.05 + 0.01 * (i % 7);
+			notes.push(vec);
+		}
+	}
+	return notes;
+}
+
+describe("approximateSemanticPairs", () => {
+	it("finds the same pairs as the exact scan on well-separated clusters", async () => {
+		const notes = clusteredNotes(3, 20, 8);
+		const { data, count, dim, owners } = flatten(notes);
+
+		const exact = scanSemanticPairs(data, count, dim, owners, notes.length, {
+			threshold: 0.8,
+			neighborCount: 3,
+		});
+		const approx = await approximateSemanticPairs(data, count, dim, owners, notes.length, {
+			threshold: 0.8,
+			neighborCount: 3,
+		});
+
+		const keys = (pairs: { source: number; target: number }[]) =>
+			new Set(pairs.map((p) => pairKey(p.source, p.target)));
+		expect(keys(approx)).toEqual(keys(exact));
+		// No cross-cluster edges survive the threshold in either kernel.
+		for (const pair of approx) {
+			expect(Math.floor(pair.source / 20)).toBe(Math.floor(pair.target / 20));
+		}
+	});
+
+	it("orders pairs source < target and never duplicates a pair", async () => {
+		const notes = clusteredNotes(2, 15, 6);
+		const { data, count, dim, owners } = flatten(notes);
+		const pairs = await approximateSemanticPairs(data, count, dim, owners, notes.length, { threshold: 0.5 });
+
+		expect(pairs.length).toBeGreaterThan(0);
+		const keys = pairs.map((p) => pairKey(p.source, p.target));
+		expect(new Set(keys).size).toBe(keys.length);
+		for (const pair of pairs) {
+			expect(pair.source).toBeLessThan(pair.target);
+		}
+	});
+
+	it("scores a note pair by its best matching chunk", async () => {
+		// Note 0 owns two chunks; only the second matches note 1.
+		const data = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 1]);
+		const owners = Int32Array.from([0, 0, 1]);
+		const pairs = await approximateSemanticPairs(data, 3, 3, owners, 2, { threshold: 0.9 });
+
+		expect(pairs).toHaveLength(1);
+		expect(pairs[0].score).toBeCloseTo(1, 5);
+	});
+
+	it("honours excluded pairs", async () => {
+		const notes = clusteredNotes(1, 10, 4);
+		const { data, count, dim, owners } = flatten(notes);
+		const excluded = pairKey(0, 1);
+		const pairs = await approximateSemanticPairs(data, count, dim, owners, notes.length, {
+			threshold: 0.5,
+			excludePairs: new Set([excluded]),
+		});
+
+		expect(pairs.length).toBeGreaterThan(0);
+		expect(pairs.map((p) => pairKey(p.source, p.target))).not.toContain(excluded);
+	});
+
+	it("is deterministic across runs despite HNSW's randomized levels", async () => {
+		const notes = clusteredNotes(4, 25, 12);
+		const a = flatten(notes);
+		const b = flatten(notes);
+
+		const first = await approximateSemanticPairs(a.data, a.count, a.dim, a.owners, notes.length, {
+			threshold: 0.6,
+		});
+		const second = await approximateSemanticPairs(b.data, b.count, b.dim, b.owners, notes.length, {
+			threshold: 0.6,
+		});
+
+		expect(first).toEqual(second);
+	});
+
+	it("returns nothing for degenerate inputs", async () => {
+		const { data, count, dim, owners } = flatten([[1, 0, 0]]);
+		expect(await approximateSemanticPairs(data, count, dim, owners, 1, { threshold: 0 })).toHaveLength(0);
+		expect(await approximateSemanticPairs(data, count, dim, owners, 2, { neighborCount: 0 })).toHaveLength(0);
+		expect(await approximateSemanticPairs(new Float32Array(0), 0, 0, new Int32Array(0), 0)).toHaveLength(0);
+	});
+
+	it("tolerates zero vectors without emitting NaN scores", async () => {
+		const { data, count, dim, owners } = flatten([
+			[0, 0, 0],
+			[1, 0, 0],
+			[0.9, 0.1, 0],
+		]);
+		const pairs = await approximateSemanticPairs(data, count, dim, owners, 3, { threshold: 0.5 });
+
+		for (const pair of pairs) {
+			expect(Number.isNaN(pair.score)).toBe(false);
+		}
+	});
+});
+
+describe("computeSemanticPairs", () => {
+	it("matches the exact scan below the HNSW crossover", async () => {
+		const notes = clusteredNotes(2, 10, 4);
+		const { data, count, dim, owners } = flatten(notes);
+
+		const dispatched = await computeSemanticPairs(data, count, dim, owners, notes.length, { threshold: 0.5 });
+		const exact = scanSemanticPairs(data, count, dim, owners, notes.length, { threshold: 0.5 });
+
+		expect(dispatched).toEqual(exact);
 	});
 });


### PR DESCRIPTION
Performance work on the smart graph, in three layers — per-frame rendering cost, costs that scale with graph size, and the data pipeline behind it — plus the cleanup that fell out of it and two mobile/visual fixes.

## 1. Rendering: draw on demand instead of every frame

The Pixi ticker was drawing a full frame at 60fps forever — at idle, and in hidden background tabs — and every pan/zoom triggered a full CPU rebuild of the scene even though world-space content rides the viewport transform for free.

- Disable the Pixi ticker (`autoStart: false`) and render once per coalesced pass, driven by a `requestRender()` that batches same-frame triggers into a single rAF. A settled, untouched graph now costs nothing.
- Split `render()` into world/zoom/overlay modes: pans skip hulls, edges and node sync entirely; zooms defer edge re-tessellation until the scale has drifted enough for the counter-scaled widths to visibly differ.
- Detect camera movement by polling `viewport.dirty` rather than the `moved` event — `dirty` is set for every movement source, including the animate plugin, which `moved` alone doesn't cover and which would otherwise freeze with the ticker off.
- Cleanups: memoized CSS color resolution (was hitting a canvas-2d context per node per frame), dropped per-node `hitArea` closures and interactive event mode, removed the dead `isLabeling` prop and its unconditional 60fps render loop.

## 2. Rendering: costs that scale with graph size

- Nodes are `Sprite`s sharing one disc texture, recolored by tint — position, size and colour are all uniform updates, so node sync never tessellates and the layer batches into a single draw call. Hover/selection rings stay vector `Graphics` in a layer above, crisp at any zoom.
- Edges outside the view (plus a 35% margin) are culled in `drawEdges`. Since pans otherwise skip edge work entirely, the viewport-moved handler re-tessellates once the view leaves the margin the last draw covered, and skips that tracking when the rect already contained the whole graph.
- Dashed semantic edges fall back to solid strokes past 500 visible edges: a dash costs path segments proportional to screen length, and at that density the pattern reads as shimmer anyway.
- `findNodeAt` answers from a uniform hash grid rather than scanning every node per mousemove. The grid rebuilds only once the layout is near rest; while it's moving the linear scan runs, since rebuilding per query would cost more than the scan it replaces.
- The simulation stops while the leaf is hidden (background tab, collapsed sidebar) and resumes on reveal, so an unseen layout no longer ticks d3-force at 60fps. A graph rebuilt while hidden starts paused too.
- The hover fingerprint keys on set identity rather than set size, which would have read a same-size replacement as unchanged; the tooltip caches its measured layout so hovering only repositions it per frame.

## 3. Data: HNSW semantic edges instead of an O(n²) scan

Semantic edges came from an exact all-pairs cosine scan over every chunk — ~2s at 2k notes, ~8s at 4k, with a hard 5000-note cap past which the graph silently stayed wiki-only.

Above 2000 chunks, a transient in-memory HNSW index is built over the batch and queried once per chunk instead: n·log n rather than n². Below that the exact scan still runs, since it's already sub-second there and exactness plus bit-for-bit determinism come free.

- The shared top-K/threshold/dedupe/wiki-exclusion tail is extracted into `selectTopPairs`, so both kernels emit pairs with identical semantics.
- A note pair scores by the best hit between any of their chunks, matching the exact scan's best-chunk behavior.
- Only the current graph's chunks are indexed, never the live vault index — its out-of-filter notes would crowd out on-screen neighbours.
- HNSW's level selection is seeded (the library uses `Math.random`), so an unchanged vault yields the same edges, and therefore the same Leiden topics, across rebuilds.
- `SEMANTIC_EDGE_MAX_NOTES` goes 5000 → 20000. The remaining bound is the vector transfer into the worker (~150 MB at dim 1024), not time.

**Review note:** this is the part worth the closest look — above the threshold, edge discovery is approximate. Scores are still exact cosine similarities; what HNSW can do is *miss* a borderline neighbour, never invent a wrong one. Since semantic edges feed Leiden, a missed edge can in principle shift topic assignment.

## 4. Removing the Detail slider and betweenness centrality

Raising the note cap exposed the next bottleneck: an exact O(V·E) Brandes pass ran on every rebuild. Rather than approximate it, it turned out to be removable outright.

The Detail slider (dev panel) thinned each topic to its top hubs plus bridges above a centrality cutoff, and had stopped being used. Node size also blended centrality with degree — which made size ambiguous, and was only half-applied anyway: it fed hit-testing, collision spacing and label offsets but never the drawn circle, so bridges had oversized hitboxes without ever looking bigger.

With both consumers gone, centrality itself goes: the `withCentrality` protocol field, both code paths, `GraphNode.centrality`, and graphology from the compute worker. Bridge notes are still surfaced by the "Highlight bridges" toggle, which keys on the structural neighbour-community vote and is untouched. `onSkeletonToggle` is renamed to `onToggleCollapseAll` — it never drove the Detail slider; it is the atom button's collapse-all toggle.

## 5. Mobile and visual fixes (found in testing)

- The sprite disc texture is now mipmapped (canvas-backed `CanvasSource` with `autoGenerateMipmaps`, power-of-two, inset from the edge). Without mipmaps a node drawn at a few screen pixels sampled only a few texels, so zoomed-out nodes had visibly ragged rims.
- Tapping the graph background on mobile tinted the whole canvas: the container is a `<button>` (it needs keyboard focus for the shortcuts) and so picked up WebKit's tap highlight and Obsidian's `:active`/`:focus` button background. Both are now suppressed.

## Test plan
- [x] `bun run check` — 2754 files, 0 errors
- [x] `bun run format` — clean
- [x] `bun run test` — 78 files, 1328 tests passed (8 new, covering the HNSW kernel)
- [x] Production build published to the `2.0.2-beta` pre-release for BRAT testing
- [x] Manual (mobile): graph renders correctly
- [ ] Manual (mobile): zoomed-out nodes look round; tapping the background no longer tints the canvas
- [ ] Manual (desktop): pan/zoom/hover/selection/topic-collapse/re-cluster still feel right; idle GPU drops with the ticker off; edges reappear promptly when panning fast while zoomed in; backgrounding a settling graph and returning resumes its motion
- [ ] Manual: topic structure on a real vault looks equivalent to `dev` (the approximate path only engages past ~700-1500 notes, depending on chunks per note)

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._