### PR TITLE
Surface failed prompt-diff saves instead of reporting success

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -453,10 +453,20 @@ export class AgentManager {
 			this.plugin,
 			{
 				getPrompt: () => promptFiles?.getBasePrompt(agentId) ?? BASE_SYSTEM_PROMPT,
+				// The modal closes synchronously after this, so a rejected write would read as
+				// a successful save (and leave an unhandled rejection). The edit only exists
+				// in the closed editor at that point — say so rather than letting the user
+				// believe it landed. Same contract as `openSkillDiff`.
 				setPrompt: (prompt: string) => {
-					void promptFiles?.writeBasePrompt(agentId, prompt).then(() => {
-						this.invalidateSystemPromptCaches();
-					});
+					void promptFiles
+						?.writeBasePrompt(agentId, prompt)
+						.then(() => {
+							this.invalidateSystemPromptCaches();
+						})
+						.catch((error) => {
+							Logger.error(`Failed to save the base prompt for ${agent.name}:`, error);
+							new Notice(`Could not save the system prompt: ${extractErrorMessage(error)}`);
+						});
 				},
 				defaultPrompt: BASE_SYSTEM_PROMPT,
 			},
@@ -478,10 +488,17 @@ export class AgentManager {
 			this.plugin,
 			{
 				getPrompt: () => promptFiles?.getMemoryPrompt(agentId) ?? DEFAULT_MEMORY_PROMPT,
+				// See `openSystemPromptDiff` — same close-then-save race.
 				setPrompt: (prompt: string) => {
-					void promptFiles?.writeMemoryPrompt(agentId, prompt).then(() => {
-						this.invalidateSystemPromptCaches();
-					});
+					void promptFiles
+						?.writeMemoryPrompt(agentId, prompt)
+						.then(() => {
+							this.invalidateSystemPromptCaches();
+						})
+						.catch((error) => {
+							Logger.error(`Failed to save the memory prompt for ${agent.name}:`, error);
+							new Notice(`Could not save the memory instructions: ${extractErrorMessage(error)}`);
+						});
 				},
 				defaultPrompt: DEFAULT_MEMORY_PROMPT,
 			},

--- a/src/components/modal/AgentEditorModal.svelte
+++ b/src/components/modal/AgentEditorModal.svelte
@@ -298,18 +298,10 @@ const memoryPromptDrifted = $derived.by(() => {
 
 function openMemoryPromptDiff() {
 	if (!selectedAgent) return;
-	const promptFiles = plugin.promptFilesService;
-	new SystemPromptModal(
-		plugin,
-		{
-			getPrompt: () => promptFiles?.getMemoryPrompt(agentId) ?? DEFAULT_MEMORY_PROMPT,
-			setPrompt: (prompt: string) => {
-				void promptFiles?.writeMemoryPrompt(agentId, prompt).then(() => applyChanges());
-			},
-			defaultPrompt: DEFAULT_MEMORY_PROMPT,
-		},
-		{ title: `Memory Instructions — ${selectedAgent.name}`, showDiff: true },
-	).open();
+	// Delegate rather than rebuild the modal here: AgentManager owns the save contract
+	// (invalidate caches on success, surface a Notice on failure), and duplicating it was
+	// how this call site ended up silently swallowing write errors.
+	plugin.agentManager?.openMemoryPromptDiff(agentId);
 	memoryPromptDriftTick++;
 }
 

--- a/test/agent/promptFiles.test.ts
+++ b/test/agent/promptFiles.test.ts
@@ -169,6 +169,24 @@ describe("PromptFilesService", () => {
 		expect(svc.getBasePrompt("default-agent")).toBe("new base prompt");
 	});
 
+	/*
+	 * The diff modal closes synchronously after calling setPrompt, so its save must be able
+	 * to detect a failed write — that rejection is what drives the error Notice in
+	 * AgentManager.openSystemPromptDiff / openMemoryPromptDiff. Resolving quietly here would
+	 * show the user a successful save that never happened, with the edit lost to the closed
+	 * editor.
+	 */
+	it("propagates a failed write instead of resolving quietly", async () => {
+		const adapter = makeAdapter();
+		const svc = makeService(adapter);
+		adapter.write.mockRejectedValueOnce(new Error("EACCES"));
+
+		await expect(svc.writeBasePrompt("default-agent", "new base prompt")).rejects.toThrow("EACCES");
+
+		// The cache must not claim the write landed either.
+		expect(svc.getBasePrompt("default-agent")).not.toBe("new base prompt");
+	});
+
 	it("resetBasePrompt rewrites the file to the current default", async () => {
 		const adapter = makeAdapter({ [DEFAULT_PATH]: "drifted" });
 		const svc = makeService(adapter);


### PR DESCRIPTION
Closes the follow-up flagged during #406's review.

## The problem

`SystemPromptModal.handleSave` calls `setPrompt` and then `modal.close()` **synchronously**. Both prompt diff surfaces passed a fire-and-forget write, so a failed vault write left an unhandled rejection while the user saw an apparently successful save — with their edit existing only in the editor that just closed.

This is the same defect Greptile reported against the *skill* diff in #406. That one was fixed there; these two predated it and were left alone to keep that PR scoped.

## The fix

`openSystemPromptDiff` and `openMemoryPromptDiff` now catch, log, and show a `Notice` naming what failed.

`AgentEditorModal` had a **third** copy of this wiring, built inline, with the same swallowed error. It now delegates to `AgentManager.openMemoryPromptDiff` rather than rebuilding the modal — duplicating that wiring is precisely how the call site ended up diverging. Incidental improvement: its invalidation broadens from `invalidateAgentRunnable(agentId)` to `invalidateSystemPromptCaches()` (all runnables + MCP caches), which is the correct scope for a prompt change.

## What didn't need changing

`PromptFilesService.write` is already correct — its post-write steps (cache update, `stampBaseVersion`) are synchronous, and the stamp swallows its own errors by design. So the write remains the only fallible step, which is the contract #406 converged on for skills:

> the write is the durable step; everything after it is either infallible or self-correcting.

Added a test pinning that `write` **propagates** a failure and doesn't poison the cache, since the new Notice depends on that rejection actually surfacing.

## Verification

`bun run test` — 1394 passing (up from 1393), `bun run check` clean, Biome clean on changed files, `bun run build` succeeds.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._