### PR TITLE
feat(graph): live vault updates and multi-graph cache persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "setup-vault": "mkdir -p 'integration/Smart2Brain Test Vault/.obsidian/plugins/smart-second-brain' && cd 'integration/Smart2Brain Test Vault/.obsidian/plugins/smart-second-brain' && ln -sf ../../../../../build/smart-second-brain/main.js main.js && ln -sf ../../../../../build/smart-second-brain/styles.css styles.css && ln -sf ../../../../../build/smart-second-brain/manifest.json manifest.json",
     "corpus:generate": "bun run scripts/generate-search-corpus.ts",
+    "bench:layout": "bun run scripts/graph-layout-bench.ts",
     "test:benchmark": "vitest run --config vitest.integration.config.ts integration/search-relevance-benchmark.test.ts"
   },
   "type": "module",

--- a/scripts/graph-layout-bench.ts
+++ b/scripts/graph-layout-bench.ts
@@ -1,0 +1,636 @@
+/**
+ * Headless layout benchmark for the smart graph's physics tuning.
+ *
+ * Runs the *production* force assembly (src/utils/graphLayout.ts — the same
+ * code GraphCanvas installs) on seeded synthetic vaults across the density
+ * range, settles each simulation, and measures the qualities that tuning
+ * rounds previously judged by screenshot:
+ *
+ * - `fit`      — the zoom the camera lands at to frame the layout in a
+ *                1200×800 viewport. Too small = user must zoom out far.
+ * - `nodePx`   — median on-screen node radius at that fit (counter-scale
+ *                applied). Too small = dust; too big = discs.
+ * - `breathe`  — median nearest-neighbour distance between clustered notes,
+ *                as a multiple of touching distance (sum of collide radii).
+ *                1.0 = collide-bound crush; higher = air between notes.
+ * - `gap`      — mean distance to the nearest other topic centroid, as a
+ *                multiple of the two topics' combined RMS radii.
+ *                ~1 = hulls touching; large = topics floating far apart.
+ * - `sat`      — median orbit of unlinked satellite notes, as a multiple of
+ *                the clustered core's 95th-percentile radius.
+ * - `ovl%`     — share of nodes overlapping their nearest neighbour on
+ *                screen at fit zoom (drawn, counter-scaled radii).
+ * - `fill`     — the on-screen extent of the graph's *core* (the central 90%
+ *                of nodes) as a fraction of the viewport at fit zoom. Low = a
+ *                small knot marooned in white space; once the overview zoom
+ *                cap binds, the camera can't fix it. Deliberately ignores
+ *                outliers: the camera frames the full bounding box, so a
+ *                couple of far-flung unsorted notes can stretch the box while
+ *                everything the user cares about huddles in one corner —
+ *                measuring the box would score that as a good fill.
+ * - `waste`    — full bounding box area ÷ core area. ~1 = the frame is all
+ *                content; high = the camera is zoomed out to include
+ *                outliers, shrinking the core.
+ *
+ * Each scenario carries guardrail bands (see `Expectations`); `--assert`
+ * exits non-zero when any are violated, so a tuning change that fixes one
+ * density while wrecking another can't pass unnoticed.
+ *
+ * Deterministic end to end: mulberry32-seeded generation, d3-force's default
+ * deterministic randomSource, phyllotaxis initial placement. Run:
+ *
+ *   bun run bench:layout            # table
+ *   bun run bench:layout --assert   # non-zero exit on band violations
+ *   bun run bench:layout --json     # machine-readable
+ */
+
+import { GRAPH_FIT_MAX_SCALE, computeCoreNodeBounds } from "../src/utils/graphAnimation";
+import {
+	type LayoutLink,
+	type LayoutNode,
+	type LayoutPhysicsConfig,
+	createLayoutSimulation,
+} from "../src/utils/graphLayout";
+import { autoNodeSize, densityForceProfile, nodeDrawRadius, zoomNodeScale } from "../src/utils/graphUtils";
+import { mulberry32 } from "../src/utils/seededRandom";
+
+// The user-facing defaults from DEFAULT_SMART_GRAPH_SETTINGS (types/graph.ts
+// imports Svelte-adjacent modules, so the values are mirrored here — if they
+// drift, the bench header shows what it ran with).
+const BASE_PHYSICS = {
+	linkDistance: 60,
+	chargeStrength: -120,
+	centerStrength: 0.07,
+	linkStrength: 1,
+	clusterCohesionStrength: 0.45,
+};
+
+const VIEWPORT_W = 1200;
+const VIEWPORT_H = 800;
+const FIT_PADDING = 40;
+
+const MAX_TICKS = 400;
+
+interface BenchNode extends LayoutNode {
+	x: number;
+	y: number;
+}
+
+interface BenchLink extends LayoutLink {
+	source: string | BenchNode;
+	target: string | BenchNode;
+}
+
+/**
+ * Guardrail bands per scenario, set ~10% under the tuned values so
+ * deterministic drift and small legitimate tweaks pass, while the class of
+ * regression the benchmark has actually caught (the unclustered-cohesion
+ * glue, the distanceMin crush — 20–50% metric swings) fails loudly.
+ *
+ * Collapsed scenarios allow breathe ≈ 1 by design: their topic graphs are
+ * near-complete, and a complete graph cannot embed in the plane with every
+ * pair at rest length — heavily-coupled topics sitting adjacent (touching,
+ * never overlapping) is the intended reading of coupling.
+ */
+interface Expectations {
+	breatheMin?: number;
+	fillMin?: number;
+	wasteMax?: number;
+	gapMin?: number;
+	gapMax?: number;
+	satMax?: number;
+	nodePxMax?: number;
+	ovlMax?: number;
+}
+
+interface Scenario {
+	name: string;
+	nodes: BenchNode[];
+	links: BenchLink[];
+	/** Notes the graph stands for (drives nodeSize; ≥ nodes.length when collapsed). */
+	representedNotes: number;
+	expect: Expectations;
+}
+
+// ── Synthetic vault generation ──────────────────────────────────────────────
+
+interface VaultShape {
+	noteCount: number;
+	topicCount: number;
+	/** Fraction of notes with no links at all (the "unsorted" satellites). */
+	satelliteFraction: number;
+	/** Mean authored links per clustered note. */
+	wikiLinksPerNote: number;
+	/** Mean inferred links per clustered note (weights 0.55–0.95). */
+	semanticLinksPerNote: number;
+	/** Fraction of links that cross topic boundaries. */
+	interTopicFraction: number;
+}
+
+/** Heavy-tailed topic sizes (Zipf-ish), matching how real vaults distribute. */
+function topicSizes(rng: () => number, noteCount: number, topicCount: number): number[] {
+	const weights = Array.from({ length: topicCount }, (_, i) => 1 / (i + 1 + rng() * 0.5));
+	const total = weights.reduce((a, b) => a + b, 0);
+	const sizes = weights.map((w) => Math.max(2, Math.round((w / total) * noteCount)));
+	// Fix rounding drift so sizes sum to noteCount.
+	let drift = noteCount - sizes.reduce((a, b) => a + b, 0);
+	for (let i = 0; drift !== 0; i = (i + 1) % sizes.length) {
+		const step = Math.sign(drift);
+		if (sizes[i] + step >= 2) {
+			sizes[i] += step;
+			drift -= step;
+		}
+	}
+	return sizes;
+}
+
+/** Skewed pick of an earlier note in the topic — low indices act as hubs. */
+function pickHubIndex(rng: () => number, upperExclusive: number): number {
+	return Math.floor(upperExclusive * rng() ** 2);
+}
+
+function generateExpandedVault(seed: number, shape: VaultShape): Pick<Scenario, "nodes" | "links"> {
+	const rng = mulberry32(seed);
+	const satelliteCount = Math.round(shape.noteCount * shape.satelliteFraction);
+	const clusteredCount = shape.noteCount - satelliteCount;
+	const sizes = topicSizes(rng, clusteredCount, shape.topicCount);
+
+	const nodes: BenchNode[] = [];
+	const byTopic: BenchNode[][] = [];
+	let noteIndex = 0;
+	for (let topic = 0; topic < sizes.length; topic++) {
+		const members: BenchNode[] = [];
+		for (let i = 0; i < sizes[topic]; i++) {
+			const node: BenchNode = { id: `n${noteIndex++}`, cluster: topic, degree: 0, x: 0, y: 0 };
+			members.push(node);
+			nodes.push(node);
+		}
+		byTopic.push(members);
+	}
+	for (let i = 0; i < satelliteCount; i++) {
+		nodes.push({ id: `sat${i}`, degree: 0, x: 0, y: 0 });
+	}
+
+	const links: BenchLink[] = [];
+	const seen = new Set<string>();
+	const addLink = (a: BenchNode, b: BenchNode, weight: number, type: string) => {
+		if (a === b) return;
+		const key = a.id < b.id ? `${a.id}|${b.id}` : `${b.id}|${a.id}`;
+		if (seen.has(key)) return;
+		seen.add(key);
+		links.push({ source: a.id, target: b.id, weight, type });
+		a.degree = (a.degree ?? 0) + 1;
+		b.degree = (b.degree ?? 0) + 1;
+	};
+
+	for (const members of byTopic) {
+		for (let i = 1; i < members.length; i++) {
+			const wikiCount = Math.max(0, Math.round(shape.wikiLinksPerNote * (0.5 + rng())));
+			for (let l = 0; l < wikiCount; l++) {
+				if (rng() < shape.interTopicFraction) {
+					const other = byTopic[Math.floor(rng() * byTopic.length)];
+					addLink(members[i], other[pickHubIndex(rng, other.length)], 1 + Math.floor(rng() * 3), "wiki");
+				} else {
+					addLink(members[i], members[pickHubIndex(rng, i)], 1 + Math.floor(rng() * 3), "wiki");
+				}
+			}
+			const semCount = Math.max(0, Math.round(shape.semanticLinksPerNote * (0.5 + rng())));
+			for (let l = 0; l < semCount; l++) {
+				if (rng() < shape.interTopicFraction / 2) {
+					const other = byTopic[Math.floor(rng() * byTopic.length)];
+					addLink(members[i], other[pickHubIndex(rng, other.length)], 0.55 + rng() * 0.4, "semantic");
+				} else {
+					addLink(members[i], members[pickHubIndex(rng, i)], 0.55 + rng() * 0.4, "semantic");
+				}
+			}
+		}
+	}
+
+	return { nodes, links };
+}
+
+/** A collapsed view of the same shape: one topic node each + the satellites. */
+function generateCollapsedVault(seed: number, shape: VaultShape): Pick<Scenario, "nodes" | "links"> {
+	const rng = mulberry32(seed);
+	const satelliteCount = Math.round(shape.noteCount * shape.satelliteFraction);
+	const clusteredCount = shape.noteCount - satelliteCount;
+	const sizes = topicSizes(rng, clusteredCount, shape.topicCount);
+
+	const nodes: BenchNode[] = sizes.map((size, topic) => ({
+		id: `topic:${topic}`,
+		kind: "topic",
+		cluster: topic,
+		// Crossing-link count scales with topic size, heavy-tailed like reality.
+		degree: Math.round(size * shape.wikiLinksPerNote * shape.interTopicFraction * (2 + rng() * 3)),
+		x: 0,
+		y: 0,
+	}));
+	for (let i = 0; i < satelliteCount; i++) {
+		nodes.push({ id: `sat${i}`, degree: 0, x: 0, y: 0 });
+	}
+
+	const links: BenchLink[] = [];
+	for (let a = 0; a < sizes.length; a++) {
+		for (let b = a + 1; b < sizes.length; b++) {
+			// Bigger topic pairs cross more; small pairs often not at all.
+			const crossings = Math.round(Math.min(sizes[a], sizes[b]) * shape.interTopicFraction * rng() * 2);
+			if (crossings > 0) {
+				links.push({ source: `topic:${a}`, target: `topic:${b}`, weight: crossings, type: "wiki" });
+			}
+		}
+	}
+	return { nodes, links };
+}
+
+// ── Metrics ─────────────────────────────────────────────────────────────────
+
+function median(values: number[]): number {
+	if (values.length === 0) return Number.NaN;
+	const sorted = [...values].sort((a, b) => a - b);
+	return sorted[Math.floor(sorted.length / 2)];
+}
+
+function percentile(values: number[], p: number): number {
+	if (values.length === 0) return Number.NaN;
+	const sorted = [...values].sort((a, b) => a - b);
+	return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))];
+}
+
+/** Nearest neighbour per node via a uniform grid — O(n) for settled layouts. */
+function nearestNeighbours(nodes: BenchNode[]): Map<string, { other: BenchNode; distance: number }> {
+	const result = new Map<string, { other: BenchNode; distance: number }>();
+	if (nodes.length < 2) return result;
+	const cell = 80;
+	const grid = new Map<string, BenchNode[]>();
+	const keyOf = (x: number, y: number) => `${Math.floor(x / cell)}:${Math.floor(y / cell)}`;
+	for (const node of nodes) {
+		const key = keyOf(node.x, node.y);
+		const bucket = grid.get(key);
+		if (bucket) bucket.push(node);
+		else grid.set(key, [node]);
+	}
+	for (const node of nodes) {
+		let best: BenchNode | null = null;
+		let bestDistance = Number.POSITIVE_INFINITY;
+		// Widen the ring search until a neighbour is found (sparse layouts).
+		for (let ring = 1; ring <= 64 && best === null; ring *= 2) {
+			const cx = Math.floor(node.x / cell);
+			const cy = Math.floor(node.y / cell);
+			for (let gx = cx - ring; gx <= cx + ring; gx++) {
+				for (let gy = cy - ring; gy <= cy + ring; gy++) {
+					for (const other of grid.get(`${gx}:${gy}`) ?? []) {
+						if (other === node) continue;
+						const d = Math.hypot(other.x - node.x, other.y - node.y);
+						if (d < bestDistance) {
+							bestDistance = d;
+							best = other;
+						}
+					}
+				}
+			}
+		}
+		if (best) result.set(node.id, { other: best, distance: bestDistance });
+	}
+	return result;
+}
+
+interface Metrics {
+	ticks: number;
+	ms: number;
+	extentW: number;
+	extentH: number;
+	fitScale: number;
+	nodeScreenPx: number;
+	breathingRatio: number;
+	topicGapRatio: number;
+	satelliteOrbit: number;
+	screenOverlapPct: number;
+	viewportFill: number;
+	framingWaste: number;
+}
+
+function measure(scenario: Scenario, config: LayoutPhysicsConfig): Metrics {
+	const start = performance.now();
+	const simulation = createLayoutSimulation(scenario.nodes, scenario.links, config);
+	let ticks = 0;
+	while (simulation.alpha() > simulation.alphaMin() && ticks < MAX_TICKS) {
+		simulation.tick();
+		ticks++;
+	}
+	const ms = performance.now() - start;
+
+	const xs = scenario.nodes.map((n) => n.x);
+	const ys = scenario.nodes.map((n) => n.y);
+	const extentW = Math.max(...xs) - Math.min(...xs);
+	const extentH = Math.max(...ys) - Math.min(...ys);
+	// Frame exactly the way the app does: full bounds (an explicit fit shows
+	// everything) under the same overview zoom cap. The core-vs-full split
+	// lives in the *metrics*: `fill`/`waste` measure how much of that honest
+	// frame the graph's core actually uses.
+	const fitScale = Math.min(
+		(VIEWPORT_W - FIT_PADDING * 2) / Math.max(extentW, 1),
+		(VIEWPORT_H - FIT_PADDING * 2) / Math.max(extentH, 1),
+		GRAPH_FIT_MAX_SCALE,
+	);
+	const zoomScale = zoomNodeScale(fitScale);
+
+	const radiusOf = (n: BenchNode) => nodeDrawRadius(n, config.nodeSize);
+	const nodeScreenPx = median(scenario.nodes.map((n) => radiusOf(n) * zoomScale * fitScale));
+
+	const neighbours = nearestNeighbours(scenario.nodes);
+	// Breathing covers every connected node — in the collapsed view the topic
+	// nodes *are* the cluster interior being judged.
+	const connected = scenario.nodes.filter((n) => (n.degree ?? 0) > 0);
+	const breathingSamples: number[] = [];
+	for (const node of connected) {
+		const nn = neighbours.get(node.id);
+		if (!nn) continue;
+		const touch = radiusOf(node) + radiusOf(nn.other) + 4; // +2 collide padding each
+		breathingSamples.push(nn.distance / touch);
+	}
+
+	// Topic separation: centroid distance to the nearest other topic, relative
+	// to the two topics' combined RMS radii.
+	const byTopic = new Map<number, BenchNode[]>();
+	for (const node of scenario.nodes) {
+		if (node.cluster == null) continue;
+		const bucket = byTopic.get(node.cluster);
+		if (bucket) bucket.push(node);
+		else byTopic.set(node.cluster, [node]);
+	}
+	// A singleton "cluster" (a collapsed topic node) has no spatial spread of
+	// its own — its drawn radius stands in for the RMS radius, so the gap
+	// metric stays meaningful in collapsed scenarios.
+	const topicStats = [...byTopic.values()].map((members) => {
+		const cx = members.reduce((s, n) => s + n.x, 0) / members.length;
+		const cy = members.reduce((s, n) => s + n.y, 0) / members.length;
+		const rms =
+			members.length >= 2
+				? Math.sqrt(members.reduce((s, n) => s + (n.x - cx) ** 2 + (n.y - cy) ** 2, 0) / members.length)
+				: radiusOf(members[0]);
+		return { cx, cy, rms };
+	});
+	const gapSamples: number[] = [];
+	for (const topic of topicStats) {
+		let best = Number.POSITIVE_INFINITY;
+		for (const other of topicStats) {
+			if (other === topic) continue;
+			const d = Math.hypot(other.cx - topic.cx, other.cy - topic.cy) / Math.max(topic.rms + other.rms, 1);
+			if (d < best) best = d;
+		}
+		if (Number.isFinite(best)) gapSamples.push(best);
+	}
+
+	// Satellites: unlinked nodes' orbit relative to the clustered core.
+	const satellites = scenario.nodes.filter((n) => (n.degree ?? 0) === 0);
+	const core = scenario.nodes.filter((n) => (n.degree ?? 0) > 0);
+	const coreRadius = percentile(
+		core.map((n) => Math.hypot(n.x, n.y)),
+		0.95,
+	);
+	const satelliteOrbit = median(satellites.map((n) => Math.hypot(n.x, n.y))) / Math.max(coreRadius, 1);
+
+	let overlapping = 0;
+	for (const node of scenario.nodes) {
+		const nn = neighbours.get(node.id);
+		if (!nn) continue;
+		if (nn.distance < (radiusOf(node) + radiusOf(nn.other)) * zoomScale * 0.95) overlapping++;
+	}
+
+	// How much of the viewport the settled layout's *core* covers once framed.
+	// The core trims the most extreme 5% per axis, so a handful of stranded
+	// outliers can't inflate the score — they inflate the camera's bounding box
+	// instead, which is exactly the failure this is meant to detect.
+	// One definition of "core" — the shared rank-trimmed bounds helper.
+	const coreBounds = computeCoreNodeBounds(scenario.nodes) ?? { minX: 0, maxX: 1, minY: 0, maxY: 1 };
+	const coreW = Math.max(coreBounds.maxX - coreBounds.minX, 1);
+	const coreH = Math.max(coreBounds.maxY - coreBounds.minY, 1);
+	const viewportFill = Math.max((coreW * fitScale) / VIEWPORT_W, (coreH * fitScale) / VIEWPORT_H);
+	// How much of the framed area is empty because outliers stretched the box.
+	const framingWaste = (Math.max(extentW, 1) * Math.max(extentH, 1)) / (coreW * coreH);
+
+	return {
+		ticks,
+		ms,
+		extentW,
+		extentH,
+		fitScale,
+		nodeScreenPx,
+		breathingRatio: median(breathingSamples),
+		topicGapRatio: gapSamples.length > 0 ? gapSamples.reduce((a, b) => a + b, 0) / gapSamples.length : Number.NaN,
+		satelliteOrbit,
+		screenOverlapPct: (overlapping / scenario.nodes.length) * 100,
+		viewportFill,
+		framingWaste,
+	};
+}
+
+// ── Scenarios ───────────────────────────────────────────────────────────────
+
+function buildScenarios(): Scenario[] {
+	const shapes: Array<{ name: string; shape: VaultShape; collapsed?: boolean; expect: Expectations }> = [
+		{
+			name: "tiny (15)",
+			// gapMax is generous for the sparsest graphs on purpose: with the
+			// centering relaxed so a handful of nodes can fill the viewport, its
+			// few topics necessarily sit further apart in relative terms.
+			expect: { breatheMin: 2.5, gapMin: 1.5, gapMax: 3.0, satMax: 0.6, nodePxMax: 10.5, fillMin: 0.65 },
+			shape: {
+				noteCount: 15,
+				topicCount: 3,
+				satelliteFraction: 0.15,
+				wikiLinksPerNote: 1.2,
+				semanticLinksPerNote: 2,
+				interTopicFraction: 0.1,
+			},
+		},
+		{
+			name: "small (60)",
+			expect: { breatheMin: 1.3, gapMin: 1.7, gapMax: 2.9, satMax: 0.7, nodePxMax: 10.5, fillMin: 0.55 },
+			shape: {
+				noteCount: 60,
+				topicCount: 6,
+				satelliteFraction: 0.12,
+				wikiLinksPerNote: 1.2,
+				semanticLinksPerNote: 2.5,
+				interTopicFraction: 0.1,
+			},
+		},
+		{
+			name: "immersed (120)",
+			expect: { breatheMin: 1.05, gapMin: 2.0, gapMax: 3.2, satMax: 1.1, fillMin: 0.5 },
+			shape: {
+				noteCount: 120,
+				topicCount: 2,
+				satelliteFraction: 0.05,
+				wikiLinksPerNote: 1.5,
+				semanticLinksPerNote: 3,
+				interTopicFraction: 0.08,
+			},
+		},
+		{
+			name: "reference (400)",
+			expect: { breatheMin: 1.2, gapMin: 1.5, gapMax: 2.4, satMax: 1.0, fillMin: 0.6 },
+			shape: {
+				noteCount: 400,
+				topicCount: 10,
+				satelliteFraction: 0.1,
+				wikiLinksPerNote: 1.3,
+				semanticLinksPerNote: 3,
+				interTopicFraction: 0.1,
+			},
+		},
+		{
+			name: "large (2000)",
+			expect: { breatheMin: 1.05, gapMin: 1.1, satMax: 0.5, ovlMax: 12, fillMin: 0.6 },
+			shape: {
+				noteCount: 2000,
+				topicCount: 14,
+				satelliteFraction: 0.08,
+				wikiLinksPerNote: 1.3,
+				semanticLinksPerNote: 3,
+				interTopicFraction: 0.12,
+			},
+		},
+		{
+			name: "huge (8000)",
+			expect: { breatheMin: 1.0, gapMin: 0.9, satMax: 0.5, fillMin: 0.55 },
+			shape: {
+				noteCount: 8000,
+				topicCount: 18,
+				satelliteFraction: 0.06,
+				wikiLinksPerNote: 1.4,
+				semanticLinksPerNote: 3,
+				interTopicFraction: 0.12,
+			},
+		},
+		{
+			// The everyday collapsed view: a handful of topics, near-complete
+			// coupling. Small enough that the fit cap binds, so the layout's own
+			// extent — not the camera — decides how much viewport it fills.
+			name: "collapsed small",
+			expect: { breatheMin: 1.2, gapMin: 1.4, satMax: 1.2, fillMin: 0.35, wasteMax: 3.5 },
+			shape: {
+				noteCount: 600,
+				topicCount: 8,
+				satelliteFraction: 0.004,
+				wikiLinksPerNote: 1.3,
+				semanticLinksPerNote: 0,
+				interTopicFraction: 0.12,
+			},
+			collapsed: true,
+		},
+		{
+			name: "collapsed large",
+			expect: { breatheMin: 1.3, gapMin: 1.5, satMax: 1.1, fillMin: 0.55, wasteMax: 2.0 },
+			shape: {
+				noteCount: 2000,
+				topicCount: 14,
+				satelliteFraction: 0.012,
+				wikiLinksPerNote: 1.3,
+				semanticLinksPerNote: 0,
+				interTopicFraction: 0.12,
+			},
+			collapsed: true,
+		},
+		{
+			name: "collapsed huge",
+			expect: { breatheMin: 0.95, gapMin: 1.05, satMax: 0.9, fillMin: 0.55, wasteMax: 2.0 },
+			shape: {
+				noteCount: 8000,
+				topicCount: 18,
+				satelliteFraction: 0.005,
+				wikiLinksPerNote: 1.4,
+				semanticLinksPerNote: 0,
+				interTopicFraction: 0.12,
+			},
+			collapsed: true,
+		},
+	];
+
+	return shapes.map(({ name, shape, collapsed, expect }, index) => {
+		const seed = 1000 + index;
+		const { nodes, links } = collapsed ? generateCollapsedVault(seed, shape) : generateExpandedVault(seed, shape);
+		return { name, nodes, links, representedNotes: shape.noteCount, expect };
+	});
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+function violations(expect: Expectations, m: Metrics): string[] {
+	const out: string[] = [];
+	if (expect.breatheMin !== undefined && !(m.breathingRatio >= expect.breatheMin))
+		out.push(`breathe ${m.breathingRatio.toFixed(2)} < ${expect.breatheMin}`);
+	if (expect.gapMin !== undefined && !(m.topicGapRatio >= expect.gapMin))
+		out.push(`gap ${m.topicGapRatio.toFixed(2)} < ${expect.gapMin}`);
+	if (expect.gapMax !== undefined && !(m.topicGapRatio <= expect.gapMax))
+		out.push(`gap ${m.topicGapRatio.toFixed(2)} > ${expect.gapMax}`);
+	if (expect.satMax !== undefined && !(m.satelliteOrbit <= expect.satMax))
+		out.push(`sat ${m.satelliteOrbit.toFixed(2)} > ${expect.satMax}`);
+	if (expect.nodePxMax !== undefined && !(m.nodeScreenPx <= expect.nodePxMax))
+		out.push(`nodePx ${m.nodeScreenPx.toFixed(1)} > ${expect.nodePxMax}`);
+	if (expect.ovlMax !== undefined && !(m.screenOverlapPct <= expect.ovlMax))
+		out.push(`ovl% ${m.screenOverlapPct.toFixed(1)} > ${expect.ovlMax}`);
+	if (expect.fillMin !== undefined && !(m.viewportFill >= expect.fillMin))
+		out.push(`fill ${m.viewportFill.toFixed(2)} < ${expect.fillMin}`);
+	if (expect.wasteMax !== undefined && !(m.framingWaste <= expect.wasteMax))
+		out.push(`waste ${m.framingWaste.toFixed(1)} > ${expect.wasteMax}`);
+	return out;
+}
+
+function run() {
+	const asJson = process.argv.includes("--json");
+	const asAssert = process.argv.includes("--assert");
+	const scenarios = buildScenarios();
+	const rows: Array<Record<string, unknown>> = [];
+	const failures: string[] = [];
+
+	for (const scenario of scenarios) {
+		const nodeSize = autoNodeSize(scenario.representedNotes);
+		const config: LayoutPhysicsConfig = {
+			...BASE_PHYSICS,
+			nodeSize,
+			visibleNodeCount: scenario.nodes.length,
+		};
+		const profile = densityForceProfile(scenario.nodes.length);
+		const m = measure(scenario, config);
+		const broken = violations(scenario.expect, m);
+		for (const violation of broken) failures.push(`${scenario.name}: ${violation}`);
+		rows.push({
+			ok: broken.length === 0 ? "✓" : "✗",
+			scenario: scenario.name,
+			nodes: scenario.nodes.length,
+			links: scenario.links.length,
+			ticks: m.ticks,
+			ms: Math.round(m.ms),
+			extent: `${Math.round(m.extentW)}×${Math.round(m.extentH)}`,
+			fit: Number(m.fitScale.toFixed(3)),
+			nodePx: Number(m.nodeScreenPx.toFixed(1)),
+			breathe: Number(m.breathingRatio.toFixed(2)),
+			gap: Number(m.topicGapRatio.toFixed(2)),
+			sat: Number(m.satelliteOrbit.toFixed(2)),
+			"ovl%": Number(m.screenOverlapPct.toFixed(1)),
+			fill: Number(m.viewportFill.toFixed(2)),
+			waste: Number(m.framingWaste.toFixed(1)),
+			profile: `s${profile.spacing.toFixed(2)}/q${profile.charge.toFixed(2)}/c${profile.center.toFixed(2)}/h${profile.cohesion.toFixed(2)}`,
+		});
+	}
+
+	if (asJson) {
+		console.log(JSON.stringify({ physics: BASE_PHYSICS, rows }, null, 2));
+		return;
+	}
+
+	console.log(`\nLayout benchmark — physics ${JSON.stringify(BASE_PHYSICS)}`);
+	console.log("Guardrail bands are per scenario (see Expectations in this file); ✗ rows list violations below.\n");
+	console.table(rows);
+	if (failures.length > 0) {
+		console.log(`\n${failures.length} band violation(s):`);
+		for (const failure of failures) console.log(`  ✗ ${failure}`);
+		if (asAssert) process.exitCode = 1;
+	} else {
+		console.log("\nAll scenarios within bands.");
+	}
+}
+
+run();

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -5,10 +5,13 @@ import { forceSimulation, type SimulationNodeDatum, type SimulationLinkDatum } f
 import type { GraphData, GraphNode, EdgeType } from "../../types/graph";
 import { deriveClusterRepresentativesFromGraph } from "../../views/smart-graph/graphDataBuilder";
 import {
+	computeCoreNodeBounds,
 	computeNodeBounds,
 	easeOutCubic,
+	framingFocus,
 	framingTransform,
 	GRAPH_FIT_MAX_SCALE,
+	type BoundingBox,
 	type FramingPadding,
 } from "../../utils/graphAnimation";
 import { buildTopicRegion, centroid } from "../../utils/convexHull";
@@ -2125,14 +2128,16 @@ function setupForceSimulation(
 				if (forceTickCount % refitEvery === 0) {
 					const bounds = computeNodeBounds(simNodes);
 					if (bounds) {
-						const frame = framingTransform(
+						// Centre on the core (so unsorted strays don't drag the view
+						// off to one side) while the scale still fits every node.
+						const frame = framingFocus(
 							bounds,
 							{ width: pixi.width, height: pixi.height },
 							GRAPH_FIT_PADDING,
+							GRAPH_FIT_MAX_SCALE,
+							computeCoreNodeBounds(simNodes),
 						);
-						const cx = (bounds.minX + bounds.maxX) / 2;
-						const cy = (bounds.minY + bounds.maxY) / 2;
-						pixi.animateToFrame(cx, cy, frame.scale, isReclustering ? 400 : 150);
+						pixi.animateToFrame(frame.centerX, frame.centerY, frame.scale, isReclustering ? 400 : 150);
 					}
 				}
 				// Once settled, do one final smooth fit and stop tracking.
@@ -2143,11 +2148,17 @@ function setupForceSimulation(
 					// The layout can still creep after alpha drops below the tracking
 					// threshold — clusters keep spreading for a while — so that "final"
 					// fit is often already stale. Take one more measurement after the
-					// drift has actually stopped.
+					// drift has actually stopped, but only *apply* it if the framing
+					// really went stale: on a collapse the graph is already settled
+					// and framed, and an unconditional refit reads as the camera
+					// lurching out for no reason a second after it arrived.
+					const settledBounds = computeNodeBounds(simNodes);
 					if (settleFitTimer != null) clearTimeout(settleFitTimer);
 					settleFitTimer = setTimeout(() => {
 						settleFitTimer = null;
-						animateCameraToNodes(undefined, GRAPH_FIT_PADDING, 500);
+						if (driftedSince(settledBounds)) {
+							animateCameraToNodes(undefined, GRAPH_FIT_PADDING, 500);
+						}
 					}, SETTLE_FIT_DELAY_MS);
 				}
 			}
@@ -2453,14 +2464,14 @@ onMount(() => {
 			if (alpha < 0.05) {
 				const bounds = computeNodeBounds(simNodes);
 				if (bounds) {
-					const frame = framingTransform(
+					const frame = framingFocus(
 						bounds,
 						{ width: renderer.width, height: renderer.height },
 						GRAPH_FIT_PADDING,
+						GRAPH_FIT_MAX_SCALE,
+						computeCoreNodeBounds(simNodes),
 					);
-					const cx = (bounds.minX + bounds.maxX) / 2;
-					const cy = (bounds.minY + bounds.maxY) / 2;
-					renderer.snapToFrame(cx, cy, frame.scale);
+					renderer.snapToFrame(frame.centerX, frame.centerY, frame.scale);
 				}
 			} else {
 				// Simulation still running — tick loop will handle fitting.
@@ -2526,6 +2537,32 @@ onMount(() => {
 	};
 });
 
+/**
+ * How much the layout's extent must change after the settle before a
+ * corrective refit is worth it. Below this the framing is still essentially
+ * right, and re-running it just moves the camera under the user.
+ */
+const SETTLE_REFIT_DRIFT_THRESHOLD = 0.12;
+
+/**
+ * Whether the layout has drifted enough since `previous` to justify refitting.
+ *
+ * A fresh build keeps spreading after alpha decays, so its first "final" fit
+ * really is stale. A collapse settles almost immediately at a layout the
+ * camera already framed — there the delayed refit had nothing to correct and
+ * only read as an unexplained zoom-out a second later.
+ */
+function driftedSince(previous: BoundingBox | null): boolean {
+	if (!previous) return false;
+	const current = computeNodeBounds(simNodes);
+	if (!current) return false;
+	const previousWidth = Math.max(previous.maxX - previous.minX, 1);
+	const previousHeight = Math.max(previous.maxY - previous.minY, 1);
+	const widthDrift = Math.abs(current.maxX - current.minX - previousWidth) / previousWidth;
+	const heightDrift = Math.abs(current.maxY - current.minY - previousHeight) / previousHeight;
+	return Math.max(widthDrift, heightDrift) > SETTLE_REFIT_DRIFT_THRESHOLD;
+}
+
 /** Animate the camera to frame the given nodes with the specified padding and duration. */
 function animateCameraToNodes(
 	filter?: (node: SimNode) => boolean,
@@ -2543,10 +2580,12 @@ function animateCameraToNodes(
 	// sparse spread), not the camera's.
 	const bounds = computeNodeBounds(simNodes, filter);
 	if (!bounds) return;
-	const target = framingTransform(bounds, { width: pixi.width, height: pixi.height }, padding, maxScale);
-	const centerX = (bounds.minX + bounds.maxX) / 2;
-	const centerY = (bounds.minY + bounds.maxY) / 2;
-	pixi.animateToFrame(centerX, centerY, target.scale, duration);
+	// Whole-graph framings centre on the core so a lopsided ring of unsorted
+	// notes doesn't shove the main graph aside; an explicit selection is
+	// centred on exactly what was selected.
+	const centreBounds = filter ? null : computeCoreNodeBounds(simNodes);
+	const target = framingFocus(bounds, { width: pixi.width, height: pixi.height }, padding, maxScale, centreBounds);
+	pixi.animateToFrame(target.centerX, target.centerY, target.scale, duration);
 }
 
 /**

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -15,6 +15,7 @@ import type { GraphData, GraphNode, EdgeType } from "../../types/graph";
 import { deriveClusterRepresentativesFromGraph } from "../../views/smart-graph/graphDataBuilder";
 import { computeNodeBounds, easeOutCubic, framingTransform, type FramingPadding } from "../../utils/graphAnimation";
 import { buildTopicRegion, centroid } from "../../utils/convexHull";
+import { densityForceProfile, nodeDrawRadius, zoomNodeScale } from "../../utils/graphUtils";
 import { resolveNodePaths, topicNodeId } from "../../utils/mergeNodes";
 import { PixiRenderer, readThemeColors, type ClusterPillHit } from "./pixiRenderer";
 
@@ -117,7 +118,30 @@ let pixi: PixiRenderer | null = null;
 
 // Node size auto-tuned from graph size: larger for small graphs, smaller for dense ones.
 // Uses a continuous log scale so the transition is smooth, clamped to a readable range.
-let nodeSize = $derived(Math.max(2, Math.round(7 - Math.log10(Math.max(graphData.nodes.length, 10)) * 1.8)));
+//
+// Counts the notes the graph *represents* — a collapsed topic counts as its
+// members, not as one node. The tune adapts to vault size, and reading the
+// on-screen node count instead made collapse-all jump the base (2 → 5 on a
+// large vault, with the degree cap and label font scaling along): the closer
+// camera fit already magnifies the handful of topic nodes, so re-inflating
+// their world radius on top rendered them as giant discs.
+let representedNoteCount = $derived(
+	graphData.nodes.reduce((count, node) => count + (node.kind === "topic" ? (node.memberPaths?.length ?? 1) : 1), 0),
+);
+let nodeSize = $derived(Math.max(2, Math.round(7 - Math.log10(Math.max(representedNoteCount, 10)) * 1.8)));
+
+// Density-adaptive physics: unlike node size (which keys off *represented*
+// notes so folding doesn't change the sizing regime), the forces key off the
+// nodes actually on screen — that count is what decides how far out the camera
+// must sit to frame everything. Each force gets its own multiplier (see
+// densityForceProfile for the asymmetry between the intra- and inter-cluster
+// length scales). The user's slider values are the baseline at the reference
+// density, where every multiplier is exactly 1.
+let forceProfile = $derived(densityForceProfile(graphData.nodes.length));
+let effectiveLinkDistance = $derived(linkDistance * forceProfile.spacing);
+let effectiveChargeStrength = $derived(chargeStrength * forceProfile.charge);
+let effectiveCenterStrength = $derived(centerStrength * forceProfile.center);
+let effectiveClusterCohesion = $derived(clusterCohesionStrength * forceProfile.cohesion);
 
 // Edge alpha auto-tuned from edge count: fade edges as the graph grows denser so
 // overlapping edges don't compound into a dark mass.  Clamped to [0.18, 0.60].
@@ -211,7 +235,12 @@ let simPausedWhileHidden = false;
 
 // D3-compatible node/link types
 type SimNode = GraphNode & SimulationNodeDatum;
-type SimLink = SimulationLinkDatum<SimNode> & { weight: number; type: EdgeType };
+type SimLink = SimulationLinkDatum<SimNode> & {
+	weight: number;
+	type: EdgeType;
+	/** Born in the latest data change — only these take the edge fade-in. */
+	isNew?: boolean;
+};
 
 let simNodes: SimNode[] = [];
 let simLinks: SimLink[] = [];
@@ -220,8 +249,10 @@ let simLinks: SimLink[] = [];
 // Holds every drawable edge type; per-type visibility is decided in drawEdges.
 let renderableSimLinks: SimLink[] = [];
 
-// Edge fade-in: edges start invisible and fade to full opacity after each
-// setupSimulation call, providing a smooth crossfade on mode/data changes.
+// Edge fade-in: edges *born in the latest data change* start invisible and
+// fade to full opacity (see `SimLink.isNew`). Pre-existing edges are exempt,
+// so a local change — one topic folding, one note arriving — doesn't flash
+// the whole graph's edges.
 let edgeFadeAlpha = 1;
 const EDGE_FADE_RATE = 0.04; // reaches 1 in 25 ticks (~0.4s at 60fps)
 
@@ -245,9 +276,23 @@ const MIN_TOPIC_LINK_DISTANCE_FACTOR = 0.45;
 /**
  * How far a topic's notes are seeded from its collapsed position when expanding.
  * Just enough that the force sim has a gradient to push them apart — seeding
- * them all on the exact same point would leave them stuck there.
+ * them all on the exact same point would leave them stuck there. Deliberately
+ * small: the visible outward travel *is* the expand animation, and any distance
+ * covered by the seed itself is a teleport the eye can't follow.
  */
-const EXPAND_SCATTER_RADIUS = 45;
+const EXPAND_SCATTER_RADIUS = 18;
+
+/**
+ * Spawn-grow animation for nodes born in a data change (a topic node on
+ * collapse, member notes on expand, a note created while the graph is open).
+ * Growing from a fraction of the final radius at the position the change
+ * happened gives the eye a single point to follow instead of a full-size pop.
+ */
+const NODE_SPAWN_MS = 320;
+const NODE_SPAWN_START_SCALE = 0.25;
+
+/** Birth timestamps of nodes still growing in, cleared as each finishes. */
+const nodeSpawnTimes = new Map<string, number>();
 
 /**
  * Alpha held during a collapse/expand transition — matches what releasing a drag
@@ -704,13 +749,13 @@ function buildHitGrid() {
 }
 
 /** The original linear scan — still used while the layout is in motion. */
-function findNodeLinear(x: number, y: number, hitRadius: number): GraphNode | null {
+function findNodeLinear(x: number, y: number, hitRadius: number, displayFactor: number): GraphNode | null {
 	// Search in reverse order (top-most nodes first)
 	for (let i = simNodes.length - 1; i >= 0; i--) {
 		const node = simNodes[i];
 		const dx = (node.x ?? 0) - x;
 		const dy = (node.y ?? 0) - y;
-		const reach = getNodeRadius(node) + hitRadius;
+		const reach = getNodeRadius(node) * displayFactor + hitRadius;
 		if (dx * dx + dy * dy <= reach * reach) {
 			return node;
 		}
@@ -728,16 +773,20 @@ function findNodeAt(screenX: number, screenY: number): GraphNode | null {
 	const { x, y } = screenToGraph(screenX, screenY);
 	const scale = pixi?.scale ?? 1;
 	const hitRadius = (Math.max(1, nodeSize) + 4) / scale;
+	// Nodes are drawn counter-scaled against the zoom, so the hit target must
+	// grow and shrink with them. Applied at query time only — the grid itself
+	// stores camera-independent positions and stays valid across zooms.
+	const displayFactor = zoomNodeScale(scale);
 
 	// While ticking, positions change under the grid every frame — scan instead.
 	if (hitGridDirty && simulation && simulation.alpha() > 0.03) {
-		return findNodeLinear(x, y, hitRadius);
+		return findNodeLinear(x, y, hitRadius, displayFactor);
 	}
 	if (hitGridDirty || !hitGrid) buildHitGrid();
 
 	// The zoomed-out hit slack can exceed one cell, so widen the neighbourhood
 	// to however many cells the search radius spans.
-	const searchRadius = hitGridMaxRadius + hitRadius;
+	const searchRadius = hitGridMaxRadius * displayFactor + hitRadius;
 	const span = Math.ceil(searchRadius / hitGridCellSize);
 	const cx = Math.floor(x / hitGridCellSize);
 	const cy = Math.floor(y / hitGridCellSize);
@@ -752,7 +801,7 @@ function findNodeAt(screenX: number, screenY: number): GraphNode | null {
 				if (order <= bestOrder) continue;
 				const dx = (node.x ?? 0) - x;
 				const dy = (node.y ?? 0) - y;
-				const reach = getNodeRadius(node) + hitRadius;
+				const reach = getNodeRadius(node) * displayFactor + hitRadius;
 				if (dx * dx + dy * dy <= reach * reach) {
 					best = node;
 					bestOrder = order;
@@ -881,27 +930,25 @@ function weightPull(link: SimLink): number {
 function weightedLinkDistance(link: SimLink): number {
 	const source = link.source as SimNode;
 	const target = link.target as SimNode;
-	if (source?.kind !== "topic" && target?.kind !== "topic") return linkDistance;
+	if (source?.kind !== "topic" && target?.kind !== "topic") return effectiveLinkDistance;
 
 	// Same log curve as the pull, inverted: the heaviest edges sit at
 	// MIN_TOPIC_LINK_DISTANCE_FACTOR of the normal length.
 	const weight = Math.max(1, link.weight);
 	const t = Math.min(1, Math.log2(weight) / Math.log2(WEIGHT_DISTANCE_SATURATION));
-	return linkDistance * (1 - t * (1 - MIN_TOPIC_LINK_DISTANCE_FACTOR));
+	return effectiveLinkDistance * (1 - t * (1 - MIN_TOPIC_LINK_DISTANCE_FACTOR));
 }
 
 /**
  * Get the draw radius for a node from its degree and the auto-tuned nodeSize.
  *
- * Size encodes exactly one thing — connectedness — so it stays unambiguous.
- * Bridge nodes are surfaced by the highlight toggle's color, not by size.
- * Must match the renderer's sprite radius (`syncNodes`), since this value
- * also drives hit-testing, collision spacing, and label offsets.
+ * Delegates to the shared {@link nodeDrawRadius} formula (also used by the
+ * renderer's `syncNodes`) so hit-testing, collision spacing and label offsets
+ * can never disagree with the drawn circle. Bridge nodes are surfaced by the
+ * highlight toggle's color, not by size.
  */
 function getNodeRadius(node: GraphNode): number {
-	const base = Math.max(1, nodeSize);
-	const degree = node.degree ?? 0;
-	return base + Math.min(Math.log1p(degree) * 2.5, base * 5);
+	return nodeDrawRadius(node, nodeSize);
 }
 
 /**
@@ -995,9 +1042,14 @@ function render(mode: RenderMode) {
 				if (hullFadeProgress >= 1) outgoingHulls = [];
 				else requestRender("world");
 			}
+			// The incoming grouping fades with the cross-fade itself, not with the
+			// edge fade: tying it to `edgeFadeAlpha` blanked every region on any
+			// data change, so folding one topic made all of them blink. During a
+			// cross-fade the unchanged topics resolve between two near-identical
+			// shapes at complementary alphas, which reads as holding steady.
 			renderer.drawHulls(hulls, {
 				focusedClusters,
-				fadeAlpha: edgeFadeAlpha,
+				fadeAlpha: outgoingHulls.length > 0 ? easeOutCubic(hullFadeProgress) : 1,
 				outgoing: outgoingHulls,
 				outgoingAlpha: outgoingHulls.length > 0 ? 1 - easeOutCubic(hullFadeProgress) : 0,
 			});
@@ -1008,7 +1060,7 @@ function render(mode: RenderMode) {
 			lastHullPaths = [];
 			lastHullSignature = "";
 			hullFadeProgress = 1;
-			renderer.drawHulls([], { focusedClusters, fadeAlpha: edgeFadeAlpha });
+			renderer.drawHulls([], { focusedClusters, fadeAlpha: 1 });
 		}
 
 		// ── Edges ──────────────────────────────────────────────
@@ -1051,6 +1103,24 @@ function render(mode: RenderMode) {
 		}
 
 		// ── Nodes ──────────────────────────────────────────────
+		// Advance spawn-grow animations: each newborn node's radius eases from a
+		// fraction to full size, finished entries drop out, and an unfinished
+		// animation requests the next world frame so it completes even once the
+		// simulation is at rest.
+		let spawnScales: Map<string, number> | null = null;
+		if (nodeSpawnTimes.size > 0) {
+			const now = performance.now();
+			spawnScales = new Map();
+			for (const [id, born] of nodeSpawnTimes) {
+				const t = (now - born) / NODE_SPAWN_MS;
+				if (t >= 1) {
+					nodeSpawnTimes.delete(id);
+					continue;
+				}
+				spawnScales.set(id, NODE_SPAWN_START_SCALE + (1 - NODE_SPAWN_START_SCALE) * easeOutCubic(t));
+			}
+			if (isWorld && nodeSpawnTimes.size > 0) requestRender("world");
+		}
 		renderer.syncNodes(simNodes, nodeSize, {
 			selectedNodes,
 			hoveredNodeId: hoveredNode?.id ?? null,
@@ -1059,6 +1129,7 @@ function render(mode: RenderMode) {
 			isForceMode: true,
 			hoverAlphas,
 			nodeClusterMap,
+			spawnScales,
 		});
 	}
 
@@ -1071,12 +1142,40 @@ function render(mode: RenderMode) {
 	const hovId = hoveredNode?.id ?? null;
 	const hoverNeighbors = hovId ? adjacency.get(hovId) : undefined;
 
+	// Nodes are drawn counter-scaled against the zoom; labels must anchor above
+	// the circle as drawn, size themselves against it, and judge visibility by
+	// the size the user actually sees.
+	const labelZoomFactor = zoomNodeScale(scale);
+
 	// Label font size in CSS pixels (screen space).
 	// The renderer counter-scales each label with t.scale.set(1/viewport_scale), which
-	// makes the effective screen size equal to t.style.fontSize exactly — so this value
-	// is the on-screen pixel height at every zoom level, no division by scale needed.
-	// Tied to nodeSize so labels feel proportional when the user adjusts node size.
-	const LABEL_FONT_PX = Math.max(Math.round(nodeSize * 2.5), 10);
+	// makes the effective screen size equal to t.style.fontSize exactly — so these
+	// values are on-screen pixel heights at every zoom level, no division by scale.
+	//
+	// Sized per node against the circle as drawn (which carries the degree curve
+	// and the zoom counter-scale on top of `nodeSize`), because a single shared
+	// size fails in both directions: derived from the base it left big collapsed
+	// topics captioned in tiny text, and derived from the largest node it made
+	// every label big whenever a few large nodes were on screen.
+	//
+	// The response is deliberately compressed — a node 4× the radius gets a 2×
+	// label, not 4× — so size differences stay legible as a hierarchy without
+	// the largest captions dominating the canvas.
+	const LABEL_FONT_MIN_PX = 10;
+	const LABEL_FONT_MAX_PX = 22;
+	/** Node screen radius that maps to the baseline font size. */
+	const LABEL_REFERENCE_RADIUS = 6;
+	const baselineFontPx = Math.max(nodeSize * 2.5, LABEL_FONT_MIN_PX);
+	function labelFontFor(node: SimNode): number {
+		const screenRadius = getNodeRadius(node) * labelZoomFactor * scale;
+		const ratio = Math.sqrt(Math.max(screenRadius, 1) / LABEL_REFERENCE_RADIUS);
+		return Math.round(Math.min(LABEL_FONT_MAX_PX, Math.max(LABEL_FONT_MIN_PX, baselineFontPx * ratio)));
+	}
+
+	// The occlusion grid is a fixed lattice, so it takes one representative
+	// size — the baseline. Per-label widths are still measured exactly in
+	// `canDrawLabel`; this only sets the row height.
+	const LABEL_FONT_PX = Math.round(Math.max(baselineFontPx, LABEL_FONT_MIN_PX));
 
 	// Label occlusion culling — grid-based O(n) instead of O(n²) linear scan.
 	// The canvas is divided into LABEL_CELL_W×LABEL_CELL_H px cells (screen space).
@@ -1096,10 +1195,10 @@ function render(mode: RenderMode) {
 		labelGrid.fill(0);
 	}
 
-	function canDrawLabel(nodeX: number, labelY: number, approxCharCount: number): boolean {
-		// LABEL_FONT_PX is already in screen px, so sw/sh are screen px directly
-		const sw = approxCharCount * LABEL_FONT_PX * 0.55;
-		const sh = LABEL_FONT_PX;
+	function canDrawLabel(nodeX: number, labelY: number, approxCharCount: number, fontPx = LABEL_FONT_PX): boolean {
+		// Font sizes are already in screen px, so sw/sh are screen px directly
+		const sw = approxCharCount * fontPx * 0.55;
+		const sh = fontPx;
 		const screen = renderer.worldToScreen(nodeX, labelY);
 		const x1 = screen.x - sw / 2 - LABEL_PAD_X;
 		const y1 = screen.y - sh - LABEL_PAD_Y;
@@ -1173,46 +1272,48 @@ function render(mode: RenderMode) {
 	}> = [];
 
 	for (const node of sortedLabelNodes) {
-		const radius = getNodeRadius(node);
+		const radius = getNodeRadius(node) * labelZoomFactor;
 		const labelY = node.y - radius - 2 / scale;
 		const nodeAlpha = hoverAlphas.get(node.id) ?? 0.85;
 		// Screen-space radius: how large the node circle appears on screen
 		const screenRadius = radius * scale;
+		// Each label is sized to its own node, so occlusion must measure with it.
+		const fontSize = labelFontFor(node);
 
 		if (hovId && node.id === hovId) {
 			// Hovered node: always show label, skip occlusion check (it wins)
-			canDrawLabel(node.x, labelY, node.label.length);
+			canDrawLabel(node.x, labelY, node.label.length, fontSize);
 			labelEntries.push({
 				nodeX: node.x,
 				nodeY: labelY,
 				text: node.label,
 				color: c.textNormal,
 				alpha: 1,
-				fontSize: LABEL_FONT_PX,
+				fontSize,
 			});
 		} else if (hovId && hoverNeighbors?.has(node.id)) {
-			if (!canDrawLabel(node.x, labelY, node.label.length)) continue;
+			if (!canDrawLabel(node.x, labelY, node.label.length, fontSize)) continue;
 			labelEntries.push({
 				nodeX: node.x,
 				nodeY: labelY,
 				text: node.label,
 				color: c.textMuted,
 				alpha: nodeAlpha,
-				fontSize: LABEL_FONT_PX,
+				fontSize,
 			});
 		} else if (node.highlighted && !hovId) {
-			if (!canDrawLabel(node.x, labelY, node.label.length)) continue;
+			if (!canDrawLabel(node.x, labelY, node.label.length, fontSize)) continue;
 			labelEntries.push({
 				nodeX: node.x,
 				nodeY: labelY,
 				text: node.label,
 				color: c.textAccent,
 				alpha: 1,
-				fontSize: LABEL_FONT_PX,
+				fontSize,
 			});
 		} else if (screenRadius >= MIN_LABEL_SCREEN_RADIUS) {
 			// Node is large enough on screen to anchor a label — show it if space allows
-			if (!canDrawLabel(node.x, labelY, node.label.length)) continue;
+			if (!canDrawLabel(node.x, labelY, node.label.length, fontSize)) continue;
 			// Smooth fade-in over a 2px radius window so labels don't pop in abruptly
 			const fadeAlpha = Math.min(1, (screenRadius - MIN_LABEL_SCREEN_RADIUS) / 2);
 			labelEntries.push({
@@ -1221,7 +1322,7 @@ function render(mode: RenderMode) {
 				text: node.label,
 				color: node.highlighted ? c.textAccent : c.textNormal,
 				alpha: nodeAlpha * fadeAlpha,
-				fontSize: LABEL_FONT_PX,
+				fontSize,
 			});
 		}
 	}
@@ -1896,6 +1997,15 @@ function buildInternalData(data: GraphData): {
 		}
 	}
 
+	// Identity of the outgoing frame, for entrance animations: nodes and edges
+	// not present in it are the *change*, and only they animate in — the rest of
+	// the graph holds still so the change is what the eye lands on.
+	const previousNodeIds = new Set(simNodes.map((n) => n.id));
+	const previousEdgeKeys = new Set<string>();
+	for (const link of renderableSimLinks) {
+		previousEdgeKeys.add(simLinkKey((link.source as SimNode).id, (link.target as SimNode).id, link.type));
+	}
+
 	// Compute centroid from all known positions (old + cached) for scattering new nodes
 	let centroidX = 0;
 	let centroidY = 0;
@@ -1930,7 +2040,7 @@ function buildInternalData(data: GraphData): {
 	const unknownCount = data.nodes.filter((n) => !oldPositions.has(n.id) && !persistentPositionCache.has(n.id)).length;
 	// Spread radius for circle pre-layout: scale with node count so the graph fills
 	// a reasonable area before forces kick in (reduces initial chaos).
-	const circleRadius = Math.max(150, Math.sqrt(unknownCount) * linkDistance * 0.5);
+	const circleRadius = Math.max(150, Math.sqrt(unknownCount) * effectiveLinkDistance * 0.5);
 
 	// A node created while the graph is open should appear next to what it
 	// connects to, not in a ring around the whole layout — seed unknown nodes at
@@ -2005,6 +2115,20 @@ function buildInternalData(data: GraphData): {
 
 	simNodeMap = new Map(simNodes.map((n) => [n.id, n]));
 
+	// Stamp entrance animations for nodes born in this change. A fresh layout is
+	// excluded — everything is new there, and it has its own reveal (the canvas
+	// stays hidden until the layout partially settles).
+	if (previousNodeIds.size > 0) {
+		const now = performance.now();
+		for (const n of simNodes) {
+			if (!previousNodeIds.has(n.id)) nodeSpawnTimes.set(n.id, now);
+		}
+	}
+	// Nodes removed by the change can't finish an animation they're no longer in.
+	for (const id of nodeSpawnTimes.keys()) {
+		if (!simNodeMap.has(id)) nodeSpawnTimes.delete(id);
+	}
+
 	simLinks = data.edges
 		.filter((e) => simNodeMap.has(e.source) && simNodeMap.has(e.target))
 		.map((e) => ({
@@ -2012,6 +2136,7 @@ function buildInternalData(data: GraphData): {
 			target: simNodeMap.get(e.target)!,
 			weight: e.weight,
 			type: e.type,
+			isNew: !previousEdgeKeys.has(simLinkKey(e.source, e.target, e.type)),
 		}));
 
 	// Pre-split by edge type to avoid filtering every render frame
@@ -2029,10 +2154,17 @@ function buildInternalData(data: GraphData): {
 		adjacency.get(tId)?.add(sId);
 	}
 
-	// Start edge fade-in on full data change
+	// Start the edge fade-in. Only edges marked `isNew` above consume it — the
+	// rest of the graph renders at full opacity throughout, so a local change
+	// (one topic folding) no longer flashes every edge on screen.
 	edgeFadeAlpha = 0;
 
 	return { oldPositions, allPositionsKnown, isFreshLayout };
+}
+
+/** Canonical identity of a rendered edge — endpoint order doesn't matter. */
+function simLinkKey(a: string, b: string, type: string): string {
+	return a < b ? `${a}\0${b}\0${type}` : `${b}\0${a}\0${type}`;
 }
 
 // ============================================================================
@@ -2061,12 +2193,12 @@ function setupForceSimulation(
 	simulation = forceSimulation<SimNode>(simNodes);
 	simulation
 		.force("link", baseLinkForce)
-		.force("charge", forceManyBody().strength(chargeStrength).distanceMin(30))
+		.force("charge", forceManyBody().strength(effectiveChargeStrength).distanceMin(30))
 		// Obsidian uses forceX + forceY for centering (spring toward origin),
 		// NOT forceCenter (which shifts the centroid). This is the key difference.
-		.force("centerX", forceX<SimNode>(0).strength(centerStrength))
-		.force("centerY", forceY<SimNode>(0).strength(centerStrength))
-		.force("cluster", clusterCohesionForce(simNodes, clusterCohesionStrength))
+		.force("centerX", forceX<SimNode>(0).strength(effectiveCenterStrength))
+		.force("centerY", forceY<SimNode>(0).strength(effectiveCenterStrength))
+		.force("cluster", clusterCohesionForce(simNodes, effectiveClusterCohesion))
 		.force(
 			"collide",
 			forceCollide<SimNode>().radius((d) => getNodeRadius(d) + 2),
@@ -2231,7 +2363,7 @@ function setupGraph(data: GraphData) {
 		}
 		// Sync the cohesion force strength to the current prop value.
 		const clusterForce = simulation?.force("cluster") as ReturnType<typeof clusterCohesionForce> | undefined;
-		if (clusterForce) clusterForce.strength(clusterCohesionStrength);
+		if (clusterForce) clusterForce.strength(effectiveClusterCohesion);
 		// Re-derive cluster metadata so pills on the canvas reflect the new segmentation.
 		// (buildInternalData is not called in this path, so we update it explicitly.)
 		refreshClusterMetadata(data);
@@ -2298,11 +2430,14 @@ $effect(() => {
 // Reading `simulation` ($state) means this effect re-runs when a new simulation
 // is created (e.g. after a full graph rebuild), so slider changes always apply.
 $effect(() => {
-	const _charge = chargeStrength;
-	const _link = linkDistance;
-	const _center = centerStrength;
+	// The density-adjusted values, so a slider change hot-applies at the same
+	// spread the full setup uses. Both are value-stable $deriveds: a color-only
+	// graph change re-evaluates them but doesn't re-fire this effect.
+	const _charge = effectiveChargeStrength;
+	const _link = effectiveLinkDistance;
+	const _center = effectiveCenterStrength;
 	const _linkStr = linkStrength;
-	const _cohesion = clusterCohesionStrength;
+	const _cohesion = effectiveClusterCohesion;
 	const sim = simulation; // $state — tracks simulation creation
 
 	if (!sim) return;
@@ -2522,7 +2657,15 @@ export function followLayout() {
 	// such a node, which is why the view stayed zoomed out until the node was
 	// dragged: releasing a drag sets alphaTarget(0.3), and *that* sustained pull
 	// is what recentred it. This gives the transition the same treatment.
-	simulation.alphaTarget(RETARGET_ALPHA).restart();
+	//
+	// Damped like the granularity transition: the sustained alpha with the
+	// default (low) drag made expanding notes spring out and rebound, and moved
+	// the camera on the fast refit cadence — jumpy on both counts. The recluster
+	// drag keeps the motion flowing, and `isReclustering` selects the slower,
+	// longer-eased camera sampling; the tick handler hands both back once the
+	// layout comes to rest.
+	simulation.alphaTarget(RETARGET_ALPHA).velocityDecay(RECLUSTER_VELOCITY_DECAY).restart();
+	isReclustering = true;
 	if (retargetTimer != null) clearTimeout(retargetTimer);
 	retargetTimer = setTimeout(() => {
 		retargetTimer = null;

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -1,21 +1,19 @@
 <script lang="ts">
 import { onMount, untrack } from "svelte";
 import { Menu } from "obsidian";
-import {
-	forceSimulation,
-	forceLink,
-	forceManyBody,
-	forceCollide,
-	forceX,
-	forceY,
-	type SimulationNodeDatum,
-	type SimulationLinkDatum,
-} from "d3-force";
+import { forceSimulation, type SimulationNodeDatum, type SimulationLinkDatum } from "d3-force";
 import type { GraphData, GraphNode, EdgeType } from "../../types/graph";
 import { deriveClusterRepresentativesFromGraph } from "../../views/smart-graph/graphDataBuilder";
-import { computeNodeBounds, easeOutCubic, framingTransform, type FramingPadding } from "../../utils/graphAnimation";
+import {
+	computeNodeBounds,
+	easeOutCubic,
+	framingTransform,
+	GRAPH_FIT_MAX_SCALE,
+	type FramingPadding,
+} from "../../utils/graphAnimation";
 import { buildTopicRegion, centroid } from "../../utils/convexHull";
-import { densityForceProfile, nodeDrawRadius, zoomNodeScale } from "../../utils/graphUtils";
+import { autoNodeSize, densityForceProfile, nodeDrawRadius, zoomNodeScale } from "../../utils/graphUtils";
+import { applyLayoutForces, clusterCohesionForce, type LayoutPhysicsConfig } from "../../utils/graphLayout";
 import { resolveNodePaths, topicNodeId } from "../../utils/mergeNodes";
 import { PixiRenderer, readThemeColors, type ClusterPillHit } from "./pixiRenderer";
 
@@ -128,7 +126,7 @@ let pixi: PixiRenderer | null = null;
 let representedNoteCount = $derived(
 	graphData.nodes.reduce((count, node) => count + (node.kind === "topic" ? (node.memberPaths?.length ?? 1) : 1), 0),
 );
-let nodeSize = $derived(Math.max(2, Math.round(7 - Math.log10(Math.max(representedNoteCount, 10)) * 1.8)));
+let nodeSize = $derived(autoNodeSize(representedNoteCount));
 
 // Density-adaptive physics: unlike node size (which keys off *represented*
 // notes so folding doesn't change the sizing regime), the forces key off the
@@ -137,11 +135,29 @@ let nodeSize = $derived(Math.max(2, Math.round(7 - Math.log10(Math.max(represent
 // densityForceProfile for the asymmetry between the intra- and inter-cluster
 // length scales). The user's slider values are the baseline at the reference
 // density, where every multiplier is exactly 1.
-let forceProfile = $derived(densityForceProfile(graphData.nodes.length));
+let visibleNodeCount = $derived(graphData.nodes.length);
+let forceProfile = $derived(densityForceProfile(visibleNodeCount));
+/** Density-adjusted link distance — for the circle pre-layout's sizing. */
 let effectiveLinkDistance = $derived(linkDistance * forceProfile.spacing);
-let effectiveChargeStrength = $derived(chargeStrength * forceProfile.charge);
-let effectiveCenterStrength = $derived(centerStrength * forceProfile.center);
+/** Density-adjusted cohesion — for the color-only path's in-place strength sync. */
 let effectiveClusterCohesion = $derived(clusterCohesionStrength * forceProfile.cohesion);
+
+/**
+ * The raw physics inputs {@link applyLayoutForces} derives everything from —
+ * the density profile is applied inside it, never here, so the canvas and the
+ * headless layout benchmark cannot disagree about the effective values.
+ */
+function layoutPhysicsConfig(): LayoutPhysicsConfig {
+	return {
+		linkDistance,
+		chargeStrength,
+		centerStrength,
+		linkStrength,
+		clusterCohesionStrength,
+		nodeSize,
+		visibleNodeCount,
+	};
+}
 
 // Edge alpha auto-tuned from edge count: fade edges as the graph grows denser so
 // overlapping edges don't compound into a dark mass.  Clamped to [0.18, 0.60].
@@ -211,9 +227,6 @@ let canvasRevealTimer: ReturnType<typeof setTimeout> | null = null;
 
 // Simulation reference — $state so the hot-update $effect re-runs when simulation is (re)created
 let simulation: ReturnType<typeof forceSimulation<SimNode>> | null = $state(null);
-// D3's default link strength function, captured at simulation init so the
-// hot-update effect can reuse it (it depends on the link topology).
-let cachedDefaultLinkStrengthFn: ((link: SimLink, i: number, links: SimLink[]) => number) | null = null;
 // Last applied force parameters, so the hot-update effect can tell a real physics
 // change from a settings-object replacement that left every number untouched.
 // Cleared whenever a simulation is created so a fresh one always gets its forces.
@@ -258,20 +271,6 @@ const EDGE_FADE_RATE = 0.04; // reaches 1 in 25 ticks (~0.4s at 60fps)
 
 /** Cross-fade speed for topic regions — reaches 1 in ~15 frames (~250ms at 60fps). */
 const HULL_FADE_RATE = 0.067;
-
-/** How much each doubling of an edge's weight increases its pull. */
-const WEIGHT_PULL_SCALE = 0.35;
-/** Ceiling on weight-based pull, so one dominant pair can't collapse together. */
-const WEIGHT_PULL_MAX = 3;
-
-/**
- * Crossing-link count at which a topic pair reaches its shortest rest length.
- * Above this the distance stops shrinking, so one dominant pair can't drag two
- * topics on top of each other.
- */
-const WEIGHT_DISTANCE_SATURATION = 64;
-/** Shortest a topic link may become, as a fraction of the normal link distance. */
-const MIN_TOPIC_LINK_DISTANCE_FACTOR = 0.45;
 
 /**
  * How far a topic's notes are seeded from its collapsed position when expanding.
@@ -319,6 +318,17 @@ const RETARGET_HOLD_MS = 1200;
 const RECLUSTER_ALPHA = 0.22;
 const RECLUSTER_ALPHA_DECAY = 0.012;
 const RECLUSTER_VELOCITY_DECAY = 0.55;
+/**
+ * Cohesion multiplier held during the re-cluster transition.
+ *
+ * The equilibrium cohesion is tuned gentle (base strength × density profile ×
+ * per-cluster member damping — combined ~5× weaker than it once was, so
+ * settled clusters keep breathing room). Migration across the layout to a
+ * *new* topic needs the strong pull back for a moment, or freshly split
+ * topics stay spatially interleaved with overlapping hulls. Restored to the
+ * equilibrium strength when the transition ends.
+ */
+const RECLUSTER_COHESION_BOOST = 3;
 
 /**
  * Delay before the corrective fit that runs after the layout has stopped
@@ -894,49 +904,6 @@ function trimOutliers(points: Array<{ x: number; y: number }>): Array<{ x: numbe
 	const kept = points.filter((_, index) => distances[index] <= limit);
 	// Never trim away so much that the region stops representing the topic.
 	return kept.length >= 3 ? kept : points;
-}
-
-/**
- * Extra pull applied to an edge based on its weight.
- *
- * Only collapsed topic-to-topic edges use this. Their weight is a *count* of how
- * many note-level links cross between two topics, so without it a pair joined by
- * 200 links sits exactly as far apart as one joined by 3 — the edge would encode
- * coupling without the layout ever showing it.
- *
- * Log-scaled and clamped: crossing counts are heavy-tailed, so a linear mapping
- * would let one dominant pair collapse onto each other while everything else
- * drifted apart. Note-level edges are left alone — their weights are cosine
- * scores and small link counts that already behave.
- */
-function weightPull(link: SimLink): number {
-	const source = link.source as SimNode;
-	const target = link.target as SimNode;
-	if (source?.kind !== "topic" && target?.kind !== "topic") return 1;
-
-	const weight = Math.max(1, link.weight);
-	return Math.min(WEIGHT_PULL_MAX, 1 + Math.log2(weight) * WEIGHT_PULL_SCALE);
-}
-
-/**
- * Rest length for a link, shortened for heavily-crossed topic pairs.
- *
- * Strength alone cannot express coupling: in d3-force every link is a spring
- * with a rest length and a stiffness, and stiffness only changes how *fast* a
- * pair converges — not where it settles. With one fixed distance, two topics
- * joined by 200 links come to rest exactly as far apart as two joined by 3.
- * Shortening the spring is what actually pulls coupled topics together.
- */
-function weightedLinkDistance(link: SimLink): number {
-	const source = link.source as SimNode;
-	const target = link.target as SimNode;
-	if (source?.kind !== "topic" && target?.kind !== "topic") return effectiveLinkDistance;
-
-	// Same log curve as the pull, inverted: the heaviest edges sit at
-	// MIN_TOPIC_LINK_DISTANCE_FACTOR of the normal length.
-	const weight = Math.max(1, link.weight);
-	const t = Math.min(1, Math.log2(weight) / Math.log2(WEIGHT_DISTANCE_SATURATION));
-	return effectiveLinkDistance * (1 - t * (1 - MIN_TOPIC_LINK_DISTANCE_FACTOR));
 }
 
 /**
@@ -1864,60 +1831,6 @@ function openNodeMenu(node: GraphNode, clientX: number, clientY: number) {
 // ============================================================================
 
 /** Compute the 2D centroid (mean x, y) for each cluster. */
-function computeClusterCentroids(nodes: SimNode[]): Map<number, { x: number; y: number }> {
-	const sums = new Map<number, { sx: number; sy: number; count: number }>();
-	for (const n of nodes) {
-		const c = n.cluster ?? 0;
-		const entry = sums.get(c) ?? { sx: 0, sy: 0, count: 0 };
-		entry.sx += n.x ?? 0;
-		entry.sy += n.y ?? 0;
-		entry.count += 1;
-		sums.set(c, entry);
-	}
-	const centroids = new Map<number, { x: number; y: number }>();
-	for (const [c, { sx, sy, count }] of sums) {
-		centroids.set(c, { x: sx / count, y: sy / count });
-	}
-	return centroids;
-}
-
-/**
- * Custom d3-force that gently pulls each node toward its cluster's 2D centroid.
- * The centroid is recomputed every tick so it tracks the moving average.
- */
-function clusterCohesionForce(nodes: SimNode[], strength: number) {
-	let _strength = strength;
-
-	function force(alpha: number) {
-		// Recompute centroids each tick so they follow the nodes
-		const centroids = computeClusterCentroids(nodes);
-
-		for (const node of nodes) {
-			// Skip pinned nodes
-			if (node.fx != null && node.fy != null) continue;
-
-			const centroid = centroids.get(node.cluster ?? 0);
-			if (!centroid) continue;
-
-			const dx = centroid.x - (node.x ?? 0);
-			const dy = centroid.y - (node.y ?? 0);
-			node.vx = (node.vx ?? 0) + dx * _strength * alpha;
-			node.vy = (node.vy ?? 0) + dy * _strength * alpha;
-		}
-	}
-
-	force.strength = (s?: number) => {
-		if (s === undefined) return _strength;
-		_strength = s;
-		return force;
-	};
-
-	// d3 force interface: initialize is a no-op since we track nodes directly
-	force.initialize = () => {};
-
-	return force;
-}
-
 // ============================================================================
 // Shared graph data setup (used by both wiki and smart modes)
 // ============================================================================
@@ -2177,40 +2090,27 @@ function setupForceSimulation(
 	isFreshLayout: boolean,
 	isIncrementalUpdate = false,
 ) {
-	// Save the default d3 link strength function so we can apply linkStrength as
-	// a multiplier, matching how Obsidian's native graph works.
-	const baseLinkForce = forceLink<SimNode, SimLink>(simLinks)
-		.id((d) => d.id)
-		.distance(weightedLinkDistance);
-	const defaultLinkStrengthFn = baseLinkForce.strength() as (link: SimLink, i: number, links: SimLink[]) => number;
-	cachedDefaultLinkStrengthFn = defaultLinkStrengthFn;
-	baseLinkForce.strength((l, i, links) => linkStrength * defaultLinkStrengthFn(l, i, links) * weightPull(l));
-
 	// A fresh simulation has no applied parameters yet, so the hot-update effect
 	// must treat its next run as a real change rather than a no-op repeat.
 	lastPhysicsSignature = null;
 
 	simulation = forceSimulation<SimNode>(simNodes);
+	// Full production force set — shared with the headless layout benchmark, so
+	// what gets measured there is exactly what runs here.
+	applyLayoutForces(simulation, simNodes, simLinks, layoutPhysicsConfig());
 	simulation
-		.force("link", baseLinkForce)
-		.force("charge", forceManyBody().strength(effectiveChargeStrength).distanceMin(30))
-		// Obsidian uses forceX + forceY for centering (spring toward origin),
-		// NOT forceCenter (which shifts the centroid). This is the key difference.
-		.force("centerX", forceX<SimNode>(0).strength(effectiveCenterStrength))
-		.force("centerY", forceY<SimNode>(0).strength(effectiveCenterStrength))
-		.force("cluster", clusterCohesionForce(simNodes, effectiveClusterCohesion))
-		.force(
-			"collide",
-			forceCollide<SimNode>().radius((d) => getNodeRadius(d) + 2),
-		)
 		.on("tick", () => {
 			// Positions moved — the spatial hit grid no longer matches them.
 			hitGridDirty = true;
 			// A finished re-cluster transition hands its slower decay back, so the
 			// next drag or retarget feels normal instead of inheriting the drift.
+			// The migration cohesion boost is handed back with it — the settled
+			// layout must live at the gentle equilibrium strength.
 			if (isReclustering && simulation && simulation.alpha() < 0.02) {
 				isReclustering = false;
 				simulation.alphaDecay(baseAlphaDecay).velocityDecay(baseVelocityDecay);
+				const clusterForce = simulation.force("cluster") as ReturnType<typeof clusterCohesionForce> | undefined;
+				clusterForce?.strength(effectiveClusterCohesion);
 			}
 
 			// During initial settling, continuously refit the camera so it
@@ -2361,9 +2261,11 @@ function setupGraph(data: GraphData) {
 				sn.highlighted = node.highlighted;
 			}
 		}
-		// Sync the cohesion force strength to the current prop value.
+		// Sync the cohesion force strength to the current prop value — but never
+		// mid-transition: a pure recolor (highlight toggle) landing while a
+		// re-cluster is still migrating would silently drop the boost early.
 		const clusterForce = simulation?.force("cluster") as ReturnType<typeof clusterCohesionForce> | undefined;
-		if (clusterForce) clusterForce.strength(effectiveClusterCohesion);
+		if (clusterForce && !isReclustering) clusterForce.strength(effectiveClusterCohesion);
 		// Re-derive cluster metadata so pills on the canvas reflect the new segmentation.
 		// (buildInternalData is not called in this path, so we update it explicitly.)
 		refreshClusterMetadata(data);
@@ -2373,6 +2275,14 @@ function setupGraph(data: GraphData) {
 		// applied to a simulation that is no longer ticking, leaving colours and
 		// hulls updated over a frozen layout.
 		if (clustersChanged && clusterCohesionStrength > 0 && simulation && simulation.alpha() < RECLUSTER_ALPHA) {
+			// Equilibrium cohesion is tuned deliberately gentle (density profile,
+			// per-cluster member damping) so settled clusters keep breathing room —
+			// but that same gentleness can no longer *migrate* nodes across the
+			// layout when a granularity change hands them new topics, so freshly
+			// split groups stayed spatially interleaved and their hulls overlapped.
+			// Boost the pull for the transition only; the tick handler that ends
+			// the re-cluster (alpha < 0.02) restores the equilibrium strength.
+			clusterForce?.strength(effectiveClusterCohesion * RECLUSTER_COHESION_BOOST);
 			simulation
 				.alpha(RECLUSTER_ALPHA)
 				.alphaDecay(RECLUSTER_ALPHA_DECAY)
@@ -2430,51 +2340,48 @@ $effect(() => {
 // Reading `simulation` ($state) means this effect re-runs when a new simulation
 // is created (e.g. after a full graph rebuild), so slider changes always apply.
 $effect(() => {
-	// The density-adjusted values, so a slider change hot-applies at the same
-	// spread the full setup uses. Both are value-stable $deriveds: a color-only
-	// graph change re-evaluates them but doesn't re-fire this effect.
-	const _charge = effectiveChargeStrength;
-	const _link = effectiveLinkDistance;
-	const _center = effectiveCenterStrength;
+	// Everything applyLayoutForces reads. Raw slider values plus the two
+	// value-stable $deriveds (nodeSize, visibleNodeCount) that feed the density
+	// profile — a color-only graph change re-evaluates the deriveds but doesn't
+	// re-fire this effect, so a settled layout can't be perturbed by a repaint.
+	const _charge = chargeStrength;
+	const _link = linkDistance;
+	const _center = centerStrength;
 	const _linkStr = linkStrength;
-	const _cohesion = effectiveClusterCohesion;
+	const _cohesion = clusterCohesionStrength;
+	const _nodeSize = nodeSize;
+	const _count = visibleNodeCount;
 	const sim = simulation; // $state — tracks simulation creation
 
 	if (!sim) return;
 
-	const charge = sim.force("charge") as ReturnType<typeof forceManyBody> | undefined;
-	if (charge) charge.strength(_charge);
-
-	const cx = sim.force("centerX") as ReturnType<typeof forceX> | undefined;
-	if (cx) cx.strength(_center);
-	const cy = sim.force("centerY") as ReturnType<typeof forceY> | undefined;
-	if (cy) cy.strength(_center);
-
-	const link = sim.force("link") as ReturnType<typeof forceLink<SimNode, SimLink>> | undefined;
-	if (link) {
-		// Re-apply the weight-aware functions, not flat constants: assigning
-		// `distance(_link)` / a plain strength here would silently drop the
-		// coupling scaling every time any physics setting changed.
-		void _link;
-		link.distance(weightedLinkDistance);
-		if (cachedDefaultLinkStrengthFn) {
-			const baseFn = cachedDefaultLinkStrengthFn;
-			link.strength((l: SimLink, i: number, links: SimLink[]) => _linkStr * baseFn(l, i, links) * weightPull(l));
-		}
+	// One shared code path with initial setup (and the layout benchmark):
+	// recreating the forces wholesale is cheap, and mutating them field-by-field
+	// here previously meant the weight-aware link functions had to be carefully
+	// re-applied by hand or the coupling scaling silently dropped.
+	applyLayoutForces(sim, simNodes, simLinks, {
+		linkDistance: _link,
+		chargeStrength: _charge,
+		centerStrength: _center,
+		linkStrength: _linkStr,
+		clusterCohesionStrength: _cohesion,
+		nodeSize: _nodeSize,
+		visibleNodeCount: _count,
+	});
+	// Recreating the forces resets cohesion to its equilibrium strength; restore
+	// the migration boost if a re-cluster is still in flight, or a settings
+	// write landing mid-transition would strand topics half-migrated.
+	if (isReclustering) {
+		const migratingCluster = sim.force("cluster") as ReturnType<typeof clusterCohesionForce> | undefined;
+		migratingCluster?.strength(effectiveClusterCohesion * RECLUSTER_COHESION_BOOST);
 	}
-
-	const collide = sim.force("collide") as ReturnType<typeof forceCollide<SimNode>> | undefined;
-	if (collide) collide.radius((d: SimNode) => getNodeRadius(d) + 2);
-
-	const clusterForce = sim.force("cluster") as ReturnType<typeof clusterCohesionForce> | undefined;
-	if (clusterForce) clusterForce.strength(_cohesion);
 
 	// Reheat only when a force parameter really changed. `settings` is replaced
 	// wholesale on every write (`{ ...settings, ...partial }`), which invalidates
 	// each property read even when the number is identical — so without this
 	// comparison a purely visual toggle (topic labels, highlights) would restart
 	// the layout at alpha 0.3 and visibly re-shuffle the graph.
-	const signature = `${_charge}:${_link}:${_center}:${_linkStr}:${_cohesion}`;
+	const signature = `${_charge}:${_link}:${_center}:${_linkStr}:${_cohesion}:${_nodeSize}:${_count}`;
 	const changed = signature !== lastPhysicsSignature;
 	lastPhysicsSignature = signature;
 	if (changed && sim.alpha() < 0.05) {
@@ -2624,11 +2531,19 @@ function animateCameraToNodes(
 	filter?: (node: SimNode) => boolean,
 	padding: number | FramingPadding = 40,
 	duration = 400,
+	// Whole-graph framings cap the zoom; selection zooms pass a permissive cap
+	// because magnifying a few chosen notes is the point of the gesture.
+	maxScale = GRAPH_FIT_MAX_SCALE,
 ) {
 	if (!pixi) return;
+	// Always frame the full bounds: an explicit fit means "show me everything",
+	// and framing only a trimmed core left excluded nodes stranded outside the
+	// viewport — which reads as a broken fit, not a smart one. Keeping strays
+	// from dominating the frame is the layout's job (satellite centering,
+	// sparse spread), not the camera's.
 	const bounds = computeNodeBounds(simNodes, filter);
 	if (!bounds) return;
-	const target = framingTransform(bounds, { width: pixi.width, height: pixi.height }, padding);
+	const target = framingTransform(bounds, { width: pixi.width, height: pixi.height }, padding, maxScale);
 	const centerX = (bounds.minX + bounds.maxX) / 2;
 	const centerY = (bounds.minY + bounds.maxY) / 2;
 	pixi.animateToFrame(centerX, centerY, target.scale, duration);
@@ -2701,7 +2616,7 @@ function zoomByFactor(factor: number) {
  */
 export function panToSelection() {
 	if (selectedNodes.size === 0) return;
-	animateCameraToNodes((n) => selectedNodes.has(n.id), 60, 400);
+	animateCameraToNodes((n) => selectedNodes.has(n.id), 60, 400, 4);
 }
 
 /**
@@ -2709,7 +2624,7 @@ export function panToSelection() {
  */
 export function panToClusters(clusters: Set<number>) {
 	if (simNodes.length === 0 || clusters.size === 0) return;
-	animateCameraToNodes((n) => n.cluster != null && clusters.has(n.cluster), 60, 400);
+	animateCameraToNodes((n) => n.cluster != null && clusters.has(n.cluster), 60, 400, 4);
 }
 </script>
 

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -562,6 +562,39 @@ let simNodesVersion = 0;
 // a full force-simulation re-settle on immersion exit.
 const persistentPositionCache = new Map<string, { x: number; y: number }>();
 
+// Set by markIncrementalUpdate() and consumed by the next setupGraph: the
+// incoming data is a live vault-change patch, so the layout settles gently in
+// place and the camera stays put instead of re-framing the whole graph.
+let incrementalUpdatePending = false;
+
+/**
+ * Arm the next graph-data change as a live incremental update (issue #404).
+ *
+ * Called by the view right before it patches `graphData` in response to vault
+ * events. Without this, any node addition takes the mode-switch path — slow
+ * drift plus a camera refit — which would yank the view around every time a
+ * note is created while the graph is open.
+ */
+export function markIncrementalUpdate() {
+	incrementalUpdatePending = true;
+}
+
+/**
+ * Carry a node's layout position across a rename.
+ *
+ * Called before the renamed graph data lands: the new id inherits the old
+ * node's position (live simulation position first, cached position as
+ * fallback), so a renamed note stays where it was instead of re-scattering.
+ */
+export function transferNodePosition(oldId: string, newId: string) {
+	if (oldId === newId) return;
+	const sim = simNodeMap.get(oldId);
+	const position =
+		sim && sim.x != null && sim.y != null ? { x: sim.x, y: sim.y } : persistentPositionCache.get(oldId);
+	if (position) persistentPositionCache.set(newId, { x: position.x, y: position.y });
+	persistentPositionCache.delete(oldId);
+}
+
 // Cached cluster map for edge rendering (nodeId → cluster).
 // Rebuilt only when simNodes changes — cluster assignments are stable between renders.
 let cachedNodeClusterMap: Map<string, number | undefined> = new Map();
@@ -1875,6 +1908,15 @@ function buildInternalData(data: GraphData): {
 		centroidX /= knownForCentroid.size;
 		centroidY /= knownForCentroid.size;
 	}
+	// Radius of the known layout, for placing connection-less new nodes on its
+	// rim. Dropping them at the centroid buries them inside the existing node
+	// mass where they're invisible (and charge repulsion pushes an isolated node
+	// out to the rim anyway — the rim is simply where it will settle).
+	let knownLayoutRadius = 0;
+	for (const { x, y } of knownForCentroid.values()) {
+		const distance = Math.hypot(x - centroidX, y - centroidY);
+		if (distance > knownLayoutRadius) knownLayoutRadius = distance;
+	}
 
 	// Create mutable copies.
 	// Priority: oldPositions (current frame) → persistentPositionCache (prior view) → circle pre-layout.
@@ -1889,6 +1931,39 @@ function buildInternalData(data: GraphData): {
 	// Spread radius for circle pre-layout: scale with node count so the graph fills
 	// a reasonable area before forces kick in (reduces initial chaos).
 	const circleRadius = Math.max(150, Math.sqrt(unknownCount) * linkDistance * 0.5);
+
+	// A node created while the graph is open should appear next to what it
+	// connects to, not in a ring around the whole layout — seed unknown nodes at
+	// the centroid of their already-positioned neighbours when they have any.
+	const knownPosition = (id: string) => oldPositions.get(id) ?? persistentPositionCache.get(id);
+	const neighborIds = new Map<string, string[]>();
+	if (unknownCount > 0 && hasAnyKnown) {
+		for (const e of data.edges) {
+			if (!neighborIds.has(e.source)) neighborIds.set(e.source, []);
+			if (!neighborIds.has(e.target)) neighborIds.set(e.target, []);
+			neighborIds.get(e.source)?.push(e.target);
+			neighborIds.get(e.target)?.push(e.source);
+		}
+	}
+	const neighborSeedPosition = (id: string): { x: number; y: number } | null => {
+		const neighbors = neighborIds.get(id);
+		if (!neighbors) return null;
+		let sumX = 0;
+		let sumY = 0;
+		let count = 0;
+		for (const neighborId of neighbors) {
+			const position = knownPosition(neighborId);
+			if (!position) continue;
+			sumX += position.x;
+			sumY += position.y;
+			count++;
+		}
+		if (count === 0) return null;
+		const angle = Math.random() * 2 * Math.PI;
+		const radius = 30 + Math.random() * 40;
+		return { x: sumX / count + Math.cos(angle) * radius, y: sumY / count + Math.sin(angle) * radius };
+	};
+
 	simNodes = data.nodes.map((n) => {
 		const sn: SimNode = { ...n };
 		// Priority matters: a position inherited from what this node *replaces on
@@ -1901,10 +1976,19 @@ function buildInternalData(data: GraphData): {
 			sn.y = old.y;
 		} else {
 			allPositionsKnown = false;
-			if (hasAnyKnown) {
-				// Scatter new nodes in a ring around the centroid of the known layout
+			const seeded = hasAnyKnown ? neighborSeedPosition(n.id) : null;
+			if (seeded) {
+				sn.x = seeded.x;
+				sn.y = seeded.y;
+			} else if (hasAnyKnown) {
+				// No positioned neighbours — scatter on the rim of the known
+				// layout: the sparse band where an unconnected node settles
+				// anyway, and still inside the current camera frame (the camera
+				// doesn't move for live updates, so "just past the furthest
+				// node" would be just out of view).
 				const angle = (2 * Math.PI * newNodeIndex) / Math.max(1, unknownCount);
-				const radius = 80 + Math.random() * 60;
+				const radius =
+					knownLayoutRadius > 0 ? knownLayoutRadius * (0.9 + Math.random() * 0.1) : 80 + Math.random() * 60;
 				sn.x = centroidX + Math.cos(angle) * radius;
 				sn.y = centroidY + Math.sin(angle) * radius;
 			} else {
@@ -1959,6 +2043,7 @@ function setupForceSimulation(
 	oldPositions: Map<string, { x: number; y: number }>,
 	allPositionsKnown: boolean,
 	isFreshLayout: boolean,
+	isIncrementalUpdate = false,
 ) {
 	// Save the default d3 link strength function so we can apply linkStrength as
 	// a multiplier, matching how Obsidian's native graph works.
@@ -2065,6 +2150,13 @@ function setupForceSimulation(
 		needsInitialFit = true;
 		forceTickCount = 0;
 	}
+	// A live vault-change patch settles locally around the changed nodes (they
+	// were seeded near their neighbours) and never moves the camera — the user
+	// may be reading the graph while a note syncs in.
+	else if (isIncrementalUpdate && oldPositions.size > 0) {
+		simulation.alpha(allPositionsKnown ? 0.05 : 0.3);
+		needsInitialFit = false;
+	}
 	// All nodes restored from cache → gentle settle, no camera refit needed.
 	// Some nodes had prior positions (mode switch) → slow drift into place.
 	// No prior positions → full simulation from scratch.
@@ -2108,6 +2200,11 @@ function isColorOnlyChange(data: GraphData): boolean {
 }
 
 function setupGraph(data: GraphData) {
+	// Consume the incremental flag whichever path this change takes, so a
+	// leftover flag can't misclassify a later unrelated rebuild.
+	const isIncrementalUpdate = incrementalUpdatePending;
+	incrementalUpdatePending = false;
+
 	if (data.nodes.length === 0) {
 		if (simulation) {
 			simulation.stop();
@@ -2166,7 +2263,7 @@ function setupGraph(data: GraphData) {
 	}
 
 	const { oldPositions, allPositionsKnown, isFreshLayout } = buildInternalData(data);
-	setupForceSimulation(oldPositions, allPositionsKnown, isFreshLayout);
+	setupForceSimulation(oldPositions, allPositionsKnown, isFreshLayout, isIncrementalUpdate);
 }
 
 // React to graphData changes — setupGraph is called via untrack so that writes

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -84,10 +84,18 @@ let {
 let isCollapsed = $state(true);
 let isDevCollapsed = $state(true);
 
+/**
+ * Live height of the main panel, so the dev panel can stack directly beneath
+ * it. Measured rather than assumed: the panel grows and shrinks as sections
+ * are opened and as the topic list fills.
+ */
+let mainPanelHeight = $state(0);
+
 let sectionOpen: Record<string, boolean> = $state({
 	devLayout: false,
 	devSemantic: false,
 	devLeiden: false,
+	devAppearance: false,
 });
 
 let graphStats = $derived.by(() => {
@@ -163,6 +171,65 @@ function handleClusterCohesionStrengthChange(val: number) {
 	onSettingsChange({ clusterCohesionStrength: val / 100 });
 }
 
+/**
+ * Set γ directly, bypassing the granularity ladder.
+ *
+ * The user-facing slider snaps to the vault's derived rungs; this one is
+ * deliberately continuous so a dev can probe values between them. Reuses the
+ * seed callback because both change the Leiden partition identity, which is
+ * exactly what needs recomputing.
+ */
+function handleResolutionChange(resolution: number) {
+	onSettingsChange({ leidenResolution: resolution });
+	onSeedChange?.();
+}
+
+/**
+ * Every knob this panel exposes, so "reset" restores exactly what it can change
+ * — and nothing else. Listing the keys explicitly (rather than spreading the
+ * whole defaults object) keeps the user's model choice, colour groups and
+ * filters untouched, and makes a newly added control's absence here obvious.
+ */
+const DEV_TUNABLE_KEYS = [
+	"linkDistance",
+	"chargeStrength",
+	"centerStrength",
+	"linkStrength",
+	"clusterCohesionStrength",
+	"semanticNeighborCount",
+	"semanticThreshold",
+	"leidenSeed",
+	"leidenResolution",
+	"bridgeThreshold",
+	"minClusterSize",
+	"linkOnlyTopics",
+	"directedWikiEdges",
+	"showTopicHulls",
+	"showClusterLabels",
+	"highlightBridges",
+	"highlightIsolated",
+	"markdownOnly",
+] as const satisfies ReadonlyArray<keyof SmartGraphSettings>;
+
+/**
+ * Restore every tuning value in this panel to its shipped default.
+ *
+ * Fires the same follow-ups the individual controls do: the seed and γ change
+ * the Leiden partition, and the semantic values change which edges exist, so
+ * both need their recompute rather than just a settings write.
+ */
+function handleResetDevSettings() {
+	const patch: Partial<SmartGraphSettings> = {};
+	for (const key of DEV_TUNABLE_KEYS) {
+		(patch as Record<string, unknown>)[key] = DEFAULT_SMART_GRAPH_SETTINGS[key];
+	}
+	onSettingsChange(patch);
+	// Re-runs community detection at the restored seed/γ. The semantic values are
+	// part of the parent's rebuild signature, so its own effect handles those.
+	onSeedChange?.();
+	onReapplySegments?.();
+}
+
 // Touch devices have no keyboard modifiers or hover, so the desktop shortcut
 // hints ("F", "hold Shift + drag", "shift/⌘ multi-select") describe gestures
 // the user cannot perform. Drop them on mobile rather than advertise a
@@ -213,7 +280,7 @@ const lassoTooltip = onMobile ? "Lasso selection" : "Lasso selection (or hold Sh
 </div>
 
 <!-- Main settings panel -->
-<div class="graph-controls" class:collapsed={isCollapsed}>
+<div class="graph-controls" class:collapsed={isCollapsed} bind:clientHeight={mainPanelHeight}>
   {#if !isCollapsed}
     <div class="graph-controls-body">
       <!-- ── Stats row ──────────────────────────── -->
@@ -377,7 +444,12 @@ const lassoTooltip = onMobile ? "Lasso selection" : "Lasso selection (or hold Sh
 
 <!-- Dev panel (dev build only) -->
 {#if import.meta.env.DEV}
-  <div class="graph-controls graph-controls--dev" class:collapsed={isDevCollapsed}>
+  <div
+    class="graph-controls graph-controls--dev"
+    class:collapsed={isDevCollapsed}
+    class:graph-controls--main-open={!isCollapsed}
+    style="--s2b-graph-main-panel-height: {mainPanelHeight}px"
+  >
     {#if !isDevCollapsed}
       <div class="graph-controls-body">
         <button
@@ -403,6 +475,35 @@ const lassoTooltip = onMobile ? "Lasso selection" : "Lasso selection (or hold Sh
           </SettingContainer>
           <SettingContainer name="Cluster cohesion" desc="How strongly nodes are pulled toward their cluster center" compact>
             <RangeSlider value={Math.round((settings.clusterCohesionStrength ?? 0.15) * 100)} min={0} max={100} step={1} showValue={true} oncommit={handleClusterCohesionStrengthChange} />
+          </SettingContainer>
+        {/if}
+
+        <button
+          type="button"
+          class="section-label section-label--collapsible"
+          onclick={() => (sectionOpen.devAppearance = !sectionOpen.devAppearance)}
+        >
+          <span>Appearance</span>
+          <svg class="section-chevron" class:open={sectionOpen.devAppearance} xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+        </button>
+        {#if sectionOpen.devAppearance}
+          <SettingContainer name="Directed links" desc="Draw arrowheads on authored wiki links" compact>
+            <Toggle checked={settings.directedWikiEdges ?? true} onchange={(v) => onSettingsChange({ directedWikiEdges: v })} />
+          </SettingContainer>
+          <SettingContainer name="Topic regions" desc="Tinted area behind each topic's notes" compact>
+            <Toggle checked={settings.showTopicHulls ?? true} onchange={(v) => onSettingsChange({ showTopicHulls: v })} />
+          </SettingContainer>
+          <SettingContainer name="Topic labels" desc="Name pills drawn over each topic" compact>
+            <Toggle checked={settings.showClusterLabels ?? true} onchange={(v) => onSettingsChange({ showClusterLabels: v })} />
+          </SettingContainer>
+          <SettingContainer name="Highlight bridges" desc="Ring notes whose neighbors are mostly in other topics" compact>
+            <Toggle checked={settings.highlightBridges ?? false} onchange={(v) => { onSettingsChange({ highlightBridges: v }); onReapplySegments?.(); }} />
+          </SettingContainer>
+          <SettingContainer name="Highlight unlinked" desc="Ring notes with no authored links" compact>
+            <Toggle checked={settings.highlightIsolated ?? false} onchange={(v) => { onSettingsChange({ highlightIsolated: v }); onReapplySegments?.(); }} />
+          </SettingContainer>
+          <SettingContainer name="Markdown only" desc="Exclude non-markdown files from the graph" compact>
+            <Toggle checked={settings.markdownOnly ?? false} onchange={(v) => onSettingsChange({ markdownOnly: v })} />
           </SettingContainer>
         {/if}
 
@@ -458,13 +559,29 @@ const lassoTooltip = onMobile ? "Lasso selection" : "Lasso selection (or hold Sh
               }}
             />
           </SettingContainer>
+          <SettingContainer name="Resolution (γ)" desc="Higher → more, smaller topics. The granularity slider's underlying value" compact>
+            <RangeSlider
+              value={Math.round((settings.leidenResolution ?? 1) * 100)}
+              min={10}
+              max={600}
+              step={5}
+              showValue={true}
+              oncommit={(v) => handleResolutionChange(v / 100)}
+            />
+          </SettingContainer>
           <SettingContainer name="Bridge threshold" desc="Min fraction of foreign-topic neighbors to qualify as a bridge" compact>
             <RangeSlider value={Math.round((settings.bridgeThreshold ?? 0.4) * 100)} min={0} max={100} step={5} showValue={true} oncommit={(v) => { onSettingsChange({ bridgeThreshold: v / 100 }); onReapplySegments?.(); }} />
+          </SettingContainer>
+          <SettingContainer name="Link-only topics" desc="Detect topics from authored links alone, ignoring inferred edges" compact>
+            <Toggle checked={settings.linkOnlyTopics ?? false} onchange={(v) => onSettingsChange({ linkOnlyTopics: v })} />
+          </SettingContainer>
+          <SettingContainer name="Min cluster size" desc="Groups smaller than this aren't treated as topics" compact>
+            <RangeSlider value={settings.minClusterSize ?? 5} min={2} max={30} step={1} showValue={true} oncommit={(v) => onSettingsChange({ minClusterSize: v })} />
           </SettingContainer>
         {/if}
 
         <div class="dev-actions">
-          <Button iconId="refresh-cw" onClick={onRefresh} tooltip="Rebuild graph" />
+          <Button iconId="rotate-ccw" onClick={handleResetDevSettings} tooltip="Reset tuning to defaults" />
         </div>
       </div>
     {/if}
@@ -521,9 +638,22 @@ const lassoTooltip = onMobile ? "Lasso selection" : "Lasso selection (or hold Sh
     display: none;
   }
 
+  /* Same column as the main panel rather than offset to its left: the two are
+     toggled independently, so a fixed sideways offset left the dev panel
+     floating over open canvas whenever the main panel was closed. Stacking
+     below it keeps both anchored to the toolbar they belong to; when the main
+     panel is closed this is the only thing in the column and sits right under
+     the toolbar. */
   .graph-controls--dev {
     top: 8px;
-    right: 356px;
+    right: 52px;
+  }
+
+  /* Clear the main panel when both are open. It is 300px wide with a 16px
+     viewport allowance, so cap the dev panel's own height to what is left. */
+  .graph-controls--main-open {
+    top: calc(8px + var(--s2b-graph-main-panel-height, 0px) + 8px);
+    max-height: calc(100% - 24px - var(--s2b-graph-main-panel-height, 0px));
   }
 
   .graph-controls-body {

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -1385,6 +1385,10 @@ async function deriveGranularityLevels(topicEdges: GraphEdge[]) {
 
 	const probes: Array<{ resolution: number; topicCount: number; isFragmented: boolean }> = [];
 	const start = performance.now();
+	// Count only what the view will actually render: Leiden runs over topic
+	// edges, so its map covers just connected nodes, and segment resolution
+	// drops communities whose members aren't on screen.
+	const visibleNodeIds = new Set(graphData.nodes.map((node) => node.id));
 
 	try {
 		for (const resolution of GRANULARITY_PROBE_RESOLUTIONS) {
@@ -1404,7 +1408,7 @@ async function deriveGranularityLevels(topicEdges: GraphEdge[]) {
 					continue;
 				}
 			}
-			probes.push({ resolution, ...summarizePartition(communities) });
+			probes.push({ resolution, ...summarizePartition(communities, visibleNodeIds) });
 		}
 
 		if (localBuildVersion !== buildVersion) return;

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -57,9 +57,9 @@ import {
 	getTopicLabelCache,
 	loadPersistedTopicCaches,
 	scheduleTopicCacheSave,
-	setActiveGraphResolution,
 	setCachedGranularityLadder,
 	setCachedPartition,
+	setCachedResolution,
 	setCachedSemanticEdges,
 	swapActiveGraphCache,
 } from "../../views/smart-graph/topicCaches";
@@ -1079,7 +1079,9 @@ function handleSettingsChange(partial: Partial<SmartGraphSettings>) {
 	// (immerse, filters) restores it rather than the last γ set anywhere. Every
 	// path that changes γ — slider drag, commit, arrow keys, dev panel — routes
 	// through here.
-	if (partial.leidenResolution !== undefined) setActiveGraphResolution(partial.leidenResolution);
+	if (partial.leidenResolution !== undefined) {
+		setCachedResolution(graphTopologySignature(graphData), partial.leidenResolution);
+	}
 }
 
 function handleFolderFilterChange(folders: string[]) {

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -868,10 +868,22 @@ function applyLivePatch(patched: GraphData, communities: Record<string, number>,
 	// Keep the current rung's cache entry in step, so a granularity round-trip
 	// back to this γ doesn't resurrect the pre-patch assignment. Other rungs go
 	// stale for the changed notes only, until drift or Refresh re-clusters.
+	//
+	// Addressed by signature rather than written to whichever slot is active.
+	// Both callers arrive from async contexts (a debounce timer, and after an
+	// awaited semantic query), so another leaf may own the slot by now — and
+	// the "does this key exist" test would then match *its* graph and overwrite
+	// that graph's partition. The entry belongs to the graph being patched,
+	// which is the pre-patch one: this vote describes how its communities move,
+	// and the caller re-keys to `patched` immediately after.
+	const patchedSignature = graphTopologySignature(graphData);
 	// Only refresh an entry that exists — a missing one means a fresh Leiden run
 	// is in flight for this key, and it will land its own (better) result.
-	if (Object.keys(communities).length > 0 && topicCaches.leiden.has(currentPartitionKey())) {
-		topicCaches.leiden.set(currentPartitionKey(), communities);
+	if (
+		Object.keys(communities).length > 0 &&
+		getCachedPartition(patchedSignature, currentPartitionKey()) !== undefined
+	) {
+		setCachedPartition(patchedSignature, currentPartitionKey(), communities);
 		scheduleTopicCacheSave();
 	}
 	graphData = patched;
@@ -896,7 +908,12 @@ function maybeReclusterAfterDrift() {
 	Logger.info(`[SmartGraph] Live topic drift ${liveTopicDrift} ≥ ${threshold} — re-running Leiden`);
 	liveTopicDrift = 0;
 	// The cached partitions and the hierarchy describe the pre-drift graph.
-	topicCaches.graphSignature = graphTopologySignature(graphData);
+	// Re-key through the swap rather than assigning the slot directly: assigning
+	// `graphSignature` and clearing the map would discard whatever graph the
+	// slot currently holds — another leaf's partitions, if it owns the slot.
+	// The swap archives that graph first, then hands us an empty map keyed to
+	// ours (or this graph's own archived entry, if it has been seen before).
+	swapActiveGraphCache(graphTopologySignature(graphData));
 	topicCaches.leiden.clear();
 	topicHierarchy = null;
 	void runLeidenSegmentation();
@@ -1574,6 +1591,10 @@ async function computeTopicHierarchy(topicEdges: GraphEdge[]) {
  * The granularity ladder is re-derived too, since its rungs came from the old seed.
  */
 async function handleSeedChange() {
+	// Claim the slot for this graph before clearing it: with a second graph leaf
+	// open, the active map may be that leaf's, and its partitions are still
+	// valid under the seed *it* is using.
+	ensureActiveGraphCache(graphTopologySignature(graphData));
 	topicCaches.leiden.clear();
 	hasDerivedGranularityLadder = false;
 	await runLeidenSegmentation();

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -1,52 +1,9 @@
-<script module lang="ts">
-import type { GraphEdge as CachedGraphEdge } from "../../types/graph";
-
-// ── Topic-derivation caches ─────────────────────────────────
-//
-// Module-scoped so they survive closing and reopening the graph view — the
-// expensive derivations (Leiden partitions, granularity probing, semantic
-// edges, AI topic labels) are pure over the graph plus the keys embedded in
-// each entry, so staleness is handled by keying, not by component lifecycle.
-// Shared by every graph leaf (they all describe the same vault); dropped only
-// when the plugin reloads.
-
-/**
- * Leiden partitions keyed by `${seed}:${resolution}:${edge mode}`, valid for
- * the graph whose topology signature is {@link leidenGraphSignature}.
- */
-let leidenCache = new Map<string, Record<string, number>>();
-
-/**
- * Signature of the graph the Leiden cache and granularity ladder were derived
- * from. A rebuild that produces an identical graph — reopening the view, a
- * Refresh over an unchanged vault, a filter round-trip — keeps them all, so
- * topics reappear from cache instead of re-spending seconds of worker time.
- */
-let leidenGraphSignature = "";
-
-/** The derived granularity ladder for that same graph, restored on reopen. */
-let savedGranularityLadder: number[] | null = null;
-
-/**
- * The last semantic edge set, keyed by wiki-graph signature + semantic
- * settings + the embedding index's `lastUpdated` stamp — so a reopen skips
- * the HNSW neighbour search entirely unless notes or embeddings changed.
- */
-let cachedSemanticEdges: { key: string; edges: CachedGraphEdge[] } | null = null;
-
-/**
- * Cache of membership-signature → generated topic label, so re-running Leiden
- * at the same grouping (or reopening the view) doesn't re-spend API calls.
- */
-let topicLabelCache = new Map<string, string>();
-</script>
-
 <script lang="ts">
 import { untrack, tick, onDestroy } from "svelte";
-import { getAllTags, Notice, type WorkspaceLeaf } from "obsidian";
+import { getAllTags, Notice, TFile, type TAbstractFile, type WorkspaceLeaf } from "obsidian";
 import { getPlugin } from "../../stores/state.svelte";
 import { getData } from "../../stores/dataStore.svelte";
-import { getIndexableVaultFiles, isAgentFilePath } from "../../utils/fileFiltering";
+import { getIndexableVaultFiles, isAgentFilePath, isEmbeddableFile } from "../../utils/fileFiltering";
 import { Logger } from "../../utils/logging";
 import { isMobileUI } from "../../utils/platform";
 import { ConfirmModal } from "../modal/ConfirmModal";
@@ -83,6 +40,20 @@ import {
 	type TopicHierarchy,
 } from "../../utils/topicHierarchy";
 import { edgeKey, graphTopologySignature } from "../../utils/graphUtils";
+import {
+	applyWikiPatch,
+	queryNoteSemanticEdges,
+	replaceSemanticEdgesForPaths,
+	voteNodeCommunity,
+} from "../../utils/liveGraphPatch";
+import {
+	getCachedSemanticEdges,
+	loadPersistedTopicCaches,
+	scheduleTopicCacheSave,
+	setCachedSemanticEdges,
+	swapActiveGraphCache,
+	topicCaches,
+} from "../../views/smart-graph/topicCaches";
 import { buildCollapsedGraph, UNSORTED_CLUSTER } from "../../utils/mergeNodes";
 import { leidenAsync } from "../../utils/computeWorkerManager";
 import { VIEW_TYPE_CHAT } from "../../views/chat/Chat";
@@ -95,6 +66,10 @@ import GraphControls from "./GraphControls.svelte";
 
 const plugin = getPlugin();
 const data = getData();
+
+// Start restoring persisted topic caches immediately so the IndexedDB read
+// overlaps mounting; buildGraph awaits the same promise before reading them.
+void loadPersistedTopicCaches();
 
 // Graph state
 
@@ -149,7 +124,8 @@ let refitAfterTopicsSettle = false;
 let leidenCommunities: Record<string, number> = $state({});
 
 // (The Leiden cache, graph signature, semantic edge cache and topic label
-// cache live in the module script above, so they survive view reopen.)
+// cache live in `topicCaches` — module-scoped so they survive view reopen,
+// and persisted to IndexedDB so they survive an Obsidian restart too.)
 
 // Filter state
 let selectedFolders: string[] = $state([]);
@@ -215,6 +191,14 @@ onDestroy(() => {
  * stays wiki-only.
  */
 const SEMANTIC_EDGE_MAX_NOTES = 20000;
+
+/**
+ * Minimum fraction of on-screen nodes a cached partition must still cover to
+ * be painted as interim topics while the real segmentation computes. High
+ * enough that a heavily changed vault paints honestly grey instead of mostly
+ * wrong; low enough that everyday edits between sessions keep instant topics.
+ */
+const INTERIM_TOPIC_MIN_COVERAGE = 0.8;
 
 /**
  * Scales cosine similarity into the same range as authored-link weights for
@@ -448,7 +432,10 @@ async function loadSemanticEdges(wikiData: GraphData, localBuildVersion: number)
 		settings.semanticNeighborCount,
 		settings.semanticThreshold,
 	].join("|");
-	if (cachedSemanticEdges?.key === cacheKey) return cachedSemanticEdges.edges;
+	// Keyed (not single-slot), so both sides of an immerse or filter round-trip
+	// keep their edge sets and the return leg is served from cache.
+	const cachedEdges = getCachedSemanticEdges(cacheKey);
+	if (cachedEdges) return cachedEdges;
 
 	const documents = await getVectorStoreService().getAllDocumentVectors();
 	if (localBuildVersion !== buildVersion || documents.length === 0) return [];
@@ -463,7 +450,8 @@ async function loadSemanticEdges(wikiData: GraphData, localBuildVersion: number)
 		threshold: settings.semanticThreshold,
 		excludeEdgeKeys: wikiEdgeKeys,
 	});
-	cachedSemanticEdges = { key: cacheKey, edges };
+	setCachedSemanticEdges(cacheKey, edges);
+	scheduleTopicCacheSave();
 	return edges;
 }
 
@@ -484,6 +472,13 @@ async function buildGraph() {
 	loadingMessage = "Building graph...";
 
 	try {
+		// Restored caches must be in place before this build reads them: the
+		// semantic-edge cache is consulted mid-build, and the signature comparison
+		// below decides whether persisted partitions apply. Resolves instantly
+		// after the first call.
+		await loadPersistedTopicCaches();
+		if (localBuildVersion !== buildVersion) return;
+
 		const filter = getFilter();
 		const { graphData: wikiData } = buildWikiGraph(plugin.app, filter, immersePaths ?? undefined);
 		// A newer build (or unmount) superseded us before we could apply.
@@ -494,6 +489,26 @@ async function buildGraph() {
 		// A pending refit belongs to the build being replaced. (Topic-state
 		// invalidation waits until the fused graph is known — see below.)
 		refitAfterTopicsSettle = false;
+
+		// Stale-while-revalidate topics: a fresh view instance starts with no
+		// communities, so even a fully cached reopen would paint grey until the
+		// fused graph resolves — and after a vault change (or a restart following
+		// one) the wait is a full semantic scan plus a Leiden run. If the cached
+		// partition still covers most of these nodes, paint it as an interim:
+		// stale for at most the few changed notes, and replaced the moment the
+		// real segmentation lands.
+		if (Object.keys(leidenCommunities).length === 0) {
+			const cached = topicCaches.leiden.get(currentPartitionKey());
+			if (cached) {
+				const covered = wikiData.nodes.reduce((n, node) => (cached[node.id] !== undefined ? n + 1 : n), 0);
+				if (covered >= wikiData.nodes.length * INTERIM_TOPIC_MIN_COVERAGE) {
+					Logger.info(
+						`[SmartGraph] Interim topics from cache (${covered}/${wikiData.nodes.length} nodes covered)`,
+					);
+					leidenCommunities = cached;
+				}
+			}
+		}
 
 		// Paint the authored graph right away so the view isn't blank while
 		// embeddings load, then refine it once semantic edges arrive.
@@ -530,19 +545,34 @@ async function buildGraph() {
 		// changes, a filter round-trip) keeps them all, so the topics reappear
 		// from cache instantly instead of re-spending seconds of worker time.
 		const signature = graphTopologySignature(graphData);
-		if (signature !== leidenGraphSignature) {
-			leidenGraphSignature = signature;
-			leidenCache.clear();
+		if (signature !== topicCaches.graphSignature) {
+			// A different graph: re-key the active cache slot. The outgoing
+			// graph's derivations are archived under its signature and restored
+			// when that graph comes back (immerse exit, a filter round-trip), so
+			// those transitions re-apply topics from cache instead of re-running
+			// Leiden, the ladder probes and labeling from scratch.
+			const restored = swapActiveGraphCache(signature);
+			// Whichever way the swap went, the archive layout changed on disk.
+			scheduleTopicCacheSave();
+			// A fresh (or restored) segmentation replaces every incremental
+			// vote, so accumulated live-update drift is settled.
+			liveTopicDrift = 0;
+			// The hierarchy is per-graph component state; recomputed by the
+			// segmentation run below (from cache when restored).
 			topicHierarchy = null;
-			granularityLadder = [...GRANULARITY_LEVEL_RESOLUTIONS];
-			// The ladder describes the old graph; hide the slider until it's re-derived.
-			hasDerivedGranularityLadder = false;
-			savedGranularityLadder = null;
-		} else if (savedGranularityLadder) {
+			if (restored && topicCaches.granularityLadder) {
+				granularityLadder = topicCaches.granularityLadder;
+				hasDerivedGranularityLadder = true;
+			} else {
+				granularityLadder = [...GRANULARITY_LEVEL_RESOLUTIONS];
+				// The ladder describes another graph; hide the slider until it's re-derived.
+				hasDerivedGranularityLadder = false;
+			}
+		} else if (topicCaches.granularityLadder) {
 			// A fresh view instance starts on the fallback ladder even though this
 			// graph has already been probed — restore the derived ladder so the
 			// slider appears immediately instead of hiding through a re-probe.
-			granularityLadder = savedGranularityLadder;
+			granularityLadder = topicCaches.granularityLadder;
 			hasDerivedGranularityLadder = true;
 		}
 
@@ -561,6 +591,9 @@ async function buildGraph() {
 		// is already stale and nodes drift out of view. Re-frame once the topics
 		// have actually landed.
 		refitAfterTopicsSettle = true;
+		// Live vault-change patches may run from here on — they diff against a
+		// graph this build has now fully established.
+		hasBuiltOnce = true;
 	} catch (e) {
 		if (ac.signal.aborted || localBuildVersion !== buildVersion) return;
 		console.error("[SmartGraph] Error building graph:", e);
@@ -643,6 +676,320 @@ onDestroy(() => {
 	labelingAbort?.abort();
 });
 
+// ─── Live vault-change updates (issue #404) ─────────────────────────────
+//
+// While the view is open, vault and metadata events patch the open graph in
+// place instead of waiting for a manual Refresh. The wiki structure is diffed
+// against a fresh (cheap) rebuild; semantic edges are re-queried per changed
+// note against the live vault index; topics are re-assigned by neighbour vote,
+// with a full Leiden re-run only once enough incremental drift accumulates.
+// Refresh remains ground truth — it rebuilds everything from scratch.
+
+/** Quiet period after the last vault/metadata event before a patch is applied. */
+const LIVE_UPDATE_DEBOUNCE_MS = 1500;
+/** Re-check cadence for notes whose embeddings haven't landed yet. */
+const SEMANTIC_RETRY_INTERVAL_MS = 5000;
+/**
+ * Give up waiting for fresh embeddings after this many checks (~2 min): covers
+ * the vector store's 10s modify debounce plus embedding latency, without
+ * polling forever for notes that will never be (re-)embedded.
+ */
+const SEMANTIC_RETRY_MAX_ATTEMPTS = 24;
+
+/**
+ * Incrementally voted topic assignments since the last full Leiden run. Each
+ * vote is a heuristic stand-in for Leiden; past a threshold the approximations
+ * compound and the real thing re-runs (see {@link maybeReclusterAfterDrift}).
+ */
+let liveTopicDrift = 0;
+/** True once the first full build has landed — live patches diff against it. */
+let hasBuiltOnce = false;
+let liveUpdateTimer: ReturnType<typeof setTimeout> | null = null;
+/** Renames since the last flush, applied to the canvas position cache first. */
+let pendingRenames: Array<{ from: string; to: string }> = [];
+/**
+ * Notes whose semantic edges need re-querying, keyed by path. `mtime` is the
+ * file mtime the stored embeddings must catch up to before the query is worth
+ * running; `attempts` bounds the wait.
+ */
+const pendingSemantic = new Map<string, { mtime: number; attempts: number }>();
+let semanticRetryTimer: ReturnType<typeof setTimeout> | null = null;
+let isProcessingSemantic = false;
+
+function isLiveRelevantFile(file: TAbstractFile): file is TFile {
+	return file instanceof TFile && !isAgentFilePath(file.path);
+}
+
+/** Queue a note for a semantic re-query once its embeddings are current. */
+function queueSemanticRefresh(file: TFile) {
+	if (!data.graphEmbedIndex || !isEmbeddableFile(file)) return;
+	pendingSemantic.set(file.path, { mtime: file.stat.mtime, attempts: 0 });
+}
+
+function scheduleLiveUpdate() {
+	if (isDestroyed) return;
+	if (liveUpdateTimer != null) clearTimeout(liveUpdateTimer);
+	liveUpdateTimer = setTimeout(() => {
+		liveUpdateTimer = null;
+		flushLiveUpdate();
+	}, LIVE_UPDATE_DEBOUNCE_MS);
+}
+
+const liveVaultEventRefs = [
+	plugin.app.vault.on("create", (file) => {
+		if (!isLiveRelevantFile(file)) return;
+		queueSemanticRefresh(file);
+		scheduleLiveUpdate();
+	}),
+	plugin.app.vault.on("modify", (file) => {
+		if (!isLiveRelevantFile(file)) return;
+		queueSemanticRefresh(file);
+		scheduleLiveUpdate();
+	}),
+	plugin.app.vault.on("delete", (file) => {
+		if (!isLiveRelevantFile(file)) return;
+		pendingSemantic.delete(file.path);
+		scheduleLiveUpdate();
+	}),
+	plugin.app.vault.on("rename", (file, oldPath) => {
+		if (!(file instanceof TFile)) return;
+		pendingSemantic.delete(oldPath);
+		if (isAgentFilePath(file.path) && isAgentFilePath(oldPath)) return;
+		pendingRenames.push({ from: oldPath, to: file.path });
+		queueSemanticRefresh(file);
+		scheduleLiveUpdate();
+	}),
+];
+// Fires when link resolution completes after any change — this is what catches
+// edits whose only effect is on OTHER notes' resolved links (e.g. creating a
+// note that turns previously unresolved links elsewhere into edges).
+const liveMetadataEventRef = plugin.app.metadataCache.on("resolved", () => scheduleLiveUpdate());
+
+onDestroy(() => {
+	for (const ref of liveVaultEventRefs) plugin.app.vault.offref(ref);
+	plugin.app.metadataCache.offref(liveMetadataEventRef);
+	if (liveUpdateTimer != null) clearTimeout(liveUpdateTimer);
+	if (semanticRetryTimer != null) clearTimeout(semanticRetryTimer);
+});
+
+/** Apply pending vault changes to the open graph. */
+function flushLiveUpdate() {
+	if (isDestroyed) return;
+	// A full build in flight already sees the current vault; patching under it
+	// would race two writers of graphData. Come back once it lands.
+	if (!hasBuiltOnce || isLoading) {
+		scheduleLiveUpdate();
+		return;
+	}
+
+	// Renames first: the canvas position cache must know the new ids before the
+	// patched data lands, so renamed notes stay in place.
+	for (const { from, to } of pendingRenames) canvasComponent?.transferNodePosition(from, to);
+	pendingRenames = [];
+
+	// New folders/tags/extensions should appear in the filter dropdowns too.
+	loadFilterOptions();
+
+	const { graphData: freshWiki } = buildWikiGraph(plugin.app, getFilter(), immersePaths ?? undefined);
+	const patch = applyWikiPatch(graphData, freshWiki);
+	if (patch.changed) {
+		const communities = { ...leidenCommunities };
+		let drift = 0;
+		for (const path of patch.removedPaths) {
+			if (communities[path] !== undefined) {
+				delete communities[path];
+				drift++;
+			}
+		}
+		const topicEdges = getTopicEdgesFor(patch.data);
+		for (const path of patch.addedPaths) {
+			const vote = voteNodeCommunity(path, topicEdges, communities, leidenWeight);
+			if (vote !== undefined) {
+				communities[path] = vote;
+				drift++;
+			}
+		}
+		// A surviving note whose links changed may now belong elsewhere; re-vote
+		// it, but only count actual moves as drift.
+		for (const path of patch.touchedPaths) {
+			const vote = voteNodeCommunity(path, topicEdges, communities, leidenWeight);
+			if (vote !== undefined && vote !== communities[path]) {
+				communities[path] = vote;
+				drift++;
+			}
+		}
+		applyLivePatch(patch.data, communities, drift);
+
+		// A removed note can't stay selected — mirror the pruned selection out so
+		// chat trays don't keep offering a note that no longer exists.
+		if (patch.removedPaths.length > 0 && selectedPaths.length > 0) {
+			const removed = new Set(patch.removedPaths);
+			const surviving = selectedPaths.filter((path) => !removed.has(path));
+			if (surviving.length !== selectedPaths.length) {
+				canvasComponent?.selectNodesByPaths(surviving);
+				handleSelectionChange(surviving);
+			}
+		}
+
+		Logger.info(
+			`[SmartGraph] Live patch: +${patch.addedPaths.length} −${patch.removedPaths.length} nodes, ${patch.touchedPaths.length} touched (drift ${liveTopicDrift})`,
+		);
+	} else {
+		Logger.debug("[SmartGraph] Live update: no structural change");
+	}
+
+	void processPendingSemanticQueries();
+}
+
+/**
+ * Land a patched graph: canvas told to stay put, communities updated, segments
+ * re-resolved, drift accounted.
+ */
+function applyLivePatch(patched: GraphData, communities: Record<string, number>, drift: number) {
+	canvasComponent?.markIncrementalUpdate();
+	leidenCommunities = communities;
+	// Keep the current rung's cache entry in step, so a granularity round-trip
+	// back to this γ doesn't resurrect the pre-patch assignment. Other rungs go
+	// stale for the changed notes only, until drift or Refresh re-clusters.
+	// Only refresh an entry that exists — a missing one means a fresh Leiden run
+	// is in flight for this key, and it will land its own (better) result.
+	if (Object.keys(communities).length > 0 && topicCaches.leiden.has(currentPartitionKey())) {
+		topicCaches.leiden.set(currentPartitionKey(), communities);
+		scheduleTopicCacheSave();
+	}
+	graphData = patched;
+	resolveAndApplySegments(graphData);
+	liveTopicDrift += drift;
+	maybeReclusterAfterDrift();
+}
+
+/**
+ * Fall back to a real Leiden run once enough incremental votes accumulated.
+ *
+ * Each vote is locally plausible but never merges or splits communities the
+ * way Leiden would, so approximation error compounds with every patch. The
+ * threshold scales with graph size — a fixed count would re-cluster a large
+ * vault constantly and a small one never. The granularity ladder survives:
+ * its rungs describe the vault's structure coarsely enough that a few percent
+ * of changed notes don't invalidate them.
+ */
+function maybeReclusterAfterDrift() {
+	const threshold = Math.max(8, Math.ceil(graphData.nodes.length * 0.02));
+	if (liveTopicDrift < threshold) return;
+	Logger.info(`[SmartGraph] Live topic drift ${liveTopicDrift} ≥ ${threshold} — re-running Leiden`);
+	liveTopicDrift = 0;
+	// The cached partitions and the hierarchy describe the pre-drift graph.
+	topicCaches.graphSignature = graphTopologySignature(graphData);
+	topicCaches.leiden.clear();
+	topicHierarchy = null;
+	void runLeidenSegmentation();
+}
+
+/**
+ * Re-query semantic edges for changed notes, waiting for their embeddings.
+ *
+ * The vector store re-embeds a modified note ~10s after the last edit, so a
+ * query at patch time would read stale vectors. Each queued note is retried on
+ * an interval until its stored mtime catches up with the file — or attempts
+ * run out, in which case whatever vectors exist are used (better than
+ * dropping the note's inferred edges entirely).
+ */
+async function processPendingSemanticQueries() {
+	if (isDestroyed || isProcessingSemantic || pendingSemantic.size === 0) return;
+	if (!data.graphEmbedIndex) {
+		pendingSemantic.clear();
+		return;
+	}
+	// Same ceiling as the full build: past it the graph is wiki-only, so there
+	// are no semantic edges to keep current.
+	if (graphData.nodes.length > SEMANTIC_EDGE_MAX_NOTES) {
+		pendingSemantic.clear();
+		return;
+	}
+	isProcessingSemantic = true;
+	const localBuildVersion = buildVersion;
+	try {
+		const serviceReady = await waitForVectorStore();
+		if (!serviceReady || isDestroyed) return;
+		const store = await getVectorStoreService()
+			.getOrCreateInstance(data.graphEmbedIndex)
+			.then((inst) => inst.store)
+			.catch(() => null);
+		if (!store || isDestroyed) return;
+
+		const nodePaths = new Set(graphData.nodes.map((node) => node.path));
+		const replacements = new Map<string, GraphEdge[]>();
+		for (const [path, entry] of [...pendingSemantic]) {
+			// Filtered out of the graph (or deleted since queueing) — nothing to do.
+			if (!nodePaths.has(path)) {
+				pendingSemantic.delete(path);
+				continue;
+			}
+			const storedMtime = await store.getDocumentMtime(path).catch(() => undefined);
+			if (isDestroyed) return;
+			const embeddingsCurrent = storedMtime !== undefined && storedMtime >= entry.mtime;
+			if (!embeddingsCurrent && entry.attempts < SEMANTIC_RETRY_MAX_ATTEMPTS) {
+				entry.attempts++;
+				continue;
+			}
+			pendingSemantic.delete(path);
+			// Never embedded (private, excluded, provider down) — no edges to infer.
+			if (storedMtime === undefined) continue;
+
+			const wikiKeys = new Set(
+				graphData.edges
+					.filter((e) => e.type === "wiki" && (e.source === path || e.target === path))
+					.map((e) => edgeKey(e.source, e.target)),
+			);
+			const edges = await queryNoteSemanticEdges(store, path, nodePaths, {
+				neighborCount: settings.semanticNeighborCount,
+				threshold: settings.semanticThreshold,
+				excludeEdgeKeys: wikiKeys,
+			}).catch((error) => {
+				Logger.error(`[SmartGraph] Live semantic query failed for ${path}:`, error);
+				return [] as GraphEdge[];
+			});
+			if (isDestroyed) return;
+			replacements.set(path, edges);
+		}
+
+		// A full rebuild landed while we were querying — it recomputed every
+		// semantic edge itself, so these results describe a replaced graph.
+		if (localBuildVersion !== buildVersion) return;
+
+		if (replacements.size > 0) {
+			const paths = new Set(replacements.keys());
+			const merged = [...replacements.values()].flat();
+			const { data: patched, changed } = replaceSemanticEdgesForPaths(graphData, paths, merged);
+			if (changed) {
+				const communities = { ...leidenCommunities };
+				let drift = 0;
+				const topicEdges = getTopicEdgesFor(patched);
+				for (const path of paths) {
+					const vote = voteNodeCommunity(path, topicEdges, communities, leidenWeight);
+					if (vote !== undefined && vote !== communities[path]) {
+						communities[path] = vote;
+						drift++;
+					}
+				}
+				applyLivePatch(patched, communities, drift);
+				Logger.info(`[SmartGraph] Live semantic patch for ${paths.size} note(s)`);
+			}
+		}
+	} finally {
+		isProcessingSemantic = false;
+		scheduleSemanticRetry();
+	}
+}
+
+function scheduleSemanticRetry() {
+	if (isDestroyed || pendingSemantic.size === 0 || semanticRetryTimer != null) return;
+	semanticRetryTimer = setTimeout(() => {
+		semanticRetryTimer = null;
+		void processPendingSemanticQueries();
+	}, SEMANTIC_RETRY_INTERVAL_MS);
+}
+
 /**
  * Drop every piece of state recorded against topic *numbers*.
  *
@@ -708,7 +1055,8 @@ function handleRevealFile(path: string) {
 		// Reveal in Obsidian's file explorer
 		const explorer = plugin.app.workspace.getLeavesOfType("file-explorer")[0];
 		if (explorer) {
-			(explorer.view as any).revealInFolder?.(file);
+			// `revealInFolder` is an undocumented internal on the file-explorer view.
+			(explorer.view as { revealInFolder?: (file: TAbstractFile) => void }).revealInFolder?.(file);
 		}
 	}
 }
@@ -898,7 +1246,12 @@ function leidenWeight(edge: GraphEdge): number {
  * topics reflect nothing but the user's own linking.
  */
 function getTopicEdges(): GraphEdge[] {
-	return graphData.edges.filter((e) =>
+	return getTopicEdgesFor(graphData);
+}
+
+/** Same filter over an arbitrary graph — used by live patches before they land. */
+function getTopicEdgesFor(gd: GraphData): GraphEdge[] {
+	return gd.edges.filter((e) =>
 		settings.linkOnlyTopics ? e.type === "wiki" : e.type === "wiki" || e.type === "semantic",
 	);
 }
@@ -935,7 +1288,7 @@ async function runLeidenSegmentation() {
 	}
 
 	const cacheKey = currentPartitionKey();
-	const cached = leidenCache.get(cacheKey);
+	const cached = topicCaches.leiden.get(cacheKey);
 	if (cached) {
 		Logger.info(`[SmartGraph] Leiden cache hit (γ=${settings.leidenResolution.toFixed(2)})`);
 		leidenCommunities = cached;
@@ -968,7 +1321,8 @@ async function runLeidenSegmentation() {
 	);
 	// Always worth caching — the result is correct for the settings it ran under,
 	// even if those are no longer the ones on screen.
-	leidenCache.set(cacheKey, result);
+	topicCaches.leiden.set(cacheKey, result);
+	scheduleTopicCacheSave();
 	// …but only *apply* it if those settings are still current. `buildVersion`
 	// alone can't tell: it tracks graph rebuilds, while γ, seed and link-mode all
 	// change the partition without touching the graph. A slow run started at one γ
@@ -1019,12 +1373,12 @@ async function deriveGranularityLevels(topicEdges: GraphEdge[]) {
 			if (localBuildVersion !== buildVersion) return;
 
 			const cacheKey = partitionKey(resolution, linkOnly, seed);
-			let communities = leidenCache.get(cacheKey);
+			let communities = topicCaches.leiden.get(cacheKey);
 			if (!communities) {
 				try {
 					const result = await leidenAsync(sources, targets, weights, seed, resolution);
 					if (localBuildVersion !== buildVersion) return;
-					leidenCache.set(cacheKey, result);
+					topicCaches.leiden.set(cacheKey, result);
 					communities = result;
 				} catch (error) {
 					// A failed probe just means one fewer candidate rung.
@@ -1066,8 +1420,10 @@ async function deriveGranularityLevels(topicEdges: GraphEdge[]) {
 		}
 		hasDerivedGranularityLadder = true;
 		// Remember the outcome for this graph, so reopening the view restores the
-		// ladder instead of re-probing.
-		savedGranularityLadder = granularityLadder;
+		// ladder instead of re-probing. The probes also filled the Leiden cache,
+		// so this save persists every rung at once.
+		topicCaches.granularityLadder = granularityLadder;
+		scheduleTopicCacheSave();
 	} finally {
 		isDerivingGranularityLadder = false;
 	}
@@ -1094,7 +1450,7 @@ async function computeTopicHierarchy(topicEdges: GraphEdge[]) {
 	const finePartition = currentPartitionKey();
 
 	let communities: Record<string, number>;
-	const cached = leidenCache.get(cacheKey);
+	const cached = topicCaches.leiden.get(cacheKey);
 	if (cached) {
 		communities = cached;
 	} else {
@@ -1107,7 +1463,8 @@ async function computeTopicHierarchy(topicEdges: GraphEdge[]) {
 				coarseResolution,
 			);
 			if (localBuildVersion !== buildVersion) return;
-			leidenCache.set(cacheKey, result);
+			topicCaches.leiden.set(cacheKey, result);
+			scheduleTopicCacheSave();
 			communities = result;
 		} catch (error) {
 			Logger.error("[SmartGraph] Coarse Leiden failed; hierarchy unavailable:", error);
@@ -1135,7 +1492,7 @@ async function computeTopicHierarchy(topicEdges: GraphEdge[]) {
  * The granularity ladder is re-derived too, since its rungs came from the old seed.
  */
 async function handleSeedChange() {
-	leidenCache.clear();
+	topicCaches.leiden.clear();
 	hasDerivedGranularityLadder = false;
 	await runLeidenSegmentation();
 }
@@ -1238,12 +1595,18 @@ function resolveAndApplySegments(gd: GraphData) {
 				const tc = leidenCommunities[edge.target];
 				if (sc === undefined || tc === undefined || sc === tc) continue;
 				// source sees a foreign neighbor tc
-				if (!neighborCommunityVotes.has(edge.source)) neighborCommunityVotes.set(edge.source, new Map());
-				const sv = neighborCommunityVotes.get(edge.source)!;
+				let sv = neighborCommunityVotes.get(edge.source);
+				if (!sv) {
+					sv = new Map();
+					neighborCommunityVotes.set(edge.source, sv);
+				}
 				sv.set(tc, (sv.get(tc) ?? 0) + 1);
 				// target sees a foreign neighbor sc
-				if (!neighborCommunityVotes.has(edge.target)) neighborCommunityVotes.set(edge.target, new Map());
-				const tv = neighborCommunityVotes.get(edge.target)!;
+				let tv = neighborCommunityVotes.get(edge.target);
+				if (!tv) {
+					tv = new Map();
+					neighborCommunityVotes.set(edge.target, tv);
+				}
 				tv.set(sc, (tv.get(sc) ?? 0) + 1);
 			}
 			// Count total topic-edge degree per node
@@ -1347,12 +1710,15 @@ async function runTopicLabeling() {
 	try {
 		const labels = await labelTopics(topics, settings.graphChatModel, {
 			signal: controller.signal,
-			cache: topicLabelCache,
+			cache: topicCaches.topicLabels,
 		});
 		// A rebuild (or unmount) landed while we were waiting — these labels are
 		// keyed to topic ids that may no longer mean the same thing.
 		if (controller.signal.aborted || localBuildVersion !== buildVersion) return;
 		generatedClusterLabels = labels;
+		// labelTopics filled the membership-keyed label cache — persist it so a
+		// restart doesn't re-spend the API calls.
+		scheduleTopicCacheSave();
 	} finally {
 		if (labelingAbort === controller) {
 			isLabeling = false;
@@ -1511,7 +1877,7 @@ function handleGranularityChange(level: number) {
 	const resolution = granularityToResolution(level, granularityLadder);
 	if (resolution === settings.leidenResolution) return;
 
-	const cached = leidenCache.get(partitionKey(resolution));
+	const cached = topicCaches.leiden.get(partitionKey(resolution));
 	if (!cached) return;
 
 	handleSettingsChange({ leidenResolution: resolution });

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -47,6 +47,7 @@ import {
 	voteNodeCommunity,
 } from "../../utils/liveGraphPatch";
 import {
+	ensureActiveGraphCache,
 	getCachedSemanticEdges,
 	loadPersistedTopicCaches,
 	scheduleTopicCacheSave,
@@ -932,10 +933,21 @@ async function processPendingSemanticQueries() {
 
 		const nodePaths = new Set(graphData.nodes.map((node) => node.path));
 		const replacements = new Map<string, GraphEdge[]>();
+		/**
+		 * Retire an entry only if it is still the one this pass processed.
+		 *
+		 * The loop awaits the vector store, and an edit landing during that await
+		 * replaces the entry with a newer mtime. Deleting by path alone would
+		 * discard that replacement, leaving the note on stale semantic edges
+		 * until some later vault event happened to requeue it.
+		 */
+		const retire = (path: string, processed: { mtime: number; attempts: number }) => {
+			if (pendingSemantic.get(path) === processed) pendingSemantic.delete(path);
+		};
 		for (const [path, entry] of [...pendingSemantic]) {
 			// Filtered out of the graph (or deleted since queueing) — nothing to do.
 			if (!nodePaths.has(path)) {
-				pendingSemantic.delete(path);
+				retire(path, entry);
 				continue;
 			}
 			const storedMtime = await store.getDocumentMtime(path).catch(() => undefined);
@@ -945,7 +957,7 @@ async function processPendingSemanticQueries() {
 				entry.attempts++;
 				continue;
 			}
-			pendingSemantic.delete(path);
+			retire(path, entry);
 			// Never embedded (private, excluded, provider down) — no edges to infer.
 			if (storedMtime === undefined) continue;
 
@@ -963,6 +975,10 @@ async function processPendingSemanticQueries() {
 				return [] as GraphEdge[];
 			});
 			if (isDestroyed) return;
+			// Requeued while the query ran: the note changed again, so this result
+			// already describes an older version. Drop it and let the retry pass
+			// (which the finally block schedules) query the current content.
+			if (pendingSemantic.has(path)) continue;
 			replacements.set(path, edges);
 		}
 
@@ -1294,6 +1310,10 @@ function currentPartitionKey(): string {
 
 async function runLeidenSegmentation() {
 	const localBuildVersion = buildVersion;
+	// Another graph leaf (a split or duplicated tab showing a different filter or
+	// immersion) may have re-keyed the shared active cache slot since this leaf
+	// last touched it. Re-assert our own graph before reading partitions from it.
+	ensureActiveGraphCache(graphTopologySignature(graphData));
 	const topicEdges = getTopicEdges();
 	if (topicEdges.length === 0) {
 		// Link-only mode on a vault with no links at all: clear stale communities so
@@ -1322,6 +1342,11 @@ async function runLeidenSegmentation() {
 	const sources = topicEdges.map((e) => e.source);
 	const targets = topicEdges.map((e) => e.target);
 	const weights = topicEdges.map(leidenWeight);
+	// The graph this run describes. A live vault patch changes the node set
+	// without bumping buildVersion or the partition key, so neither of those
+	// guards would notice — the result would be applied over, and cached
+	// against, a graph it was never computed for.
+	const runSignature = graphTopologySignature(graphData);
 	const start = performance.now();
 	isLeidenRunning = true;
 	let result: Awaited<ReturnType<typeof leidenAsync>>;
@@ -1334,6 +1359,14 @@ async function runLeidenSegmentation() {
 	// communities are keyed by nodes that may no longer exist. Discard them
 	// rather than applying stale segments over the current graph.
 	if (localBuildVersion !== buildVersion) return;
+	// Same for a live patch, which changes the graph without a rebuild: the
+	// result describes a node set that has since moved on. The patch's own
+	// neighbour-vote already covers the affected notes, and drift will trigger
+	// a fresh run when it accumulates.
+	if (graphTopologySignature(graphData) !== runSignature) {
+		Logger.info("[SmartGraph] Discarding a Leiden result the graph has moved past");
+		return;
+	}
 	Logger.info(
 		`[SmartGraph] Leiden (γ=${settings.leidenResolution.toFixed(2)}, ${topicEdges.length} edges, ${graphData.nodes.length} nodes): ${Math.round(performance.now() - start)}ms`,
 	);
@@ -1373,6 +1406,9 @@ async function deriveGranularityLevels(topicEdges: GraphEdge[]) {
 	isDerivingGranularityLadder = true;
 
 	const localBuildVersion = buildVersion;
+	// Same shared-slot guard as runLeidenSegmentation: the probes both read and
+	// fill the active Leiden cache.
+	ensureActiveGraphCache(graphTopologySignature(graphData));
 	// Captured once, and used for every probe below. The loop awaits between
 	// rungs, so reading these live would let a mid-loop change split the ladder
 	// across two partitions — and, because they also form the cache key, file

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -48,10 +48,12 @@ import {
 } from "../../utils/liveGraphPatch";
 import {
 	ensureActiveGraphCache,
+	getCachedPartition,
 	getCachedSemanticEdges,
 	loadPersistedTopicCaches,
 	scheduleTopicCacheSave,
 	setActiveGraphResolution,
+	setCachedPartition,
 	setCachedSemanticEdges,
 	swapActiveGraphCache,
 	topicCaches,
@@ -1371,8 +1373,10 @@ async function runLeidenSegmentation() {
 		`[SmartGraph] Leiden (γ=${settings.leidenResolution.toFixed(2)}, ${topicEdges.length} edges, ${graphData.nodes.length} nodes): ${Math.round(performance.now() - start)}ms`,
 	);
 	// Always worth caching — the result is correct for the settings it ran under,
-	// even if those are no longer the ones on screen.
-	topicCaches.leiden.set(cacheKey, result);
+	// even if those are no longer the ones on screen. Addressed by signature:
+	// another leaf may have re-keyed the active slot while this ran, and an
+	// unaddressed write would file this partition under *its* graph.
+	setCachedPartition(runSignature, cacheKey, result);
 	scheduleTopicCacheSave();
 	// …but only *apply* it if those settings are still current. `buildVersion`
 	// alone can't tell: it tracks graph rebuilds, while γ, seed and link-mode all
@@ -1425,18 +1429,22 @@ async function deriveGranularityLevels(topicEdges: GraphEdge[]) {
 	// edges, so its map covers just connected nodes, and segment resolution
 	// drops communities whose members aren't on screen.
 	const visibleNodeIds = new Set(graphData.nodes.map((node) => node.id));
+	// The graph this sweep describes. The loop awaits per rung, so another leaf
+	// can re-key the active slot between them — every read and write below is
+	// addressed by signature rather than trusting whichever slot is current.
+	const runSignature = graphTopologySignature(graphData);
 
 	try {
 		for (const resolution of GRANULARITY_PROBE_RESOLUTIONS) {
 			if (localBuildVersion !== buildVersion) return;
 
 			const cacheKey = partitionKey(resolution, linkOnly, seed);
-			let communities = topicCaches.leiden.get(cacheKey);
+			let communities = getCachedPartition(runSignature, cacheKey);
 			if (!communities) {
 				try {
 					const result = await leidenAsync(sources, targets, weights, seed, resolution);
 					if (localBuildVersion !== buildVersion) return;
-					topicCaches.leiden.set(cacheKey, result);
+					setCachedPartition(runSignature, cacheKey, result);
 					communities = result;
 				} catch (error) {
 					// A failed probe just means one fewer candidate rung.
@@ -1506,9 +1514,12 @@ async function computeTopicHierarchy(topicEdges: GraphEdge[]) {
 	// which one that is: the coarse Leiden below may await long enough for γ, the
 	// seed or the link mode to move on.
 	const finePartition = currentPartitionKey();
+	// Addressed by signature for the same reason as the segmentation run: the
+	// coarse Leiden below awaits, and another leaf may re-key the active slot.
+	const runSignature = graphTopologySignature(graphData);
 
 	let communities: Record<string, number>;
-	const cached = topicCaches.leiden.get(cacheKey);
+	const cached = getCachedPartition(runSignature, cacheKey);
 	if (cached) {
 		communities = cached;
 	} else {
@@ -1521,7 +1532,7 @@ async function computeTopicHierarchy(topicEdges: GraphEdge[]) {
 				coarseResolution,
 			);
 			if (localBuildVersion !== buildVersion) return;
-			topicCaches.leiden.set(cacheKey, result);
+			setCachedPartition(runSignature, cacheKey, result);
 			scheduleTopicCacheSave();
 			communities = result;
 		} catch (error) {

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -1571,6 +1571,16 @@ async function computeTopicHierarchy(topicEdges: GraphEdge[]) {
 				coarseResolution,
 			);
 			if (localBuildVersion !== buildVersion) return;
+			// Same live-patch hazard as the segmentation run: a vault patch changes
+			// the node set without bumping buildVersion or the partition key, so
+			// this coarse result describes a topology that has moved on. Caching it
+			// under the current signature would pair it with fine communities it
+			// never nested under, and the outline would show parents that match
+			// neither the canvas nor the controls.
+			if (graphTopologySignature(graphData) !== runSignature) {
+				Logger.info("[SmartGraph] Discarding a coarse partition the graph has moved past");
+				return;
+			}
 			setCachedPartition(runSignature, cacheKey, result);
 			scheduleTopicCacheSave();
 			communities = result;
@@ -1581,6 +1591,12 @@ async function computeTopicHierarchy(topicEdges: GraphEdge[]) {
 	}
 
 	if (localBuildVersion !== buildVersion) return;
+	// A live patch moves the node set without touching buildVersion or the
+	// partition key, so neither guard below would catch it.
+	if (graphTopologySignature(graphData) !== runSignature) {
+		Logger.info("[SmartGraph] Discarding a hierarchy the graph has moved past");
+		return;
+	}
 	// Pairing this coarse partition with a fine one it never nested under would
 	// describe a parent structure that matches neither the controls nor the
 	// canvas. The run triggered by whatever changed will rebuild it.

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -47,9 +47,14 @@ import {
 	voteNodeCommunity,
 } from "../../utils/liveGraphPatch";
 import {
+	clearCachedPartitions,
 	ensureActiveGraphCache,
+	getActiveGraphSignature,
+	getCachedGranularityLadder,
 	getCachedPartition,
+	getCachedResolution,
 	getCachedSemanticEdges,
+	getTopicLabelCache,
 	loadPersistedTopicCaches,
 	scheduleTopicCacheSave,
 	setActiveGraphResolution,
@@ -57,7 +62,6 @@ import {
 	setCachedPartition,
 	setCachedSemanticEdges,
 	swapActiveGraphCache,
-	topicCaches,
 } from "../../views/smart-graph/topicCaches";
 import { buildCollapsedGraph, UNSORTED_CLUSTER } from "../../utils/mergeNodes";
 import { leidenAsync } from "../../utils/computeWorkerManager";
@@ -503,7 +507,7 @@ async function buildGraph() {
 		// stale for at most the few changed notes, and replaced the moment the
 		// real segmentation lands.
 		if (Object.keys(leidenCommunities).length === 0) {
-			const cached = topicCaches.leiden.get(currentPartitionKey());
+			const cached = getCachedPartition(graphTopologySignature(wikiData), currentPartitionKey());
 			if (cached) {
 				const covered = wikiData.nodes.reduce((n, node) => (cached[node.id] !== undefined ? n + 1 : n), 0);
 				if (covered >= wikiData.nodes.length * INTERIM_TOPIC_MIN_COVERAGE) {
@@ -550,7 +554,7 @@ async function buildGraph() {
 		// changes, a filter round-trip) keeps them all, so the topics reappear
 		// from cache instantly instead of re-spending seconds of worker time.
 		const signature = graphTopologySignature(graphData);
-		if (signature !== topicCaches.graphSignature) {
+		if (signature !== getActiveGraphSignature()) {
 			// A different graph: re-key the active cache slot. The outgoing
 			// graph's derivations are archived under its signature and restored
 			// when that graph comes back (immerse exit, a filter round-trip), so
@@ -567,8 +571,9 @@ async function buildGraph() {
 			// The hierarchy is per-graph component state; recomputed by the
 			// segmentation run below (from cache when restored).
 			topicHierarchy = null;
-			if (restored && topicCaches.granularityLadder) {
-				granularityLadder = topicCaches.granularityLadder;
+			const restoredLadder = getCachedGranularityLadder(signature);
+			if (restored && restoredLadder) {
+				granularityLadder = restoredLadder;
 				hasDerivedGranularityLadder = true;
 			} else {
 				granularityLadder = [...GRANULARITY_LEVEL_RESOLUTIONS];
@@ -579,17 +584,18 @@ async function buildGraph() {
 			// describes the subset, not the vault. Restore this graph's own γ so
 			// returning to it re-segments the way the user left it rather than
 			// inheriting the granularity set on the graph in between.
-			if (topicCaches.resolution != null && topicCaches.resolution !== settings.leidenResolution) {
-				data.smartGraphSettings = { ...settings, leidenResolution: topicCaches.resolution };
+			const restoredResolution = getCachedResolution(signature);
+			if (restoredResolution != null && restoredResolution !== settings.leidenResolution) {
+				data.smartGraphSettings = { ...settings, leidenResolution: restoredResolution };
 				// Topic ids are positions in a fresh partition, so anything holding
 				// an id (folds, focus, selection) refers to a different grouping now.
 				clearTopicIndexedState();
 			}
-		} else if (topicCaches.granularityLadder) {
+		} else if (getCachedGranularityLadder(signature)) {
 			// A fresh view instance starts on the fallback ladder even though this
 			// graph has already been probed — restore the derived ladder so the
 			// slider appears immediately instead of hiding through a re-probe.
-			granularityLadder = topicCaches.granularityLadder;
+			granularityLadder = getCachedGranularityLadder(signature) ?? granularityLadder;
 			hasDerivedGranularityLadder = true;
 		}
 
@@ -913,8 +919,9 @@ function maybeReclusterAfterDrift() {
 	// slot currently holds — another leaf's partitions, if it owns the slot.
 	// The swap archives that graph first, then hands us an empty map keyed to
 	// ours (or this graph's own archived entry, if it has been seen before).
-	swapActiveGraphCache(graphTopologySignature(graphData));
-	topicCaches.leiden.clear();
+	const signature = graphTopologySignature(graphData);
+	swapActiveGraphCache(signature);
+	clearCachedPartitions(signature);
 	topicHierarchy = null;
 	void runLeidenSegmentation();
 }
@@ -1330,10 +1337,15 @@ function currentPartitionKey(): string {
 
 async function runLeidenSegmentation() {
 	const localBuildVersion = buildVersion;
-	// Another graph leaf (a split or duplicated tab showing a different filter or
-	// immersion) may have re-keyed the shared active cache slot since this leaf
-	// last touched it. Re-assert our own graph before reading partitions from it.
-	ensureActiveGraphCache(graphTopologySignature(graphData));
+	// The graph this run describes, captured before any await. A live vault patch
+	// changes the node set without bumping buildVersion or the partition key, so
+	// neither of those guards would notice — the result would be applied over,
+	// and cached against, a graph it was never computed for. It also addresses
+	// every cache access below, so another leaf owning the shared active slot
+	// cannot divert them.
+	const runSignature = graphTopologySignature(graphData);
+	// Re-assert our own graph in the active slot before reading from it.
+	ensureActiveGraphCache(runSignature);
 	const topicEdges = getTopicEdges();
 	if (topicEdges.length === 0) {
 		// Link-only mode on a vault with no links at all: clear stale communities so
@@ -1346,7 +1358,7 @@ async function runLeidenSegmentation() {
 	}
 
 	const cacheKey = currentPartitionKey();
-	const cached = topicCaches.leiden.get(cacheKey);
+	const cached = getCachedPartition(runSignature, cacheKey);
 	if (cached) {
 		Logger.info(`[SmartGraph] Leiden cache hit (γ=${settings.leidenResolution.toFixed(2)})`);
 		leidenCommunities = cached;
@@ -1362,11 +1374,6 @@ async function runLeidenSegmentation() {
 	const sources = topicEdges.map((e) => e.source);
 	const targets = topicEdges.map((e) => e.target);
 	const weights = topicEdges.map(leidenWeight);
-	// The graph this run describes. A live vault patch changes the node set
-	// without bumping buildVersion or the partition key, so neither of those
-	// guards would notice — the result would be applied over, and cached
-	// against, a graph it was never computed for.
-	const runSignature = graphTopologySignature(graphData);
 	const start = performance.now();
 	isLeidenRunning = true;
 	let result: Awaited<ReturnType<typeof leidenAsync>>;
@@ -1594,8 +1601,9 @@ async function handleSeedChange() {
 	// Claim the slot for this graph before clearing it: with a second graph leaf
 	// open, the active map may be that leaf's, and its partitions are still
 	// valid under the seed *it* is using.
-	ensureActiveGraphCache(graphTopologySignature(graphData));
-	topicCaches.leiden.clear();
+	const signature = graphTopologySignature(graphData);
+	ensureActiveGraphCache(signature);
+	clearCachedPartitions(signature);
 	hasDerivedGranularityLadder = false;
 	await runLeidenSegmentation();
 }
@@ -1813,7 +1821,7 @@ async function runTopicLabeling() {
 	try {
 		const labels = await labelTopics(topics, settings.graphChatModel, {
 			signal: controller.signal,
-			cache: topicCaches.topicLabels,
+			cache: getTopicLabelCache(),
 		});
 		// A rebuild (or unmount) landed while we were waiting — these labels are
 		// keyed to topic ids that may no longer mean the same thing.
@@ -1980,7 +1988,7 @@ function handleGranularityChange(level: number) {
 	const resolution = granularityToResolution(level, granularityLadder);
 	if (resolution === settings.leidenResolution) return;
 
-	const cached = topicCaches.leiden.get(partitionKey(resolution));
+	const cached = getCachedPartition(graphTopologySignature(graphData), partitionKey(resolution));
 	if (!cached) return;
 
 	handleSettingsChange({ leidenResolution: resolution });

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -50,6 +50,7 @@ import {
 	getCachedSemanticEdges,
 	loadPersistedTopicCaches,
 	scheduleTopicCacheSave,
+	setActiveGraphResolution,
 	setCachedSemanticEdges,
 	swapActiveGraphCache,
 	topicCaches,
@@ -551,7 +552,9 @@ async function buildGraph() {
 			// when that graph comes back (immerse exit, a filter round-trip), so
 			// those transitions re-apply topics from cache instead of re-running
 			// Leiden, the ladder probes and labeling from scratch.
-			const restored = swapActiveGraphCache(signature);
+			// Pass the γ on screen so it's recorded against the *outgoing* graph
+			// before the slot re-keys.
+			const restored = swapActiveGraphCache(signature, settings.leidenResolution);
 			// Whichever way the swap went, the archive layout changed on disk.
 			scheduleTopicCacheSave();
 			// A fresh (or restored) segmentation replaces every incremental
@@ -567,6 +570,16 @@ async function buildGraph() {
 				granularityLadder = [...GRANULARITY_LEVEL_RESOLUTIONS];
 				// The ladder describes another graph; hide the slider until it's re-derived.
 				hasDerivedGranularityLadder = false;
+			}
+			// Granularity is per-graph: dialling the topics finer while immersed
+			// describes the subset, not the vault. Restore this graph's own γ so
+			// returning to it re-segments the way the user left it rather than
+			// inheriting the granularity set on the graph in between.
+			if (topicCaches.resolution != null && topicCaches.resolution !== settings.leidenResolution) {
+				data.smartGraphSettings = { ...settings, leidenResolution: topicCaches.resolution };
+				// Topic ids are positions in a fresh partition, so anything holding
+				// an id (folds, focus, selection) refers to a different grouping now.
+				clearTopicIndexedState();
 			}
 		} else if (topicCaches.granularityLadder) {
 			// A fresh view instance starts on the fallback ladder even though this
@@ -1019,6 +1032,11 @@ function handleSettingsChange(partial: Partial<SmartGraphSettings>) {
 	const previousKey = currentPartitionKey();
 	data.smartGraphSettings = { ...settings, ...partial };
 	if (currentPartitionKey() !== previousKey) clearTopicIndexedState();
+	// Remember the granularity against *this* graph, so switching away and back
+	// (immerse, filters) restores it rather than the last γ set anywhere. Every
+	// path that changes γ — slider drag, commit, arrow keys, dev panel — routes
+	// through here.
+	if (partial.leidenResolution !== undefined) setActiveGraphResolution(partial.leidenResolution);
 }
 
 function handleFolderFilterChange(folders: string[]) {

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -53,6 +53,7 @@ import {
 	loadPersistedTopicCaches,
 	scheduleTopicCacheSave,
 	setActiveGraphResolution,
+	setCachedGranularityLadder,
 	setCachedPartition,
 	setCachedSemanticEdges,
 	swapActiveGraphCache,
@@ -1472,6 +1473,15 @@ async function deriveGranularityLevels(topicEdges: GraphEdge[]) {
 			void deriveGranularityLevels(getTopicEdges());
 			return;
 		}
+		// A live patch changed the graph under the sweep (no rebuild, so
+		// buildVersion didn't move). The rungs describe a topology that is no
+		// longer on screen; re-probe rather than publishing them.
+		if (graphTopologySignature(graphData) !== runSignature) {
+			Logger.info("[SmartGraph] Re-probing the granularity ladder: the graph changed mid-derivation");
+			isDerivingGranularityLadder = false;
+			void deriveGranularityLevels(getTopicEdges());
+			return;
+		}
 
 		const ladder = deriveGranularityLadder(probes);
 		if (ladder) {
@@ -1487,8 +1497,11 @@ async function deriveGranularityLevels(topicEdges: GraphEdge[]) {
 		hasDerivedGranularityLadder = true;
 		// Remember the outcome for this graph, so reopening the view restores the
 		// ladder instead of re-probing. The probes also filled the Leiden cache,
-		// so this save persists every rung at once.
-		topicCaches.granularityLadder = granularityLadder;
+		// so this save persists every rung at once. Addressed by signature: the
+		// sweep awaits a Leiden run per rung, so another leaf may hold the active
+		// slot by now, and an unaddressed write would hand *its* slider levels
+		// derived from this topology.
+		setCachedGranularityLadder(runSignature, granularityLadder);
 		scheduleTopicCacheSave();
 	} finally {
 		isDerivingGranularityLadder = false;

--- a/src/components/graph/pixiRenderer.ts
+++ b/src/components/graph/pixiRenderer.ts
@@ -20,6 +20,7 @@ import {
 	type PointData,
 } from "pixi.js";
 import { Viewport } from "pixi-viewport";
+import { edgeAlphaZoomLift, nodeDrawRadius, zoomNodeScale } from "../../utils/graphUtils";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -622,6 +623,8 @@ export class PixiRenderer {
 			color?: string;
 			degree?: number;
 			highlighted?: boolean;
+			/** "topic" for a collapsed topic node — sized on its own curve. */
+			kind?: string;
 		}>,
 		nodeSize: number,
 		opts: {
@@ -632,6 +635,11 @@ export class PixiRenderer {
 			isForceMode: boolean;
 			hoverAlphas: Map<string, number>;
 			nodeClusterMap: Map<string, number | undefined>;
+			/**
+			 * Per-node radius multiplier for spawn animations (grow-in on
+			 * collapse/expand and live additions). Absent or 1 = full size.
+			 */
+			spawnScales?: Map<string, number> | null;
 		},
 	): void {
 		const nodeIds = new Set(nodes.map((n) => n.id));
@@ -672,9 +680,12 @@ export class PixiRenderer {
 			}
 
 			const alpha = opts.hoverAlphas.get(node.id) ?? 0.85;
-			const base = Math.max(1, nodeSize);
-			const degree = node.degree ?? 0;
-			const radius = base + Math.min(Math.log1p(degree) * 2.5, base * 5);
+			const spawnScale = opts.spawnScales?.get(node.id) ?? 1;
+			// Shared formula — must agree with GraphCanvas's getNodeRadius or hover
+			// targets drift off the drawn circles. The zoom counter-scale keeps
+			// nodes visible when the camera is far out (GraphCanvas applies the
+			// same factor to hit-testing and label anchoring).
+			const radius = nodeDrawRadius(node, nodeSize) * spawnScale * zoomNodeScale(scale);
 			const rawFill = node.highlighted ? c.accent : (node.color ?? c.graphNode);
 			// Resolve hsl()/calc() colors to hex so Pixi.js can parse them
 			const resolvedFillColor = rawFill.startsWith("#") ? rawFill : resolveColor(rawFill, c.graphNode);
@@ -814,6 +825,12 @@ export class PixiRenderer {
 			target: { id: string; x: number; y: number; kind?: string };
 			type: string;
 			weight?: number;
+			/**
+			 * True when this edge appeared in the latest data change. Only new
+			 * edges take the fade-in (`edgeFadeAlpha`) — fading the whole graph on
+			 * every change made a one-topic fold flash every edge on screen.
+			 */
+			isNew?: boolean;
 		}>,
 		opts: {
 			showWikiLinks: boolean;
@@ -857,6 +874,10 @@ export class PixiRenderer {
 		// Dashed segments can't share the batched line buckets (each needs its own
 		// sub-path walk), so they collect separately and draw underneath.
 		const semanticLineBuckets = new Map<string, Array<{ sx: number; sy: number; tx: number; ty: number }>>();
+
+		// Loop-invariant: the base alpha is tuned for the overview, lifted as the
+		// camera zooms in (where few edges are on screen to crowd each other).
+		const safeBaseEdgeAlpha = clampUnitInterval(opts.baseEdgeAlpha * edgeAlphaZoomLift(scale), 0.25);
 
 		// Batch edges by style bucket to minimize draw calls.
 		// Key: "color|width|alpha" → list of segments
@@ -920,8 +941,9 @@ export class PixiRenderer {
 						0.85,
 					)
 				: 1;
-			const safeBaseEdgeAlpha = clampUnitInterval(opts.baseEdgeAlpha, 0.25);
-			const safeEdgeFadeAlpha = clampUnitInterval(opts.edgeFadeAlpha, 1);
+			// Pre-existing edges stay at full opacity through a data change; only
+			// edges born in it fade in, so the eye is drawn to what changed.
+			const safeEdgeFadeAlpha = edge.isNew ? clampUnitInterval(opts.edgeFadeAlpha, 1) : 1;
 
 			const rawAlpha =
 				(!inFocus ? 0.05 : !inSelection ? 0.05 : isHighlighted ? 0.9 : safeBaseEdgeAlpha) *

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -227,7 +227,7 @@ export const DEFAULT_SMART_GRAPH_SETTINGS: SmartGraphSettings = {
 	chargeStrength: -120,
 	centerStrength: 0.07,
 	linkStrength: 1,
-	clusterCohesionStrength: 0.55,
+	clusterCohesionStrength: 0.45,
 	showWikiLinks: true,
 	showSemanticLinks: true,
 	linkOnlyTopics: false,

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -225,7 +225,7 @@ export const DEFAULT_SMART_GRAPH_SETTINGS: SmartGraphSettings = {
 	// mild repulsion and strong cluster cohesion keep topics as compact blobs.
 	linkDistance: 60,
 	chargeStrength: -120,
-	centerStrength: 0.05,
+	centerStrength: 0.07,
 	linkStrength: 1,
 	clusterCohesionStrength: 0.55,
 	showWikiLinks: true,

--- a/src/utils/graphAnimation.ts
+++ b/src/utils/graphAnimation.ts
@@ -66,6 +66,63 @@ export function computeNodeBounds<T extends { x?: number | null; y?: number | nu
 	return count > 0 ? { minX, minY, maxX, maxY } : null;
 }
 
+/** Fraction of nodes excluded from each end of each axis by {@link computeCoreNodeBounds}. */
+const CORE_BOUNDS_TRIM_FRACTION = 0.06;
+/** Never trim so much that the result stops describing the graph. */
+const CORE_BOUNDS_MAX_TRIM_FRACTION = 0.2;
+
+/**
+ * Bounding box of the graph's *core*, ignoring the most extreme outliers.
+ *
+ * **Not** used for camera framing: an explicit "fit to view" must show every
+ * node, and framing a trimmed core strands the excluded ones off-screen, which
+ * reads as a broken fit. Keeping strays from dominating the frame is the
+ * layout's job (satellite centering, sparse spread), not the camera's.
+ *
+ * This exists for *measurement* — the layout benchmark's `fill`/`waste`
+ * metrics compare the honest full frame against the area the graph's core
+ * actually occupies, which is how "a knot marooned in white space" gets
+ * quantified rather than eyeballed.
+ *
+ * Trims by rank rather than distance so the result is stable regardless of how
+ * far a stray drifted, and always keeps at least one node per end so small
+ * graphs (where a single satellite is a large share of the population) are
+ * trimmed too — a proportional-only trim rounds to zero there, which is
+ * exactly the case that motivated this.
+ *
+ * Falls back to the full bounds when the graph is too small to trim
+ * meaningfully.
+ */
+export function computeCoreNodeBounds<T extends { x?: number | null; y?: number | null }>(
+	nodes: ReadonlyArray<T>,
+	filter?: (node: T) => boolean,
+): BoundingBox | null {
+	const xs: number[] = [];
+	const ys: number[] = [];
+	for (const node of nodes) {
+		if (node.x != null && node.y != null && (!filter || filter(node))) {
+			xs.push(node.x);
+			ys.push(node.y);
+		}
+	}
+	if (xs.length === 0) return null;
+	// Below ~8 nodes every node is a meaningful share of the picture.
+	if (xs.length < 8) return computeNodeBounds(nodes, filter);
+
+	const maxTrim = Math.floor((xs.length * CORE_BOUNDS_MAX_TRIM_FRACTION) / 2);
+	const trim = Math.min(Math.max(1, Math.round(xs.length * CORE_BOUNDS_TRIM_FRACTION)), maxTrim);
+	if (trim < 1) return computeNodeBounds(nodes, filter);
+
+	xs.sort((a, b) => a - b);
+	ys.sort((a, b) => a - b);
+	return {
+		minX: xs[trim],
+		maxX: xs[xs.length - 1 - trim],
+		minY: ys[trim],
+		maxY: ys[ys.length - 1 - trim],
+	};
+}
+
 /**
  * Calculate the target camera transform that frames a bounding box
  * within a viewport of the given width and height.
@@ -75,6 +132,19 @@ export function computeNodeBounds<T extends { x?: number | null; y?: number | nu
  * @param padding  Pixel padding around the edges.
  * @param maxScale Maximum allowed zoom level (default 4).
  */
+/**
+ * Zoom ceiling for framing the *whole* graph.
+ *
+ * Without a cap, fitting a tiny vault (or a collapsed view) magnifies a
+ * handful of nodes to fill the viewport — giant discs with giant labels. A
+ * small graph should sit comfortably at near-natural scale with room around
+ * it instead. Selection zooms deliberately ignore this: zooming *to* a few
+ * chosen notes is exactly when high magnification is wanted.
+ *
+ * Shared with the layout benchmark so measured `fit`/`nodePx` match the app.
+ */
+export const GRAPH_FIT_MAX_SCALE = 1.3;
+
 export function framingTransform(
 	bounds: BoundingBox,
 	viewport: { width: number; height: number },

--- a/src/utils/graphAnimation.ts
+++ b/src/utils/graphAnimation.ts
@@ -74,15 +74,15 @@ const CORE_BOUNDS_MAX_TRIM_FRACTION = 0.2;
 /**
  * Bounding box of the graph's *core*, ignoring the most extreme outliers.
  *
- * **Not** used for camera framing: an explicit "fit to view" must show every
- * node, and framing a trimmed core strands the excluded ones off-screen, which
- * reads as a broken fit. Keeping strays from dominating the frame is the
- * layout's job (satellite centering, sparse spread), not the camera's.
+ * Used for the framing *centre* and for measurement, never for the zoom:
+ * framing a trimmed core strands the excluded nodes off-screen, which reads as
+ * a broken fit. Splitting the two decisions is what lets a lopsided ring of
+ * unsorted notes stop shoving the main graph off-centre while every node stays
+ * visible — see {@link framingTransform}'s `centreBounds`.
  *
- * This exists for *measurement* — the layout benchmark's `fill`/`waste`
- * metrics compare the honest full frame against the area the graph's core
- * actually occupies, which is how "a knot marooned in white space" gets
- * quantified rather than eyeballed.
+ * Also backs the layout benchmark's `fill`/`waste` metrics, which compare the
+ * honest full frame against the area the graph's core actually occupies —
+ * how "a knot marooned in white space" gets quantified rather than eyeballed.
  *
  * Trims by rank rather than distance so the result is stable regardless of how
  * far a stray drifted, and always keeps at least one node per end so small
@@ -124,15 +124,6 @@ export function computeCoreNodeBounds<T extends { x?: number | null; y?: number 
 }
 
 /**
- * Calculate the target camera transform that frames a bounding box
- * within a viewport of the given width and height.
- *
- * @param bounds   The bounding box to frame.
- * @param viewport The viewport dimensions `{ width, height }`.
- * @param padding  Pixel padding around the edges.
- * @param maxScale Maximum allowed zoom level (default 4).
- */
-/**
  * Zoom ceiling for framing the *whole* graph.
  *
  * Without a cap, fitting a tiny vault (or a collapsed view) magnifies a
@@ -145,11 +136,61 @@ export function computeCoreNodeBounds<T extends { x?: number | null; y?: number 
  */
 export const GRAPH_FIT_MAX_SCALE = 1.3;
 
+/**
+ * The world point a framing settles on, plus its scale — what the renderer's
+ * `animateToFrame`/`snapToFrame` take. Callers should use this rather than
+ * averaging a bounding box themselves, or they lose the outlier-aware centring
+ * and its clamp.
+ */
+export interface FramingFocus {
+	centerX: number;
+	centerY: number;
+	scale: number;
+}
+
+/** {@link framingTransform}'s centre and scale, for the renderer's frame API. */
+export function framingFocus(
+	bounds: BoundingBox,
+	viewport: { width: number; height: number },
+	padding: number | FramingPadding = 40,
+	maxScale = 4,
+	centreBounds?: BoundingBox | null,
+): FramingFocus {
+	const insets = normalizeFramingPadding(padding);
+	const usableWidth = Math.max(1, viewport.width - insets.left - insets.right);
+	const usableHeight = Math.max(1, viewport.height - insets.top - insets.bottom);
+	const transform = framingTransform(bounds, viewport, padding, maxScale, centreBounds);
+	// Invert the transform to recover the world point at the viewport's centre.
+	return {
+		centerX: (insets.left + usableWidth / 2 - transform.x) / transform.scale,
+		centerY: (insets.top + usableHeight / 2 - transform.y) / transform.scale,
+		scale: transform.scale,
+	};
+}
+
+/**
+ * Calculate the target camera transform that frames a bounding box
+ * within a viewport of the given width and height.
+ *
+ * @param bounds   The bounding box to frame — every node in it stays visible.
+ * @param viewport The viewport dimensions `{ width, height }`.
+ * @param padding  Pixel padding around the edges.
+ * @param maxScale Maximum allowed zoom level (default 4).
+ * @param centreBounds
+ *   Optional box to centre on instead of `bounds`. Framing is really two
+ *   decisions — where to look and how far out — and only the first should
+ *   care about outliers. Unsorted notes settle in a lopsided ring, so
+ *   centring on the *full* box shoves the main graph off to one side; centring
+ *   on the core puts it back in the middle. The centre is then clamped so
+ *   `bounds` still fits, which keeps the zoom's promise that nothing is
+ *   stranded off-screen.
+ */
 export function framingTransform(
 	bounds: BoundingBox,
 	viewport: { width: number; height: number },
 	padding: number | FramingPadding = 40,
 	maxScale = 4,
+	centreBounds?: BoundingBox | null,
 ): Transform {
 	const insets = normalizeFramingPadding(padding);
 	const graphWidth = bounds.maxX - bounds.minX || 1;
@@ -161,8 +202,32 @@ export function framingTransform(
 	const scaleY = usableHeight / graphHeight;
 	const scale = Math.min(scaleX, scaleY, maxScale);
 
-	const centerX = (bounds.minX + bounds.maxX) / 2;
-	const centerY = (bounds.minY + bounds.maxY) / 2;
+	const focus = centreBounds ?? bounds;
+	let centerX = (focus.minX + focus.maxX) / 2;
+	let centerY = (focus.minY + focus.maxY) / 2;
+
+	// Keep every node in `bounds` on screen: the centre may only move as far as
+	// the slack between what the viewport shows at this scale and the full
+	// extent. When the graph exactly fills the view there is no slack and the
+	// centre stays put; when the zoom cap left room to spare, the core can
+	// shift into the middle of it.
+	const halfViewWidth = usableWidth / (2 * scale);
+	const halfViewHeight = usableHeight / (2 * scale);
+	const minCenterX = bounds.maxX - halfViewWidth;
+	const maxCenterX = bounds.minX + halfViewWidth;
+	const minCenterY = bounds.maxY - halfViewHeight;
+	const maxCenterY = bounds.minY + halfViewHeight;
+	// When the extent exceeds the view the bounds invert; fall back to the
+	// full box's centre rather than picking an arbitrary edge.
+	centerX =
+		minCenterX <= maxCenterX
+			? Math.min(Math.max(centerX, minCenterX), maxCenterX)
+			: (bounds.minX + bounds.maxX) / 2;
+	centerY =
+		minCenterY <= maxCenterY
+			? Math.min(Math.max(centerY, minCenterY), maxCenterY)
+			: (bounds.minY + bounds.maxY) / 2;
+
 	const viewportCenterX = insets.left + usableWidth / 2;
 	const viewportCenterY = insets.top + usableHeight / 2;
 

--- a/src/utils/graphLayout.ts
+++ b/src/utils/graphLayout.ts
@@ -1,0 +1,333 @@
+/**
+ * Graph Layout Physics
+ *
+ * The force assembly behind the smart graph's d3-force simulation, extracted
+ * from the canvas so the *identical* physics can run headlessly — the layout
+ * benchmark (`scripts/graph-layout-bench.ts`) measures the same forces the
+ * user sees, not a reimplementation that could drift.
+ *
+ * {@link applyLayoutForces} is idempotent: it (re)creates every force from the
+ * given config, so the canvas uses it both for initial setup and for
+ * hot-applying slider changes. The density profile is applied *inside* —
+ * callers pass raw baseline values plus the visible-node count, which makes it
+ * impossible for a caller to forget the density scaling.
+ *
+ * Free of Svelte and Pixi; depends only on d3-force and the pure tuning
+ * functions in graphUtils.
+ */
+
+import {
+	forceCollide,
+	forceLink,
+	forceManyBody,
+	forceSimulation,
+	forceX,
+	forceY,
+	type Simulation,
+	type SimulationLinkDatum,
+	type SimulationNodeDatum,
+} from "d3-force";
+import { densityForceProfile, nodeDrawRadius } from "./graphUtils";
+
+/** The node shape the physics needs — a structural subset of the canvas's SimNode. */
+export interface LayoutNode extends SimulationNodeDatum {
+	id: string;
+	degree?: number;
+	kind?: string;
+	cluster?: number;
+}
+
+/** The link shape the physics needs — a structural subset of the canvas's SimLink. */
+export interface LayoutLink<N extends LayoutNode = LayoutNode> extends SimulationLinkDatum<N> {
+	weight: number;
+	type: string;
+}
+
+/** Raw (pre-density) physics parameters — the user's slider values. */
+export interface LayoutPhysicsConfig {
+	linkDistance: number;
+	chargeStrength: number;
+	centerStrength: number;
+	linkStrength: number;
+	clusterCohesionStrength: number;
+	/** Auto-tuned base node radius (drives collide spacing). */
+	nodeSize: number;
+	/** Visible node count — drives the density force profile. */
+	visibleNodeCount: number;
+}
+
+/**
+ * Distance below which charge repulsion stops growing (d3 `distanceMin`).
+ *
+ * Guards against the 1/d² singularity when nodes start stacked, but it also
+ * sets how much short-range "breathing room" charge can create: with the old
+ * value of 30 — half a link length — repulsion was capped across exactly the
+ * range where neighbouring notes sit, so intra-cluster spacing collapsed onto
+ * the collide floor (benchmark `breathe` ≈ 1.0 at every density ≥ 120 nodes).
+ */
+const CHARGE_DISTANCE_MIN = 12;
+
+/** How much each doubling of an edge's weight increases its pull. */
+const WEIGHT_PULL_SCALE = 0.35;
+/** Ceiling on weight-based pull, so one dominant pair can't collapse together. */
+const WEIGHT_PULL_MAX = 3;
+
+/**
+ * Coupling ratio (pair weight ÷ the graph's median topic-link weight) at which
+ * a topic pair reaches its shortest rest length. Above this the distance stops
+ * shrinking, so one dominant pair can't drag two topics on top of each other.
+ */
+const WEIGHT_DISTANCE_REL_SATURATION = 6;
+/** Shortest a topic link may become, as a fraction of the normal link distance. */
+const MIN_TOPIC_LINK_DISTANCE_FACTOR = 0.45;
+
+/**
+ * Minimum surface-to-surface gap a topic link's rest length preserves.
+ *
+ * Rest length is measured between *centers*, but coupling is about surfaces:
+ * without this floor, a heavily-crossed pair of large topics gets a rest
+ * length shorter than the sum of their radii — the spring literally asks the
+ * discs to overlap, the pair sits collide-bound, and the collapsed view's
+ * breathing room pins at 1.0 regardless of every other force.
+ */
+const TOPIC_SURFACE_GAP = 8;
+
+/**
+ * Extra pull applied to an edge based on its weight.
+ *
+ * Only collapsed topic-to-topic edges use this. Their weight is a *count* of how
+ * many note-level links cross between two topics, so without it a pair joined by
+ * 200 links sits exactly as far apart as one joined by 3 — the edge would encode
+ * coupling without the layout ever showing it.
+ *
+ * Log-scaled and clamped: crossing counts are heavy-tailed, so a linear mapping
+ * would let one dominant pair collapse onto each other while everything else
+ * drifted apart. Note-level edges are left alone — their weights are cosine
+ * scores and small link counts that already behave.
+ */
+export function weightPull(link: LayoutLink): number {
+	const source = link.source as LayoutNode;
+	const target = link.target as LayoutNode;
+	if (source?.kind !== "topic" && target?.kind !== "topic") return 1;
+
+	const weight = Math.max(1, link.weight);
+	return Math.min(WEIGHT_PULL_MAX, 1 + Math.log2(weight) * WEIGHT_PULL_SCALE);
+}
+
+/**
+ * Rest length for a link, shortened for heavily-crossed topic pairs.
+ *
+ * Strength alone cannot express coupling: in d3-force every link is a spring
+ * with a rest length and a stiffness, and stiffness only changes how *fast* a
+ * pair converges — not where it settles. With one fixed distance, two topics
+ * joined by 200 links come to rest exactly as far apart as two joined by 3.
+ * Shortening the spring is what actually pulls coupled topics together.
+ *
+ * The shortening is *relative* to the graph's own median coupling, not an
+ * absolute crossing count. Absolute counts scale with vault size: on a small
+ * collapsed view nearly every pair blew past a fixed saturation, so all
+ * springs shrank in unison and the whole ring compressed — uniform shrinkage
+ * conveys no coupling structure at all. Measured against the median, the
+ * typical pair keeps a moderate length and only genuinely-above-average
+ * coupling pulls tighter, at every vault size.
+ *
+ * The median is computed lazily on first call, because the endpoints are only
+ * resolved to node objects (with their `kind`) once the link force
+ * initializes — before that, callers may hold string ids.
+ */
+export function makeWeightedLinkDistance(
+	effectiveLinkDistance: number,
+	nodeSize: number,
+	links: readonly LayoutLink[],
+): (link: LayoutLink) => number {
+	const isTopicLink = (link: LayoutLink) =>
+		(link.source as LayoutNode)?.kind === "topic" || (link.target as LayoutNode)?.kind === "topic";
+
+	let medianTopicWeight: number | null = null;
+	const computeMedianTopicWeight = () => {
+		const weights = links
+			.filter(isTopicLink)
+			.map((link) => Math.max(1, link.weight))
+			.sort((a, b) => a - b);
+		return weights.length > 0 ? weights[Math.floor(weights.length / 2)] : 1;
+	};
+
+	return (link) => {
+		if (!isTopicLink(link)) return effectiveLinkDistance;
+
+		if (medianTopicWeight === null) medianTopicWeight = computeMedianTopicWeight();
+		// Log curve over the coupling *ratio*: the median pair sits partway in,
+		// pairs several times the median reach full shortening.
+		const relative = Math.max(1, link.weight) / medianTopicWeight;
+		const t = Math.min(1, Math.log2(1 + relative) / Math.log2(1 + WEIGHT_DISTANCE_REL_SATURATION));
+		const desired = effectiveLinkDistance * (1 - t * (1 - MIN_TOPIC_LINK_DISTANCE_FACTOR));
+		// Never ask two discs to interpenetrate — floor at touching + a gap.
+		const source = link.source as LayoutNode;
+		const target = link.target as LayoutNode;
+		const surfaceFloor = nodeDrawRadius(source, nodeSize) + nodeDrawRadius(target, nodeSize) + TOPIC_SURFACE_GAP;
+		return Math.max(desired, surfaceFloor);
+	};
+}
+
+function computeClusterCentroids(nodes: LayoutNode[]): Map<number, { x: number; y: number; count: number }> {
+	const sums = new Map<number, { sx: number; sy: number; count: number }>();
+	for (const n of nodes) {
+		if (n.cluster == null) continue;
+		const c = n.cluster;
+		const entry = sums.get(c) ?? { sx: 0, sy: 0, count: 0 };
+		entry.sx += n.x ?? 0;
+		entry.sy += n.y ?? 0;
+		entry.count += 1;
+		sums.set(c, entry);
+	}
+	const centroids = new Map<number, { x: number; y: number; count: number }>();
+	for (const [c, { sx, sy, count }] of sums) {
+		centroids.set(c, { x: sx / count, y: sy / count, count });
+	}
+	return centroids;
+}
+
+/** Cluster size at which the cohesion pull is undamped. */
+const COHESION_REFERENCE_MEMBERS = 40;
+/**
+ * Damping floor, so huge clusters never lose coherence entirely.
+ *
+ * Set by the layout benchmark: at 0.4 the biggest clusters swelled until
+ * neighbouring topics interpenetrated (`gap` < 1.0 on the 8k scenario). This
+ * keeps most of the breathing room the damping buys while holding topics
+ * visually separate.
+ */
+const COHESION_MEMBER_DAMP_FLOOR = 0.55;
+
+/**
+ * Per-cluster damping of the cohesion pull by member count.
+ *
+ * The pull is proportional to a node's distance from its cluster centroid, and
+ * that distance grows ~√members — so at one shared strength, a 900-member
+ * cluster compresses its rim about five times harder than a 40-member one.
+ * That was the benchmark's stuck `breathe` signature: the crushed scenarios
+ * (immersed, large, huge) were exactly the ones with the biggest clusters, at
+ * every graph size. √-damping cancels the geometric growth, so cohesion holds
+ * clusters together without squeezing bigger ones harder.
+ */
+function cohesionMemberDamp(memberCount: number): number {
+	if (memberCount <= COHESION_REFERENCE_MEMBERS) return 1;
+	return Math.max(COHESION_MEMBER_DAMP_FLOOR, Math.sqrt(COHESION_REFERENCE_MEMBERS / memberCount));
+}
+
+/**
+ * Custom d3-force that gently pulls each node toward its cluster's 2D centroid.
+ * The centroid is recomputed every tick so it tracks the moving average.
+ */
+export function clusterCohesionForce(nodes: LayoutNode[], strength: number) {
+	let _strength = strength;
+
+	function force(alpha: number) {
+		// Recompute centroids each tick so they follow the nodes
+		const centroids = computeClusterCentroids(nodes);
+
+		for (const node of nodes) {
+			// Skip pinned nodes
+			if (node.fx != null && node.fy != null) continue;
+
+			// Unclustered nodes feel no cohesion. The previous `?? 0` fallback
+			// silently treated them as members of community 0 — and ids are
+			// size-sorted, so every unsorted note was dragged toward the *largest*
+			// topic, piling up as a crescent on its rim instead of settling where
+			// charge and centering balance.
+			if (node.cluster == null) continue;
+			const centroid = centroids.get(node.cluster);
+			if (!centroid) continue;
+
+			const damp = cohesionMemberDamp(centroid.count);
+			const dx = centroid.x - (node.x ?? 0);
+			const dy = centroid.y - (node.y ?? 0);
+			node.vx = (node.vx ?? 0) + dx * _strength * damp * alpha;
+			node.vy = (node.vy ?? 0) + dy * _strength * damp * alpha;
+		}
+	}
+
+	force.strength = (s?: number) => {
+		if (s === undefined) return _strength;
+		_strength = s;
+		return force;
+	};
+
+	// d3 force interface: initialize is a no-op since we track nodes directly
+	force.initialize = () => {};
+
+	return force;
+}
+
+/**
+ * (Re)install every layout force on the simulation from raw config.
+ *
+ * Idempotent — forces are recreated wholesale, so this serves both initial
+ * setup and hot-applying a changed parameter. Recreating rather than mutating
+ * keeps one code path: d3's per-force initialize is cheap (link bias/count,
+ * collide radii), and it re-reads anything derived from the nodes.
+ */
+export function applyLayoutForces<N extends LayoutNode, L extends LayoutLink<N>>(
+	// `Simulation<N, undefined>` matches what `forceSimulation<N>()` returns —
+	// the link datum only matters on the link force itself, registered below.
+	simulation: Simulation<N, undefined>,
+	nodes: N[],
+	links: L[],
+	config: LayoutPhysicsConfig,
+): void {
+	const profile = densityForceProfile(config.visibleNodeCount);
+	const effectiveLinkDistance = config.linkDistance * profile.spacing;
+	const effectiveCharge = config.chargeStrength * profile.charge;
+	const effectiveCenter = config.centerStrength * profile.center;
+	const effectiveCohesion = config.clusterCohesionStrength * profile.cohesion;
+
+	// The base d3 link strength (1 / max degree of the endpoints) is kept as a
+	// factor so the user's linkStrength acts as a multiplier, matching how
+	// Obsidian's native graph behaves.
+	const linkForce = forceLink<N, L>(links)
+		.id((d) => d.id)
+		.distance(makeWeightedLinkDistance(effectiveLinkDistance, config.nodeSize, links));
+	const defaultLinkStrengthFn = linkForce.strength() as (link: L, i: number, links: L[]) => number;
+	linkForce.strength((l, i, all) => config.linkStrength * defaultLinkStrengthFn(l, i, all) * weightPull(l));
+
+	// Clustered nodes take the density-profiled centering; satellites take
+	// exactly twice it. Centering is the sole inward force an unlinked node
+	// feels, so at the same strength it settles well outside the linked
+	// structure — the doubling stands in for the links it doesn't have. A
+	// *ratio* (rather than an absolute boost or floor, both tried) is what
+	// behaves at every density: an absolute boost out-pulled deeply-relaxed
+	// sparse graphs ~6× and dragged satellites inside the topic ring, while a
+	// floor collapsed to no compensation at all wherever the profile is
+	// neutral, sending them far out again.
+	const satelliteCenter = effectiveCenter * 2;
+	const centerStrengthOf = (node: N) => (node.cluster == null ? satelliteCenter : effectiveCenter);
+
+	simulation
+		.force("link", linkForce)
+		.force("charge", forceManyBody().strength(effectiveCharge).distanceMin(CHARGE_DISTANCE_MIN))
+		// Obsidian uses forceX + forceY for centering (spring toward origin),
+		// NOT forceCenter (which shifts the centroid). This is the key difference.
+		.force("centerX", forceX<N>(0).strength(centerStrengthOf))
+		.force("centerY", forceY<N>(0).strength(centerStrengthOf))
+		.force("cluster", clusterCohesionForce(nodes, effectiveCohesion))
+		.force(
+			"collide",
+			forceCollide<N>().radius((d) => nodeDrawRadius(d, config.nodeSize) + 2),
+		);
+}
+
+/**
+ * Build a simulation with the full production force set, stopped.
+ *
+ * The canvas manages its own alpha/decay/tick lifecycle; headless callers
+ * (the layout benchmark) tick it manually.
+ */
+export function createLayoutSimulation<N extends LayoutNode, L extends LayoutLink<N>>(
+	nodes: N[],
+	links: L[],
+	config: LayoutPhysicsConfig,
+): Simulation<N, undefined> {
+	const simulation = forceSimulation<N>(nodes).stop();
+	applyLayoutForces(simulation, nodes, links, config);
+	return simulation;
+}

--- a/src/utils/graphUtils.ts
+++ b/src/utils/graphUtils.ts
@@ -45,6 +45,16 @@ const TOPIC_RADIUS_HALF_POINT = 18;
  * doubling of connections visible while approaching the ceiling
  * asymptotically instead of hitting it.
  */
+/**
+ * Auto-tuned base node radius from how many notes the graph *represents* —
+ * larger for small vaults, smaller for dense ones, on a continuous log scale.
+ * A collapsed topic counts as its members, not as one node, so folding doesn't
+ * change the sizing regime (see the canvas's representedNoteCount).
+ */
+export function autoNodeSize(representedNoteCount: number): number {
+	return Math.max(2, Math.round(7 - Math.log10(Math.max(representedNoteCount, 10)) * 1.8));
+}
+
 export function nodeDrawRadius(node: { degree?: number; kind?: string }, nodeSize: number): number {
 	const base = Math.max(1, nodeSize);
 	const degree = Math.max(0, node.degree ?? 0);
@@ -59,8 +69,26 @@ export function nodeDrawRadius(node: { degree?: number; kind?: string }, nodeSiz
 const SPREAD_REFERENCE_NODES = 400;
 /** Compaction floor for very large graphs. */
 const SPREAD_FACTOR_MIN = 0.65;
-/** Spread ceiling for very small graphs (immerse, tiny vault, collapse-all). */
-const SPREAD_FACTOR_MAX = 1.7;
+/**
+ * Spread ceiling — reached only by the sparsest graphs via the extra boost
+ * below {@link SPARSE_SPREAD_BOOST_NODES}.
+ */
+const SPREAD_FACTOR_MAX = 4.5;
+
+/**
+ * Below this node count an extra spread boost kicks in on top of the base
+ * ¼-power curve.
+ *
+ * The base curve is sized for note-level graphs; on a collapsed view of a
+ * handful of topics it tops out around 2.5×, which still lays 8 topics out in
+ * ~300 world px — a knot the overview zoom cap then refuses to magnify, so
+ * most of the viewport stays white. The layout has to be bigger in *world*
+ * units: no camera policy can fill a screen with a knot without inflating
+ * nodes into discs. The boost is continuous at the threshold (its factor is
+ * exactly 1 there).
+ */
+const SPARSE_SPREAD_BOOST_NODES = 60;
+const SPARSE_SPREAD_BOOST_EXPONENT = 0.35;
 
 /**
  * Base spread multiplier from how many nodes are on screen — the raw signal
@@ -77,9 +105,21 @@ const SPREAD_FACTOR_MAX = 1.7;
  */
 export function densitySpreadFactor(visibleNodeCount: number): number {
 	const count = Math.max(1, visibleNodeCount);
-	const factor = (SPREAD_REFERENCE_NODES / count) ** 0.25;
+	let factor = (SPREAD_REFERENCE_NODES / count) ** 0.25;
+	if (count < SPARSE_SPREAD_BOOST_NODES) {
+		factor *= (SPARSE_SPREAD_BOOST_NODES / count) ** SPARSE_SPREAD_BOOST_EXPONENT;
+	}
 	return Math.min(SPREAD_FACTOR_MAX, Math.max(SPREAD_FACTOR_MIN, factor));
 }
+
+/**
+ * Node count below which centering starts easing off, reaching its floor at a
+ * handful of nodes. Sized so a typical collapsed view (a dozen or two topics)
+ * opens up, while anything approaching a real note-level graph is untouched.
+ */
+const SPARSE_CENTER_RELAX_NODES = 60;
+/** How weak the centering may get on the sparsest graphs. */
+const SPARSE_CENTER_RELAX_FLOOR = 0.35;
 
 /** Per-force multipliers derived from the visible-node density. */
 export interface DensityForceProfile {
@@ -103,21 +143,26 @@ export interface DensityForceProfile {
  * act on only one of the scales carry the asymmetry:
  *
  * - **spacing** follows the spread factor directly.
- * - **charge** follows its square root — charge acts on both scales at once
+ * - **charge** follows √spread when spreading and spread^0.35 when
+ *   compacting — charge acts on both scales at once
  *   (it separates notes within a cluster *and* pushes clusters apart), so
  *   scaling it fully squeezed cluster interiors on big graphs and flung
  *   unlinked satellites to the horizon on small ones. Softened, it keeps more
  *   note-to-note breathing room at high density and calmer satellites at low.
  * - **center** strengthens on dense graphs, supra-quadratically in the
- *   compaction (exponent 2.5, capped 2.8×) — it's the only inward force an
+ *   compaction (exponent 2.5, capped 2.2× — the cap was 2.8 until the layout
+ *   benchmark showed the extra pull compressing cluster *interiors* about as
+ *   hard as cohesion itself, right when gaps sat at the tight end of their
+ *   band already) — it's the only inward force an
  *   unlinked node feels, and negligible against local forces inside a
  *   cluster, so it closes inter-cluster gaps without compressing anything.
  *   Steep because the pull must *outpace* the compaction: a linear response
  *   barely engaged before the spread floor bound it, and clusters still
- *   floated far apart. Never weakened below 1× for small graphs, where
- *   satellites already sit far out.
- * - **cohesion** relaxes on dense graphs, faster than spacing (spread^1.5,
- *   floored at 0.45) — it is the intra-cluster crush, and letting clusters
+ *   floated far apart. Below the reference density it relaxes instead
+ *   (floored at 0.55): on a sparse graph centering is what holds the few
+ *   nodes in a knot, and there is no crowding for it to counteract.
+ * - **cohesion** relaxes on dense graphs, faster than spacing (spread^1.8,
+ *   floored at 0.4) — it is the intra-cluster crush, and letting clusters
  *   expand fills the very gaps the center pull is closing. Never strengthened
  *   above 1×.
  *
@@ -126,11 +171,25 @@ export interface DensityForceProfile {
  */
 export function densityForceProfile(visibleNodeCount: number): DensityForceProfile {
 	const spread = densitySpreadFactor(visibleNodeCount);
+	// Node count, not the spread factor, decides which side of the reference
+	// density we are on: `spread` saturates at both clamps, so comparing it
+	// against 1 misclassifies every graph past a clamp.
+	const isSparse = visibleNodeCount < SPREAD_REFERENCE_NODES;
 	return {
 		spacing: spread,
-		charge: Math.sqrt(spread),
-		center: Math.min(2.8, Math.max(1, (1 / spread) ** 2.5)),
-		cohesion: Math.min(1, Math.max(0.45, spread ** 1.5)),
+		// Asymmetric: small graphs keep the stronger √spread (their satellites
+		// and sparse clusters need real repulsion to spread out), dense graphs
+		// get the gentler power (their interiors must not be squeezed as hard
+		// as the global structure compacts).
+		charge: isSparse ? Math.sqrt(spread) : spread ** 0.35,
+		// Very sparse graphs relax the centering: it is the force holding a
+		// handful of nodes in a knot, and there is no crowding for it to
+		// counteract. Only below SPARSE_CENTER_RELAX_NODES, and floored, so a
+		// small graph still reads as one object rather than a scatter.
+		center: isSparse
+			? Math.max(SPARSE_CENTER_RELAX_FLOOR, Math.min(1, visibleNodeCount / SPARSE_CENTER_RELAX_NODES))
+			: Math.min(2.2, (1 / spread) ** 2.5),
+		cohesion: Math.min(1, Math.max(0.4, spread ** 1.8)),
 	};
 }
 

--- a/src/utils/graphUtils.ts
+++ b/src/utils/graphUtils.ts
@@ -16,6 +16,177 @@ export function splitEdgeKey(key: string): [string, string] {
 	return [key.slice(0, separator), key.slice(separator + 1)];
 }
 
+/**
+ * Ceiling (in world px, on top of the base size) that a collapsed topic's
+ * radius approaches asymptotically as its connection count grows.
+ */
+const TOPIC_RADIUS_CEILING = 26;
+/**
+ * √degree at which a topic reaches half the ceiling. Chosen so the everyday
+ * range differentiates most: half size at ~320 crossing links, with real
+ * growth still visible out past a few thousand.
+ */
+const TOPIC_RADIUS_HALF_POINT = 18;
+
+/**
+ * Draw radius for a graph node, from its degree and the auto-tuned base size.
+ *
+ * Size encodes exactly one thing — connectedness — so it stays unambiguous.
+ * The single source of truth shared by the canvas (hit-testing, collision
+ * spacing, label offsets) and the Pixi renderer (sprite/ring radius); the two
+ * must agree or hover targets drift off the drawn circles.
+ *
+ * Notes use a log curve under a hard cap: their degrees are small and
+ * heavy-tailed, and past a point "very connected" is all a size can say.
+ * Collapsed topics get their own curve because their degree is a *crossing
+ * link count* spanning a few to several thousand — under the note formula
+ * everything past ~55 links saturated, so a 180-note and a 2000-note topic
+ * rendered identically. A smooth saturating curve over √degree keeps every
+ * doubling of connections visible while approaching the ceiling
+ * asymptotically instead of hitting it.
+ */
+export function nodeDrawRadius(node: { degree?: number; kind?: string }, nodeSize: number): number {
+	const base = Math.max(1, nodeSize);
+	const degree = Math.max(0, node.degree ?? 0);
+	if (node.kind === "topic") {
+		const spread = Math.sqrt(degree);
+		return base + TOPIC_RADIUS_CEILING * (spread / (spread + TOPIC_RADIUS_HALF_POINT));
+	}
+	return base + Math.min(Math.log1p(degree) * 2.5, base * 5);
+}
+
+/** Visible-node count at which the density spread factor is exactly 1. */
+const SPREAD_REFERENCE_NODES = 400;
+/** Compaction floor for very large graphs. */
+const SPREAD_FACTOR_MIN = 0.65;
+/** Spread ceiling for very small graphs (immerse, tiny vault, collapse-all). */
+const SPREAD_FACTOR_MAX = 1.7;
+
+/**
+ * Base spread multiplier from how many nodes are on screen — the raw signal
+ * behind {@link densityForceProfile}, which maps it onto each force.
+ *
+ * Fit zoom is roughly `viewport / (spacing × √n)`, so with constant spacing a
+ * large graph forces the camera far out (nodes shrink to dust) while a small
+ * one huddles in a blob the camera merely magnifies. Scaling spacing by
+ * `(reference / n)^¼` splits the burden: big graphs compact, small graphs
+ * spread into the room they have — deliberately gentler than the `1/√n` that
+ * would hold fit zoom constant, because {@link zoomNodeScale} carries the
+ * other half by keeping far-out nodes visible. Clamped so the extremes can't
+ * push the tuned force balance into a regime it was never tested in.
+ */
+export function densitySpreadFactor(visibleNodeCount: number): number {
+	const count = Math.max(1, visibleNodeCount);
+	const factor = (SPREAD_REFERENCE_NODES / count) ** 0.25;
+	return Math.min(SPREAD_FACTOR_MAX, Math.max(SPREAD_FACTOR_MIN, factor));
+}
+
+/** Per-force multipliers derived from the visible-node density. */
+export interface DensityForceProfile {
+	/** Link distance — spacing of the connected structure. */
+	spacing: number;
+	/** Charge strength. */
+	charge: number;
+	/** Centering force. */
+	center: number;
+	/** Cluster cohesion. */
+	cohesion: number;
+}
+
+/**
+ * How each layout force scales with graph density.
+ *
+ * One uniform factor compacts everything equally, but the two length scales
+ * want opposite treatment: on a large vault the *between-cluster* gaps should
+ * shrink while the *inside* of each cluster gets room to breathe (a uniform
+ * squeeze produced tight solid blobs floating far apart). So the forces that
+ * act on only one of the scales carry the asymmetry:
+ *
+ * - **spacing** follows the spread factor directly.
+ * - **charge** follows its square root — charge acts on both scales at once
+ *   (it separates notes within a cluster *and* pushes clusters apart), so
+ *   scaling it fully squeezed cluster interiors on big graphs and flung
+ *   unlinked satellites to the horizon on small ones. Softened, it keeps more
+ *   note-to-note breathing room at high density and calmer satellites at low.
+ * - **center** strengthens on dense graphs, supra-quadratically in the
+ *   compaction (exponent 2.5, capped 2.8×) — it's the only inward force an
+ *   unlinked node feels, and negligible against local forces inside a
+ *   cluster, so it closes inter-cluster gaps without compressing anything.
+ *   Steep because the pull must *outpace* the compaction: a linear response
+ *   barely engaged before the spread floor bound it, and clusters still
+ *   floated far apart. Never weakened below 1× for small graphs, where
+ *   satellites already sit far out.
+ * - **cohesion** relaxes on dense graphs, faster than spacing (spread^1.5,
+ *   floored at 0.45) — it is the intra-cluster crush, and letting clusters
+ *   expand fills the very gaps the center pull is closing. Never strengthened
+ *   above 1×.
+ *
+ * All multipliers are exactly 1 at the reference density, so the tuned
+ * defaults are the behaviour at "normal" vault size.
+ */
+export function densityForceProfile(visibleNodeCount: number): DensityForceProfile {
+	const spread = densitySpreadFactor(visibleNodeCount);
+	return {
+		spacing: spread,
+		charge: Math.sqrt(spread),
+		center: Math.min(2.8, Math.max(1, (1 / spread) ** 2.5)),
+		cohesion: Math.min(1, Math.max(0.45, spread ** 1.5)),
+	};
+}
+
+/** How strongly node radii resist the camera zoom (0 = not at all, 1 = fully). */
+const NODE_ZOOM_EXPONENT = 0.28;
+const NODE_ZOOM_SCALE_MIN = 1 / 3;
+const NODE_ZOOM_SCALE_MAX = 4;
+
+/**
+ * Partial counter-zoom for node radii: the drawn radius is multiplied by
+ * `viewportScale^-0.28`, so on screen nodes scale with `zoom^0.72` instead of
+ * linearly. (Higher exponents made nodes visually crowd into each other at
+ * overview zoom, reading as cramped clusters even where the layout had room.)
+ *
+ * Edges and labels already counter-scale fully — nodes were the only element
+ * shrinking 1:1 with zoom-out, which is why a fitted large vault read as
+ * "edges with no nodes". Partial (rather than full) so zoom still conveys
+ * depth: zoomed far out nodes stay visible, zoomed far in they stop
+ * ballooning. Exactly 1 at unit zoom, so the tuned world-space sizes are
+ * unchanged where layout and camera agree. Render/hit-test only — the physics
+ * (collide spacing) must never see a camera-dependent radius.
+ */
+export function zoomNodeScale(viewportScale: number): number {
+	if (!Number.isFinite(viewportScale) || viewportScale <= 0) return 1;
+	const factor = viewportScale ** -NODE_ZOOM_EXPONENT;
+	return Math.min(NODE_ZOOM_SCALE_MAX, Math.max(NODE_ZOOM_SCALE_MIN, factor));
+}
+
+/** Zoom at and below which edges get no lift — the overview, where crowding is real. */
+const EDGE_ALPHA_LIFT_START_SCALE = 1;
+/** Zoom at which the lift is fully applied. */
+const EDGE_ALPHA_LIFT_FULL_SCALE = 4;
+/** Strongest multiplier applied to the base edge alpha when fully zoomed in. */
+const EDGE_ALPHA_LIFT_MAX = 2.6;
+
+/**
+ * Multiplier that makes edges more opaque as the camera zooms in.
+ *
+ * The base alpha is tuned for the *overview* of a dense vault, where thousands
+ * of overlapping edges would otherwise compound into a dark mass — on a large
+ * graph it pins to its floor. But that floor then applied at every zoom level,
+ * so zooming into a handful of nodes left their edges nearly invisible even
+ * though almost none were on screen to crowd each other. Interpolating on
+ * zoom restores them where the crowding it guards against no longer exists.
+ *
+ * Ramps between {@link EDGE_ALPHA_LIFT_START_SCALE} and
+ * {@link EDGE_ALPHA_LIFT_FULL_SCALE}; exactly 1 at or below the start, so the
+ * fitted overview keeps the tuned appearance.
+ */
+export function edgeAlphaZoomLift(viewportScale: number): number {
+	if (!Number.isFinite(viewportScale) || viewportScale <= EDGE_ALPHA_LIFT_START_SCALE) return 1;
+	const span = EDGE_ALPHA_LIFT_FULL_SCALE - EDGE_ALPHA_LIFT_START_SCALE;
+	const t = Math.min(1, (viewportScale - EDGE_ALPHA_LIFT_START_SCALE) / span);
+	return 1 + (EDGE_ALPHA_LIFT_MAX - 1) * t;
+}
+
 function djb2(text: string): number {
 	let hash = 5381;
 	for (let i = 0; i < text.length; i++) {

--- a/src/utils/liveGraphPatch.ts
+++ b/src/utils/liveGraphPatch.ts
@@ -1,0 +1,293 @@
+/**
+ * Live Graph Patching
+ *
+ * Incremental updates for an open smart graph (issue #404). While the graph
+ * view is open, vault changes are folded into the existing `GraphData` in
+ * place instead of rebuilding everything — the expensive derivations (full
+ * semantic scan, Leiden) are replaced by targeted equivalents:
+ *
+ * - {@link applyWikiPatch} swaps in a freshly built wiki structure while
+ *   preserving surviving semantic edges and per-node presentation state.
+ * - {@link queryNoteSemanticEdges} re-queries the live vault index for just
+ *   one note's chunks instead of re-running the batch neighbour search.
+ * - {@link voteNodeCommunity} assigns a note to the community that dominates
+ *   its neighbours (the same vote as the bridge heuristic) instead of
+ *   re-running Leiden.
+ *
+ * Everything here is pure over its inputs (the store interface is injected)
+ * so it unit-tests without Obsidian. The view layer owns event debouncing,
+ * drift counting, and when to fall back to a full Leiden run.
+ */
+
+import type { GraphData, GraphEdge, GraphNode } from "../types/graph";
+import type { DocumentVector, ScoredDocument } from "../vectorstore/types";
+import { edgeKey } from "./graphUtils";
+
+export interface WikiPatchResult {
+	data: GraphData;
+	/** Note paths present in the fresh wiki graph but not in the current one. */
+	addedPaths: string[];
+	/** Note paths that left the graph (deleted, renamed away, filtered out). */
+	removedPaths: string[];
+	/**
+	 * Surviving paths whose incident wiki edges changed — candidates for a
+	 * community re-vote, since their neighbourhood is no longer what Leiden saw.
+	 */
+	touchedPaths: string[];
+	/** False when the fresh wiki structure is identical — callers should no-op. */
+	changed: boolean;
+}
+
+/** Recompute per-node degree over the fused edge set (wiki + semantic). */
+function withRecomputedDegrees(nodes: GraphNode[], edges: GraphEdge[]): GraphNode[] {
+	const degrees = new Map<string, number>();
+	for (const edge of edges) {
+		degrees.set(edge.source, (degrees.get(edge.source) ?? 0) + 1);
+		degrees.set(edge.target, (degrees.get(edge.target) ?? 0) + 1);
+	}
+	return nodes.map((node) => {
+		const degree = degrees.get(node.path) ?? 0;
+		return node.degree === degree ? node : { ...node, degree };
+	});
+}
+
+/**
+ * Fold a freshly built wiki graph into the current (fused) graph data.
+ *
+ * The wiki structure — node set and authored edges — is taken wholesale from
+ * `freshWiki`; it's cheap to build and diffing per-event edge cases (renames,
+ * links resolving against a newly created note) out of vault events would be
+ * far more fragile than rebuilding it. What's preserved from `current` is
+ * everything the wiki rebuild can't produce:
+ *
+ * - semantic edges whose endpoints both survive (a pair the user has since
+ *   linked by hand loses its inferred edge — the authored link supersedes it),
+ * - per-node presentation state (colour, cluster, highlight) so topics don't
+ *   flash away while the incremental re-vote runs.
+ *
+ * Degrees are recomputed over the fused edge set, matching the full build.
+ */
+export function applyWikiPatch(current: GraphData, freshWiki: GraphData): WikiPatchResult {
+	const currentByPath = new Map(current.nodes.map((node) => [node.path, node]));
+	const freshPaths = new Set(freshWiki.nodes.map((node) => node.path));
+	const addedPaths = freshWiki.nodes.filter((node) => !currentByPath.has(node.path)).map((node) => node.path);
+	const removedPaths = current.nodes.filter((node) => !freshPaths.has(node.path)).map((node) => node.path);
+
+	// Diff the wiki edge sets by canonical key + weight, collecting the
+	// endpoints of every difference — those notes' neighbourhoods changed.
+	const currentWikiWeights = new Map<string, number>();
+	for (const edge of current.edges) {
+		if (edge.type === "wiki") currentWikiWeights.set(edgeKey(edge.source, edge.target), edge.weight);
+	}
+	const freshWikiKeys = new Set<string>();
+	const touched = new Set<string>();
+	for (const edge of freshWiki.edges) {
+		const key = edgeKey(edge.source, edge.target);
+		freshWikiKeys.add(key);
+		if (currentWikiWeights.get(key) !== edge.weight) {
+			touched.add(edge.source);
+			touched.add(edge.target);
+		}
+	}
+	for (const edge of current.edges) {
+		if (edge.type !== "wiki") continue;
+		if (!freshWikiKeys.has(edgeKey(edge.source, edge.target))) {
+			touched.add(edge.source);
+			touched.add(edge.target);
+		}
+	}
+
+	const wikiChanged = currentWikiWeights.size !== freshWikiKeys.size || touched.size > 0;
+	if (addedPaths.length === 0 && removedPaths.length === 0 && !wikiChanged) {
+		return { data: current, addedPaths, removedPaths, touchedPaths: [], changed: false };
+	}
+
+	const nodes = freshWiki.nodes.map((node) => {
+		const previous = currentByPath.get(node.path);
+		if (!previous) return node;
+		return {
+			...node,
+			x: previous.x,
+			y: previous.y,
+			color: previous.color,
+			cluster: previous.cluster,
+			highlighted: previous.highlighted,
+		};
+	});
+
+	// A semantic edge survives unless one of its notes left the graph, or the
+	// user has *newly* linked the pair by hand — an authored link is the
+	// stronger statement, and the full build excludes such pairs from the scan.
+	// Only newly-authored links supersede: a pair that already carried both edge
+	// types (the scan excluded pairs against the wiki links existing at scan
+	// time, so later-arriving ones coexist) must keep its inferred edge, or
+	// every patch would silently erode the semantic edge set.
+	const semanticEdges = current.edges.filter((edge) => {
+		if (edge.type !== "semantic") return false;
+		if (!freshPaths.has(edge.source) || !freshPaths.has(edge.target)) return false;
+		const key = edgeKey(edge.source, edge.target);
+		return !freshWikiKeys.has(key) || currentWikiWeights.has(key);
+	});
+	const edges = [...freshWiki.edges, ...semanticEdges];
+
+	// Added/removed nodes get dedicated handling by the caller (vote / cleanup);
+	// only surviving nodes count as "touched".
+	const touchedPaths = [...touched].filter((path) => freshPaths.has(path) && currentByPath.has(path));
+
+	return {
+		data: { nodes: withRecomputedDegrees(nodes, edges), edges },
+		addedPaths,
+		removedPaths,
+		touchedPaths,
+		changed: true,
+	};
+}
+
+/**
+ * Replace the semantic edges incident to a set of notes with freshly queried
+ * ones, leaving every other edge untouched.
+ *
+ * Dropping all incident edges first is deliberate: an edge some *other* note
+ * proposed against this note's old content is exactly as stale as this note's
+ * own proposals. The incremental query can't reproduce foreign proposals (only
+ * a full scan sees them), so the live edge set under-approximates until the
+ * next full rebuild — the documented trade-off of the incremental path.
+ */
+export function replaceSemanticEdgesForPaths(
+	current: GraphData,
+	paths: Set<string>,
+	newEdges: GraphEdge[],
+): { data: GraphData; changed: boolean } {
+	const nodePaths = new Set(current.nodes.map((node) => node.path));
+	const kept: GraphEdge[] = [];
+	const removedWeights = new Map<string, number>();
+	for (const edge of current.edges) {
+		if (edge.type === "semantic" && (paths.has(edge.source) || paths.has(edge.target))) {
+			removedWeights.set(edgeKey(edge.source, edge.target), edge.weight);
+		} else {
+			kept.push(edge);
+		}
+	}
+
+	// Dedupe against surviving *semantic* edges only. A kept wiki edge on the
+	// same pair must not block its semantic edge here: whether an authored link
+	// suppresses an inferred one is decided at query time via `excludeEdgeKeys`,
+	// and blocking on it again would drop edges for every linked pair.
+	const existingKeys = new Set(
+		kept.filter((edge) => edge.type === "semantic").map((edge) => edgeKey(edge.source, edge.target)),
+	);
+	const additions: GraphEdge[] = [];
+	let identicalReplacements = 0;
+	for (const edge of newEdges) {
+		if (edge.source === edge.target) continue;
+		if (!nodePaths.has(edge.source) || !nodePaths.has(edge.target)) continue;
+		const key = edgeKey(edge.source, edge.target);
+		if (existingKeys.has(key)) continue;
+		existingKeys.add(key);
+		additions.push(edge);
+		if (removedWeights.get(key) === edge.weight) identicalReplacements++;
+	}
+
+	const changed = removedWeights.size !== additions.length || identicalReplacements !== additions.length;
+	if (!changed) return { data: current, changed: false };
+
+	const edges = [...kept, ...additions];
+	return { data: { nodes: withRecomputedDegrees(current.nodes, edges), edges }, changed: true };
+}
+
+/**
+ * Assign a note to the community that dominates its neighbours.
+ *
+ * The same vote the bridge heuristic runs, reused as an incremental stand-in
+ * for Leiden: a note's community is overwhelmingly determined by who it
+ * connects to, so summing edge weight per neighbouring community and taking
+ * the maximum lands on Leiden's answer in the common case. Ties break on the
+ * smaller community id so repeated votes are stable.
+ *
+ * Returns `undefined` when no neighbour carries a community — the note stays
+ * unsorted, exactly as Leiden would leave a disconnected node.
+ */
+export function voteNodeCommunity(
+	path: string,
+	edges: GraphEdge[],
+	communities: Record<string, number>,
+	weightOf: (edge: GraphEdge) => number,
+): number | undefined {
+	const votes = new Map<number, number>();
+	for (const edge of edges) {
+		const other = edge.source === path ? edge.target : edge.target === path ? edge.source : null;
+		if (other === null) continue;
+		const community = communities[other];
+		if (community === undefined) continue;
+		votes.set(community, (votes.get(community) ?? 0) + weightOf(edge));
+	}
+
+	let best: number | undefined;
+	let bestWeight = Number.NEGATIVE_INFINITY;
+	for (const [community, weight] of votes) {
+		if (weight > bestWeight || (weight === bestWeight && best !== undefined && community < best)) {
+			best = community;
+			bestWeight = weight;
+		}
+	}
+	return best;
+}
+
+/** The slice of the vector store the incremental semantic query needs. */
+export interface SemanticQueryStore {
+	getAllByPath(path: string): Promise<DocumentVector[]>;
+	search(queryVector: Float32Array, topK: number, threshold?: number): Promise<ScoredDocument[]>;
+}
+
+export interface NoteSemanticQueryOptions {
+	/** Max semantic neighbours this note may propose. */
+	neighborCount: number;
+	/** Minimum cosine similarity for an edge to be emitted. */
+	threshold: number;
+	/** Edge keys (from `edgeKey`) that exist as wiki links and must not be duplicated. */
+	excludeEdgeKeys?: Set<string>;
+}
+
+/**
+ * Semantic edges for a single note, queried against the live vault index.
+ *
+ * The batch scan ({@link buildSemanticEdges}) rebuilds a transient index over
+ * every on-screen chunk; for one changed note that's all waste. Instead each
+ * of the note's chunks queries the store's existing HNSW index and the best
+ * hit per neighbouring note wins — the same best-chunk semantics as the batch
+ * kernels. The live index also contains notes outside the current graph, so
+ * hits are filtered to `includePaths` and the per-chunk fetch over-fetches to
+ * compensate (own chunks, duplicate chunks of one neighbour, and off-screen
+ * notes all occupy raw result slots).
+ */
+export async function queryNoteSemanticEdges(
+	store: SemanticQueryStore,
+	path: string,
+	includePaths: Set<string>,
+	options: NoteSemanticQueryOptions,
+): Promise<GraphEdge[]> {
+	const { neighborCount, threshold } = options;
+	if (neighborCount <= 0) return [];
+
+	const chunks = await store.getAllByPath(path);
+	if (chunks.length === 0) return [];
+
+	const topK = neighborCount * 3 + chunks.length;
+	const bestByNeighbor = new Map<string, number>();
+	for (const chunk of chunks) {
+		const hits = await store.search(chunk.vector, topK, threshold);
+		for (const hit of hits) {
+			const neighbor = hit.doc.path;
+			if (neighbor === path || !includePaths.has(neighbor)) continue;
+			if (options.excludeEdgeKeys?.has(edgeKey(path, neighbor))) continue;
+			if (!Number.isFinite(hit.score) || hit.score < threshold) continue;
+			const existing = bestByNeighbor.get(neighbor);
+			if (existing === undefined || hit.score > existing) bestByNeighbor.set(neighbor, hit.score);
+		}
+	}
+
+	return [...bestByNeighbor.entries()]
+		.sort((left, right) => right[1] - left[1] || (left[0] < right[0] ? -1 : 1))
+		.slice(0, neighborCount)
+		.map(([target, score]) => ({ source: path, target, weight: score, type: "semantic" as const }));
+}

--- a/src/utils/topicHierarchy.ts
+++ b/src/utils/topicHierarchy.ts
@@ -155,7 +155,7 @@ export const GRANULARITY_PROBE_RESOLUTIONS = [
 ] as const;
 
 /** Never derive a ladder longer than this, however varied the vault. */
-export const MAX_DERIVED_GRANULARITY_LEVELS = 7;
+export const MAX_DERIVED_GRANULARITY_LEVELS = 6;
 
 /**
  * Most topics a granularity level may produce and still be offered.

--- a/src/utils/topicHierarchy.ts
+++ b/src/utils/topicHierarchy.ts
@@ -155,7 +155,28 @@ export const GRANULARITY_PROBE_RESOLUTIONS = [
 ] as const;
 
 /** Never derive a ladder longer than this, however varied the vault. */
-export const MAX_DERIVED_GRANULARITY_LEVELS = 10;
+export const MAX_DERIVED_GRANULARITY_LEVELS = 7;
+
+/**
+ * Most topics a granularity level may produce and still be offered.
+ *
+ * Past a few dozen topics the view stops being readable regardless of vault
+ * size: the colour palette has 24 slots (collisions past that are guaranteed),
+ * label pills crowd each other out, and hulls tile the canvas. The finest
+ * rungs were "more topics", not "more insight". When every probe exceeds this
+ * (a huge vault whose coarsest partition is already large), the cap is waived
+ * rather than offering no ladder at all.
+ */
+export const MAX_USEFUL_TOPICS = 30;
+
+/**
+ * How much bigger a rung's topic count must be than the previous rung's.
+ *
+ * Distinct counts alone allowed near-duplicate steps — 22 topics vs 24 topics
+ * is not a different way of seeing the vault, but it cost a slider stop and a
+ * Leiden run. Requiring a real jump keeps each step a visible regrouping.
+ */
+export const MIN_RUNG_TOPIC_RATIO = 1.3;
 
 /**
  * Smallest group that counts as a topic.
@@ -204,12 +225,18 @@ export function summarizePartition(communities: CommunityMap): { topicCount: num
 /**
  * Choose the ladder's rungs from probe results.
  *
- * Keeps the *first* γ producing each distinct topic count, so every step visibly
- * changes the grouping and adjacent rungs are never duplicates. Two kinds of
- * probe are discarded outright: those that found no topics (γ too low to
- * separate anything, or a graph with no edges), and those flagged as fragmented
- * — a γ so high that the vault shattered into mostly one-note groups is not a
- * level worth offering.
+ * Keeps the *first* γ producing each distinct topic count, then thins the
+ * candidates twice:
+ *
+ * - counts above {@link MAX_USEFUL_TOPICS} are dropped — the finest rungs were
+ *   "more topics", not "more insight" (waived if the cap would leave fewer
+ *   than two rungs, so a huge vault still gets a ladder);
+ * - each surviving rung must have at least {@link MIN_RUNG_TOPIC_RATIO}× the
+ *   previous rung's topics, so every slider step is a visible regrouping
+ *   rather than a near-duplicate.
+ *
+ * Probes that found no topics (γ too low, or an edgeless graph) and those
+ * flagged as fragmented (mostly one-note groups) are discarded outright.
  *
  * Returns null when fewer than two usable levels exist — the caller falls back
  * to the static ladder rather than showing a slider that cannot move.
@@ -225,10 +252,22 @@ export function deriveGranularityLadder(
 		if (!byCount.has(probe.topicCount)) byCount.set(probe.topicCount, probe.resolution);
 	}
 
-	const ladder = [...byCount.entries()]
-		.sort((a, b) => a[0] - b[0])
-		.map(([, resolution]) => resolution)
-		.sort((a, b) => a - b);
+	const buildLadder = (maxTopics: number): number[] => {
+		const ascending = [...byCount.entries()].sort((a, b) => a[0] - b[0]);
+		const rungs: Array<{ count: number; resolution: number }> = [];
+		for (const [count, resolution] of ascending) {
+			if (count > maxTopics) continue;
+			const previous = rungs[rungs.length - 1];
+			if (previous && count < previous.count * MIN_RUNG_TOPIC_RATIO) continue;
+			rungs.push({ count, resolution });
+		}
+		return rungs.map((rung) => rung.resolution).sort((a, b) => a - b);
+	};
+
+	let ladder = buildLadder(MAX_USEFUL_TOPICS);
+	// Every grouping this vault supports is past the readability cap — offer
+	// the ladder anyway rather than no slider at all.
+	if (ladder.length < 2) ladder = buildLadder(Number.POSITIVE_INFINITY);
 
 	if (ladder.length < 2) return null;
 	if (ladder.length <= MAX_DERIVED_GRANULARITY_LEVELS) return ladder;
@@ -246,6 +285,25 @@ export function deriveGranularityLadder(
 
 /** Lowest selectable granularity level (broadest topics). */
 export const MIN_GRANULARITY_LEVEL = 1;
+
+/**
+ * Identity of the rules {@link deriveGranularityLadder} currently applies.
+ *
+ * A cached ladder is keyed by graph signature, which says nothing about the
+ * *code* that derived it — so tightening the derivation leaves every existing
+ * cache entry describing a slider this build would never produce (observed:
+ * a persisted 10-rung ladder surviving the switch to 7). Including this in
+ * the cache key retires those entries automatically, instead of relying on
+ * someone remembering to bump a schema version.
+ */
+export const GRANULARITY_LADDER_RULES_KEY = [
+	MAX_DERIVED_GRANULARITY_LEVELS,
+	MAX_USEFUL_TOPICS,
+	MIN_RUNG_TOPIC_RATIO,
+	MIN_TOPIC_SIZE,
+	MAX_SINGLETON_SHARE,
+	GRANULARITY_PROBE_RESOLUTIONS.join(","),
+].join("|");
 
 /** Highest level on a given ladder. */
 export function maxGranularityLevel(ladder: readonly number[] = GRANULARITY_LEVEL_RESOLUTIONS): number {

--- a/src/utils/topicHierarchy.ts
+++ b/src/utils/topicHierarchy.ts
@@ -202,9 +202,21 @@ export const MAX_SINGLETON_SHARE = 0.5;
  *
  * Takes the community map directly so callers don't each re-derive group sizes.
  */
-export function summarizePartition(communities: CommunityMap): { topicCount: number; isFragmented: boolean } {
+export function summarizePartition(
+	communities: CommunityMap,
+	/**
+	 * Node ids present in the rendered graph. Leiden runs over *topic edges*
+	 * only, so its map covers just the connected nodes — while the graph shows
+	 * every node, and `resolveSegmentsByLeiden` discards communities whose
+	 * members aren't on screen. Counting without this filter produced ladder
+	 * rungs labelled with topic counts the view never displays, which is how a
+	 * ladder ended up going 4 topics → 3 topics as granularity increased.
+	 */
+	visibleNodeIds?: ReadonlySet<string>,
+): { topicCount: number; isFragmented: boolean } {
 	const sizes = new Map<number, number>();
-	for (const community of Object.values(communities)) {
+	for (const [nodeId, community] of Object.entries(communities)) {
+		if (visibleNodeIds && !visibleNodeIds.has(nodeId)) continue;
 		sizes.set(community, (sizes.get(community) ?? 0) + 1);
 	}
 	if (sizes.size === 0) return { topicCount: 0, isFragmented: false };
@@ -231,9 +243,11 @@ export function summarizePartition(communities: CommunityMap): { topicCount: num
  * - counts above {@link MAX_USEFUL_TOPICS} are dropped — the finest rungs were
  *   "more topics", not "more insight" (waived if the cap would leave fewer
  *   than two rungs, so a huge vault still gets a ladder);
- * - each surviving rung must have at least {@link MIN_RUNG_TOPIC_RATIO}× the
- *   previous rung's topics, so every slider step is a visible regrouping
- *   rather than a near-duplicate.
+ * - walking in γ order, each surviving rung must have at least
+ *   {@link MIN_RUNG_TOPIC_RATIO}× the previous rung's topics — so every slider
+ *   step is a visible regrouping rather than a near-duplicate, and a γ that
+ *   happens to yield *fewer* topics than a lower one is skipped rather than
+ *   producing a slider that walks backwards.
  *
  * Probes that found no topics (γ too low, or an edgeless graph) and those
  * flagged as fragmented (mostly one-note groups) are discarded outright.
@@ -252,16 +266,29 @@ export function deriveGranularityLadder(
 		if (!byCount.has(probe.topicCount)) byCount.set(probe.topicCount, probe.resolution);
 	}
 
+	/**
+	 * Walk the probes in γ order, keeping only rungs that also increase the
+	 * topic count.
+	 *
+	 * Leiden's topic count trends upward with γ but is not guaranteed monotonic
+	 * — it is a stochastic heuristic, and a higher γ can land on a partition
+	 * with *fewer* real topics. Ordering rungs by count and their resolutions
+	 * separately let those two orderings disagree, so the slider could go 4
+	 * topics at level 2 → 3 topics at level 3. Requiring both to rise together
+	 * keeps every step a genuine refinement; a γ that dips is simply skipped.
+	 */
 	const buildLadder = (maxTopics: number): number[] => {
-		const ascending = [...byCount.entries()].sort((a, b) => a[0] - b[0]);
+		const byResolution = [...byCount.entries()]
+			.map(([count, resolution]) => ({ count, resolution }))
+			.sort((a, b) => a.resolution - b.resolution);
 		const rungs: Array<{ count: number; resolution: number }> = [];
-		for (const [count, resolution] of ascending) {
-			if (count > maxTopics) continue;
+		for (const rung of byResolution) {
+			if (rung.count > maxTopics) continue;
 			const previous = rungs[rungs.length - 1];
-			if (previous && count < previous.count * MIN_RUNG_TOPIC_RATIO) continue;
-			rungs.push({ count, resolution });
+			if (previous && rung.count < previous.count * MIN_RUNG_TOPIC_RATIO) continue;
+			rungs.push(rung);
 		}
-		return rungs.map((rung) => rung.resolution).sort((a, b) => a - b);
+		return rungs.map((rung) => rung.resolution);
 	};
 
 	let ladder = buildLadder(MAX_USEFUL_TOPICS);
@@ -297,6 +324,12 @@ export const MIN_GRANULARITY_LEVEL = 1;
  * someone remembering to bump a schema version.
  */
 export const GRANULARITY_LADDER_RULES_KEY = [
+	// Bump when the *algorithm* changes in a way the constants below don't
+	// capture. v2: rungs are selected in γ order and must increase the topic
+	// count (was: sorted by count and by resolution independently, which let a
+	// non-monotonic Leiden result produce a slider that walked backwards), and
+	// probe counts are filtered to nodes the view actually renders.
+	"v2",
 	MAX_DERIVED_GRANULARITY_LEVELS,
 	MAX_USEFUL_TOPICS,
 	MIN_RUNG_TOPIC_RATIO,

--- a/src/vectorstore/HNSWVectorStore.ts
+++ b/src/vectorstore/HNSWVectorStore.ts
@@ -468,6 +468,16 @@ export class HNSWVectorStore implements VectorStore {
 	}
 
 	/**
+	 * Get every chunk vector of a note. `getByPath` returns only one chunk;
+	 * per-note operations (e.g. the graph's incremental semantic re-query)
+	 * need all of them.
+	 */
+	async getAllByPath(path: string): Promise<DocumentVector[]> {
+		const stored = await this.getAllStoredForPath(path);
+		return stored.map((s) => this.toDocumentVector(s));
+	}
+
+	/**
 	 * Check if a document exists and get its mtime.
 	 */
 	async getDocumentMtime(path: string): Promise<number | undefined> {

--- a/src/vectorstore/HNSWWorkerProxy.ts
+++ b/src/vectorstore/HNSWWorkerProxy.ts
@@ -93,6 +93,10 @@ export class HNSWWorkerProxy implements VectorStore {
 		return (result as DocumentVector) ?? undefined;
 	}
 
+	async getAllByPath(path: string): Promise<DocumentVector[]> {
+		return (await this.call("getAllByPath", path)) as DocumentVector[];
+	}
+
 	async getDocumentMtime(path: string): Promise<number | undefined> {
 		const result = await this.call("getDocumentMtime", path);
 		return (result as number) ?? undefined;

--- a/src/vectorstore/hnswWorker.ts
+++ b/src/vectorstore/hnswWorker.ts
@@ -100,6 +100,10 @@ globalThis.onmessage = async (e: MessageEvent<HNSWWorkerRequest>) => {
 				result = doc ?? null;
 				break;
 			}
+			case "getAllByPath": {
+				result = await requireStore().getAllByPath(args[0] as string);
+				break;
+			}
 			case "getDocumentMtime": {
 				result = (await requireStore().getDocumentMtime(args[0] as string)) ?? null;
 				break;

--- a/src/vectorstore/types.ts
+++ b/src/vectorstore/types.ts
@@ -319,6 +319,12 @@ export interface VectorStore {
 	getByPath(path: string): Promise<DocumentVector | undefined>;
 
 	/**
+	 * Get every chunk vector of a note (a large note is stored as several
+	 * chunk rows; `getByPath` returns only one of them).
+	 */
+	getAllByPath(path: string): Promise<DocumentVector[]>;
+
+	/**
 	 * Check if a document exists and get its mtime.
 	 */
 	getDocumentMtime(path: string): Promise<number | undefined>;

--- a/src/views/smart-graph/topicCaches.ts
+++ b/src/views/smart-graph/topicCaches.ts
@@ -36,7 +36,7 @@ import { GRANULARITY_LADDER_RULES_KEY } from "../../utils/topicHierarchy";
 import { getData } from "../../stores/dataStore.svelte";
 import { Logger } from "../../utils/logging";
 
-export interface TopicCaches {
+interface TopicCaches {
 	/**
 	 * Leiden partitions keyed by `${seed}:${resolution}:${edge mode}`, valid for
 	 * the graph whose topology signature is {@link TopicCaches.graphSignature}.
@@ -70,8 +70,22 @@ export interface TopicCaches {
 	topicLabels: Map<string, string>;
 }
 
-/** The active graph's caches. Mutated in place so persistence sees live state. */
-export const topicCaches: TopicCaches = {
+/**
+ * The active graph's caches.
+ *
+ * **Module-private on purpose.** Every derivation here is produced by async
+ * work — a Leiden run, a probe sweep, a labeling pass — that starts while one
+ * graph is active and finishes an arbitrary time later, by which point another
+ * graph leaf may own this slot. Four separate bugs came from code reaching in
+ * and reading or writing it directly, each one a variation of "the slot I
+ * assumed was mine belongs to someone else now".
+ *
+ * The exported API is signature-addressed instead: callers say *which graph*
+ * they mean, and the accessors route to the active slot or the archive
+ * accordingly. That makes the unsafe pattern unavailable rather than merely
+ * discouraged, so a future derivation cannot repeat the mistake.
+ */
+const topicCaches: TopicCaches = {
 	leiden: new Map(),
 	graphSignature: "",
 	granularityLadder: null,
@@ -218,6 +232,50 @@ export function setCachedPartition(signature: string, key: string, communities: 
 export function getCachedPartition(signature: string, key: string): Record<string, number> | undefined {
 	if (signature === topicCaches.graphSignature) return topicCaches.leiden.get(key);
 	return archivedGraphs.get(signature)?.leiden.get(key);
+}
+
+/**
+ * Drop every cached partition for a graph, keeping its other derivations.
+ *
+ * Used when the seed changes, or when accumulated live-update drift makes the
+ * incremental votes untrustworthy: the partitions are invalid but the ladder
+ * and γ still describe the same graph.
+ */
+export function clearCachedPartitions(signature: string): void {
+	if (signature === topicCaches.graphSignature) {
+		topicCaches.leiden.clear();
+		return;
+	}
+	archivedGraphs.get(signature)?.leiden.clear();
+}
+
+/** The granularity ladder derived for a graph, if one has been. */
+export function getCachedGranularityLadder(signature: string): number[] | null {
+	if (signature === topicCaches.graphSignature) return topicCaches.granularityLadder;
+	return archivedGraphs.get(signature)?.granularityLadder ?? null;
+}
+
+/** The γ a graph was last viewed at, or null if the user never chose one. */
+export function getCachedResolution(signature: string): number | null {
+	if (signature === topicCaches.graphSignature) return topicCaches.resolution;
+	return archivedGraphs.get(signature)?.resolution ?? null;
+}
+
+/**
+ * The membership-keyed topic label cache.
+ *
+ * Deliberately global rather than per-graph — a topic present in both the full
+ * and an immersed graph is the same topic and shares its name — so handing out
+ * the map directly is safe here in a way it is not for the graph-scoped
+ * derivations.
+ */
+export function getTopicLabelCache(): Map<string, string> {
+	return topicCaches.topicLabels;
+}
+
+/** Signature of the graph currently occupying the active slot. */
+export function getActiveGraphSignature(): string {
+	return topicCaches.graphSignature;
 }
 
 /**

--- a/src/views/smart-graph/topicCaches.ts
+++ b/src/views/smart-graph/topicCaches.ts
@@ -160,6 +160,24 @@ export function setActiveGraphResolution(resolution: number): void {
 	topicCaches.resolution = resolution;
 }
 
+/**
+ * Ensure the active slot describes `signature`, swapping it in if not.
+ *
+ * The slot is module-level and shared by every graph leaf. One leaf is the
+ * normal case (the command reuses the existing view), but a user can split or
+ * duplicate the tab, or restore a layout with two — and then two leaves
+ * showing different filtered or immersed topologies each re-key the slot under
+ * the other. Whoever reads next would consume the other leaf's Leiden
+ * partition or ladder.
+ *
+ * Callers hold the signature of the graph they are actually rendering, so any
+ * entry point that is going to read or write the slot can cheaply re-assert
+ * it. A no-op when the slot already matches, which is every single-leaf case.
+ */
+export function ensureActiveGraphCache(signature: string): void {
+	if (signature !== topicCaches.graphSignature) swapActiveGraphCache(signature);
+}
+
 /** Look up a cached semantic edge set by its full cache key. */
 export function getCachedSemanticEdges(key: string): GraphEdge[] | null {
 	const entry = semanticEdgeSets.get(key);

--- a/src/views/smart-graph/topicCaches.ts
+++ b/src/views/smart-graph/topicCaches.ts
@@ -1,0 +1,452 @@
+/**
+ * Topic-derivation caches + restart persistence
+ *
+ * The expensive smart-graph derivations (Leiden partitions, the granularity
+ * ladder, semantic edges, AI topic labels) are pure over the graph plus the
+ * keys embedded in each entry, so staleness is handled by keying, not by
+ * lifecycle. The caches live here — module-scoped, shared by every graph leaf
+ * (they all describe the same vault) — so they survive closing and reopening
+ * the view.
+ *
+ * **Multiple graphs are cached at once.** The component works against one
+ * *active* slot ({@link topicCaches}), but a signature change doesn't discard
+ * the outgoing graph's derivations: {@link swapActiveGraphCache} archives them
+ * under their signature and restores an archived slot when its graph comes
+ * back. That's what makes immerse enter/exit and filter round-trips instant —
+ * before this, immersing re-keyed the single slot to the subset and exiting
+ * re-ran Leiden, the ladder probes and labeling over the full vault from
+ * scratch. Semantic edge sets are keyed the same way (their cache key embeds
+ * the wiki-graph signature), so both sides of a round-trip keep theirs too.
+ *
+ * Everything is also persisted to IndexedDB (issue #404): each entry's
+ * invalidation key already exists (graph topology signature, partition key,
+ * the embedding index's `lastUpdated` stamp, topic membership signature), so
+ * hydration is unconditional and the *consumers'* key checks decide what is
+ * still valid. That makes the first graph open after an Obsidian restart as
+ * instant as a reopen within a session — a stale persisted entry simply
+ * misses its key and is recomputed exactly as before.
+ *
+ * Partitions are stored as one shared path list per graph plus per-partition
+ * community arrays: the same 20k paths repeated across ~15 cached rungs would
+ * otherwise dominate the payload.
+ */
+
+import type { GraphEdge } from "../../types/graph";
+import { getData } from "../../stores/dataStore.svelte";
+import { Logger } from "../../utils/logging";
+
+export interface TopicCaches {
+	/**
+	 * Leiden partitions keyed by `${seed}:${resolution}:${edge mode}`, valid for
+	 * the graph whose topology signature is {@link TopicCaches.graphSignature}.
+	 */
+	leiden: Map<string, Record<string, number>>;
+	/**
+	 * Signature of the graph the Leiden cache and granularity ladder were
+	 * derived from. A rebuild that produces an identical graph — reopening the
+	 * view, a Refresh over an unchanged vault, a filter round-trip, a restart —
+	 * keeps them all, so topics reappear from cache instead of re-spending
+	 * seconds of worker time.
+	 */
+	graphSignature: string;
+	/** The derived granularity ladder for that same graph, restored on reopen. */
+	granularityLadder: number[] | null;
+	/**
+	 * Membership-signature → generated topic label, so re-running Leiden at the
+	 * same grouping (or reopening the view) doesn't re-spend API calls. Global
+	 * across graphs: a topic that exists in both the full and an immersed graph
+	 * shares its name.
+	 */
+	topicLabels: Map<string, string>;
+}
+
+/** The active graph's caches. Mutated in place so persistence sees live state. */
+export const topicCaches: TopicCaches = {
+	leiden: new Map(),
+	graphSignature: "",
+	granularityLadder: null,
+	topicLabels: new Map(),
+};
+
+interface ArchivedGraphCaches {
+	leiden: Map<string, Record<string, number>>;
+	granularityLadder: number[] | null;
+	lastUsed: number;
+}
+
+/**
+ * Graphs other than the active one, keyed by topology signature — the full
+ * vault while immersed, an immersed subset after exit, a filtered view.
+ * Bounded: the oldest entry is evicted past {@link MAX_CACHED_GRAPHS}.
+ */
+const archivedGraphs = new Map<string, ArchivedGraphCaches>();
+
+/** Active slot + archived graphs kept at once. */
+const MAX_CACHED_GRAPHS = 4;
+
+/** Cached semantic edge sets (full key → edges), bounded the same way. */
+const semanticEdgeSets = new Map<string, { edges: GraphEdge[]; lastUsed: number }>();
+const MAX_CACHED_SEMANTIC_EDGE_SETS = 4;
+
+function evictOldest<T extends { lastUsed: number }>(map: Map<string, T>, maxSize: number): void {
+	while (map.size > maxSize) {
+		let oldestKey: string | null = null;
+		let oldestUsed = Number.POSITIVE_INFINITY;
+		for (const [key, entry] of map) {
+			if (entry.lastUsed < oldestUsed) {
+				oldestUsed = entry.lastUsed;
+				oldestKey = key;
+			}
+		}
+		if (oldestKey === null) return;
+		map.delete(oldestKey);
+	}
+}
+
+/**
+ * Re-key the active cache slot to a different graph.
+ *
+ * The outgoing graph's derivations (partitions + ladder) are archived under
+ * its signature rather than cleared; if the incoming signature was archived
+ * earlier, its derivations are restored and the caller can treat the switch
+ * like a signature match. Returns true when a restore happened.
+ */
+export function swapActiveGraphCache(signature: string): boolean {
+	if (signature === topicCaches.graphSignature) return true;
+
+	// Archive the outgoing graph — but only when it actually derived something.
+	if (topicCaches.graphSignature && topicCaches.leiden.size > 0) {
+		archivedGraphs.set(topicCaches.graphSignature, {
+			leiden: topicCaches.leiden,
+			granularityLadder: topicCaches.granularityLadder,
+			lastUsed: Date.now(),
+		});
+	}
+
+	const restored = archivedGraphs.get(signature);
+	archivedGraphs.delete(signature);
+	topicCaches.graphSignature = signature;
+	topicCaches.leiden = restored?.leiden ?? new Map();
+	topicCaches.granularityLadder = restored?.granularityLadder ?? null;
+
+	evictOldest(archivedGraphs, MAX_CACHED_GRAPHS - 1);
+	return restored !== undefined;
+}
+
+/** Look up a cached semantic edge set by its full cache key. */
+export function getCachedSemanticEdges(key: string): GraphEdge[] | null {
+	const entry = semanticEdgeSets.get(key);
+	if (!entry) return null;
+	entry.lastUsed = Date.now();
+	return entry.edges;
+}
+
+/** Cache a semantic edge set under its full cache key. */
+export function setCachedSemanticEdges(key: string, edges: GraphEdge[]): void {
+	semanticEdgeSets.set(key, { edges, lastUsed: Date.now() });
+	evictOldest(semanticEdgeSets, MAX_CACHED_SEMANTIC_EDGE_SETS);
+}
+
+// ============================================================================
+// Serialization
+// ============================================================================
+
+/** v2: multiple graphs (active + archived) instead of a single slot. */
+const TOPIC_CACHE_VERSION = 2;
+
+/** One graph's cached derivations, as carried in a snapshot. */
+export interface CachedGraphEntry {
+	leiden: Map<string, Record<string, number>>;
+	granularityLadder: number[] | null;
+	lastUsed: number;
+}
+
+/** All cache state as plain data — the unit that persistence round-trips. */
+export interface TopicCacheSnapshot {
+	activeSignature: string;
+	/** Every cached graph (the active one included), keyed by signature. */
+	graphs: Map<string, CachedGraphEntry>;
+	semanticEdges: Map<string, { edges: GraphEdge[]; lastUsed: number }>;
+	topicLabels: Map<string, string>;
+}
+
+interface PersistedGraphCaches {
+	signature: string;
+	/** Union of every node path appearing in any of this graph's partitions. */
+	nodePaths: string[];
+	/** Partition key → community id per node, aligned with `nodePaths`; -1 = absent. */
+	partitions: Record<string, number[]>;
+	granularityLadder: number[] | null;
+	lastUsed: number;
+}
+
+export interface PersistedTopicCaches {
+	version: number;
+	activeSignature: string;
+	graphs: PersistedGraphCaches[];
+	semanticEdges: Array<{ key: string; edges: GraphEdge[]; lastUsed: number }>;
+	topicLabels: Record<string, string>;
+	savedAt: number;
+}
+
+/** Collect the live module state (active slot + archives) into a snapshot. */
+export function snapshotTopicCaches(): TopicCacheSnapshot {
+	const graphs: TopicCacheSnapshot["graphs"] = new Map();
+	for (const [signature, entry] of archivedGraphs) {
+		graphs.set(signature, {
+			leiden: entry.leiden,
+			granularityLadder: entry.granularityLadder,
+			lastUsed: entry.lastUsed,
+		});
+	}
+	if (topicCaches.graphSignature && topicCaches.leiden.size > 0) {
+		graphs.set(topicCaches.graphSignature, {
+			leiden: topicCaches.leiden,
+			granularityLadder: topicCaches.granularityLadder,
+			lastUsed: Date.now(),
+		});
+	}
+	return {
+		activeSignature: topicCaches.graphSignature,
+		graphs,
+		semanticEdges: new Map(semanticEdgeSets),
+		topicLabels: new Map(topicCaches.topicLabels),
+	};
+}
+
+/** Install a snapshot as the live module state (hydration). */
+function restoreSnapshot(snapshot: TopicCacheSnapshot): void {
+	archivedGraphs.clear();
+	for (const [signature, entry] of snapshot.graphs) {
+		if (signature === snapshot.activeSignature) continue;
+		archivedGraphs.set(signature, {
+			leiden: entry.leiden,
+			granularityLadder: entry.granularityLadder,
+			lastUsed: entry.lastUsed,
+		});
+	}
+	const active = snapshot.graphs.get(snapshot.activeSignature);
+	topicCaches.graphSignature = snapshot.activeSignature;
+	topicCaches.leiden = active?.leiden ?? new Map();
+	topicCaches.granularityLadder = active?.granularityLadder ?? null;
+	for (const [key, entry] of snapshot.semanticEdges) semanticEdgeSets.set(key, entry);
+	for (const [key, label] of snapshot.topicLabels) topicCaches.topicLabels.set(key, label);
+}
+
+function encodeGraph(signature: string, entry: CachedGraphEntry): PersistedGraphCaches {
+	const pathIndex = new Map<string, number>();
+	for (const partition of entry.leiden.values()) {
+		for (const path of Object.keys(partition)) {
+			if (!pathIndex.has(path)) pathIndex.set(path, pathIndex.size);
+		}
+	}
+	const nodePaths = [...pathIndex.keys()];
+	const partitions: Record<string, number[]> = {};
+	for (const [key, partition] of entry.leiden) {
+		const communities = new Array<number>(nodePaths.length).fill(-1);
+		for (const [path, community] of Object.entries(partition)) {
+			const index = pathIndex.get(path);
+			if (index !== undefined) communities[index] = community;
+		}
+		partitions[key] = communities;
+	}
+	return {
+		signature,
+		nodePaths,
+		partitions,
+		granularityLadder: entry.granularityLadder ? [...entry.granularityLadder] : null,
+		lastUsed: entry.lastUsed,
+	};
+}
+
+export function encodeTopicCaches(snapshot: TopicCacheSnapshot): PersistedTopicCaches {
+	return {
+		version: TOPIC_CACHE_VERSION,
+		activeSignature: snapshot.activeSignature,
+		graphs: [...snapshot.graphs].map(([signature, entry]) => encodeGraph(signature, entry)),
+		semanticEdges: [...snapshot.semanticEdges].map(([key, entry]) => ({
+			key,
+			edges: entry.edges.map((edge) => ({ ...edge })),
+			lastUsed: entry.lastUsed,
+		})),
+		topicLabels: Object.fromEntries(snapshot.topicLabels),
+		savedAt: Date.now(),
+	};
+}
+
+function decodeGraph(raw: unknown): { signature: string; entry: CachedGraphEntry } | null {
+	if (typeof raw !== "object" || raw === null) return null;
+	const persisted = raw as Partial<PersistedGraphCaches>;
+	if (typeof persisted.signature !== "string") return null;
+	if (
+		!Array.isArray(persisted.nodePaths) ||
+		typeof persisted.partitions !== "object" ||
+		persisted.partitions === null
+	)
+		return null;
+
+	const nodePaths = persisted.nodePaths.filter((path): path is string => typeof path === "string");
+	if (nodePaths.length !== persisted.nodePaths.length) return null;
+
+	const leiden = new Map<string, Record<string, number>>();
+	for (const [key, communities] of Object.entries(persisted.partitions)) {
+		if (!Array.isArray(communities) || communities.length !== nodePaths.length) return null;
+		const partition: Record<string, number> = {};
+		for (let i = 0; i < communities.length; i++) {
+			const community = communities[i];
+			if (typeof community !== "number") return null;
+			if (community >= 0) partition[nodePaths[i]] = community;
+		}
+		leiden.set(key, partition);
+	}
+
+	const ladder = persisted.granularityLadder;
+	return {
+		signature: persisted.signature,
+		entry: {
+			leiden,
+			granularityLadder: Array.isArray(ladder) && ladder.every((g) => typeof g === "number") ? [...ladder] : null,
+			lastUsed: typeof persisted.lastUsed === "number" ? persisted.lastUsed : 0,
+		},
+	};
+}
+
+/**
+ * Decode a persisted payload back into a snapshot, or `null` when it is from
+ * a different schema version or structurally not what we wrote. No content
+ * validation beyond that — every entry is key-checked by its consumer anyway.
+ */
+export function decodeTopicCaches(raw: unknown): TopicCacheSnapshot | null {
+	if (typeof raw !== "object" || raw === null) return null;
+	const persisted = raw as Partial<PersistedTopicCaches>;
+	if (persisted.version !== TOPIC_CACHE_VERSION) return null;
+	if (typeof persisted.activeSignature !== "string" || !Array.isArray(persisted.graphs)) return null;
+
+	const graphs: TopicCacheSnapshot["graphs"] = new Map();
+	for (const rawGraph of persisted.graphs) {
+		const decoded = decodeGraph(rawGraph);
+		if (!decoded) return null;
+		graphs.set(decoded.signature, decoded.entry);
+	}
+
+	const semanticEdges: TopicCacheSnapshot["semanticEdges"] = new Map();
+	for (const entry of persisted.semanticEdges ?? []) {
+		if (typeof entry?.key !== "string" || !Array.isArray(entry.edges)) continue;
+		semanticEdges.set(entry.key, {
+			edges: entry.edges,
+			lastUsed: typeof entry.lastUsed === "number" ? entry.lastUsed : 0,
+		});
+	}
+
+	return {
+		activeSignature: persisted.activeSignature,
+		graphs,
+		semanticEdges,
+		topicLabels: new Map(
+			Object.entries(persisted.topicLabels ?? {}).filter(
+				(entry): entry is [string, string] => typeof entry[1] === "string",
+			),
+		),
+	};
+}
+
+// ============================================================================
+// IndexedDB persistence
+// ============================================================================
+
+const DB_NAME_PREFIX = "s2b-topic-cache";
+const DB_VERSION = 1;
+const STORE_NAME = "caches";
+const RECORD_KEY = "topic-caches";
+const SAVE_DEBOUNCE_MS = 3000;
+
+function openDatabase(): Promise<IDBDatabase> {
+	const dbName = `${DB_NAME_PREFIX}-${getData().vaultSlug}`;
+	return new Promise((resolve, reject) => {
+		const request = indexedDB.open(dbName, DB_VERSION);
+		request.onupgradeneeded = () => {
+			if (!request.result.objectStoreNames.contains(STORE_NAME)) {
+				request.result.createObjectStore(STORE_NAME);
+			}
+		};
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () => reject(request.error);
+	});
+}
+
+async function readPersisted(): Promise<unknown> {
+	const db = await openDatabase();
+	try {
+		return await new Promise((resolve, reject) => {
+			const tx = db.transaction(STORE_NAME, "readonly");
+			const request = tx.objectStore(STORE_NAME).get(RECORD_KEY);
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+	} finally {
+		db.close();
+	}
+}
+
+async function writePersisted(payload: PersistedTopicCaches): Promise<void> {
+	const db = await openDatabase();
+	try {
+		await new Promise<void>((resolve, reject) => {
+			const tx = db.transaction(STORE_NAME, "readwrite");
+			tx.objectStore(STORE_NAME).put(payload, RECORD_KEY);
+			tx.oncomplete = () => resolve();
+			tx.onerror = () => reject(tx.error);
+		});
+	} finally {
+		db.close();
+	}
+}
+
+let hydration: Promise<void> | null = null;
+
+/**
+ * Hydrate the caches from IndexedDB, once per plugin load.
+ *
+ * Callers await this before their first cache read; later calls resolve
+ * immediately. Hydration never *overwrites* in-session state: if any Leiden
+ * entry exists already, this session has fresher derivations than the disk
+ * copy and the load is skipped.
+ */
+export function loadPersistedTopicCaches(): Promise<void> {
+	if (hydration) return hydration;
+	hydration = (async () => {
+		if (typeof indexedDB === "undefined") return;
+		const start = performance.now();
+		const decoded = decodeTopicCaches(await readPersisted());
+		if (!decoded || topicCaches.leiden.size > 0 || archivedGraphs.size > 0) return;
+		restoreSnapshot(decoded);
+		Logger.info(
+			`[SmartGraph] Restored topic caches (${decoded.graphs.size} graph(s), ` +
+				`${decoded.semanticEdges.size} semantic edge set(s)) in ${Math.round(performance.now() - start)}ms`,
+		);
+	})().catch((error) => {
+		Logger.warn("[SmartGraph] Could not restore persisted topic caches:", error);
+	});
+	return hydration;
+}
+
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Persist the current caches, debounced — derivations land in bursts (probe
+ * ladder, hierarchy, labels), and one write at the end covers all of them.
+ * An entirely empty cache is never written: it would clobber a useful
+ * persisted copy with the transient state right after an invalidation, before
+ * the fresh run (which triggers its own save) has landed.
+ */
+export function scheduleTopicCacheSave(): void {
+	if (typeof indexedDB === "undefined") return;
+	if (saveTimer != null) clearTimeout(saveTimer);
+	saveTimer = setTimeout(() => {
+		saveTimer = null;
+		if (topicCaches.leiden.size === 0 && archivedGraphs.size === 0) return;
+		writePersisted(encodeTopicCaches(snapshotTopicCaches())).catch((error) => {
+			Logger.warn("[SmartGraph] Could not persist topic caches:", error);
+		});
+	}, SAVE_DEBOUNCE_MS);
+}

--- a/src/views/smart-graph/topicCaches.ts
+++ b/src/views/smart-graph/topicCaches.ts
@@ -32,6 +32,7 @@
  */
 
 import type { GraphEdge } from "../../types/graph";
+import { GRANULARITY_LADDER_RULES_KEY } from "../../utils/topicHierarchy";
 import { getData } from "../../stores/dataStore.svelte";
 import { Logger } from "../../utils/logging";
 
@@ -180,8 +181,13 @@ export function setCachedSemanticEdges(key: string, edges: GraphEdge[]): void {
 /**
  * v2: multiple graphs (active + archived) instead of a single slot.
  * v3: each cached graph carries the γ it was last viewed at.
+ * v4: granularity ladders are derived by different rules (readability cap,
+ *     minimum step between rungs), so ladders cached under v3 describe a
+ *     slider this build would never produce. Bump whenever the *derivation*
+ *     changes — the cache is keyed by graph signature, which cannot notice
+ *     that the code computing the value changed.
  */
-const TOPIC_CACHE_VERSION = 3;
+const TOPIC_CACHE_VERSION = 4;
 
 /** One graph's cached derivations, as carried in a snapshot. */
 export interface CachedGraphEntry {
@@ -208,6 +214,8 @@ interface PersistedGraphCaches {
 	/** Partition key → community id per node, aligned with `nodePaths`; -1 = absent. */
 	partitions: Record<string, number[]>;
 	granularityLadder: number[] | null;
+	/** Identity of the derivation rules that produced `granularityLadder`. */
+	granularityLadderRules?: string;
 	resolution: number | null;
 	lastUsed: number;
 }
@@ -291,6 +299,7 @@ function encodeGraph(signature: string, entry: CachedGraphEntry): PersistedGraph
 		nodePaths,
 		partitions,
 		granularityLadder: entry.granularityLadder ? [...entry.granularityLadder] : null,
+		granularityLadderRules: GRANULARITY_LADDER_RULES_KEY,
 		resolution: entry.resolution,
 		lastUsed: entry.lastUsed,
 	};
@@ -337,7 +346,10 @@ function decodeGraph(raw: unknown): { signature: string; entry: CachedGraphEntry
 		leiden.set(key, partition);
 	}
 
-	const ladder = persisted.granularityLadder;
+	// A ladder derived under different rules describes a slider this build
+	// would never produce — drop it so it is re-probed rather than restored.
+	const rulesMatch = persisted.granularityLadderRules === GRANULARITY_LADDER_RULES_KEY;
+	const ladder = rulesMatch ? persisted.granularityLadder : null;
 	return {
 		signature: persisted.signature,
 		entry: {

--- a/src/views/smart-graph/topicCaches.ts
+++ b/src/views/smart-graph/topicCaches.ts
@@ -178,6 +178,48 @@ export function ensureActiveGraphCache(signature: string): void {
 	if (signature !== topicCaches.graphSignature) swapActiveGraphCache(signature);
 }
 
+/**
+ * Store a Leiden partition against the graph it was computed for.
+ *
+ * Async work (a Leiden run, a probe sweep) starts while one graph is active
+ * and finishes an arbitrary time later — by which point another leaf may have
+ * re-keyed the active slot. Writing to `topicCaches.leiden` at that point
+ * files the result under the *other* graph, where it would later be served as
+ * that graph's partition and paint the wrong communities.
+ *
+ * Addressing the write by signature makes it land correctly whichever slot is
+ * active: the active map when it still matches, the archived entry otherwise.
+ * A signature with no entry either way is simply dropped — that graph is gone
+ * (evicted, or never derived anything), so nothing would ever read it back.
+ */
+export function setCachedPartition(signature: string, key: string, communities: Record<string, number>): void {
+	if (signature === topicCaches.graphSignature) {
+		topicCaches.leiden.set(key, communities);
+		return;
+	}
+	const archived = archivedGraphs.get(signature);
+	if (archived) {
+		archived.leiden.set(key, communities);
+		archived.lastUsed = Date.now();
+		return;
+	}
+	// Not the active graph and not archived: preserve it rather than lose the
+	// computation, so returning to that graph finds its partition waiting.
+	archivedGraphs.set(signature, {
+		leiden: new Map([[key, communities]]),
+		granularityLadder: null,
+		resolution: null,
+		lastUsed: Date.now(),
+	});
+	evictOldest(archivedGraphs, MAX_CACHED_GRAPHS - 1);
+}
+
+/** Read a partition from the graph it belongs to, active slot or archive. */
+export function getCachedPartition(signature: string, key: string): Record<string, number> | undefined {
+	if (signature === topicCaches.graphSignature) return topicCaches.leiden.get(key);
+	return archivedGraphs.get(signature)?.leiden.get(key);
+}
+
 /** Look up a cached semantic edge set by its full cache key. */
 export function getCachedSemanticEdges(key: string): GraphEdge[] | null {
 	const entry = semanticEdgeSets.get(key);

--- a/src/views/smart-graph/topicCaches.ts
+++ b/src/views/smart-graph/topicCaches.ts
@@ -220,6 +220,35 @@ export function getCachedPartition(signature: string, key: string): Record<strin
 	return archivedGraphs.get(signature)?.leiden.get(key);
 }
 
+/**
+ * Store a derived granularity ladder against the graph it describes.
+ *
+ * Same hazard as {@link setCachedPartition}: probing sweeps several γ values,
+ * awaiting a Leiden run at each, so another leaf can become the active graph
+ * before the finished ladder is written. Storing it in whichever slot happens
+ * to be active would give that graph's slider levels derived from a different
+ * topology.
+ */
+export function setCachedGranularityLadder(signature: string, ladder: number[] | null): void {
+	if (signature === topicCaches.graphSignature) {
+		topicCaches.granularityLadder = ladder;
+		return;
+	}
+	const archived = archivedGraphs.get(signature);
+	if (archived) {
+		archived.granularityLadder = ladder;
+		archived.lastUsed = Date.now();
+		return;
+	}
+	archivedGraphs.set(signature, {
+		leiden: new Map(),
+		granularityLadder: ladder,
+		resolution: null,
+		lastUsed: Date.now(),
+	});
+	evictOldest(archivedGraphs, MAX_CACHED_GRAPHS - 1);
+}
+
 /** Look up a cached semantic edge set by its full cache key. */
 export function getCachedSemanticEdges(key: string): GraphEdge[] | null {
 	const entry = semanticEdgeSets.get(key);

--- a/src/views/smart-graph/topicCaches.ts
+++ b/src/views/smart-graph/topicCaches.ts
@@ -169,9 +169,33 @@ export function swapActiveGraphCache(signature: string, currentResolution?: numb
 	return restored !== undefined;
 }
 
-/** Record the γ the active graph is being viewed at. */
-export function setActiveGraphResolution(resolution: number): void {
-	topicCaches.resolution = resolution;
+/**
+ * Record the γ a graph is being viewed at.
+ *
+ * Signature-addressed like the other setters: this is called from a settings
+ * write, which can land while another leaf owns the active slot. Writing there
+ * would give that graph this leaf's granularity, so restoring it would
+ * re-segment at the wrong γ — and because topic ids are positions in a fresh
+ * partition, that also clears its folds, focus and selection.
+ */
+export function setCachedResolution(signature: string, resolution: number): void {
+	if (signature === topicCaches.graphSignature) {
+		topicCaches.resolution = resolution;
+		return;
+	}
+	const archived = archivedGraphs.get(signature);
+	if (archived) {
+		archived.resolution = resolution;
+		archived.lastUsed = Date.now();
+		return;
+	}
+	archivedGraphs.set(signature, {
+		leiden: new Map(),
+		granularityLadder: null,
+		resolution,
+		lastUsed: Date.now(),
+	});
+	evictOldest(archivedGraphs, MAX_CACHED_GRAPHS - 1);
 }
 
 /**

--- a/src/views/smart-graph/topicCaches.ts
+++ b/src/views/smart-graph/topicCaches.ts
@@ -52,6 +52,15 @@ export interface TopicCaches {
 	/** The derived granularity ladder for that same graph, restored on reopen. */
 	granularityLadder: number[] | null;
 	/**
+	 * The γ this graph was last viewed at, so granularity is per-graph rather
+	 * than one global setting. Immersing and dialling the topics finer is a
+	 * statement about the subset, not about the vault — without this, exiting
+	 * immerse would leave the full graph re-segmented at the subset's γ.
+	 * Null until the user has actually chosen a granularity for this graph;
+	 * the stored global setting is the fallback.
+	 */
+	resolution: number | null;
+	/**
 	 * Membership-signature → generated topic label, so re-running Leiden at the
 	 * same grouping (or reopening the view) doesn't re-spend API calls. Global
 	 * across graphs: a topic that exists in both the full and an immersed graph
@@ -65,12 +74,14 @@ export const topicCaches: TopicCaches = {
 	leiden: new Map(),
 	graphSignature: "",
 	granularityLadder: null,
+	resolution: null,
 	topicLabels: new Map(),
 };
 
 interface ArchivedGraphCaches {
 	leiden: Map<string, Record<string, number>>;
 	granularityLadder: number[] | null;
+	resolution: number | null;
 	lastUsed: number;
 }
 
@@ -106,19 +117,28 @@ function evictOldest<T extends { lastUsed: number }>(map: Map<string, T>, maxSiz
 /**
  * Re-key the active cache slot to a different graph.
  *
- * The outgoing graph's derivations (partitions + ladder) are archived under
- * its signature rather than cleared; if the incoming signature was archived
- * earlier, its derivations are restored and the caller can treat the switch
- * like a signature match. Returns true when a restore happened.
+ * The outgoing graph's derivations (partitions + ladder + the γ it was last
+ * viewed at) are archived under its signature rather than cleared; if the
+ * incoming signature was archived earlier, they're restored and the caller can
+ * treat the switch like a signature match. Returns true when a restore
+ * happened.
+ *
+ * `currentResolution` is the γ on screen right now — recorded against the
+ * outgoing graph so returning to it re-applies its own granularity instead of
+ * inheriting whatever the graph in between was dialled to.
  */
-export function swapActiveGraphCache(signature: string): boolean {
-	if (signature === topicCaches.graphSignature) return true;
+export function swapActiveGraphCache(signature: string, currentResolution?: number): boolean {
+	if (signature === topicCaches.graphSignature) {
+		if (currentResolution !== undefined) topicCaches.resolution = currentResolution;
+		return true;
+	}
 
 	// Archive the outgoing graph — but only when it actually derived something.
 	if (topicCaches.graphSignature && topicCaches.leiden.size > 0) {
 		archivedGraphs.set(topicCaches.graphSignature, {
 			leiden: topicCaches.leiden,
 			granularityLadder: topicCaches.granularityLadder,
+			resolution: currentResolution ?? topicCaches.resolution,
 			lastUsed: Date.now(),
 		});
 	}
@@ -128,9 +148,15 @@ export function swapActiveGraphCache(signature: string): boolean {
 	topicCaches.graphSignature = signature;
 	topicCaches.leiden = restored?.leiden ?? new Map();
 	topicCaches.granularityLadder = restored?.granularityLadder ?? null;
+	topicCaches.resolution = restored?.resolution ?? null;
 
 	evictOldest(archivedGraphs, MAX_CACHED_GRAPHS - 1);
 	return restored !== undefined;
+}
+
+/** Record the γ the active graph is being viewed at. */
+export function setActiveGraphResolution(resolution: number): void {
+	topicCaches.resolution = resolution;
 }
 
 /** Look up a cached semantic edge set by its full cache key. */
@@ -151,13 +177,18 @@ export function setCachedSemanticEdges(key: string, edges: GraphEdge[]): void {
 // Serialization
 // ============================================================================
 
-/** v2: multiple graphs (active + archived) instead of a single slot. */
-const TOPIC_CACHE_VERSION = 2;
+/**
+ * v2: multiple graphs (active + archived) instead of a single slot.
+ * v3: each cached graph carries the γ it was last viewed at.
+ */
+const TOPIC_CACHE_VERSION = 3;
 
 /** One graph's cached derivations, as carried in a snapshot. */
 export interface CachedGraphEntry {
 	leiden: Map<string, Record<string, number>>;
 	granularityLadder: number[] | null;
+	/** The γ this graph was last viewed at; null when never chosen. */
+	resolution: number | null;
 	lastUsed: number;
 }
 
@@ -177,6 +208,7 @@ interface PersistedGraphCaches {
 	/** Partition key → community id per node, aligned with `nodePaths`; -1 = absent. */
 	partitions: Record<string, number[]>;
 	granularityLadder: number[] | null;
+	resolution: number | null;
 	lastUsed: number;
 }
 
@@ -196,6 +228,7 @@ export function snapshotTopicCaches(): TopicCacheSnapshot {
 		graphs.set(signature, {
 			leiden: entry.leiden,
 			granularityLadder: entry.granularityLadder,
+			resolution: entry.resolution,
 			lastUsed: entry.lastUsed,
 		});
 	}
@@ -203,6 +236,7 @@ export function snapshotTopicCaches(): TopicCacheSnapshot {
 		graphs.set(topicCaches.graphSignature, {
 			leiden: topicCaches.leiden,
 			granularityLadder: topicCaches.granularityLadder,
+			resolution: topicCaches.resolution,
 			lastUsed: Date.now(),
 		});
 	}
@@ -222,6 +256,7 @@ function restoreSnapshot(snapshot: TopicCacheSnapshot): void {
 		archivedGraphs.set(signature, {
 			leiden: entry.leiden,
 			granularityLadder: entry.granularityLadder,
+			resolution: entry.resolution,
 			lastUsed: entry.lastUsed,
 		});
 	}
@@ -229,6 +264,7 @@ function restoreSnapshot(snapshot: TopicCacheSnapshot): void {
 	topicCaches.graphSignature = snapshot.activeSignature;
 	topicCaches.leiden = active?.leiden ?? new Map();
 	topicCaches.granularityLadder = active?.granularityLadder ?? null;
+	topicCaches.resolution = active?.resolution ?? null;
 	for (const [key, entry] of snapshot.semanticEdges) semanticEdgeSets.set(key, entry);
 	for (const [key, label] of snapshot.topicLabels) topicCaches.topicLabels.set(key, label);
 }
@@ -255,6 +291,7 @@ function encodeGraph(signature: string, entry: CachedGraphEntry): PersistedGraph
 		nodePaths,
 		partitions,
 		granularityLadder: entry.granularityLadder ? [...entry.granularityLadder] : null,
+		resolution: entry.resolution,
 		lastUsed: entry.lastUsed,
 	};
 }
@@ -306,6 +343,7 @@ function decodeGraph(raw: unknown): { signature: string; entry: CachedGraphEntry
 		entry: {
 			leiden,
 			granularityLadder: Array.isArray(ladder) && ladder.every((g) => typeof g === "number") ? [...ladder] : null,
+			resolution: typeof persisted.resolution === "number" ? persisted.resolution : null,
 			lastUsed: typeof persisted.lastUsed === "number" ? persisted.lastUsed : 0,
 		},
 	};

--- a/test/utils/graphAnimation.test.ts
+++ b/test/utils/graphAnimation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { computeCoreNodeBounds, computeNodeBounds } from "../../src/utils/graphAnimation";
+import { computeCoreNodeBounds, computeNodeBounds, framingFocus } from "../../src/utils/graphAnimation";
 
 /** A tight knot of connected nodes plus far-flung unlinked ones. */
 function knotWithOutliers(knotSize: number, outliers: Array<{ x: number; y: number }>) {
@@ -61,5 +61,57 @@ describe("computeCoreNodeBounds", () => {
 		const nodes = knotWithOutliers(20, [{ x: 9999, y: 9999 }]);
 		expect(computeCoreNodeBounds(nodes, (n) => n.x < 0)).toBeNull();
 		expect(computeCoreNodeBounds([])).toBeNull();
+	});
+});
+
+describe("framingFocus", () => {
+	const viewport = { width: 1000, height: 1000 };
+
+	// Small enough that the 1.3x zoom cap binds instead of the extent, which is
+	// what leaves slack for the centre to move within.
+	const bounds = { minX: -100, maxX: 300, minY: -100, maxY: 100 };
+	const core = { minX: -100, maxX: 100, minY: -100, maxY: 100 };
+
+	it("centres on the core rather than the full extent", () => {
+		// Main graph around the origin, one stray off to the right: centring on
+		// the full box would shove the graph to the left of the viewport.
+		const focus = framingFocus(bounds, viewport, 40, 1.3, core);
+		const fullCentre = (bounds.minX + bounds.maxX) / 2;
+		expect(focus.centerX).toBeLessThan(fullCentre);
+		expect(focus.centerX).toBeCloseTo(0, 6);
+	});
+
+	it("keeps every node in bounds visible despite the recentring", () => {
+		const focus = framingFocus(bounds, viewport, 40, 1.3, core);
+		const halfW = (viewport.width - 80) / (2 * focus.scale);
+		// The clamp is what stops the stray being pushed off-screen.
+		expect(focus.centerX + halfW).toBeGreaterThanOrEqual(bounds.maxX - 1e-6);
+		expect(focus.centerX - halfW).toBeLessThanOrEqual(bounds.minX + 1e-6);
+	});
+
+	it("clamps the recentring when the core sits too far from the extent's edge", () => {
+		// Core hard against the left of a wide extent: centring fully on it
+		// would push the right-hand nodes out, so the clamp pulls it back.
+		const wide = { minX: -100, maxX: 800, minY: -100, maxY: 100 };
+		const focus = framingFocus(wide, viewport, 40, 1.3, core);
+		const halfW = (viewport.width - 80) / (2 * focus.scale);
+		expect(focus.centerX).toBeGreaterThan(0);
+		expect(focus.centerX + halfW).toBeGreaterThanOrEqual(wide.maxX - 1e-6);
+	});
+
+	it("falls back to the full centre when the graph exceeds the viewport", () => {
+		// No slack: the scale is set by the extent, so the centre cannot move.
+		const bounds = { minX: -5000, maxX: 5000, minY: -5000, maxY: 5000 };
+		const core = { minX: -100, maxX: 100, minY: -100, maxY: 100 };
+		const focus = framingFocus(bounds, viewport, 40, 1.3, core);
+		expect(focus.centerX).toBeCloseTo(0, 6);
+		expect(focus.centerY).toBeCloseTo(0, 6);
+	});
+
+	it("matches the plain centre when no core bounds are given", () => {
+		const bounds = { minX: 0, maxX: 200, minY: 0, maxY: 200 };
+		const focus = framingFocus(bounds, viewport, 40, 1.3);
+		expect(focus.centerX).toBeCloseTo(100, 6);
+		expect(focus.centerY).toBeCloseTo(100, 6);
 	});
 });

--- a/test/utils/graphAnimation.test.ts
+++ b/test/utils/graphAnimation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { computeCoreNodeBounds, computeNodeBounds } from "../../src/utils/graphAnimation";
+
+/** A tight knot of connected nodes plus far-flung unlinked ones. */
+function knotWithOutliers(knotSize: number, outliers: Array<{ x: number; y: number }>) {
+	return [...Array.from({ length: knotSize }, (_, i) => ({ x: i * 10, y: i * 8 })), ...outliers];
+}
+
+// Measurement helper (the benchmark's fill/waste metrics), not a framing
+// policy — the camera deliberately frames full bounds so an explicit fit
+// never strands nodes off-screen.
+describe("computeCoreNodeBounds", () => {
+	it("excludes far outliers that would otherwise dominate the measurement", () => {
+		const nodes = knotWithOutliers(20, [
+			{ x: 5000, y: 0 },
+			{ x: -5000, y: 4000 },
+		]);
+		const full = computeNodeBounds(nodes);
+		const core = computeCoreNodeBounds(nodes);
+		expect(full?.maxX).toBe(5000);
+		// The core ignores both strays, so the frame describes the knot.
+		expect(core!.maxX).toBeLessThan(500);
+		expect(core!.minX).toBeGreaterThan(-500);
+	});
+
+	it("trims small graphs too, where one satellite is a large share of the population", () => {
+		// The regression this exists for: a proportional-only trim rounds to
+		// zero here, so the outlier stayed inside the "core".
+		const nodes = knotWithOutliers(9, [{ x: 4000, y: 4000 }]);
+		const core = computeCoreNodeBounds(nodes);
+		expect(core!.maxX).toBeLessThan(1000);
+	});
+
+	it("falls back to full bounds when the graph is too small to trim", () => {
+		const nodes = [
+			{ x: 0, y: 0 },
+			{ x: 10, y: 10 },
+			{ x: 900, y: 900 },
+		];
+		expect(computeCoreNodeBounds(nodes)).toEqual(computeNodeBounds(nodes));
+	});
+
+	it("never trims more than a fifth of the population", () => {
+		// 20 evenly spaced nodes: a 6% trim keeps the frame near the full span
+		// rather than collapsing onto the middle few.
+		const nodes = Array.from({ length: 20 }, (_, i) => ({ x: i * 100, y: 0 }));
+		const core = computeCoreNodeBounds(nodes)!;
+		const span = core.maxX - core.minX;
+		expect(span).toBeGreaterThan(0.7 * 1900);
+	});
+
+	it("matches full bounds when there are no outliers", () => {
+		const nodes = Array.from({ length: 30 }, (_, i) => ({ x: Math.cos(i) * 100, y: Math.sin(i) * 100 }));
+		const full = computeNodeBounds(nodes)!;
+		const core = computeCoreNodeBounds(nodes)!;
+		// Trimming a uniform ring shrinks it slightly, never drastically.
+		expect(core.maxX - core.minX).toBeGreaterThan(0.6 * (full.maxX - full.minX));
+	});
+
+	it("respects the filter and handles empty input", () => {
+		const nodes = knotWithOutliers(20, [{ x: 9999, y: 9999 }]);
+		expect(computeCoreNodeBounds(nodes, (n) => n.x < 0)).toBeNull();
+		expect(computeCoreNodeBounds([])).toBeNull();
+	});
+});

--- a/test/utils/graphUtils.test.ts
+++ b/test/utils/graphUtils.test.ts
@@ -134,10 +134,10 @@ describe("densitySpreadFactor", () => {
 	});
 
 	it("clamps at both extremes so the force balance stays in its tested regime", () => {
-		expect(densitySpreadFactor(1)).toBe(1.7);
+		expect(densitySpreadFactor(1)).toBe(4.5);
 		expect(densitySpreadFactor(1_000_000)).toBe(0.65);
 		// Degenerate inputs behave like a tiny graph rather than exploding.
-		expect(densitySpreadFactor(0)).toBe(1.7);
+		expect(densitySpreadFactor(0)).toBe(4.5);
 	});
 });
 
@@ -163,15 +163,41 @@ describe("densityForceProfile", () => {
 		expect(dense.center).toBeLessThanOrEqual(2.8);
 	});
 
-	it("on small graphs: spreads spacing, softens the charge spread, never weakens centering or boosts cohesion", () => {
+	it("on small graphs: spreads spacing, softens the charge spread, relaxes centering, never boosts cohesion", () => {
 		const small = densityForceProfile(12);
 		expect(small.spacing).toBeGreaterThan(1);
 		// Softer than spacing so unlinked satellites aren't flung to the horizon.
 		expect(small.charge).toBeLessThan(small.spacing);
 		expect(small.charge).toBeGreaterThan(1);
-		// Weakening the only inward pull a satellite feels would push them out.
-		expect(small.center).toBe(1);
+		// Centering eases off so a handful of nodes can open up to fill the
+		// viewport instead of settling as a knot — but stays firm enough that
+		// the graph still reads as one object.
+		expect(small.center).toBeLessThan(1);
+		expect(small.center).toBeGreaterThanOrEqual(0.35);
 		expect(small.cohesion).toBe(1);
+	});
+});
+
+describe("densityForceProfile sparse/dense split", () => {
+	it("relaxes centering only for sparse graphs, never for dense ones", () => {
+		// Regression: the sparse branch once keyed off the spread factor, which
+		// saturates at both clamps — so every graph past the compaction floor
+		// was misread as sparse and had its centering relaxed instead of
+		// boosted, blowing dense layouts out to several times their extent.
+		for (const count of [800, 2000, 8000, 100_000]) {
+			expect(densityForceProfile(count).center).toBeGreaterThan(1);
+		}
+		for (const count of [5, 10, 30]) {
+			expect(densityForceProfile(count).center).toBeLessThan(1);
+		}
+	});
+
+	it("keeps the reference density exactly neutral on both sides of the split", () => {
+		expect(densityForceProfile(400)).toEqual({ spacing: 1, charge: 1, center: 1, cohesion: 1 });
+		// Just below the reference the profile must not jump discontinuously.
+		const justBelow = densityForceProfile(399);
+		expect(justBelow.center).toBeGreaterThan(0.9);
+		expect(justBelow.spacing).toBeGreaterThanOrEqual(1);
 	});
 });
 

--- a/test/utils/graphUtils.test.ts
+++ b/test/utils/graphUtils.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { edgeKey, graphTopologySignature, splitEdgeKey } from "../../src/utils/graphUtils";
+import {
+	densityForceProfile,
+	densitySpreadFactor,
+	edgeAlphaZoomLift,
+	edgeKey,
+	graphTopologySignature,
+	nodeDrawRadius,
+	splitEdgeKey,
+	zoomNodeScale,
+} from "../../src/utils/graphUtils";
 
 describe("edgeKey / splitEdgeKey", () => {
 	it("is order-independent and invertible", () => {
@@ -63,5 +72,155 @@ describe("graphTopologySignature", () => {
 		const empty = { nodes: [], edges: [] };
 		expect(graphTopologySignature(empty)).toBe(graphTopologySignature({ nodes: [], edges: [] }));
 		expect(graphTopologySignature(empty)).not.toBe(graphTopologySignature(base()));
+	});
+});
+
+describe("nodeDrawRadius", () => {
+	const NODE_SIZE = 2;
+
+	it("caps note radius but never a topic's (smooth saturation)", () => {
+		// Note formula saturates hard: past the cap, more degree changes nothing.
+		const note = (degree: number) => nodeDrawRadius({ degree }, NODE_SIZE);
+		expect(note(200)).toBe(note(2000));
+
+		// Topic curve keeps growing: every doubling of connections stays visible.
+		const topic = (degree: number) => nodeDrawRadius({ degree, kind: "topic" }, NODE_SIZE);
+		let previous = topic(0);
+		for (const degree of [10, 50, 100, 200, 400, 800, 1600, 3200]) {
+			const radius = topic(degree);
+			expect(radius).toBeGreaterThan(previous);
+			previous = radius;
+		}
+	});
+
+	it("differentiates topics across the realistic crossing-link range", () => {
+		// The regression this curve replaces: a 180-note and a 2000-note topic
+		// (hundreds vs thousands of crossing links) rendered identically.
+		const topic = (degree: number) => nodeDrawRadius({ degree, kind: "topic" }, NODE_SIZE);
+		expect(topic(2000) - topic(180)).toBeGreaterThan(5);
+	});
+
+	it("stays bounded for a degenerate mega-topic", () => {
+		const huge = nodeDrawRadius({ degree: 1_000_000, kind: "topic" }, NODE_SIZE);
+		expect(huge).toBeLessThan(NODE_SIZE + 26);
+	});
+
+	it("keeps a small topic near note size", () => {
+		const smallTopic = nodeDrawRadius({ degree: 5, kind: "topic" }, NODE_SIZE);
+		const hubNote = nodeDrawRadius({ degree: 20 }, NODE_SIZE);
+		expect(smallTopic).toBeLessThan(hubNote);
+	});
+
+	it("treats missing degree as zero and enforces the minimum base", () => {
+		expect(nodeDrawRadius({}, 0)).toBe(1);
+		expect(nodeDrawRadius({ kind: "topic" }, 0)).toBe(1);
+	});
+});
+
+describe("densitySpreadFactor", () => {
+	it("is exactly 1 at the reference density", () => {
+		expect(densitySpreadFactor(400)).toBe(1);
+	});
+
+	it("spreads small graphs and compacts large ones, monotonically", () => {
+		expect(densitySpreadFactor(12)).toBeGreaterThan(1);
+		expect(densitySpreadFactor(5000)).toBeLessThan(1);
+		let previous = densitySpreadFactor(1);
+		for (const count of [10, 50, 400, 2000, 20000]) {
+			const factor = densitySpreadFactor(count);
+			expect(factor).toBeLessThanOrEqual(previous);
+			previous = factor;
+		}
+	});
+
+	it("clamps at both extremes so the force balance stays in its tested regime", () => {
+		expect(densitySpreadFactor(1)).toBe(1.7);
+		expect(densitySpreadFactor(1_000_000)).toBe(0.65);
+		// Degenerate inputs behave like a tiny graph rather than exploding.
+		expect(densitySpreadFactor(0)).toBe(1.7);
+	});
+});
+
+describe("densityForceProfile", () => {
+	it("is the identity at the reference density", () => {
+		expect(densityForceProfile(400)).toEqual({ spacing: 1, charge: 1, center: 1, cohesion: 1 });
+	});
+
+	it("on dense graphs: compacts spacing, relaxes cohesion, boosts centering — charge softest", () => {
+		const dense = densityForceProfile(5000);
+		expect(dense.spacing).toBeLessThan(1);
+		// Cohesion relaxes *faster* than spacing compacts, so cluster interiors
+		// gain breathing room even as the global structure tightens.
+		expect(dense.cohesion).toBeLessThan(dense.spacing);
+		expect(dense.cohesion).toBeGreaterThanOrEqual(0.45);
+		// Charge scales gentler than spacing: it also separates notes *within* a
+		// cluster, which must not be squeezed as hard as the global structure.
+		expect(dense.charge).toBeGreaterThan(dense.spacing);
+		expect(dense.charge).toBeLessThan(1);
+		// The center pull strengthens steeply to close inter-cluster gaps —
+		// meaningfully past the linear response, but bounded.
+		expect(dense.center).toBeGreaterThan(1.6);
+		expect(dense.center).toBeLessThanOrEqual(2.8);
+	});
+
+	it("on small graphs: spreads spacing, softens the charge spread, never weakens centering or boosts cohesion", () => {
+		const small = densityForceProfile(12);
+		expect(small.spacing).toBeGreaterThan(1);
+		// Softer than spacing so unlinked satellites aren't flung to the horizon.
+		expect(small.charge).toBeLessThan(small.spacing);
+		expect(small.charge).toBeGreaterThan(1);
+		// Weakening the only inward pull a satellite feels would push them out.
+		expect(small.center).toBe(1);
+		expect(small.cohesion).toBe(1);
+	});
+});
+
+describe("edgeAlphaZoomLift", () => {
+	it("leaves the overview untouched", () => {
+		expect(edgeAlphaZoomLift(1)).toBe(1);
+		expect(edgeAlphaZoomLift(0.25)).toBe(1);
+	});
+
+	it("ramps up monotonically as the camera zooms in, then saturates", () => {
+		let previous = edgeAlphaZoomLift(1);
+		for (const scale of [1.5, 2, 3, 4]) {
+			const lift = edgeAlphaZoomLift(scale);
+			expect(lift).toBeGreaterThan(previous);
+			previous = lift;
+		}
+		expect(edgeAlphaZoomLift(4)).toBeCloseTo(2.6, 10);
+		// Past the full-lift zoom it stops growing rather than running away.
+		expect(edgeAlphaZoomLift(50)).toBe(edgeAlphaZoomLift(4));
+	});
+
+	it("tolerates degenerate scales", () => {
+		expect(edgeAlphaZoomLift(0)).toBe(1);
+		expect(edgeAlphaZoomLift(Number.NaN)).toBe(1);
+	});
+});
+
+describe("zoomNodeScale", () => {
+	it("is exactly 1 at unit zoom", () => {
+		expect(zoomNodeScale(1)).toBe(1);
+	});
+
+	it("counter-scales partially: grows zoomed out, shrinks zoomed in — both sublinearly", () => {
+		const zoomedOut = zoomNodeScale(0.25);
+		expect(zoomedOut).toBeGreaterThan(1);
+		// On screen the node still shrinks when zooming out (factor < 1/scale) —
+		// the counter-scale is partial, not a fixed screen size.
+		expect(zoomedOut).toBeLessThan(1 / 0.25);
+
+		const zoomedIn = zoomNodeScale(4);
+		expect(zoomedIn).toBeLessThan(1);
+		// And it still grows on screen when zooming in (factor × scale > 1).
+		expect(zoomedIn * 4).toBeGreaterThan(1);
+	});
+
+	it("clamps at extreme zooms and tolerates degenerate scales", () => {
+		expect(zoomNodeScale(0.001)).toBe(4);
+		expect(zoomNodeScale(1000)).toBeCloseTo(1 / 3, 10);
+		expect(zoomNodeScale(0)).toBe(1);
+		expect(zoomNodeScale(Number.NaN)).toBe(1);
 	});
 });

--- a/test/utils/liveGraphPatch.test.ts
+++ b/test/utils/liveGraphPatch.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import type { GraphData, GraphEdge, GraphNode } from "../../src/types/graph";
+import {
+	applyWikiPatch,
+	queryNoteSemanticEdges,
+	replaceSemanticEdgesForPaths,
+	voteNodeCommunity,
+	type SemanticQueryStore,
+} from "../../src/utils/liveGraphPatch";
+import type { DocumentVector, ScoredDocument } from "../../src/vectorstore/types";
+
+function node(path: string, extra: Partial<GraphNode> = {}): GraphNode {
+	return { id: path, path, label: path.replace(/\.md$/, ""), x: 0, y: 0, degree: 0, highlighted: false, ...extra };
+}
+
+function wiki(source: string, target: string, weight = 1): GraphEdge {
+	return { source, target, weight, type: "wiki" };
+}
+
+function semantic(source: string, target: string, weight = 0.8): GraphEdge {
+	return { source, target, weight, type: "semantic" };
+}
+
+function graph(nodes: GraphNode[], edges: GraphEdge[]): GraphData {
+	return { nodes, edges };
+}
+
+describe("applyWikiPatch", () => {
+	const current = () =>
+		graph(
+			[
+				node("a.md", { cluster: 0, color: "red", degree: 2 }),
+				node("b.md", { cluster: 0, color: "red", degree: 2 }),
+				node("c.md", { cluster: 1, color: "blue", degree: 1 }),
+			],
+			[wiki("a.md", "b.md"), semantic("a.md", "c.md"), semantic("b.md", "a.md", 0.7)],
+		);
+
+	it("reports no change for an identical wiki structure", () => {
+		const cur = current();
+		const fresh = graph([node("a.md"), node("b.md"), node("c.md")], [wiki("a.md", "b.md")]);
+		const patch = applyWikiPatch(cur, fresh);
+		expect(patch.changed).toBe(false);
+		// Same object back, so callers can no-op on identity.
+		expect(patch.data).toBe(cur);
+		expect(patch.addedPaths).toEqual([]);
+		expect(patch.touchedPaths).toEqual([]);
+	});
+
+	it("adds new nodes and keeps surviving presentation state", () => {
+		const fresh = graph(
+			[node("a.md"), node("b.md"), node("c.md"), node("d.md")],
+			[wiki("a.md", "b.md"), wiki("c.md", "d.md")],
+		);
+		const patch = applyWikiPatch(current(), fresh);
+		expect(patch.changed).toBe(true);
+		expect(patch.addedPaths).toEqual(["d.md"]);
+		expect(patch.removedPaths).toEqual([]);
+		const a = patch.data.nodes.find((n) => n.path === "a.md");
+		expect(a?.cluster).toBe(0);
+		expect(a?.color).toBe("red");
+		// Semantic edges survive the wiki swap.
+		expect(patch.data.edges.filter((e) => e.type === "semantic")).toHaveLength(2);
+	});
+
+	it("removes deleted nodes along with their semantic edges", () => {
+		const fresh = graph([node("a.md"), node("b.md")], [wiki("a.md", "b.md")]);
+		const patch = applyWikiPatch(current(), fresh);
+		expect(patch.removedPaths).toEqual(["c.md"]);
+		expect(patch.data.edges.filter((e) => e.type === "semantic")).toEqual([semantic("b.md", "a.md", 0.7)]);
+	});
+
+	it("drops a semantic edge superseded by a newly authored link", () => {
+		const fresh = graph([node("a.md"), node("b.md"), node("c.md")], [wiki("a.md", "b.md"), wiki("c.md", "a.md")]);
+		const patch = applyWikiPatch(current(), fresh);
+		const keys = patch.data.edges.map((e) => `${e.type}:${[e.source, e.target].sort().join("|")}`);
+		expect(keys).toContain("wiki:a.md|c.md");
+		expect(keys).not.toContain("semantic:a.md|c.md");
+	});
+
+	it("marks endpoints of changed wiki edges as touched, excluding added/removed nodes", () => {
+		const fresh = graph(
+			[node("a.md"), node("b.md"), node("c.md"), node("d.md")],
+			[wiki("a.md", "b.md", 3), wiki("c.md", "d.md")],
+		);
+		const patch = applyWikiPatch(current(), fresh);
+		// a↔b changed weight, c gained an edge to the new node d.
+		expect([...patch.touchedPaths].sort()).toEqual(["a.md", "b.md", "c.md"]);
+	});
+
+	it("recomputes degrees over the fused edge set", () => {
+		const fresh = graph([node("a.md"), node("b.md"), node("c.md")], [wiki("a.md", "b.md")]);
+		const withNewLink = graph(
+			[node("a.md"), node("b.md"), node("c.md")],
+			[wiki("a.md", "b.md"), wiki("b.md", "c.md")],
+		);
+		const patch = applyWikiPatch(applyWikiPatch(current(), fresh).data, withNewLink);
+		const b = patch.data.nodes.find((n) => n.path === "b.md");
+		// b: wiki a–b, wiki b–c, semantic b–a → 3
+		expect(b?.degree).toBe(3);
+	});
+});
+
+describe("replaceSemanticEdgesForPaths", () => {
+	const base = () =>
+		graph(
+			[node("a.md"), node("b.md"), node("c.md")],
+			[wiki("a.md", "b.md"), semantic("a.md", "c.md", 0.8), semantic("b.md", "c.md", 0.7)],
+		);
+
+	it("replaces only the edges incident to the given paths", () => {
+		const { data, changed } = replaceSemanticEdgesForPaths(base(), new Set(["a.md"]), [
+			semantic("a.md", "b.md", 0.9),
+		]);
+		expect(changed).toBe(true);
+		const semantics = data.edges.filter((e) => e.type === "semantic");
+		expect(semantics).toHaveLength(2);
+		expect(semantics.map((e) => `${e.source}->${e.target}`).sort()).toEqual(["a.md->b.md", "b.md->c.md"]);
+	});
+
+	it("reports no change when the re-query reproduces the same edges", () => {
+		const { changed } = replaceSemanticEdgesForPaths(base(), new Set(["a.md"]), [semantic("a.md", "c.md", 0.8)]);
+		expect(changed).toBe(false);
+	});
+
+	it("ignores new edges whose endpoint is off-graph, and self-loops", () => {
+		const { data } = replaceSemanticEdgesForPaths(base(), new Set(["a.md"]), [
+			semantic("a.md", "missing.md", 0.9),
+			semantic("a.md", "a.md", 0.9),
+		]);
+		expect(data.edges.filter((e) => e.type === "semantic")).toHaveLength(1);
+	});
+
+	it("never emits two semantic edges for the same pair", () => {
+		// Both orderings of the same pair — only one edge may survive.
+		const { data } = replaceSemanticEdgesForPaths(base(), new Set(["a.md"]), [
+			semantic("a.md", "c.md", 0.9),
+			semantic("c.md", "a.md", 0.85),
+		]);
+		const semantics = data.edges.filter((e) => e.type === "semantic");
+		expect(semantics.filter((e) => [e.source, e.target].sort().join("|") === "a.md|c.md")).toHaveLength(1);
+	});
+
+	it("keeps a semantic edge for a pair that also has a wiki link", () => {
+		// Suppressing wiki-linked pairs is the query's job (`excludeEdgeKeys`);
+		// re-applying it here would erode the edge set on every patch, since a
+		// pair can legitimately carry both types.
+		const { data } = replaceSemanticEdgesForPaths(base(), new Set(["a.md"]), [semantic("b.md", "a.md", 0.9)]);
+		const keys = data.edges.map((e) => `${e.type}:${[e.source, e.target].sort().join("|")}`);
+		expect(keys).toContain("wiki:a.md|b.md");
+		expect(keys).toContain("semantic:a.md|b.md");
+	});
+});
+
+describe("voteNodeCommunity", () => {
+	const communities = { "a.md": 0, "b.md": 0, "c.md": 1 };
+	const weightOf = (edge: GraphEdge) => edge.weight;
+
+	it("picks the community with the largest summed edge weight", () => {
+		const edges = [wiki("x.md", "a.md", 1), wiki("x.md", "b.md", 1), wiki("x.md", "c.md", 1)];
+		expect(voteNodeCommunity("x.md", edges, communities, weightOf)).toBe(0);
+	});
+
+	it("lets one heavy edge outvote several light ones", () => {
+		const edges = [wiki("x.md", "a.md", 1), wiki("x.md", "b.md", 1), wiki("x.md", "c.md", 5)];
+		expect(voteNodeCommunity("x.md", edges, communities, weightOf)).toBe(1);
+	});
+
+	it("returns undefined when no neighbour carries a community", () => {
+		const edges = [wiki("x.md", "unassigned.md", 1)];
+		expect(voteNodeCommunity("x.md", edges, communities, weightOf)).toBeUndefined();
+		expect(voteNodeCommunity("x.md", [], communities, weightOf)).toBeUndefined();
+	});
+
+	it("ignores edges not incident to the node", () => {
+		const edges = [wiki("a.md", "b.md", 10), wiki("x.md", "c.md", 1)];
+		expect(voteNodeCommunity("x.md", edges, communities, weightOf)).toBe(1);
+	});
+});
+
+describe("queryNoteSemanticEdges", () => {
+	const chunk = (path: string, chunkIndex = 0): DocumentVector => ({
+		id: `${path}#${chunkIndex}`,
+		path,
+		mtime: 0,
+		checksum: "",
+		vector: new Float32Array([1, 0]),
+		chunkIndex,
+	});
+
+	function fakeStore(chunks: DocumentVector[], hitsByChunkId: Record<string, ScoredDocument[]>): SemanticQueryStore {
+		return {
+			getAllByPath: async (path) => chunks.filter((c) => c.path === path),
+			search: async () => Object.values(hitsByChunkId).flat(),
+		};
+	}
+
+	const hit = (path: string, score: number): ScoredDocument => ({ doc: chunk(path), score });
+
+	it("emits the best hit per neighbour, capped at neighborCount", async () => {
+		const store = fakeStore([chunk("x.md")], {
+			all: [hit("a.md", 0.9), hit("a.md", 0.7), hit("b.md", 0.8), hit("c.md", 0.6)],
+		});
+		const edges = await queryNoteSemanticEdges(store, "x.md", new Set(["x.md", "a.md", "b.md", "c.md"]), {
+			neighborCount: 2,
+			threshold: 0.55,
+		});
+		expect(edges).toEqual([
+			{ source: "x.md", target: "a.md", weight: 0.9, type: "semantic" },
+			{ source: "x.md", target: "b.md", weight: 0.8, type: "semantic" },
+		]);
+	});
+
+	it("filters self hits, off-graph notes, sub-threshold scores and wiki pairs", async () => {
+		const store = fakeStore([chunk("x.md")], {
+			all: [hit("x.md", 1), hit("off.md", 0.9), hit("a.md", 0.4), hit("b.md", 0.8)],
+		});
+		const edges = await queryNoteSemanticEdges(store, "x.md", new Set(["x.md", "a.md", "b.md"]), {
+			neighborCount: 5,
+			threshold: 0.55,
+			excludeEdgeKeys: new Set(["b.md\0x.md"]),
+		});
+		expect(edges).toEqual([]);
+	});
+
+	it("returns nothing when the note has no stored chunks", async () => {
+		const store = fakeStore([], { all: [hit("a.md", 0.9)] });
+		const edges = await queryNoteSemanticEdges(store, "x.md", new Set(["x.md", "a.md"]), {
+			neighborCount: 5,
+			threshold: 0.55,
+		});
+		expect(edges).toEqual([]);
+	});
+});

--- a/test/utils/topicHierarchy.test.ts
+++ b/test/utils/topicHierarchy.test.ts
@@ -277,6 +277,35 @@ describe("deriveGranularityLadder", () => {
 		expect(ladder).toEqual([0.5, 2.0]);
 	});
 
+	it("skips a γ that yields fewer topics than a lower one", () => {
+		// Leiden is a stochastic heuristic: its topic count trends upward with γ
+		// but can dip. Sorting rungs by count and by resolution independently let
+		// those orders disagree, so the slider showed 4 topics at one level and 3
+		// at the next.
+		const ladder = deriveGranularityLadder([
+			{ resolution: 0.5, topicCount: 3 },
+			{ resolution: 1.0, topicCount: 8 },
+			{ resolution: 2.0, topicCount: 4 },
+			{ resolution: 4.0, topicCount: 14 },
+		]);
+		// γ 2.0 dips back to 4 topics — dropped, not reordered ahead of γ 1.0.
+		expect(ladder).toEqual([0.5, 1.0, 4.0]);
+	});
+
+	it("keeps topic counts rising in step with the resolutions", () => {
+		const probes = [
+			{ resolution: 0.2, topicCount: 2 },
+			{ resolution: 0.6, topicCount: 5 },
+			{ resolution: 1.2, topicCount: 3 },
+			{ resolution: 2.5, topicCount: 9 },
+			{ resolution: 5.0, topicCount: 7 },
+		];
+		const ladder = deriveGranularityLadder(probes)!;
+		const counts = ladder.map((r) => probes.find((p) => p.resolution === r)!.topicCount);
+		expect([...ladder]).toEqual([...ladder].sort((a, b) => a - b));
+		expect([...counts]).toEqual([...counts].sort((a, b) => a - b));
+	});
+
 	it("waives the readability cap when every grouping exceeds it", () => {
 		// A huge vault whose coarsest partition is already past the cap still
 		// deserves a slider — capped-only filtering would return nothing.
@@ -294,6 +323,24 @@ describe("summarizePartition", () => {
 		// Two real topics (a/b and c/d) plus two loners.
 		const communities = { a: 0, b: 0, c: 1, d: 1, e: 2, f: 3 };
 		expect(summarizePartition(communities).topicCount).toBe(2);
+	});
+
+	it("counts only communities the view will actually render", () => {
+		// Leiden runs over topic edges, so its map can hold nodes the graph
+		// isn't showing; segment resolution drops those communities. Counting
+		// them anyway labelled ladder rungs with topic counts never displayed.
+		const communities = { a: 0, b: 0, c: 1, d: 1 };
+		expect(summarizePartition(communities).topicCount).toBe(2);
+		// Only the first community's nodes are on screen.
+		const visible = new Set(["a", "b"]);
+		expect(summarizePartition(communities, visible).topicCount).toBe(1);
+	});
+
+	it("drops a community left below the topic threshold by filtering", () => {
+		// c/d is a real topic in the partition, but only c is rendered — a lone
+		// note is not a topic, exactly as resolveSegmentsByLeiden decides.
+		const communities = { a: 0, b: 0, c: 1, d: 1 };
+		expect(summarizePartition(communities, new Set(["a", "b", "c"])).topicCount).toBe(1);
 	});
 
 	it("flags a partition that has shattered into singletons", () => {

--- a/test/utils/topicHierarchy.test.ts
+++ b/test/utils/topicHierarchy.test.ts
@@ -247,9 +247,45 @@ describe("deriveGranularityLadder", () => {
 		const ladder = deriveGranularityLadder(probes);
 
 		expect(ladder!.length).toBeLessThanOrEqual(MAX_DERIVED_GRANULARITY_LEVELS);
-		// The extremes must survive trimming, or the slider loses reach.
+		// The broad extreme must survive trimming, or the slider loses reach.
 		expect(ladder![0]).toBeCloseTo(0.1, 5);
-		expect(ladder![ladder!.length - 1]).toBeCloseTo(0.1 + 29 * 0.25, 5);
+		// The fine extreme is deliberately NOT the finest grouping found: rungs
+		// past the readability cap (30 topics here → count 31 dropped) and
+		// near-duplicate steps are trimmed first, so the top rung is the finest
+		// *useful* grouping — count 26 at γ 0.1 + 24×0.25.
+		expect(ladder![ladder!.length - 1]).toBeCloseTo(0.1 + 24 * 0.25, 5);
+	});
+
+	it("drops rungs whose topic count exceeds the readability cap", () => {
+		const ladder = deriveGranularityLadder([
+			{ resolution: 0.5, topicCount: 8 },
+			{ resolution: 1.0, topicCount: 20 },
+			{ resolution: 2.0, topicCount: 45 },
+			{ resolution: 4.0, topicCount: 80 },
+		]);
+		expect(ladder).toEqual([0.5, 1.0]);
+	});
+
+	it("requires a real jump in topic count between rungs", () => {
+		// 10 → 11 → 12 are near-duplicate groupings; only 10 and 20 remain.
+		const ladder = deriveGranularityLadder([
+			{ resolution: 0.5, topicCount: 10 },
+			{ resolution: 1.0, topicCount: 11 },
+			{ resolution: 1.5, topicCount: 12 },
+			{ resolution: 2.0, topicCount: 20 },
+		]);
+		expect(ladder).toEqual([0.5, 2.0]);
+	});
+
+	it("waives the readability cap when every grouping exceeds it", () => {
+		// A huge vault whose coarsest partition is already past the cap still
+		// deserves a slider — capped-only filtering would return nothing.
+		const ladder = deriveGranularityLadder([
+			{ resolution: 0.5, topicCount: 40 },
+			{ resolution: 1.0, topicCount: 60 },
+			{ resolution: 2.0, topicCount: 90 },
+		]);
+		expect(ladder).toEqual([0.5, 1.0, 2.0]);
 	});
 });
 

--- a/test/views/topicCaches.test.ts
+++ b/test/views/topicCaches.test.ts
@@ -9,9 +9,9 @@ import {
 	getCachedPartition,
 	getCachedResolution,
 	getCachedSemanticEdges,
-	setActiveGraphResolution,
 	setCachedGranularityLadder,
 	setCachedPartition,
+	setCachedResolution,
 	setCachedSemanticEdges,
 	snapshotTopicCaches,
 	swapActiveGraphCache,
@@ -158,12 +158,12 @@ describe("swapActiveGraphCache", () => {
 		// Full graph viewed at γ 1.0.
 		swapActiveGraphCache("res-full");
 		setCachedPartition("res-full", "7:1:fused", { "a.md": 0 });
-		setActiveGraphResolution(1.0);
+		setCachedResolution("res-full", 1.0);
 
 		// Immerse and dial the topics finer — a statement about the subset.
 		swapActiveGraphCache("res-immersed", 1.0);
 		setCachedPartition("res-immersed", "7:4.2:fused", { "a.md": 0 });
-		setActiveGraphResolution(4.2);
+		setCachedResolution("res-immersed", 4.2);
 
 		// Exiting restores the full graph's own γ, not the immersed one.
 		expect(swapActiveGraphCache("res-full", 4.2)).toBe(true);
@@ -177,7 +177,7 @@ describe("swapActiveGraphCache", () => {
 	it("leaves resolution null for a graph never assigned one", () => {
 		swapActiveGraphCache("res-fresh-a");
 		setCachedPartition("res-fresh-a", "7:1:fused", { "a.md": 0 });
-		setActiveGraphResolution(2.2);
+		setCachedResolution("res-fresh-a", 2.2);
 		// A graph seen for the first time has no γ of its own — the caller keeps
 		// the current global setting rather than being moved.
 		swapActiveGraphCache("res-fresh-b", 2.2);
@@ -235,6 +235,22 @@ describe("signature-addressed partitions", () => {
 		expect(getCachedPartition("addr-a", "7:1:fused")).toEqual({ "a.md": 1 });
 		expect(swapActiveGraphCache("addr-a")).toBe(true);
 		expect(getCachedPartition("addr-a", "7:1:fused")).toEqual({ "a.md": 1 });
+	});
+
+	it("records a γ against its own graph, not whichever slot is active", () => {
+		// A settings write can land while another leaf owns the slot; storing the
+		// γ there would re-segment that graph at the wrong granularity on restore
+		// — and since topic ids are positions in a fresh partition, that also
+		// clears its folds, focus and selection.
+		swapActiveGraphCache("gamma-a");
+		setCachedResolution("gamma-a", 1.0);
+		swapActiveGraphCache("gamma-b");
+		setCachedResolution("gamma-b", 2.2);
+
+		setCachedResolution("gamma-a", 4.2);
+
+		expect(getCachedResolution("gamma-b")).toBe(2.2);
+		expect(getCachedResolution("gamma-a")).toBe(4.2);
 	});
 
 	it("writes straight through when the graph is still active", () => {

--- a/test/views/topicCaches.test.ts
+++ b/test/views/topicCaches.test.ts
@@ -6,6 +6,7 @@ import {
 	getCachedPartition,
 	getCachedSemanticEdges,
 	setActiveGraphResolution,
+	setCachedGranularityLadder,
 	setCachedPartition,
 	setCachedSemanticEdges,
 	snapshotTopicCaches,
@@ -237,6 +238,25 @@ describe("signature-addressed partitions", () => {
 		setCachedPartition("addr-active", "7:1:fused", { "x.md": 2 });
 		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "x.md": 2 });
 		expect(getCachedPartition("addr-active", "7:1:fused")).toEqual({ "x.md": 2 });
+	});
+
+	it("files a derived ladder under its own graph, not whichever slot is active", () => {
+		// Probing sweeps several γ values, awaiting a Leiden run at each, so
+		// another leaf can take the active slot before the ladder is stored —
+		// which would give that graph's slider levels from a different topology.
+		swapActiveGraphCache("ladder-a");
+		topicCaches.leiden.set("seed", { "a.md": 0 });
+		swapActiveGraphCache("ladder-b");
+		topicCaches.leiden.set("seed", { "b.md": 0 });
+		topicCaches.granularityLadder = [1, 2];
+
+		setCachedGranularityLadder("ladder-a", [0.5, 1.0, 2.0]);
+
+		// The active graph keeps its own ladder…
+		expect(topicCaches.granularityLadder).toEqual([1, 2]);
+		// …and A's is waiting when we return to it.
+		expect(swapActiveGraphCache("ladder-a")).toBe(true);
+		expect(topicCaches.granularityLadder).toEqual([0.5, 1.0, 2.0]);
 	});
 
 	it("preserves a result for a graph that is neither active nor archived", () => {

--- a/test/views/topicCaches.test.ts
+++ b/test/views/topicCaches.test.ts
@@ -96,6 +96,22 @@ describe("encodeTopicCaches / decodeTopicCaches", () => {
 		expect(wikiPartition).toHaveLength(3);
 	});
 
+	it("discards a ladder derived under different rules, keeping the rest of the entry", () => {
+		// The regression: a persisted 10-rung ladder survived the switch to a
+		// 7-rung derivation, because the cache is keyed by graph signature —
+		// which cannot notice that the code computing the ladder changed.
+		const encoded = encodeTopicCaches(sampleSnapshot());
+		const stale = structuredClone(encoded);
+		for (const graph of stale.graphs) graph.granularityLadderRules = "rules-from-an-older-build";
+
+		const decoded = decodeTopicCaches(stale);
+		expect(decoded).not.toBeNull();
+		const entry = decoded?.graphs.get("full-graph-sig");
+		expect(entry?.granularityLadder).toBeNull();
+		// The expensive partitions are unaffected — only the ladder is re-derived.
+		expect(entry?.leiden.get("7:1:fused")).toEqual({ "a.md": 0, "b.md": 0, "c.md": 1 });
+	});
+
 	it("rejects payloads from another schema version or malformed shapes", () => {
 		const encoded = encodeTopicCaches(sampleSnapshot());
 		expect(decodeTopicCaches({ ...encoded, version: 999 })).toBeNull();

--- a/test/views/topicCaches.test.ts
+++ b/test/views/topicCaches.test.ts
@@ -4,6 +4,7 @@ import {
 	decodeTopicCaches,
 	encodeTopicCaches,
 	getCachedSemanticEdges,
+	setActiveGraphResolution,
 	setCachedSemanticEdges,
 	snapshotTopicCaches,
 	swapActiveGraphCache,
@@ -26,6 +27,7 @@ function sampleSnapshot(): TopicCacheSnapshot {
 						["7:0.5:wiki", { "a.md": 0, "b.md": 0 }],
 					]),
 					granularityLadder: [0.4, 1.0, 2.2],
+					resolution: 1.0,
 					lastUsed: 100,
 				},
 			],
@@ -34,6 +36,7 @@ function sampleSnapshot(): TopicCacheSnapshot {
 				{
 					leiden: new Map([["7:1:fused", { "a.md": 0, "b.md": 1 }]]),
 					granularityLadder: null,
+					resolution: 2.2,
 					lastUsed: 50,
 				},
 			],
@@ -53,6 +56,7 @@ describe("encodeTopicCaches / decodeTopicCaches", () => {
 		for (const [signature, entry] of original.graphs) {
 			const decodedEntry = decoded?.graphs.get(signature);
 			expect(decodedEntry?.granularityLadder).toEqual(entry.granularityLadder);
+			expect(decodedEntry?.resolution).toBe(entry.resolution);
 			expect([...decodedEntry!.leiden.keys()].sort()).toEqual([...entry.leiden.keys()].sort());
 			for (const [key, partition] of entry.leiden) {
 				expect(decodedEntry?.leiden.get(key)).toEqual(partition);
@@ -68,12 +72,15 @@ describe("encodeTopicCaches / decodeTopicCaches", () => {
 	it("round-trips empty optional caches", () => {
 		const original: TopicCacheSnapshot = {
 			activeSignature: "sig",
-			graphs: new Map([["sig", { leiden: new Map([["7:1:fused", { "a.md": 0 }]]), granularityLadder: null, lastUsed: 1 }]]),
+			graphs: new Map([
+				["sig", { leiden: new Map([["7:1:fused", { "a.md": 0 }]]), granularityLadder: null, resolution: null, lastUsed: 1 }],
+			]),
 			semanticEdges: new Map(),
 			topicLabels: new Map(),
 		};
 		const decoded = decodeTopicCaches(encodeTopicCaches(original));
 		expect(decoded?.graphs.get("sig")?.granularityLadder).toBeNull();
+		expect(decoded?.graphs.get("sig")?.resolution).toBeNull();
 		expect(decoded?.semanticEdges.size).toBe(0);
 		expect(decoded?.topicLabels.size).toBe(0);
 		expect(decoded?.graphs.get("sig")?.leiden.get("7:1:fused")).toEqual({ "a.md": 0 });
@@ -123,6 +130,36 @@ describe("swapActiveGraphCache", () => {
 		// And re-immersing restores the immersed slot too.
 		expect(swapActiveGraphCache("swap-immersed")).toBe(true);
 		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "a.md": 0 });
+	});
+
+	it("keeps granularity per graph across an immerse round-trip", () => {
+		// Full graph viewed at γ 1.0.
+		swapActiveGraphCache("res-full");
+		topicCaches.leiden.set("7:1:fused", { "a.md": 0 });
+		setActiveGraphResolution(1.0);
+
+		// Immerse and dial the topics finer — a statement about the subset.
+		swapActiveGraphCache("res-immersed", 1.0);
+		topicCaches.leiden.set("7:4.2:fused", { "a.md": 0 });
+		setActiveGraphResolution(4.2);
+
+		// Exiting restores the full graph's own γ, not the immersed one.
+		expect(swapActiveGraphCache("res-full", 4.2)).toBe(true);
+		expect(topicCaches.resolution).toBe(1.0);
+
+		// …and re-immersing brings the subset's γ back.
+		expect(swapActiveGraphCache("res-immersed", 1.0)).toBe(true);
+		expect(topicCaches.resolution).toBe(4.2);
+	});
+
+	it("leaves resolution null for a graph never assigned one", () => {
+		swapActiveGraphCache("res-fresh-a");
+		topicCaches.leiden.set("7:1:fused", { "a.md": 0 });
+		setActiveGraphResolution(2.2);
+		// A graph seen for the first time has no γ of its own — the caller keeps
+		// the current global setting rather than being moved.
+		swapActiveGraphCache("res-fresh-b", 2.2);
+		expect(topicCaches.resolution).toBeNull();
 	});
 
 	it("treats a swap to the current signature as a restore no-op", () => {

--- a/test/views/topicCaches.test.ts
+++ b/test/views/topicCaches.test.ts
@@ -3,7 +3,11 @@ import type { GraphEdge } from "../../src/types/graph";
 import {
 	decodeTopicCaches,
 	encodeTopicCaches,
+	clearCachedPartitions,
+	getActiveGraphSignature,
+	getCachedGranularityLadder,
 	getCachedPartition,
+	getCachedResolution,
 	getCachedSemanticEdges,
 	setActiveGraphResolution,
 	setCachedGranularityLadder,
@@ -11,7 +15,6 @@ import {
 	setCachedSemanticEdges,
 	snapshotTopicCaches,
 	swapActiveGraphCache,
-	topicCaches,
 	type TopicCacheSnapshot,
 } from "../../src/views/smart-graph/topicCaches";
 
@@ -132,65 +135,66 @@ describe("swapActiveGraphCache", () => {
 	it("archives the outgoing graph and restores it when its signature returns", () => {
 		// Establish a "full graph" slot with content.
 		swapActiveGraphCache("swap-full");
-		topicCaches.leiden.set("7:1:fused", { "a.md": 0, "b.md": 1 });
-		topicCaches.granularityLadder = [0.5, 1.5];
+		setCachedPartition("swap-full", "7:1:fused", { "a.md": 0, "b.md": 1 });
+		setCachedGranularityLadder("swap-full", [0.5, 1.5]);
 
 		// Immerse: different signature, nothing cached for it yet.
 		expect(swapActiveGraphCache("swap-immersed")).toBe(false);
-		expect(topicCaches.leiden.size).toBe(0);
-		expect(topicCaches.granularityLadder).toBeNull();
-		topicCaches.leiden.set("7:1:fused", { "a.md": 0 });
+		expect(getCachedPartition("swap-immersed", "7:1:fused")).toBeUndefined();
+		expect(getCachedGranularityLadder("swap-immersed")).toBeNull();
+		setCachedPartition("swap-immersed", "7:1:fused", { "a.md": 0 });
 
 		// Exit immerse: the full graph's derivations come back untouched.
 		expect(swapActiveGraphCache("swap-full")).toBe(true);
-		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "a.md": 0, "b.md": 1 });
-		expect(topicCaches.granularityLadder).toEqual([0.5, 1.5]);
+		expect(getCachedPartition("swap-full", "7:1:fused")).toEqual({ "a.md": 0, "b.md": 1 });
+		expect(getCachedGranularityLadder("swap-full")).toEqual([0.5, 1.5]);
 
 		// And re-immersing restores the immersed slot too.
 		expect(swapActiveGraphCache("swap-immersed")).toBe(true);
-		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "a.md": 0 });
+		expect(getCachedPartition("swap-immersed", "7:1:fused")).toEqual({ "a.md": 0 });
 	});
 
 	it("keeps granularity per graph across an immerse round-trip", () => {
 		// Full graph viewed at γ 1.0.
 		swapActiveGraphCache("res-full");
-		topicCaches.leiden.set("7:1:fused", { "a.md": 0 });
+		setCachedPartition("res-full", "7:1:fused", { "a.md": 0 });
 		setActiveGraphResolution(1.0);
 
 		// Immerse and dial the topics finer — a statement about the subset.
 		swapActiveGraphCache("res-immersed", 1.0);
-		topicCaches.leiden.set("7:4.2:fused", { "a.md": 0 });
+		setCachedPartition("res-immersed", "7:4.2:fused", { "a.md": 0 });
 		setActiveGraphResolution(4.2);
 
 		// Exiting restores the full graph's own γ, not the immersed one.
 		expect(swapActiveGraphCache("res-full", 4.2)).toBe(true);
-		expect(topicCaches.resolution).toBe(1.0);
+		expect(getCachedResolution("res-full")).toBe(1.0);
 
 		// …and re-immersing brings the subset's γ back.
 		expect(swapActiveGraphCache("res-immersed", 1.0)).toBe(true);
-		expect(topicCaches.resolution).toBe(4.2);
+		expect(getCachedResolution("res-immersed")).toBe(4.2);
 	});
 
 	it("leaves resolution null for a graph never assigned one", () => {
 		swapActiveGraphCache("res-fresh-a");
-		topicCaches.leiden.set("7:1:fused", { "a.md": 0 });
+		setCachedPartition("res-fresh-a", "7:1:fused", { "a.md": 0 });
 		setActiveGraphResolution(2.2);
 		// A graph seen for the first time has no γ of its own — the caller keeps
 		// the current global setting rather than being moved.
 		swapActiveGraphCache("res-fresh-b", 2.2);
-		expect(topicCaches.resolution).toBeNull();
+		expect(getCachedResolution("res-fresh-b")).toBeNull();
 	});
 
 	it("treats a swap to the current signature as a restore no-op", () => {
 		swapActiveGraphCache("swap-same");
-		topicCaches.leiden.set("7:1:fused", { "a.md": 0 });
+		setCachedPartition("swap-same", "7:1:fused", { "a.md": 0 });
 		expect(swapActiveGraphCache("swap-same")).toBe(true);
-		expect(topicCaches.leiden.size).toBe(1);
+		// The no-op swap must leave the entry in place, not reset the slot.
+		expect(getCachedPartition("swap-same", "7:1:fused")).toEqual({ "a.md": 0 });
 	});
 
 	it("does not archive a slot that never derived anything", () => {
 		swapActiveGraphCache("swap-empty");
-		expect(topicCaches.leiden.size).toBe(0);
+		expect(getCachedPartition("swap-empty", "7:1:fused")).toBeUndefined();
 		swapActiveGraphCache("swap-elsewhere");
 		// Coming back finds nothing archived — the empty slot wasn't kept.
 		expect(swapActiveGraphCache("swap-empty")).toBe(false);
@@ -200,14 +204,14 @@ describe("swapActiveGraphCache", () => {
 		// Fill well past MAX_CACHED_GRAPHS with distinct non-empty graphs.
 		for (let i = 0; i < 8; i++) {
 			swapActiveGraphCache(`swap-evict-${i}`);
-			topicCaches.leiden.set("7:1:fused", { "a.md": i });
+			setCachedPartition(`swap-evict-${i}`, "7:1:fused", { "a.md": i });
 		}
 		// The earliest graphs must have been evicted…
 		expect(swapActiveGraphCache("swap-evict-0")).toBe(false);
 		// …while the most recent previous one survives. (Returning to 0 above
 		// re-keyed the slot, so the latest graph was archived, not lost.)
 		expect(swapActiveGraphCache("swap-evict-7")).toBe(true);
-		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "a.md": 7 });
+		expect(getCachedPartition("swap-evict-7", "7:1:fused")).toEqual({ "a.md": 7 });
 	});
 });
 
@@ -217,26 +221,26 @@ describe("signature-addressed partitions", () => {
 		// active slot to graph B, and the completed partition lands in B's map —
 		// where it would later be served as B's partition.
 		swapActiveGraphCache("addr-a");
-		topicCaches.leiden.set("seed", { "a.md": 0 });
+		setCachedPartition("addr-a", "seed", { "a.md": 0 });
 		swapActiveGraphCache("addr-b");
-		topicCaches.leiden.set("seed", { "b.md": 0 });
+		setCachedPartition("addr-b", "seed", { "b.md": 0 });
 
 		// Result of a run that started while A was active.
 		setCachedPartition("addr-a", "7:1:fused", { "a.md": 1 });
 
 		// B (the active slot) must be untouched…
-		expect(topicCaches.graphSignature).toBe("addr-b");
+		expect(getActiveGraphSignature()).toBe("addr-b");
 		expect(getCachedPartition("addr-b", "7:1:fused")).toBeUndefined();
 		// …and A must have it when we return.
 		expect(getCachedPartition("addr-a", "7:1:fused")).toEqual({ "a.md": 1 });
 		expect(swapActiveGraphCache("addr-a")).toBe(true);
-		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "a.md": 1 });
+		expect(getCachedPartition("addr-a", "7:1:fused")).toEqual({ "a.md": 1 });
 	});
 
 	it("writes straight through when the graph is still active", () => {
 		swapActiveGraphCache("addr-active");
 		setCachedPartition("addr-active", "7:1:fused", { "x.md": 2 });
-		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "x.md": 2 });
+		expect(getCachedPartition("addr-active", "7:1:fused")).toEqual({ "x.md": 2 });
 		expect(getCachedPartition("addr-active", "7:1:fused")).toEqual({ "x.md": 2 });
 	});
 
@@ -245,23 +249,23 @@ describe("signature-addressed partitions", () => {
 		// another leaf can take the active slot before the ladder is stored —
 		// which would give that graph's slider levels from a different topology.
 		swapActiveGraphCache("ladder-a");
-		topicCaches.leiden.set("seed", { "a.md": 0 });
+		setCachedPartition("ladder-a", "seed", { "a.md": 0 });
 		swapActiveGraphCache("ladder-b");
-		topicCaches.leiden.set("seed", { "b.md": 0 });
-		topicCaches.granularityLadder = [1, 2];
+		setCachedPartition("ladder-b", "seed", { "b.md": 0 });
+		setCachedGranularityLadder("ladder-b", [1, 2]);
 
 		setCachedGranularityLadder("ladder-a", [0.5, 1.0, 2.0]);
 
 		// The active graph keeps its own ladder…
-		expect(topicCaches.granularityLadder).toEqual([1, 2]);
+		expect(getCachedGranularityLadder("ladder-b")).toEqual([1, 2]);
 		// …and A's is waiting when we return to it.
 		expect(swapActiveGraphCache("ladder-a")).toBe(true);
-		expect(topicCaches.granularityLadder).toEqual([0.5, 1.0, 2.0]);
+		expect(getCachedGranularityLadder("ladder-a")).toEqual([0.5, 1.0, 2.0]);
 	});
 
 	it("preserves a result for a graph that is neither active nor archived", () => {
 		swapActiveGraphCache("addr-elsewhere");
-		topicCaches.leiden.set("seed", { "e.md": 0 });
+		setCachedPartition("addr-elsewhere", "seed", { "e.md": 0 });
 		setCachedPartition("addr-unknown", "7:1:fused", { "u.md": 3 });
 		// Returning to that graph finds its computation waiting.
 		expect(getCachedPartition("addr-unknown", "7:1:fused")).toEqual({ "u.md": 3 });
@@ -289,9 +293,9 @@ describe("semantic edge set cache", () => {
 describe("snapshotTopicCaches", () => {
 	it("includes the active graph and archived graphs", () => {
 		swapActiveGraphCache("snap-a");
-		topicCaches.leiden.set("7:1:fused", { "a.md": 0 });
+		setCachedPartition("snap-a", "7:1:fused", { "a.md": 0 });
 		swapActiveGraphCache("snap-b");
-		topicCaches.leiden.set("7:1:fused", { "b.md": 1 });
+		setCachedPartition("snap-b", "7:1:fused", { "b.md": 1 });
 
 		const snapshot = snapshotTopicCaches();
 		expect(snapshot.activeSignature).toBe("snap-b");

--- a/test/views/topicCaches.test.ts
+++ b/test/views/topicCaches.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import type { GraphEdge } from "../../src/types/graph";
+import {
+	decodeTopicCaches,
+	encodeTopicCaches,
+	getCachedSemanticEdges,
+	setCachedSemanticEdges,
+	snapshotTopicCaches,
+	swapActiveGraphCache,
+	topicCaches,
+	type TopicCacheSnapshot,
+} from "../../src/views/smart-graph/topicCaches";
+
+function sampleSnapshot(): TopicCacheSnapshot {
+	const semantic: GraphEdge = { source: "a.md", target: "c.md", weight: 0.81, type: "semantic" };
+	return {
+		activeSignature: "full-graph-sig",
+		graphs: new Map([
+			[
+				"full-graph-sig",
+				{
+					leiden: new Map([
+						["7:1:fused", { "a.md": 0, "b.md": 0, "c.md": 1 }],
+						// A different rung over the same graph may cover a different
+						// node set (e.g. link-only mode sees fewer edges).
+						["7:0.5:wiki", { "a.md": 0, "b.md": 0 }],
+					]),
+					granularityLadder: [0.4, 1.0, 2.2],
+					lastUsed: 100,
+				},
+			],
+			[
+				"immersed-sig",
+				{
+					leiden: new Map([["7:1:fused", { "a.md": 0, "b.md": 1 }]]),
+					granularityLadder: null,
+					lastUsed: 50,
+				},
+			],
+		]),
+		semanticEdges: new Map([["sig|index|123|5|0.55", { edges: [semantic], lastUsed: 100 }]]),
+		topicLabels: new Map([["a b c", "Test Topic"]]),
+	};
+}
+
+describe("encodeTopicCaches / decodeTopicCaches", () => {
+	it("round-trips every cached graph exactly", () => {
+		const original = sampleSnapshot();
+		const decoded = decodeTopicCaches(encodeTopicCaches(original));
+		expect(decoded).not.toBeNull();
+		expect(decoded?.activeSignature).toBe(original.activeSignature);
+		expect([...decoded!.graphs.keys()].sort()).toEqual([...original.graphs.keys()].sort());
+		for (const [signature, entry] of original.graphs) {
+			const decodedEntry = decoded?.graphs.get(signature);
+			expect(decodedEntry?.granularityLadder).toEqual(entry.granularityLadder);
+			expect([...decodedEntry!.leiden.keys()].sort()).toEqual([...entry.leiden.keys()].sort());
+			for (const [key, partition] of entry.leiden) {
+				expect(decodedEntry?.leiden.get(key)).toEqual(partition);
+			}
+		}
+		expect([...decoded!.semanticEdges.keys()]).toEqual([...original.semanticEdges.keys()]);
+		expect(decoded?.semanticEdges.get("sig|index|123|5|0.55")?.edges).toEqual(
+			original.semanticEdges.get("sig|index|123|5|0.55")?.edges,
+		);
+		expect([...decoded!.topicLabels]).toEqual([...original.topicLabels]);
+	});
+
+	it("round-trips empty optional caches", () => {
+		const original: TopicCacheSnapshot = {
+			activeSignature: "sig",
+			graphs: new Map([["sig", { leiden: new Map([["7:1:fused", { "a.md": 0 }]]), granularityLadder: null, lastUsed: 1 }]]),
+			semanticEdges: new Map(),
+			topicLabels: new Map(),
+		};
+		const decoded = decodeTopicCaches(encodeTopicCaches(original));
+		expect(decoded?.graphs.get("sig")?.granularityLadder).toBeNull();
+		expect(decoded?.semanticEdges.size).toBe(0);
+		expect(decoded?.topicLabels.size).toBe(0);
+		expect(decoded?.graphs.get("sig")?.leiden.get("7:1:fused")).toEqual({ "a.md": 0 });
+	});
+
+	it("shares one path list per graph across its partitions", () => {
+		const encoded = encodeTopicCaches(sampleSnapshot());
+		const fullGraph = encoded.graphs.find((graph) => graph.signature === "full-graph-sig");
+		expect(fullGraph?.nodePaths.slice().sort()).toEqual(["a.md", "b.md", "c.md"]);
+		// The wiki-only partition has no c.md — its slot is the -1 sentinel.
+		const wikiPartition = fullGraph?.partitions["7:0.5:wiki"];
+		expect(wikiPartition).toContain(-1);
+		expect(wikiPartition).toHaveLength(3);
+	});
+
+	it("rejects payloads from another schema version or malformed shapes", () => {
+		const encoded = encodeTopicCaches(sampleSnapshot());
+		expect(decodeTopicCaches({ ...encoded, version: 999 })).toBeNull();
+		expect(decodeTopicCaches(null)).toBeNull();
+		expect(decodeTopicCaches("junk")).toBeNull();
+		expect(decodeTopicCaches({ ...encoded, graphs: "not-an-array" })).toBeNull();
+		// A partition whose length disagrees with its graph's path list is corrupt.
+		const corrupt = structuredClone(encoded);
+		corrupt.graphs[0].partitions["7:1:fused"] = [0];
+		expect(decodeTopicCaches(corrupt)).toBeNull();
+	});
+});
+
+describe("swapActiveGraphCache", () => {
+	it("archives the outgoing graph and restores it when its signature returns", () => {
+		// Establish a "full graph" slot with content.
+		swapActiveGraphCache("swap-full");
+		topicCaches.leiden.set("7:1:fused", { "a.md": 0, "b.md": 1 });
+		topicCaches.granularityLadder = [0.5, 1.5];
+
+		// Immerse: different signature, nothing cached for it yet.
+		expect(swapActiveGraphCache("swap-immersed")).toBe(false);
+		expect(topicCaches.leiden.size).toBe(0);
+		expect(topicCaches.granularityLadder).toBeNull();
+		topicCaches.leiden.set("7:1:fused", { "a.md": 0 });
+
+		// Exit immerse: the full graph's derivations come back untouched.
+		expect(swapActiveGraphCache("swap-full")).toBe(true);
+		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "a.md": 0, "b.md": 1 });
+		expect(topicCaches.granularityLadder).toEqual([0.5, 1.5]);
+
+		// And re-immersing restores the immersed slot too.
+		expect(swapActiveGraphCache("swap-immersed")).toBe(true);
+		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "a.md": 0 });
+	});
+
+	it("treats a swap to the current signature as a restore no-op", () => {
+		swapActiveGraphCache("swap-same");
+		topicCaches.leiden.set("7:1:fused", { "a.md": 0 });
+		expect(swapActiveGraphCache("swap-same")).toBe(true);
+		expect(topicCaches.leiden.size).toBe(1);
+	});
+
+	it("does not archive a slot that never derived anything", () => {
+		swapActiveGraphCache("swap-empty");
+		expect(topicCaches.leiden.size).toBe(0);
+		swapActiveGraphCache("swap-elsewhere");
+		// Coming back finds nothing archived — the empty slot wasn't kept.
+		expect(swapActiveGraphCache("swap-empty")).toBe(false);
+	});
+
+	it("evicts the least recently used graph past the cap", () => {
+		// Fill well past MAX_CACHED_GRAPHS with distinct non-empty graphs.
+		for (let i = 0; i < 8; i++) {
+			swapActiveGraphCache(`swap-evict-${i}`);
+			topicCaches.leiden.set("7:1:fused", { "a.md": i });
+		}
+		// The earliest graphs must have been evicted…
+		expect(swapActiveGraphCache("swap-evict-0")).toBe(false);
+		// …while the most recent previous one survives. (Returning to 0 above
+		// re-keyed the slot, so the latest graph was archived, not lost.)
+		expect(swapActiveGraphCache("swap-evict-7")).toBe(true);
+		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "a.md": 7 });
+	});
+});
+
+describe("semantic edge set cache", () => {
+	it("stores and retrieves edge sets by key, missing on unknown keys", () => {
+		const edges: GraphEdge[] = [{ source: "a.md", target: "b.md", weight: 0.9, type: "semantic" }];
+		setCachedSemanticEdges("sem-key-1", edges);
+		expect(getCachedSemanticEdges("sem-key-1")).toEqual(edges);
+		expect(getCachedSemanticEdges("sem-key-unknown")).toBeNull();
+	});
+
+	it("keeps multiple keys alive at once (immerse round-trip)", () => {
+		const full: GraphEdge[] = [{ source: "a.md", target: "b.md", weight: 0.9, type: "semantic" }];
+		const immersed: GraphEdge[] = [{ source: "a.md", target: "c.md", weight: 0.8, type: "semantic" }];
+		setCachedSemanticEdges("sem-full", full);
+		setCachedSemanticEdges("sem-immersed", immersed);
+		expect(getCachedSemanticEdges("sem-full")).toEqual(full);
+		expect(getCachedSemanticEdges("sem-immersed")).toEqual(immersed);
+	});
+});
+
+describe("snapshotTopicCaches", () => {
+	it("includes the active graph and archived graphs", () => {
+		swapActiveGraphCache("snap-a");
+		topicCaches.leiden.set("7:1:fused", { "a.md": 0 });
+		swapActiveGraphCache("snap-b");
+		topicCaches.leiden.set("7:1:fused", { "b.md": 1 });
+
+		const snapshot = snapshotTopicCaches();
+		expect(snapshot.activeSignature).toBe("snap-b");
+		expect(snapshot.graphs.get("snap-a")?.leiden.get("7:1:fused")).toEqual({ "a.md": 0 });
+		expect(snapshot.graphs.get("snap-b")?.leiden.get("7:1:fused")).toEqual({ "b.md": 1 });
+	});
+});

--- a/test/views/topicCaches.test.ts
+++ b/test/views/topicCaches.test.ts
@@ -3,8 +3,10 @@ import type { GraphEdge } from "../../src/types/graph";
 import {
 	decodeTopicCaches,
 	encodeTopicCaches,
+	getCachedPartition,
 	getCachedSemanticEdges,
 	setActiveGraphResolution,
+	setCachedPartition,
 	setCachedSemanticEdges,
 	snapshotTopicCaches,
 	swapActiveGraphCache,
@@ -205,6 +207,44 @@ describe("swapActiveGraphCache", () => {
 		// re-keyed the slot, so the latest graph was archived, not lost.)
 		expect(swapActiveGraphCache("swap-evict-7")).toBe(true);
 		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "a.md": 7 });
+	});
+});
+
+describe("signature-addressed partitions", () => {
+	it("files an async result under its own graph when another leaf re-keyed the slot", () => {
+		// The race: a Leiden run starts on graph A, another leaf swaps the shared
+		// active slot to graph B, and the completed partition lands in B's map —
+		// where it would later be served as B's partition.
+		swapActiveGraphCache("addr-a");
+		topicCaches.leiden.set("seed", { "a.md": 0 });
+		swapActiveGraphCache("addr-b");
+		topicCaches.leiden.set("seed", { "b.md": 0 });
+
+		// Result of a run that started while A was active.
+		setCachedPartition("addr-a", "7:1:fused", { "a.md": 1 });
+
+		// B (the active slot) must be untouched…
+		expect(topicCaches.graphSignature).toBe("addr-b");
+		expect(getCachedPartition("addr-b", "7:1:fused")).toBeUndefined();
+		// …and A must have it when we return.
+		expect(getCachedPartition("addr-a", "7:1:fused")).toEqual({ "a.md": 1 });
+		expect(swapActiveGraphCache("addr-a")).toBe(true);
+		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "a.md": 1 });
+	});
+
+	it("writes straight through when the graph is still active", () => {
+		swapActiveGraphCache("addr-active");
+		setCachedPartition("addr-active", "7:1:fused", { "x.md": 2 });
+		expect(topicCaches.leiden.get("7:1:fused")).toEqual({ "x.md": 2 });
+		expect(getCachedPartition("addr-active", "7:1:fused")).toEqual({ "x.md": 2 });
+	});
+
+	it("preserves a result for a graph that is neither active nor archived", () => {
+		swapActiveGraphCache("addr-elsewhere");
+		topicCaches.leiden.set("seed", { "e.md": 0 });
+		setCachedPartition("addr-unknown", "7:1:fused", { "u.md": 3 });
+		// Returning to that graph finds its computation waiting.
+		expect(getCachedPartition("addr-unknown", "7:1:fused")).toEqual({ "u.md": 3 });
 	});
 });
 


### PR DESCRIPTION
Closes #404.

The smart graph didn't react to vault changes while open — `buildGraph()` only ran on view open, manual Refresh, and filter/semantic-setting changes, so notes created, renamed, re-linked or deleted meanwhile didn't appear until the next manual rebuild.

## Live updates

Vault `create`/`modify`/`delete`/`rename` plus `metadataCache` `resolved`, debounced 1.5s, patch the open graph in place:

- **Wiki structure** is diffed against a fresh (cheap) rebuild rather than reconstructed from per-event deltas — diffing out renames and links resolving against newly created notes would be far more fragile. Surviving semantic edges and per-node presentation state (colour, cluster, highlight) carry over, so topics don't flash away mid-patch.
- **Semantic edges** are re-queried per changed note against the live HNSW index instead of re-running the batch scan. The vector store re-embeds ~10s after the last edit, so each queued note is retried on an interval until its stored mtime catches up (bounded at ~2 min).
- **Topics** are re-assigned by neighbour vote — the same vote the bridge heuristic uses — with a full Leiden re-run only once accumulated drift crosses ~2% of nodes, or on explicit Refresh. Each vote is locally plausible but never merges or splits communities the way Leiden does, so the drift counter bounds how far the approximation can wander.
- **Layout**: new nodes seed at their positioned neighbours' centroid (rim of the layout when they have none — an isolated node settles there anyway, and the centroid would bury it inside the existing node mass), renames carry their position across, and the camera never moves for a live patch.

## Cache persistence

- Topic-derivation caches move out of the component into `topicCaches.ts` and persist to IndexedDB, so the first open after an Obsidian restart is instant too. Hydration is unconditional — each entry's existing invalidation key (topology signature, partition key, index `lastUpdated`, label membership) decides what still applies, so a stale entry simply misses its key and is recomputed exactly as before.
- **Multiple graphs are cached at once** (LRU, 4). Previously a single signature-keyed slot meant immersing discarded the full vault's partitions/ladder and exiting re-ran Leiden, ladder probing and labeling from scratch. Semantic edge sets are keyed the same way, so both sides of an immerse or filter round-trip stay cached.
- A cached partition still covering ≥80% of on-screen nodes paints as **interim topics** while the real segmentation computes — otherwise any vault change invalidates the signature and a reload paints grey until a full semantic scan plus Leiden finish.

## Per-graph granularity

Granularity was one global setting, so dialling the topics finer while immersed overwrote the full graph's γ — exiting immerse re-segmented the whole vault at the subset's resolution instead of the one it was left at.

γ now rides along with the rest of a graph's cached derivations: the archived entry records the resolution its graph was last viewed at, and a swap restores it. Immerse → change granularity → exit returns the full graph to its own γ, and re-immersing brings the subset's back.

- A graph seen for the **first time** has no γ of its own and keeps whatever is currently set, so this only ever restores a granularity the user actually chose for that graph rather than yanking new views to an unrelated default.
- Restoring a γ clears topic-indexed state (folds, focus, selection), since a different resolution renumbers every topic — the same rule `handleSettingsChange` already applies.
- Recording happens in `handleSettingsChange`, which every γ path funnels through (slider drag, commit, arrow keys, dev panel).

Adds `VectorStore.getAllByPath()` (all chunk vectors of one note) across the store, worker and proxy — `getByPath` returns only one chunk.

## Layout tuning, measured

The graph's sizing and physics were tuned against a **headless benchmark** rather than screenshots. `src/utils/graphLayout.ts` extracts the force assembly so the *same* code the canvas installs can run without a DOM, and `scripts/graph-layout-bench.ts` settles seeded synthetic vaults across the density range (15 → 8000 nodes, expanded and collapsed) and measures what earlier rounds judged by eye:

| metric | what it catches |
|---|---|
| `fit` / `nodePx` | "have to zoom out too far" / "nodes are dust" / "giant discs" |
| `breathe` | cramped cluster interiors (1.0 = collide-bound crush) |
| `gap` | topics floating apart, or hulls interpenetrating |
| `sat` | unlinked notes flung to the horizon |
| `ovl%` | clusters reading as solid paint |
| `fill` / `waste` | a knot marooned in white space |

Each scenario carries guardrail bands; `bun run bench:layout --assert` exits non-zero on violations. It's deterministic (seeded generation + d3's deterministic `randomSource`), so runs diff cleanly across constant changes.

**Two real bugs it found**, both invisible in screenshots:

- Unsorted notes were glued to the largest topic — the cohesion force read `cluster ?? 0`, and community ids are size-sorted, so every unclustered note was pulled toward community 0.
- `distanceMin(30)` capped charge repulsion across exactly the range neighbouring notes occupy, so intra-cluster spacing was collide-bound at *every* density — including the reference density where all multipliers are 1, which is why no amount of profile tuning had fixed it.

**Layout changes:** per-force density profile (spacing/charge/centering/cohesion each scale differently — a uniform squeeze produced tight blobs floating far apart); per-cluster cohesion damping by member count (the pull grows with distance-to-centroid, so one strength squeezed a 900-member cluster ~5× harder than a 40-member one); satellites get their own centering, immune to the sparse relaxation; sparse graphs spread further so a handful of collapsed topics fills the viewport in world units; topic link rest length floored at the two discs' radii (coupling is about surfaces — the shortened spring was asking large topic nodes to overlap).

**Node sizing:** collapsed topics get their own radius curve (the note formula saturated past ~55 crossing links, so a 180-note and a 2000-note topic rendered identically); the base size counts the notes a graph *represents*, so folding doesn't jump the sizing regime; node radii partially counter-scale with zoom, as edges and labels already did; edge alpha ramps up when zoomed in, where nothing crowds; labels are sized per node against the circle as drawn.

## Camera framing

- Overview framing is capped at 1.3× zoom (selection zooms keep 4× — magnifying chosen notes is the point of that gesture).
- Whole-graph framings **centre on the graph's core while the zoom still fits every node**. Unsorted notes settle in a lopsided ring that dragged the main graph off to one side. The centre is clamped to the slack between viewport and full extent, so nothing is stranded off-screen — when the graph exactly fills the view the centre cannot move at all.
- The delayed corrective refit only fires when the framing actually went stale (>12% extent drift). It exists for fresh builds, which keep spreading after alpha decays, but ran unconditionally — on an already-settled collapse it read as the camera lurching out a second after arriving.

## Granularity ladder

The slider could show **4 topics at one level and 3 at the next**. Two causes:

- Rungs were chosen in topic-count order, then their resolutions sorted independently. Leiden's count trends upward with γ but is *not* monotonic (stochastic heuristic), and when the orderings disagreed the slider walked backwards. Rungs are now selected walking in γ order, each required to increase the count.
- Probes counted communities the view never renders — Leiden runs over topic edges only, so its map covers just connected nodes, while the graph shows every node and segment resolution drops off-screen communities. Rungs were labelled with counts that didn't match the display.

Ladder length also drops (≤7 levels, was 10): rungs above 30 topics are dropped (the palette has 24 slots; past that it's noise, waived if every grouping exceeds it), and each rung must have 1.3× the previous rung's topics so every step is a visible regrouping.

**Cached ladders are keyed by the derivation rules that produced them.** The cache is keyed by graph signature, which cannot notice that the *code* computing a value changed — a persisted 10-rung ladder survived the switch to 7 until this. The same trap applies to any cached derivation.

## Dev panel

Rebuild → reset-to-defaults (restoring exactly the knobs the panel exposes, listed explicitly so user settings are untouched); the remaining tunables exposed (appearance toggles, raw γ, link-only topics, min cluster size); anchored to the same edge as the main panel instead of a hardcoded sideways offset that put it mid-canvas whenever the main panel was closed.

## Notes for review

Two subtleties worth a look, both caught by the unit tests:

- `edgeKey` is order-independent, so using it to let wiki edges suppress semantic ones on the same pair was wrong in two places. A pair can legitimately carry both types (the batch scan only excludes pairs against the wiki links existing *at scan time*), so only a **newly authored** link supersedes an inferred edge, and the re-query dedupe guards semantic-vs-semantic only.
- The incremental semantic path can't reproduce edges some *other* note proposed against the changed note, so the live edge set slightly under-approximates until the next full rebuild. Documented at the call site.

## Testing

- `bun run test` — 1476/1476 passing (86 files). New coverage across `liveGraphPatch`, `topicCaches`, `graphUtils`, `graphAnimation` and `topicHierarchy`: patch/vote/query semantics, snapshot round-trip, archive/restore and per-graph γ across an immerse round-trip, LRU eviction, the sizing/density/zoom curves, outlier-aware framing and its clamp, and the ladder's monotonicity and visible-node counting.
- `bun run check` — 0 errors, 0 warnings (2760 files).
- `bun run bench:layout --assert` — 9/9 scenarios within their guardrail bands.
- `bun run format` clean; `bun run lint` shows only pre-existing errors — 3 fewer than the baseline (removing the old `<script module>` block made `SmartGraphView.svelte` lintable for the first time, surfacing three pre-existing issues, which are fixed here).

Verified live in a large personal vault across several rounds: live note creation, reload-after-change, immerse round-trips, collapse/expand, granularity stepping, and the camera's behaviour on each.

The persisted cache schema is versioned (currently v4); an older payload decodes to null and is rebuilt once, which is invisible apart from one slower first open.

**Tuning constants are eyeballed against one vault**, then held in place by the benchmark's bands. They're all named constants with the reasoning documented at each site — if the layout reads wrong on a differently-shaped vault, those are the dials, and the bench will say what a change costs elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._