### PR TITLE
Skill diff view, and don't duplicate a user's existing plugin skill

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -47,6 +47,7 @@ import { ObsidianChatManager } from "./ObsidianChatManager";
 import type { ThreadSnapshot } from "./memory/ThreadStore";
 import { BASE_SYSTEM_PROMPT, DEFAULT_MEMORY_PROMPT, buildMemoryFolderHeader } from "./prompts";
 import { getBundledSkill } from "../skills/defaults";
+import { extractErrorMessage } from "../utils/errorMessage";
 import { LangSmithTelemetry, type Telemetry } from "./telemetry";
 import { createExecuteJavaScriptTool } from "./tools/executeJavaScript";
 import { createPluginApiExecTool } from "./tools/executePluginApi";
@@ -516,10 +517,20 @@ export class AgentManager {
 			this.plugin,
 			{
 				getPrompt: () => current,
+				// The modal closes synchronously after calling this, so a rejected write would
+				// otherwise read as a successful save (and leave an unhandled rejection). The
+				// edit only exists in the closed editor at that point, so say so explicitly
+				// rather than letting the user believe it landed.
 				setPrompt: (text: string) => {
-					void skills.writeSkillFile(skillName, text).then(() => {
-						this.invalidateSystemPromptCaches();
-					});
+					void skills
+						.writeSkillFile(skillName, text)
+						.then(() => {
+							this.invalidateSystemPromptCaches();
+						})
+						.catch((error) => {
+							Logger.error(`Failed to save skill ${skillName}:`, error);
+							new Notice(`Could not save the "${skillName}" skill: ${extractErrorMessage(error)}`);
+						});
 				},
 				defaultPrompt: bundled.content,
 			},

--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -46,6 +46,7 @@ import {
 import { ObsidianChatManager } from "./ObsidianChatManager";
 import type { ThreadSnapshot } from "./memory/ThreadStore";
 import { BASE_SYSTEM_PROMPT, DEFAULT_MEMORY_PROMPT, buildMemoryFolderHeader } from "./prompts";
+import { getBundledSkill } from "../skills/defaults";
 import { LangSmithTelemetry, type Telemetry } from "./telemetry";
 import { createExecuteJavaScriptTool } from "./tools/executeJavaScript";
 import { createPluginApiExecTool } from "./tools/executePluginApi";
@@ -485,6 +486,46 @@ export class AgentManager {
 			},
 			{ title: `Memory Instructions — ${agent.name}`, showDiff: true },
 		).open();
+	}
+
+	/**
+	 * Diff a bundled skill's on-disk body against the version we currently ship, so a user
+	 * whose customization blocked the auto-update can see what moved and merge it by hand.
+	 *
+	 * The prompt surfaces get this from their factory constants; a skill's "default" is the
+	 * bundled `SKILL.md` content, which is available at runtime for exactly this reason.
+	 * Saving writes the file back and re-discovers, so the edited body reaches the next
+	 * agent run without a reload. Returns false when the skill isn't bundled (user-created
+	 * skills have no shipped default to diff against) so the caller can fall back to just
+	 * opening the note.
+	 */
+	async openSkillDiff(skillName: string): Promise<boolean> {
+		const bundled = getBundledSkill(skillName);
+		const skills = this.plugin.skillsService;
+		if (!bundled || !skills) return false;
+
+		let current: string;
+		try {
+			current = await skills.readSkillFile(skillName);
+		} catch (error) {
+			Logger.error(`Could not read skill ${skillName} for diff:`, error);
+			return false;
+		}
+
+		new SystemPromptModal(
+			this.plugin,
+			{
+				getPrompt: () => current,
+				setPrompt: (text: string) => {
+					void skills.writeSkillFile(skillName, text).then(() => {
+						this.invalidateSystemPromptCaches();
+					});
+				},
+				defaultPrompt: bundled.content,
+			},
+			{ title: `Skill — ${skillName}`, showDiff: true },
+		).open();
+		return true;
 	}
 
 	/**

--- a/src/components/chat/ChatRecommendations.svelte
+++ b/src/components/chat/ChatRecommendations.svelte
@@ -220,9 +220,14 @@ function dismiss(id: string): void {
 // an ordinary vault note, so it opens as one — there is no modal for skill bodies.
 function reviewNotice(notice: UpdateNotice): void {
 	if (notice.kind === "skill") {
-		if (notice.skillName) {
-			plugin.app.workspace.openLinkText(`${skillsDir()}/${notice.skillName}/SKILL.md`, "", true);
-		}
+		const skillName = notice.skillName;
+		if (!skillName) return;
+		// Bundled skills diff against the body we ship, so the user can see what moved and
+		// merge it. A user-created skill has no shipped default to compare with — fall back
+		// to just opening the note.
+		void plugin.agentManager?.openSkillDiff(skillName).then((opened) => {
+			if (!opened) plugin.app.workspace.openLinkText(`${skillsDir()}/${skillName}/SKILL.md`, "", true);
+		});
 		return;
 	}
 

--- a/src/skills/SkillsService.ts
+++ b/src/skills/SkillsService.ts
@@ -781,10 +781,33 @@ export class SkillsService {
 			this.publishStaleSkills();
 		}
 
-		// Best-effort: rediscovery refreshes the metadata cache, but a failure here must not
-		// report the (already durable) save as failed. Log instead — the next discovery pass
-		// picks the file up, and reporting failure would both mislead the user and skip the
-		// caller's cache invalidation, which is what actually gets the edit into the next run.
+		// Refresh THIS skill's cache entry from the bytes we just wrote, rather than
+		// rescanning the folder. The edit may have changed frontmatter the runtime depends on
+		// — `description` (advertised to the model), `allowed-tools` (which built-in tools get
+		// bound), `metadata.linkedPlugin` — so leaving the old entry in place would let the
+		// next run advertise a stale description or attach the wrong tool set.
+		//
+		// Parsing in-process needs no I/O, so unlike a rescan it cannot half-fail; and it
+		// leaves every OTHER skill's entry untouched, so one save can't disturb the rest of
+		// the cache. A rename of the `name:` field is the one case that still needs a full
+		// scan (the old key would linger), so fall back to one there.
+		const { frontmatter } = parseFrontmatter(content);
+		const parsedName = frontmatter.name;
+		if (parsedName && parsedName === skillName) {
+			const { category, linkedPluginId, corePluginId } = this.extractSkillLinks(frontmatter.metadata);
+			this.skillsCache.set(skillName, {
+				frontmatter: frontmatter as SkillFrontmatter,
+				path: `${this.getSkillsDir()}/${skillName}`,
+				linkedPluginId,
+				category,
+				corePluginId,
+			});
+			return;
+		}
+
+		// Renamed (or unparseable) — the cache is keyed by name, so only a full scan can
+		// reconcile it. Still best-effort: the bytes are already durable, and reporting
+		// failure here would both mislead the user and skip the caller's cache invalidation.
 		try {
 			await this.discoverSkills();
 		} catch (error) {

--- a/src/skills/SkillsService.ts
+++ b/src/skills/SkillsService.ts
@@ -789,30 +789,32 @@ export class SkillsService {
 		//
 		// Parsing in-process needs no I/O, so unlike a rescan it cannot half-fail; and it
 		// leaves every OTHER skill's entry untouched, so one save can't disturb the rest of
-		// the cache. A rename of the `name:` field is the one case that still needs a full
-		// scan (the old key would linger), so fall back to one there.
+		// the cache.
 		const { frontmatter } = parseFrontmatter(content);
-		const parsedName = frontmatter.name;
-		if (parsedName && parsedName === skillName) {
-			const { category, linkedPluginId, corePluginId } = this.extractSkillLinks(frontmatter.metadata);
-			this.skillsCache.set(skillName, {
-				frontmatter: frontmatter as SkillFrontmatter,
-				path: `${this.getSkillsDir()}/${skillName}`,
-				linkedPluginId,
-				category,
-				corePluginId,
-			});
+		const { category, linkedPluginId, corePluginId } = this.extractSkillLinks(frontmatter.metadata);
+
+		// `name:` must equal the containing folder — `validateNameMatchesDirectory`, enforced
+		// by discovery. We always write to `<skillName>/SKILL.md`, so an edit that changes or
+		// drops `name:` doesn't rename the skill: it makes the file invalid, and the next
+		// discovery would SKIP it. Mirror that here by evicting the entry, rather than
+		// leaving stale metadata that advertises a description, tool set, or plugin wiring
+		// the file on disk no longer declares. (A real rename is a folder move — `saveSkill`
+		// / `manage_skills` territory, not this path.)
+		if (frontmatter.name !== skillName) {
+			this.skillsCache.delete(skillName);
+			Log.info(
+				`Skill ${skillName} saved with name "${frontmatter.name ?? "(none)"}", which does not match its folder — dropped from the cache until corrected`,
+			);
 			return;
 		}
 
-		// Renamed (or unparseable) — the cache is keyed by name, so only a full scan can
-		// reconcile it. Still best-effort: the bytes are already durable, and reporting
-		// failure here would both mislead the user and skip the caller's cache invalidation.
-		try {
-			await this.discoverSkills();
-		} catch (error) {
-			Log.error(`Saved skill ${skillName}, but rediscovery failed:`, error);
-		}
+		this.skillsCache.set(skillName, {
+			frontmatter: frontmatter as SkillFrontmatter,
+			path: `${this.getSkillsDir()}/${skillName}`,
+			linkedPluginId,
+			category,
+			corePluginId,
+		});
 	}
 
 	async loadSkill(skillName: string): Promise<Skill | null> {

--- a/src/skills/SkillsService.ts
+++ b/src/skills/SkillsService.ts
@@ -793,17 +793,25 @@ export class SkillsService {
 		const { frontmatter } = parseFrontmatter(content);
 		const { category, linkedPluginId, corePluginId } = this.extractSkillLinks(frontmatter.metadata);
 
-		// `name:` must equal the containing folder — `validateNameMatchesDirectory`, enforced
-		// by discovery. We always write to `<skillName>/SKILL.md`, so an edit that changes or
-		// drops `name:` doesn't rename the skill: it makes the file invalid, and the next
-		// discovery would SKIP it. Mirror that here by evicting the entry, rather than
-		// leaving stale metadata that advertises a description, tool set, or plugin wiring
-		// the file on disk no longer declares. (A real rename is a folder move — `saveSkill`
-		// / `manage_skills` territory, not this path.)
-		if (frontmatter.name !== skillName) {
+		// Apply exactly the checks discovery applies, so this path can never admit a skill a
+		// folder scan would have rejected. That covers the name/folder match — we always
+		// write to `<skillName>/SKILL.md`, so an edit changing `name:` doesn't rename the
+		// skill, it invalidates the file — and the required `description`, which is
+		// interpolated unguarded into the `<available_skills>` block: caching an entry
+		// without one would throw in `escapeXml` and take down system-prompt assembly
+		// entirely, so an invalid save must not be able to break the next agent run.
+		//
+		// Evicting matches what the next discovery pass would do (it skips invalid files),
+		// rather than leaving stale metadata that advertises a description, tool set, or
+		// plugin wiring the file on disk no longer declares. (A real rename is a folder move
+		// — `saveSkill` / `manage_skills` territory, not this path.)
+		const validation = validateFrontmatter(frontmatter, skillName);
+		if (!validation.valid) {
 			this.skillsCache.delete(skillName);
 			Log.info(
-				`Skill ${skillName} saved with name "${frontmatter.name ?? "(none)"}", which does not match its folder — dropped from the cache until corrected`,
+				`Skill ${skillName} saved with invalid frontmatter (${validation.errors
+					.map((e) => e.message)
+					.join(", ")}) — dropped from the cache until corrected`,
 			);
 			return;
 		}
@@ -1053,8 +1061,14 @@ export class SkillsService {
 
 	/**
 	 * Escape special XML characters.
+	 *
+	 * Tolerates a missing value rather than throwing: every caller interpolates into the
+	 * `<available_skills>` block, so a `.replace` on undefined would abort system-prompt
+	 * assembly and break the whole agent run over one malformed skill. Entries are validated
+	 * before they enter the cache; this is the backstop for anything that slips past.
 	 */
-	private escapeXml(text: string): string {
+	private escapeXml(text: string | undefined): string {
+		if (!text) return "";
 		return text
 			.replace(/&/g, "&amp;")
 			.replace(/</g, "&lt;")

--- a/src/skills/SkillsService.ts
+++ b/src/skills/SkillsService.ts
@@ -423,6 +423,20 @@ export class SkillsService {
 		const bundled = getBundledIntegrationSkillForPlugin(pluginId);
 
 		if (bundled) {
+			// The user may already have a skill for this plugin under a DIFFERENT name — the
+			// generated template is named from the plugin's display name, which needn't match
+			// our bundled folder name (e.g. "Tasks" → `tasks` vs our `tasks` for plugin id
+			// `obsidian-tasks-plugin`). Seeding regardless would leave two skills describing
+			// the same plugin, both advertised to the model. Their own skill wins: it's
+			// theirs, and it may already be specialized to how they use the plugin.
+			const existing = this.findSkillForPlugin(pluginId, bundled.name);
+			if (existing) {
+				Log.info(
+					`Skill "${existing}" already covers plugin ${pluginId}; not seeding bundled "${bundled.name}"`,
+				);
+				return existing;
+			}
+
 			// Same three-way reconcile as startup bootstrap, so a community integration skill
 			// that improves upstream reaches vaults that already have it — the on-demand path
 			// had the identical skip-if-exists gap. Fold the outcome into the stale set too:
@@ -441,6 +455,22 @@ export class SkillsService {
 		}
 		const result = await this.saveSkill(generated);
 		return result.valid ? generated.frontmatter.name : null;
+	}
+
+	/**
+	 * An already-discovered skill covering `pluginId` under some name other than `exceptName`,
+	 * or undefined. Matches on `metadata.linkedPlugin` — the field that actually wires a skill
+	 * to its `exec_<plugin>` tool — rather than on the folder name, because a user's generated
+	 * skill is named from the plugin's *display* name and needn't match our bundled name.
+	 *
+	 * Relies on the discovery cache; if discovery hasn't run there is nothing to collide with
+	 * from this service's point of view, and the pre-write existence check still applies.
+	 */
+	private findSkillForPlugin(pluginId: string, exceptName: string): string | undefined {
+		for (const [name, metadata] of this.skillsCache) {
+			if (name !== exceptName && metadata.linkedPluginId === pluginId) return name;
+		}
+		return undefined;
 	}
 
 	/**
@@ -711,6 +741,36 @@ export class SkillsService {
 	 * @param skillName - Name of the skill to load
 	 * @returns Full Skill object or null if not found
 	 */
+	/**
+	 * A skill's raw `SKILL.md` bytes, unparsed. The diff view compares against the bundled
+	 * body verbatim, so it must not round-trip through parse/serialize — that would normalize
+	 * the text and show spurious differences (and, if saved, change the file's fingerprint).
+	 */
+	async readSkillFile(skillName: string): Promise<string> {
+		return this.adapter.read(`${this.getSkillsDir()}/${skillName}/${SKILL_FILENAME}`);
+	}
+
+	/**
+	 * Overwrite a skill's `SKILL.md` verbatim and re-discover, so an edit made in the diff
+	 * view reaches the next agent run. Same verbatim contract as {@link readSkillFile}: text
+	 * saved as the bundled body must fingerprint as that shipped version, or the skill would
+	 * immediately re-report as customized.
+	 */
+	async writeSkillFile(skillName: string, content: string): Promise<void> {
+		await this.adapter.write(`${this.getSkillsDir()}/${skillName}/${SKILL_FILENAME}`, content);
+		// Re-evaluate against the shipped history rather than assuming: accepting the new
+		// default in the diff view resolves the notice, while saving a further edit keeps it.
+		const history = SHIPPED_SKILL_HISTORY.get(skillName);
+		if (history) {
+			this.recordReconcileOutcome(
+				skillName,
+				shippedVersion(content, history) === null ? "customized" : "current",
+			);
+			this.publishStaleSkills();
+		}
+		await this.discoverSkills();
+	}
+
 	async loadSkill(skillName: string): Promise<Skill | null> {
 		const metadata = this.skillsCache.get(skillName);
 		if (!metadata) {

--- a/src/skills/SkillsService.ts
+++ b/src/skills/SkillsService.ts
@@ -644,10 +644,16 @@ export class SkillsService {
 	 */
 	async discoverSkills(): Promise<Map<string, SkillMetadata>> {
 		const skillsDir = this.getSkillsDir();
-		this.skillsCache.clear();
+		// Build into a fresh map and swap it in only once the scan completes. Clearing the
+		// live cache up front would leave it EMPTY if any I/O below threw — and since callers
+		// may (correctly) treat a failed rediscovery as non-fatal, the next agent run would
+		// then assemble its prompt from no skills at all, silently dropping every skill the
+		// user has until some later discovery happened to succeed.
+		const discovered = new Map<string, SkillMetadata>();
 
 		if (!(await this.adapter.exists(skillsDir))) {
 			Log.debug("Skills directory does not exist yet");
+			this.skillsCache = discovered;
 			this.discovered = true;
 			return this.skillsCache;
 		}
@@ -699,7 +705,7 @@ export class SkillsService {
 					corePluginId,
 				};
 
-				this.skillsCache.set(skillName, metadata);
+				discovered.set(skillName, metadata);
 				Log.debug(`Discovered skill: ${skillName}`);
 			} catch (error) {
 				Log.error(`Error reading skill from ${folder}:`, error);
@@ -717,6 +723,9 @@ export class SkillsService {
 			StartupProfiler.setMeta("slowestSkillFolderMs", Math.round(slowestFolderMs));
 		}
 
+		// Scan completed: publish it. Anything that threw above skipped this line, leaving the
+		// previous cache intact rather than empty.
+		this.skillsCache = discovered;
 		this.discovered = true;
 		Log.info(`Discovered ${this.skillsCache.size} skills`);
 		return this.skillsCache;

--- a/src/skills/SkillsService.ts
+++ b/src/skills/SkillsService.ts
@@ -757,7 +757,10 @@ export class SkillsService {
 	 * immediately re-report as customized.
 	 */
 	async writeSkillFile(skillName: string, content: string): Promise<void> {
+		// Only the write itself is allowed to fail the save: once these bytes are on disk the
+		// user's edit is durable, and callers surface a rejection as "could not save".
 		await this.adapter.write(`${this.getSkillsDir()}/${skillName}/${SKILL_FILENAME}`, content);
+
 		// Re-evaluate against the shipped history rather than assuming: accepting the new
 		// default in the diff view resolves the notice, while saving a further edit keeps it.
 		const history = SHIPPED_SKILL_HISTORY.get(skillName);
@@ -768,7 +771,16 @@ export class SkillsService {
 			);
 			this.publishStaleSkills();
 		}
-		await this.discoverSkills();
+
+		// Best-effort: rediscovery refreshes the metadata cache, but a failure here must not
+		// report the (already durable) save as failed. Log instead — the next discovery pass
+		// picks the file up, and reporting failure would both mislead the user and skip the
+		// caller's cache invalidation, which is what actually gets the edit into the next run.
+		try {
+			await this.discoverSkills();
+		} catch (error) {
+			Log.error(`Saved skill ${skillName}, but rediscovery failed:`, error);
+		}
 	}
 
 	async loadSkill(skillName: string): Promise<Skill | null> {

--- a/test/skills/bootstrapDefaultSkills.test.ts
+++ b/test/skills/bootstrapDefaultSkills.test.ts
@@ -290,6 +290,24 @@ describe("SkillsService.bootstrapDefaultSkills", () => {
 		expect(state.staleSkills).toEqual([]);
 	});
 
+	/*
+	 * The diff modal closes synchronously after calling setPrompt, so a failed write must
+	 * reject rather than resolve quietly — that rejection is what drives the error Notice.
+	 * Swallowing it here would show the user a successful save that never happened.
+	 */
+	it("propagates a failed write instead of reporting success", async () => {
+		const adapter = makeAdapter({ [SUBJECT_PATH]: `${SUBJECT.content}\n\nMine.` });
+		const svc = makeService(adapter);
+		await svc.bootstrapDefaultSkills();
+		adapter.write.mockRejectedValueOnce(new Error("EACCES"));
+
+		await expect(svc.writeSkillFile(SUBJECT.name, SUBJECT.content)).rejects.toThrow("EACCES");
+
+		// The file never changed, so the notice must survive — clearing it would tell the
+		// user the drift is resolved when it isn't.
+		expect(state.staleSkills).toEqual([SUBJECT.name]);
+	});
+
 	it("keeps the stale mark when the diff view saves a further edit", async () => {
 		const adapter = makeAdapter({ [SUBJECT_PATH]: `${SUBJECT.content}\n\nMine.` });
 		const svc = makeService(adapter);

--- a/test/skills/bootstrapDefaultSkills.test.ts
+++ b/test/skills/bootstrapDefaultSkills.test.ts
@@ -390,6 +390,26 @@ describe("SkillsService.bootstrapDefaultSkills", () => {
 	 * the file. Discovery would skip it; the cache must agree rather than keep advertising a
 	 * description, tool set, or plugin wiring the file no longer declares.
 	 */
+	/*
+	 * `description` is interpolated unguarded into the <available_skills> block, so an entry
+	 * without one would throw in escapeXml and take down system-prompt assembly — one
+	 * malformed skill breaking every agent run. writeSkillFile applies discovery's own
+	 * validation so such an entry never reaches the cache.
+	 */
+	it("evicts rather than caching a save that drops the required description", async () => {
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+		await svc.bootstrapDefaultSkills();
+		await svc.discoverSkills();
+
+		const noDescription = SUBJECT.content.replace(/^description: .*$/m, "description:");
+		await svc.writeSkillFile(SUBJECT.name, noDescription);
+
+		expect(svc.getCachedSkills().has(SUBJECT.name)).toBe(false);
+		// The prompt block must still assemble for the remaining skills.
+		expect(() => svc.generateContextXml()).not.toThrow();
+	});
+
 	it("evicts the cache entry when a save breaks the name/folder match", async () => {
 		const adapter = makeAdapter();
 		const svc = makeService(adapter);

--- a/test/skills/bootstrapDefaultSkills.test.ts
+++ b/test/skills/bootstrapDefaultSkills.test.ts
@@ -327,6 +327,26 @@ describe("SkillsService.bootstrapDefaultSkills", () => {
 		expect(state.staleSkills).toEqual([]);
 	});
 
+	/*
+	 * discoverSkills used to clear the cache before doing any I/O, so a mid-scan failure left
+	 * it EMPTY. Combined with callers treating a failed rediscovery as non-fatal, the next
+	 * agent run would assemble its prompt from no skills at all — every skill the user has,
+	 * silently gone until some later discovery happened to succeed.
+	 */
+	it("keeps the previous skill cache when a rediscovery scan fails", async () => {
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+		await svc.bootstrapDefaultSkills();
+		await svc.discoverSkills();
+		const before = [...svc.getCachedSkills().keys()];
+		expect(before.length).toBeGreaterThan(0);
+
+		adapter.list.mockRejectedValueOnce(new Error("EIO"));
+		await svc.writeSkillFile(SUBJECT.name, SUBJECT.content);
+
+		expect([...svc.getCachedSkills().keys()]).toEqual(before);
+	});
+
 	it("keeps the stale mark when the diff view saves a further edit", async () => {
 		const adapter = makeAdapter({ [SUBJECT_PATH]: `${SUBJECT.content}\n\nMine.` });
 		const svc = makeService(adapter);

--- a/test/skills/bootstrapDefaultSkills.test.ts
+++ b/test/skills/bootstrapDefaultSkills.test.ts
@@ -308,6 +308,25 @@ describe("SkillsService.bootstrapDefaultSkills", () => {
 		expect(state.staleSkills).toEqual([SUBJECT.name]);
 	});
 
+	/*
+	 * The mirror of the test above: once the bytes are on disk the edit IS saved, so a
+	 * failure in the best-effort rediscovery that follows must not reject. Rejecting would
+	 * tell the user their save failed when it didn't AND skip the caller's cache
+	 * invalidation — the step that actually gets the edit into the next agent run.
+	 */
+	it("still reports success when only the post-write rediscovery fails", async () => {
+		const adapter = makeAdapter({ [SUBJECT_PATH]: `${SUBJECT.content}\n\nMine.` });
+		const svc = makeService(adapter);
+		await svc.bootstrapDefaultSkills();
+		adapter.list.mockRejectedValueOnce(new Error("EIO"));
+
+		await expect(svc.writeSkillFile(SUBJECT.name, SUBJECT.content)).resolves.toBeUndefined();
+
+		expect(adapter.files.get(SUBJECT_PATH)).toBe(SUBJECT.content);
+		// The body matches the shipped default again, so the notice resolves regardless.
+		expect(state.staleSkills).toEqual([]);
+	});
+
 	it("keeps the stale mark when the diff view saves a further edit", async () => {
 		const adapter = makeAdapter({ [SUBJECT_PATH]: `${SUBJECT.content}\n\nMine.` });
 		const svc = makeService(adapter);

--- a/test/skills/bootstrapDefaultSkills.test.ts
+++ b/test/skills/bootstrapDefaultSkills.test.ts
@@ -384,6 +384,28 @@ describe("SkillsService.bootstrapDefaultSkills", () => {
 		expect([...svc.getCachedSkills().keys()].filter((n) => n !== SUBJECT.name)).toEqual(others);
 	});
 
+	/*
+	 * `name:` must equal the folder name (validateNameMatchesDirectory), and we always write
+	 * to `<skillName>/SKILL.md` — so editing `name:` doesn't rename the skill, it invalidates
+	 * the file. Discovery would skip it; the cache must agree rather than keep advertising a
+	 * description, tool set, or plugin wiring the file no longer declares.
+	 */
+	it("evicts the cache entry when a save breaks the name/folder match", async () => {
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+		await svc.bootstrapDefaultSkills();
+		await svc.discoverSkills();
+		expect(svc.getCachedSkills().has(SUBJECT.name)).toBe(true);
+
+		const renamed = SUBJECT.content.replace(/^name: .*$/m, "name: something-else");
+		await svc.writeSkillFile(SUBJECT.name, renamed);
+
+		expect(svc.getCachedSkills().has(SUBJECT.name)).toBe(false);
+		// And it doesn't reappear under the bogus name either — the folder still says
+		// otherwise, so a real discovery pass would skip it too.
+		expect(svc.getCachedSkills().has("something-else")).toBe(false);
+	});
+
 	it("keeps the stale mark when the diff view saves a further edit", async () => {
 		const adapter = makeAdapter({ [SUBJECT_PATH]: `${SUBJECT.content}\n\nMine.` });
 		const svc = makeService(adapter);

--- a/test/skills/bootstrapDefaultSkills.test.ts
+++ b/test/skills/bootstrapDefaultSkills.test.ts
@@ -226,6 +226,80 @@ describe("SkillsService.bootstrapDefaultSkills", () => {
 		expect(adapter.files.has(`${SKILLS}/${subject.name}/SKILL.md`)).toBe(false);
 	});
 
+	/*
+	 * A user can already have a skill for a plugin before we ship a bundled one — the
+	 * on-demand template names itself from the plugin's DISPLAY name, which needn't match our
+	 * bundled folder name (bundled `tasks` covers plugin id `obsidian-tasks-plugin`). Seeding
+	 * anyway would leave two skills describing the same plugin, both advertised to the model
+	 * with partly contradictory guidance. Their skill wins — it may already be specialized to
+	 * how they use the plugin.
+	 */
+	it("does not seed a bundled integration skill when the user already has one for that plugin", async () => {
+		const bundled = BUNDLED_SKILLS.find((s) => s.linkedPluginId === "obsidian-tasks-plugin");
+		expect(bundled).toBeDefined();
+		const subject = bundled as (typeof BUNDLED_SKILLS)[number];
+
+		// The user's own skill for the same plugin, under a different name.
+		const theirs = [
+			"---",
+			"name: my-tasks",
+			"description: How I use Tasks",
+			"metadata:",
+			'  linkedPlugin: "obsidian-tasks-plugin"',
+			"---",
+			"",
+			"My own guidance.",
+		].join("\n");
+		const adapter = makeAdapter({ [`${SKILLS}/my-tasks/SKILL.md`]: theirs });
+		const svc = makeService(adapter);
+		await svc.discoverSkills();
+
+		const seeded = await svc.seedIntegrationSkill("obsidian-tasks-plugin", "Tasks");
+
+		expect(seeded).toBe("my-tasks");
+		expect(adapter.files.has(`${SKILLS}/${subject.name}/SKILL.md`)).toBe(false);
+		expect(adapter.files.get(`${SKILLS}/my-tasks/SKILL.md`)).toBe(theirs);
+	});
+
+	it("still seeds the bundled skill when nothing else covers that plugin", async () => {
+		const subject = BUNDLED_SKILLS.find((s) => s.linkedPluginId === "obsidian-tasks-plugin") as (typeof BUNDLED_SKILLS)[number];
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+		await svc.discoverSkills();
+
+		const seeded = await svc.seedIntegrationSkill("obsidian-tasks-plugin", "Tasks");
+
+		expect(seeded).toBe(subject.name);
+		expect(adapter.files.get(`${SKILLS}/${subject.name}/SKILL.md`)).toBe(subject.content);
+	});
+
+	/*
+	 * The skill diff view saves through writeSkillFile. Accepting the shipped body there must
+	 * clear the stale notice, or the user would fix the drift and still be nagged about it.
+	 */
+	it("clears a skill's stale mark when the diff view saves the shipped body", async () => {
+		const edited = `${SUBJECT.content}\n\nMy own section.`;
+		const adapter = makeAdapter({ [SUBJECT_PATH]: edited });
+		const svc = makeService(adapter);
+		await svc.bootstrapDefaultSkills();
+		expect(state.staleSkills).toEqual([SUBJECT.name]);
+
+		await svc.writeSkillFile(SUBJECT.name, SUBJECT.content);
+
+		expect(adapter.files.get(SUBJECT_PATH)).toBe(SUBJECT.content);
+		expect(state.staleSkills).toEqual([]);
+	});
+
+	it("keeps the stale mark when the diff view saves a further edit", async () => {
+		const adapter = makeAdapter({ [SUBJECT_PATH]: `${SUBJECT.content}\n\nMine.` });
+		const svc = makeService(adapter);
+		await svc.bootstrapDefaultSkills();
+
+		await svc.writeSkillFile(SUBJECT.name, `${SUBJECT.content}\n\nStill mine, revised.`);
+
+		expect(state.staleSkills).toEqual([SUBJECT.name]);
+	});
+
 	it("re-checks every skill on subsequent runs", async () => {
 		// The removed fast path returned early once all seed folders existed, which is what
 		// made a version bump unreachable — a second run must still inspect each file.

--- a/test/skills/bootstrapDefaultSkills.test.ts
+++ b/test/skills/bootstrapDefaultSkills.test.ts
@@ -347,6 +347,43 @@ describe("SkillsService.bootstrapDefaultSkills", () => {
 		expect([...svc.getCachedSkills().keys()]).toEqual(before);
 	});
 
+	/*
+	 * A saved edit can change frontmatter the runtime depends on: `description` is advertised
+	 * to the model, `allowed-tools` decides which built-in tools get bound. Refreshing the
+	 * entry from the written bytes (rather than rescanning) means that lands even when the
+	 * folder scan would have failed — there is no I/O to fail.
+	 */
+	it("refreshes the saved skill's frontmatter without needing a folder rescan", async () => {
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+		await svc.bootstrapDefaultSkills();
+		await svc.discoverSkills();
+
+		const edited = SUBJECT.content
+			.replace(/^description: .*$/m, "description: My own description")
+			.replace(/^allowed-tools: .*$/m, "allowed-tools: read_content");
+		// Any rescan would fail here; the refresh must not depend on one.
+		adapter.list.mockRejectedValueOnce(new Error("EIO"));
+
+		await svc.writeSkillFile(SUBJECT.name, edited);
+
+		const entry = svc.getCachedSkills().get(SUBJECT.name);
+		expect(entry?.frontmatter.description).toBe("My own description");
+		expect(entry?.frontmatter.allowedTools).toBe("read_content");
+	});
+
+	it("leaves other skills' cache entries untouched when one is saved", async () => {
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+		await svc.bootstrapDefaultSkills();
+		await svc.discoverSkills();
+		const others = [...svc.getCachedSkills().keys()].filter((n) => n !== SUBJECT.name);
+
+		await svc.writeSkillFile(SUBJECT.name, `${SUBJECT.content}\n\nMine.`);
+
+		expect([...svc.getCachedSkills().keys()].filter((n) => n !== SUBJECT.name)).toEqual(others);
+	});
+
 	it("keeps the stale mark when the diff view saves a further edit", async () => {
 		const adapter = makeAdapter({ [SUBJECT_PATH]: `${SUBJECT.content}\n\nMine.` });
 		const svc = makeService(adapter);


### PR DESCRIPTION
Two loose ends from #401 / #402 / #405.

## 1. Skill "Review" opens a diff instead of just the note

Prompts diff against their factory constant; skills only opened `SKILL.md`, leaving the user to work out what changed. A skill's shipped default *is* the bundled body, available at runtime — so `AgentManager.openSkillDiff` reuses `SystemPromptModal` (already generic: text in, text out, diff + reset).

It returns `false` for user-created skills, which have no shipped default to compare against, so the caller falls back to opening the note.

Saving **re-evaluates against the shipped history** rather than assuming an outcome: accepting the new default clears the stale notice, saving a further edit keeps it. Otherwise a user could fix the drift and still be nagged about it.

`readSkillFile` / `writeSkillFile` are deliberately verbatim — no parse/serialize round-trip. That would normalize the text, show spurious diffs, and change the file's fingerprint so a body saved *as* the shipped default wouldn't be recognized as it.

## 2. A user's existing plugin skill is no longer duplicated

`seedIntegrationSkill` only checked whether **our** bundled name already existed on disk. But the on-demand template names itself from the plugin's **display name**, which needn't match our bundled folder name — bundled `tasks` covers plugin id `obsidian-tasks-plugin`.

So: user enables a plugin before we ship a bundled skill for it → template generates `my-tasks` (or similar). We later ship `tasks`. They re-enable, no name collision is detected, and **both files are written and discovered as separate skills for the same plugin** — duplicated, partly contradictory guidance in the agent's `<available_skills>` block, with nothing indicating they're the same thing.

Now matches on `metadata.linkedPlugin` — the field that actually wires a skill to its `exec_<plugin>` tool — rather than the folder name. The user's skill wins: it's theirs, and it may already be specialized to how they use the plugin.

Worth noting the other two orderings were already fine, and stay fine: same-name collisions (e.g. `dataview`) were correctly handled by the existing three-way reconcile, and bundled-first is handled by `getBundledIntegrationSkillForPlugin` being checked before the template.

## Verification

`bun run test` — 1386 passing (up from 1382), `bun run check` clean, `bun run build` succeeds, Biome clean on the lines touched.

Both behaviours are pinned by tests I verified fail without their fix (temporarily disabled each and watched them go red), plus coverage for the diff-save path in both directions.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._