### PR TITLE
Notify users when a shipped default moves under their customized prompt

### DIFF
--- a/src/agent/promptFiles.ts
+++ b/src/agent/promptFiles.ts
@@ -1,7 +1,8 @@
 import type { App, DataAdapter } from "obsidian";
-import type { AgentsConfig, PromptFileReader } from "../types/plugin";
+import type { AgentsConfig, PromptFileReader, PromptKindId } from "../types/plugin";
 import { agentPromptDir, agentRootDir, basePromptPath, memoryPromptPath, systemPromptsDir } from "../utils/agentPaths";
 import { Logger as Log } from "../utils/logging";
+import { getData } from "../stores/dataStore.svelte";
 import { type ShippedHistory, currentShippedVersion, shippedVersion } from "../utils/shippedDefaults";
 import { BASE_SYSTEM_PROMPT, DEFAULT_MEMORY_PROMPT, SHIPPED_BASE_PROMPTS, SHIPPED_MEMORY_PROMPTS } from "./prompts";
 
@@ -12,6 +13,8 @@ import { BASE_SYSTEM_PROMPT, DEFAULT_MEMORY_PROMPT, SHIPPED_BASE_PROMPTS, SHIPPE
  * and differ only in their filename within the shared subfolder, and their factory default.
  */
 interface PromptKind {
+	/** Stable key for this kind in `AgentConfig.promptBaseVersions`. */
+	id: PromptKindId;
 	/** Human-readable label, used only in log messages. */
 	label: string;
 	/** Resolve the note path for an agent (name-derived; see `agentPaths`). */
@@ -25,6 +28,7 @@ interface PromptKind {
 }
 
 const BASE_PROMPT: PromptKind = {
+	id: "base",
 	label: "base prompt",
 	path: basePromptPath,
 	fallback: BASE_SYSTEM_PROMPT,
@@ -33,6 +37,7 @@ const BASE_PROMPT: PromptKind = {
 };
 
 const MEMORY_PROMPT: PromptKind = {
+	id: "memory",
 	label: "memory prompt",
 	path: memoryPromptPath,
 	fallback: DEFAULT_MEMORY_PROMPT,
@@ -119,14 +124,27 @@ export class PromptFilesService {
 						this.clearMigrated(kind, agent);
 						const content = await this.adapter.read(path);
 						const version = shippedVersion(content, kind.history);
-						if (version !== null && version !== currentShippedVersion(kind.history)) {
+						if (version === null) {
+							// The user's own text. Leave it, but if this agent predates the
+							// stamp there is no baseline to compare a future bump against —
+							// seed it at the current version so drift is detectable from now
+							// on. (Backdating to the oldest version instead would fire a
+							// notice about a change the edit may already incorporate.)
+							this.stampBaseVersionIfAbsent(kind, agentId);
+						} else if (version !== currentShippedVersion(kind.history)) {
 							await this.adapter.write(path, kind.fallback);
+							this.stampBaseVersion(kind, agentId);
 							Log.info(`Updated ${kind.label} for ${agentId} from shipped v${version} to current`);
+						} else {
+							this.stampBaseVersion(kind, agentId);
 						}
 						continue;
 					}
 					await this.ensureParent(path);
 					await this.adapter.write(path, migrated ?? kind.fallback);
+					// A migrated pre-file customization is the user's text, but it was written
+					// against the defaults current at migration time — stamp either way.
+					this.stampBaseVersion(kind, agentId);
 					// Only clear AFTER a successful write — the customized prompt is now durable in
 					// the file. On a write failure we deliberately keep the transient so a later
 					// seedDefaults (e.g. next startup / folder change) can retry, rather than
@@ -252,6 +270,49 @@ export class PromptFilesService {
 		await this.ensureParent(path);
 		await this.adapter.write(path, text);
 		this.cache(kind).set(agentId, text);
+		this.stampBaseVersion(kind, agentId);
+	}
+
+	/**
+	 * Record which shipped version this agent's prompt is now based on. Called after every
+	 * write — seeding, the silent old-default update, a reset, and the user saving their own
+	 * text all funnel through here.
+	 *
+	 * The stamp is always the CURRENT shipped version, including when the user saves a
+	 * customization: at that moment their edit is, by definition, based on today's default.
+	 * A later bump then makes `stamp !== current` true and the drift notice fires exactly
+	 * once — which is the whole point of the field.
+	 */
+	/**
+	 * Stamp only when no baseline exists yet — for agents whose customized prompt predates
+	 * the field. Never overwrites an existing stamp, which would erase the very drift the
+	 * stamp is there to detect.
+	 */
+	private stampBaseVersionIfAbsent(kind: PromptKind, agentId: string): void {
+		try {
+			if (getData().agents[agentId]?.promptBaseVersions?.[kind.id] !== undefined) return;
+		} catch {
+			return;
+		}
+		this.stampBaseVersion(kind, agentId);
+	}
+
+	private stampBaseVersion(kind: PromptKind, agentId: string): void {
+		// Bookkeeping, never load-bearing for the prompt itself: a failure here must not
+		// abort the surrounding write, or a store hiccup would leave the user without the
+		// prompt file entirely. Worst case a stamp is missed and drift stays silent.
+		try {
+			const agent = getData().agents[agentId];
+			if (!agent) return;
+			const current = currentShippedVersion(kind.history);
+			if (current === undefined) return;
+			const existing = agent.promptBaseVersions ?? {};
+			if (existing[kind.id] === current) return;
+			// Reassign rather than mutate in place so $state reactivity fires.
+			getData().updateAgent(agentId, { promptBaseVersions: { ...existing, [kind.id]: current } });
+		} catch (error) {
+			Log.debug(`Could not stamp ${kind.label} base version for ${agentId}:`, error);
+		}
 	}
 
 	private async ensure(kind: PromptKind, agentId: string): Promise<void> {

--- a/src/agent/promptFiles.ts
+++ b/src/agent/promptFiles.ts
@@ -246,7 +246,14 @@ export class PromptFilesService {
 	 * inherits the source's edited prompts rather than starting from the bare defaults.
 	 */
 	async copyAgentPrompts(fromId: string, toId: string): Promise<void> {
-		for (const kind of ALL_KINDS) await this.write(kind, toId, this.get(kind, fromId));
+		for (const kind of ALL_KINDS) {
+			await this.write(kind, toId, this.get(kind, fromId));
+			// The copy is the source's text verbatim, so it inherits the source's baseline —
+			// NOT the current version that `write` just stamped. Duplicating an agent whose
+			// customization was based on an older default must not silently clear the drift
+			// notice that customization is owed.
+			this.inheritBaseVersion(kind, fromId, toId);
+		}
 	}
 
 	// --- shared per-kind implementations -------------------------------------------------
@@ -295,6 +302,30 @@ export class PromptFilesService {
 			return;
 		}
 		this.stampBaseVersion(kind, agentId);
+	}
+
+	/**
+	 * Carry one agent's baseline for a kind over to another, used when duplicating an agent.
+	 * Overwrites whatever `write` stamped, because the copied text's real baseline is the
+	 * source's. A source with no stamp clears the target's too — "unknown baseline" is the
+	 * honest answer for copied text we have no provenance for, and it stays silent rather
+	 * than claiming the copy is current.
+	 */
+	private inheritBaseVersion(kind: PromptKind, fromId: string, toId: string): void {
+		try {
+			const data = getData();
+			const source = data.agents[fromId]?.promptBaseVersions?.[kind.id];
+			const target = data.agents[toId];
+			if (!target) return;
+			const existing = target.promptBaseVersions ?? {};
+			if (existing[kind.id] === source) return;
+			const next = { ...existing };
+			if (source === undefined) delete next[kind.id];
+			else next[kind.id] = source;
+			data.updateAgent(toId, { promptBaseVersions: next });
+		} catch (error) {
+			Log.debug(`Could not inherit ${kind.label} base version for ${toId}:`, error);
+		}
 	}
 
 	private stampBaseVersion(kind: PromptKind, agentId: string): void {

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -29,6 +29,7 @@ import type {
 	PluginData,
 	PrivacyMode,
 	PromptFileReader,
+	PromptKindId,
 	RecentNoteEntry,
 	SearchAlgorithm,
 	StaleGuidance,
@@ -2317,18 +2318,22 @@ let _pluginDataStore: PluginDataStore | null = null;
  */
 const PROMPT_SURFACES = [
 	{
+		id: "base",
 		kind: "system-prompt",
 		label: "system prompt",
 		history: SHIPPED_BASE_PROMPTS,
 		read: (reader: PromptFileReader, agentId: string) => reader.getBasePrompt(agentId),
 	},
 	{
+		id: "memory",
 		kind: "memory-prompt",
 		label: "memory instructions",
 		history: SHIPPED_MEMORY_PROMPTS,
 		read: (reader: PromptFileReader, agentId: string) => reader.getMemoryPrompt(agentId),
 	},
 ] as const satisfies readonly {
+	/** Key into `AgentConfig.promptBaseVersions` for this surface. */
+	id: PromptKindId;
 	kind: StaleGuidance["kind"];
 	label: string;
 	history: ShippedHistory;
@@ -2354,19 +2359,38 @@ function detectStaleGuidance(agent: AgentConfig, reader: PromptFileReader | null
 	for (const surface of PROMPT_SURFACES) {
 		const content = surface.read(reader, agent.id);
 		if (content === null) continue;
+		const current = currentShippedVersion(surface.history);
 		const version = shippedVersion(content, surface.history);
-		// null ⇒ user's own text; the newest key ⇒ already current. Only an older shipped
-		// version means "the default moved out from under an untouched copy" — which
-		// PromptFilesService.seedDefaults rewrites silently at startup, so reaching here
-		// means that rewrite failed (or hasn't run against this file yet). Surface it.
-		if (version === null || version === currentShippedVersion(surface.history)) continue;
+
+		if (version === null) {
+			// The user's own text. It matches no shipped fingerprint, so the content alone
+			// can't say whether the default has moved since they wrote it — that's what the
+			// stamp recorded. Only flag when we have a baseline AND it has been superseded;
+			// an absent stamp stays silent rather than asserting drift we can't substantiate.
+			const stamp = agent.promptBaseVersions?.[surface.id];
+			if (stamp === undefined || stamp === current) continue;
+			stale.push({
+				agentId: agent.id,
+				agentName: agent.name,
+				kind: surface.kind,
+				label: surface.label,
+				currentVersion: current,
+				// Their edit is intact — we never touch a customized file.
+				customized: true,
+			});
+			continue;
+		}
+
+		// An OLD shipped default, verbatim: PromptFilesService.seedDefaults rewrites these
+		// silently at startup, so reaching here means that rewrite failed (or hasn't run
+		// against this file yet). Surface it — but not as a "customization".
+		if (version === current) continue;
 		stale.push({
 			agentId: agent.id,
 			agentName: agent.name,
 			kind: surface.kind,
 			label: surface.label,
-			currentVersion: currentShippedVersion(surface.history),
-			// The file IS an old shipped default, verbatim — the user never customized it.
+			currentVersion: current,
 			customized: false,
 		});
 	}

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -445,7 +445,24 @@ export interface AgentConfig {
 	 * eagerly to read/record is agent behavior.
 	 */
 	memoryEnabled?: boolean;
+	/**
+	 * Which shipped version each prompt file was last written from, keyed by prompt kind
+	 * ("base" / "memory"). Stamped whenever we write the file from a shipped default (seed,
+	 * silent update, reset) and refreshed when the user saves their own text.
+	 *
+	 * This is what makes "the default moved out from under YOUR edit" detectable. A
+	 * customized file matches no shipped fingerprint, so on its own it cannot distinguish
+	 * "you edited it and the default has since changed" (worth a notice) from "you edited it
+	 * and nothing changed" (silence) — the stamp records the baseline the edit started from.
+	 *
+	 * Absent for agents predating this field: treated as "unknown baseline", which stays
+	 * silent rather than firing a notice we can't substantiate.
+	 */
+	promptBaseVersions?: Partial<Record<PromptKindId, number | string>>;
 }
+
+/** The two file-backed prompt surfaces, as stable keys for {@link AgentConfig.promptBaseVersions}. */
+export type PromptKindId = "base" | "memory";
 
 /**
  * Record of agent configurations keyed by agent ID

--- a/test/agent/promptFiles.test.ts
+++ b/test/agent/promptFiles.test.ts
@@ -16,6 +16,11 @@ vi.mock("../../src/stores/dataStore.svelte", () => ({
 		get agents() {
 			return state.agents;
 		},
+		// Used by the promptBaseVersions stamp on every write; see promptFilesReconcile.test.ts
+		// for the tests that assert the stamping behaviour itself.
+		updateAgent: (agentId: string, updates: Record<string, unknown>) => {
+			state.agents[agentId] = { ...state.agents[agentId], ...updates };
+		},
 	}),
 }));
 

--- a/test/agent/promptFilesReconcile.test.ts
+++ b/test/agent/promptFilesReconcile.test.ts
@@ -2,7 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("obsidian", () => import("../__mocks__/obsidian"));
 
-const state: { agentFolder: string; agents: Record<string, { id: string; name?: string }> } = {
+type TestAgent = {
+	id: string;
+	name?: string;
+	promptBaseVersions?: Partial<Record<"base" | "memory", number | string>>;
+};
+const state: { agentFolder: string; agents: Record<string, TestAgent> } = {
 	agentFolder: "Agents",
 	agents: { "default-agent": { id: "default-agent", name: "Default Agent" } },
 };
@@ -13,6 +18,9 @@ vi.mock("../../src/stores/dataStore.svelte", () => ({
 		},
 		get agents() {
 			return state.agents;
+		},
+		updateAgent: (agentId: string, updates: Partial<TestAgent>) => {
+			state.agents[agentId] = { ...state.agents[agentId], ...updates };
 		},
 	}),
 }));
@@ -141,5 +149,59 @@ describe("PromptFilesService.seedDefaults — reconciling existing files against
 
 		expect(adapter.files.get(BASE_PATH)).toBe(CURRENT_BASE);
 		expect(adapter.files.get(MEMORY_PATH)).toBe(CURRENT_MEMORY);
+	});
+});
+
+/*
+ * A customized file matches no shipped fingerprint, so its content alone can't say whether
+ * the default moved since the user wrote it. The stamp records the baseline their edit
+ * started from — without it, flagging every no-match would fire a false "the default
+ * changed" notice at everyone who has ever customized a prompt.
+ */
+describe("PromptFilesService — promptBaseVersions stamp", () => {
+	beforeEach(() => {
+		state.agentFolder = "Agents";
+		state.agents = { "default-agent": { id: "default-agent", name: "Default Agent" } };
+	});
+
+	it("stamps the current version when seeding a fresh file", async () => {
+		await makeService(makeAdapter()).seedDefaults(AGENTS);
+
+		expect(state.agents["default-agent"].promptBaseVersions).toEqual({ base: 2, memory: 2 });
+	});
+
+	it("stamps after the silent update of an old default", async () => {
+		const adapter = makeAdapter({ [BASE_PATH]: OLD_BASE });
+		await makeService(adapter).seedDefaults(AGENTS);
+
+		expect(state.agents["default-agent"].promptBaseVersions?.base).toBe(2);
+	});
+
+	it("stamps the user's save, so their edit is baselined at today's default", async () => {
+		const svc = makeService(makeAdapter());
+		await svc.writeBasePrompt("default-agent", "my own prompt");
+
+		// Their text is theirs, but it was written against v2 — a later v3 is what should
+		// raise the drift notice, not this save.
+		expect(state.agents["default-agent"].promptBaseVersions?.base).toBe(2);
+	});
+
+	it("back-fills a baseline for a customized file that predates the field", async () => {
+		const adapter = makeAdapter({ [BASE_PATH]: "customized before stamps existed" });
+		await makeService(adapter).seedDefaults(AGENTS);
+
+		// Seeded at the current version, not backdated: backdating would claim their edit
+		// predates a change it may already incorporate.
+		expect(state.agents["default-agent"].promptBaseVersions?.base).toBe(2);
+		expect(adapter.files.get(BASE_PATH)).toBe("customized before stamps existed");
+	});
+
+	it("never overwrites an existing older stamp", async () => {
+		state.agents["default-agent"].promptBaseVersions = { base: 1 };
+		const adapter = makeAdapter({ [BASE_PATH]: "my customization, written against v1" });
+		await makeService(adapter).seedDefaults(AGENTS);
+
+		// Overwriting with 2 here would erase exactly the drift the stamp exists to detect.
+		expect(state.agents["default-agent"].promptBaseVersions?.base).toBe(1);
 	});
 });

--- a/test/agent/promptFilesReconcile.test.ts
+++ b/test/agent/promptFilesReconcile.test.ts
@@ -196,6 +196,35 @@ describe("PromptFilesService — promptBaseVersions stamp", () => {
 		expect(adapter.files.get(BASE_PATH)).toBe("customized before stamps existed");
 	});
 
+	/*
+	 * A duplicated agent starts with its source's prompt text verbatim, so it inherits the
+	 * source's baseline too. Stamping the copy at the current version instead would silently
+	 * clear a drift notice the copied customization is owed — the same invariant as "never
+	 * overwrite an older stamp", one level removed.
+	 */
+	it("carries the source's older baseline to a duplicated agent", async () => {
+		state.agents["default-agent"].promptBaseVersions = { base: 1, memory: 1 };
+		state.agents.copy = { id: "copy", name: "Copy" };
+		const adapter = makeAdapter({ [BASE_PATH]: "customization based on v1" });
+		const svc = makeService(adapter);
+		await svc.refresh(AGENTS);
+
+		await svc.copyAgentPrompts("default-agent", "copy");
+
+		expect(state.agents.copy.promptBaseVersions?.base).toBe(1);
+	});
+
+	it("leaves a duplicate unstamped when the source has no baseline", async () => {
+		state.agents.copy = { id: "copy", name: "Copy" };
+		const svc = makeService(makeAdapter());
+
+		await svc.copyAgentPrompts("default-agent", "copy");
+
+		// "Unknown baseline" is the honest answer for text with no provenance, and it stays
+		// silent — better than claiming the copy is current.
+		expect(state.agents.copy.promptBaseVersions?.base).toBeUndefined();
+	});
+
 	it("never overwrites an existing older stamp", async () => {
 		state.agents["default-agent"].promptBaseVersions = { base: 1 };
 		const adapter = makeAdapter({ [BASE_PATH]: "my customization, written against v1" });

--- a/test/stores/dataStore.test.ts
+++ b/test/stores/dataStore.test.ts
@@ -652,17 +652,51 @@ describe("PluginDataStore – staleGuidance", () => {
 		expect(store.staleGuidance).toEqual([]);
 	});
 
-	it("does NOT flag unrecognized customizations of either prompt", () => {
-		const { store } = makeStore(agentData() as never);
+	it("does NOT flag a customization whose baseline is still the current default", () => {
+		const data = agentData();
+		// Stamped at the current version: they customized it, but the default hasn't moved
+		// since — there is nothing to tell them about.
+		data.agents[DEFAULT_AGENT_ID].promptBaseVersions = { base: 1, memory: 1 };
+		const { store } = makeStore(data as never);
 		store.setPromptFileReader(
 			makeReader({
 				basePrompt: { [DEFAULT_AGENT_ID]: "my own custom prompt" },
 				memoryPrompt: { [DEFAULT_AGENT_ID]: "my own memory instructions" },
 			}),
 		);
-		// The user wrote these on purpose — leaving them alone is the point, and nagging
-		// about text we never shipped would be noise.
 		expect(store.staleGuidance).toEqual([]);
+	});
+
+	it("does NOT flag a customization with no recorded baseline", () => {
+		const { store } = makeStore(agentData() as never);
+		store.setPromptFileReader(
+			makeReader({ basePrompt: { [DEFAULT_AGENT_ID]: "my own custom prompt" } }),
+		);
+		// No stamp ⇒ we cannot substantiate that the default moved under this edit. Staying
+		// silent beats asserting drift we can't prove.
+		expect(store.staleGuidance).toEqual([]);
+	});
+
+	/*
+	 * The case this stamp exists for: the user customized a prompt, and a LATER release
+	 * changed the shipped default. Their edit is untouched (correct), but they'd otherwise
+	 * never learn the default moved — the improvement would be invisible to exactly the
+	 * users who engaged with the prompt enough to edit it.
+	 */
+	it("flags a customization whose baseline has been superseded", () => {
+		const data = agentData();
+		data.agents[DEFAULT_AGENT_ID].promptBaseVersions = { base: 0 };
+		const { store } = makeStore(data as never);
+		store.setPromptFileReader(
+			makeReader({ basePrompt: { [DEFAULT_AGENT_ID]: "my own custom prompt" } }),
+		);
+
+		const stale = store.staleGuidance;
+		expect(stale.map((s) => s.kind)).toEqual(["system-prompt"]);
+		// `customized: true` drives the "your customized version was kept" wording and the
+		// Review action's diff — distinct from the untouched-old-default case.
+		expect(stale[0].customized).toBe(true);
+		expect(stale[0].agentId).toBe(DEFAULT_AGENT_ID);
 	});
 
 	it("does NOT flag a prompt whose only difference is line endings or a trailing newline", () => {


### PR DESCRIPTION
Follow-up to #402 — the last gap in #401's notification story.

## The gap

Skills and prompts disagreed about the customized case:

| | untouched | customized |
|---|---|---|
| **Skill** | silently updated | notice + Review |
| **Prompt** | silently updated | **nothing** |

`detectStaleGuidance` skipped `version === null` outright, so a user who edited their base or memory prompt was **never told** when we later shipped an improved default. That silently excluded exactly the users engaged enough to customize the prompt in the first place — the improvement was invisible to them unless they happened to open the Agent editor and spot the "Diff with default" button.

## Why the skip wasn't arbitrary

A customized file matches no shipped fingerprint, so the content alone cannot distinguish:

- "you edited it **and the default has since moved**" → worth a notice
- "you edited it **and nothing changed**" → silence

Both are just `null`. Removing the skip would have fired a false "the default changed" notice at every user who has ever customized a prompt.

## The fix

Adds `AgentConfig.promptBaseVersions` — which shipped version each prompt file was last written from, keyed by prompt kind. Stamped on **every** write: seeding, the silent old-default update, a reset, and the user saving their own text (which baselines their edit at today's default, so a *later* bump is what raises the notice).

Drift then becomes exact: **stamp exists AND stamp ≠ current**.

Edge cases, all pinned by tests:
- **No stamp** → stays silent. We can't substantiate drift we have no baseline for.
- **Customized file predating the field** → gets a stamp seeded at the current version, so it's detectable from the next bump onward. Deliberately *not* backdated — that would claim their edit predates a change it may already incorporate.
- **Existing older stamp** → never overwritten, since that would erase the very drift the field exists to detect.

Stamping is non-fatal by design: it's bookkeeping, and a store hiccup must not abort the surrounding write and leave the user with no prompt file at all. Worst case, a stamp is missed and drift stays silent.

## Scope

Only the detection was missing — the notice, the `customized: true` wording ("your customized version was kept"), the version-stamped dismissal id, and Review-opens-the-diff all already handle this case from #402.

One incidental fix: `test/agent/promptFiles.test.ts` mocked `getData()` without `updateAgent`, which the stamp now calls. That surfaced the non-fatal concern above, which is why stamping is wrapped rather than left to throw.

## Verification

`bun run test` — 1380 passing (82 files, up from 1359/81), `bun run check` clean, Biome clean on changed files, `bun run build` succeeds.

New coverage: the stamp is written on seed / silent-update / user-save / back-fill and never overwritten when older; and on the detection side, a superseded baseline flags with `customized: true` while a current baseline and an absent baseline both stay silent.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._