### PR TITLE
Keep the AI provider registry in step with provider config

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -75,6 +75,7 @@ import {
 } from "./integrations/pluginIntegrations";
 
 import { getRegistry } from "../providers/registry";
+import { ensureProviderRegistered } from "../providers/registrySync";
 
 import type { StructuredToolInterface } from "@langchain/core/tools";
 import type { MultiServerMCPClient } from "@langchain/mcp-adapters";
@@ -1437,6 +1438,18 @@ export class AgentManager {
 		const subAgents = this.resolveSubAgentSpecs(selectedAgent);
 		const cacheKey = this.buildRunnableCacheKey(selectedAgent, chatModel, summarizationModel);
 
+		// Self-heal before resolving: the registry is normally kept in step by the data
+		// store's provider mutations, but a run can still reach a provider that isn't
+		// registered (a code path that mutated config without going through those hooks).
+		// Registering on demand here is far cheaper than the alternative failure mode below,
+		// which clears the user's model selection. Mirrors VectorStoreService, which has had
+		// the same on-demand registration for embeddings.
+		for (const provider of new Set(
+			[chatModel.provider, summarizationModel.provider, titleModel.provider].filter(Boolean),
+		)) {
+			ensureProviderRegistered(pluginData, provider);
+		}
+
 		let resolved: ResolvedRun;
 		try {
 			resolved = await agent.resolveRun({
@@ -1450,6 +1463,8 @@ export class AgentManager {
 			});
 		} catch (error) {
 			if (error instanceof ProviderNotFoundError) {
+				// Genuinely gone (deleted, or its secret was cleared) — on-demand registration
+				// above already had its chance, so clearing the model is the correct response.
 				pluginData.updateAgent(selectedAgent.id, { chatModel: null });
 				new Notice(`Provider "${chatModel.provider}" is no longer available. Please select a new model.`);
 			}

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -174,16 +174,18 @@ export function invalidateAuthState(provider: string) {
 }
 
 /**
- * Remove all cached state for a provider (auth + combined). Use on delete: provider IDs
- * are deterministic (slug-based), so re-adding a same-named provider would otherwise serve
- * the deleted provider's stale cached auth verdict — showing it "connected" and even
- * auto-committing it before the user enters any credentials. removeQueries drops the
- * entries entirely (invalidate only marks them stale, and staleTime keeps them served).
+ * Remove all cached state for a provider (auth + combined + discovered models). Use on
+ * delete: provider IDs are deterministic (slug-based), so re-adding a same-named provider
+ * would otherwise serve the deleted provider's stale cached auth verdict — showing it
+ * "connected" and even auto-committing it before the user enters any credentials, and
+ * offering its old model list. removeQueries drops the entries entirely (invalidate only
+ * marks them stale, and staleTime keeps them served).
  */
 export function removeProviderQueries(provider: string) {
 	const plugin = getPlugin();
 	plugin.queryClient.removeQueries({ queryKey: ["authState", provider] });
 	plugin.queryClient.removeQueries({ queryKey: ["provider", provider] });
+	plugin.queryClient.removeQueries({ queryKey: ["models", provider] });
 }
 
 /**

--- a/src/providers/registrySync.ts
+++ b/src/providers/registrySync.ts
@@ -1,0 +1,95 @@
+/**
+ * Registry synchronization
+ *
+ * Keeps the runtime `ProviderRegistry` in step with the persisted provider config in
+ * `dataStore`. The registry used to be written exactly once, during
+ * `AgentManager.runInitialize()` at `onLayoutReady` — so adding a provider left it
+ * unregistered until the next Obsidian reload (the chat path threw `ProviderNotFoundError`
+ * and cleared the agent's model), and deleting one left its entry (including the resolved
+ * API key) live in memory and still usable.
+ *
+ * These helpers are deliberately standalone rather than methods on AgentManager: the data
+ * store performs the mutations and must not depend on the agent layer, and
+ * `VectorStoreService` needs the same on-demand registration before the agent exists.
+ */
+
+import type { AuthObject, ProviderInstanceMeta } from "../types/provider/index";
+import { getProviderDefinition } from "./index";
+import { getRegistry } from "./registry";
+
+/**
+ * The slice of the data store these helpers read. Declared structurally so this module
+ * doesn't import the store (which imports this one).
+ */
+export interface ProviderConfigSource {
+	getConfiguredProviders(): string[];
+	getResolvedAuthState(providerId: string): AuthObject | undefined;
+	getAllProviderMeta(): Record<string, ProviderInstanceMeta>;
+}
+
+/**
+ * Registers a single provider, or refreshes its auth if already registered.
+ *
+ * @returns true if the provider is registered and usable afterwards.
+ */
+export function syncProvider(data: ProviderConfigSource, providerId: string): boolean {
+	const registry = getRegistry();
+	const auth = data.getResolvedAuthState(providerId);
+	if (!auth) {
+		// Configured but unresolvable (e.g. its secret was cleared) — drop any stale entry
+		// rather than leaving the previous credentials live.
+		registry.unregister(providerId);
+		return false;
+	}
+
+	const definition = getProviderDefinition(providerId, data.getAllProviderMeta());
+	if (!definition) {
+		registry.unregister(providerId);
+		return false;
+	}
+
+	// `register` overwrites, so this covers both first registration and an auth edit.
+	// Going through it (rather than `updateAuth`) also refreshes the definition, which
+	// matters for template providers whose meta feeds `createTemplateDefinition`.
+	registry.register(providerId, definition, auth);
+	return true;
+}
+
+/**
+ * Removes a provider from the registry. Call on delete, and on the old ID of a rename.
+ */
+export function unsyncProvider(providerId: string): void {
+	getRegistry().unregister(providerId);
+}
+
+/**
+ * Reconciles the whole registry against the configured providers: registers/refreshes
+ * everything configured, and unregisters anything the registry still holds that no longer
+ * is. Cheap (a handful of map writes, no network), so it's safe to call after any provider
+ * mutation whose blast radius isn't a single ID — e.g. a rename, which changes two.
+ */
+export function syncAllProviders(data: ProviderConfigSource): void {
+	const registry = getRegistry();
+	const configured = new Set(data.getConfiguredProviders());
+
+	for (const providerId of registry.list()) {
+		if (!configured.has(providerId)) {
+			registry.unregister(providerId);
+		}
+	}
+
+	for (const providerId of configured) {
+		syncProvider(data, providerId);
+	}
+}
+
+/**
+ * Ensures a provider is registered, registering it on demand if not.
+ *
+ * A safety net for callers that may run before/independently of the mutation hooks above.
+ * Returns false when the provider can't be registered (unknown, or no resolvable auth).
+ */
+export function ensureProviderRegistered(data: ProviderConfigSource, providerId: string): boolean {
+	if (getRegistry().has(providerId)) return true;
+	return syncProvider(data, providerId);
+}

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -51,6 +51,7 @@ import {
 	type ProviderInstanceMeta,
 	type ProviderTemplateId,
 } from "../providers/index";
+import { syncAllProviders, syncProvider, unsyncProvider } from "../providers/registrySync";
 
 const LANGSMITH_API_KEY_SECRET_ID = buildManagedSecretId("langsmith", "apiKey");
 /** Managed secret id for a web-search provider's API key, e.g. "web-search-brave-api-key". */
@@ -2070,6 +2071,15 @@ export class PluginDataStore {
 			}
 		}
 
+		// This is the commit point for a newly added provider (ProviderSetup flips it on a
+		// successful connection). Registering here is what makes the provider usable in chat
+		// immediately, instead of only after the next Obsidian reload.
+		if (isConfigured) {
+			syncProvider(this, providerId);
+		} else {
+			unsyncProvider(providerId);
+		}
+
 		this.saveSettings();
 	}
 
@@ -2091,6 +2101,9 @@ export class PluginDataStore {
 			// Store directly
 			config.auth.values[fieldName] = value;
 		}
+		// Refresh the registry's cached auth — it snapshots the resolved AuthObject at
+		// registration, so an edited key/baseUrl would otherwise keep using the old value.
+		this.syncProviderIfConfigured(providerId);
 		this.saveSettings();
 	}
 
@@ -2108,6 +2121,7 @@ export class PluginDataStore {
 		} else {
 			delete config.auth.secretIds[fieldName];
 		}
+		this.syncProviderIfConfigured(providerId);
 		this.saveSettings();
 	}
 
@@ -2128,7 +2142,19 @@ export class PluginDataStore {
 		const config = this.#data.providerConfig[providerId];
 		if (!config) return;
 		config.auth.authMode = authMode;
+		this.syncProviderIfConfigured(providerId);
 		this.saveSettings();
+	}
+
+	/**
+	 * Refreshes the runtime registry entry for a provider after its auth changed, but only
+	 * once it's configured. Drafts are deliberately skipped: an unconfigured provider is a
+	 * half-filled Setup modal, and registering it would expose a provider the user hasn't
+	 * committed (and that onClose may delete).
+	 */
+	private syncProviderIfConfigured(providerId: string): void {
+		if (!this.isProviderConfigured(providerId)) return;
+		syncProvider(this, providerId);
 	}
 
 	isProviderUsingCodexAuth(providerId: string): boolean {
@@ -2276,6 +2302,10 @@ export class PluginDataStore {
 			}
 		}
 
+		// A rename touches two IDs (drop the old entry, add the new), so reconcile the whole
+		// registry rather than syncing a single ID.
+		syncAllProviders(this);
+
 		await this.saveSettings();
 	}
 
@@ -2305,6 +2335,11 @@ export class PluginDataStore {
 				removeSecret(this._plugin.app, secretId);
 			}
 		}
+
+		// Drop the runtime registry entry. Without this the deleted provider stays live and
+		// fully usable in memory — holding the resolved API key we just cleared from
+		// SecretStorage — until the next Obsidian reload.
+		unsyncProvider(providerId);
 
 		await this.saveSettings();
 	}

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -11,11 +11,11 @@ import { decode, encode } from "@msgpack/msgpack";
 import { Notice, TFile, getAllTags } from "obsidian";
 import { hydrateEmbeddingModel } from "../lib/modelMetadataNormalizer";
 import type SecondBrainPlugin from "../main";
-import { getProviderDefinition } from "../providers/index";
 import { fetchModelsDevData } from "../providers/modelsDevApi";
 import { getOllamaModelsCache } from "../providers/ollamaModels";
 import { fetchOpenRouterModels } from "../providers/openrouterModels";
 import { getRegistry } from "../providers/registry";
+import { ensureProviderRegistered } from "../providers/registrySync";
 import { getData } from "../stores/dataStore.svelte";
 import { chunkText } from "../utils/chunkText";
 import { getEmbeddableVaultFiles, isEmbeddableFile, readIndexableContent } from "../utils/fileFiltering";
@@ -1066,22 +1066,7 @@ export class VectorStoreService {
 	 * on demand here when needed.
 	 */
 	private ensureProviderRegistered(providerId: string): boolean {
-		const registry = getRegistry();
-		if (registry.has(providerId)) return true;
-
-		const data = getData();
-		const auth = data.getResolvedAuthState(providerId);
-		if (!auth) return false;
-
-		const def = getProviderDefinition(providerId, data.getAllProviderMeta());
-		if (!def) return false;
-
-		try {
-			registry.register(providerId, def, auth);
-			return true;
-		} catch {
-			return false;
-		}
+		return ensureProviderRegistered(getData(), providerId);
 	}
 
 	/**

--- a/test/providers/registrySync.test.ts
+++ b/test/providers/registrySync.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for registry synchronization.
+ *
+ * These cover the two leaks the sync helpers exist to close: a deleted provider staying
+ * live (and usable) in the runtime registry, and a newly added provider not being usable
+ * until the next Obsidian reload.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AuthObject, ProviderInstanceMeta } from "../../src/types/provider/index.ts";
+import { getRegistry, resetRegistry } from "../../src/providers/registry.ts";
+import {
+	type ProviderConfigSource,
+	ensureProviderRegistered,
+	syncAllProviders,
+	syncProvider,
+	unsyncProvider,
+} from "../../src/providers/registrySync.ts";
+
+/** Minimal stand-in for the data store, holding only what the sync helpers read. */
+class FakeConfigSource implements ProviderConfigSource {
+	configured = new Set<string>();
+	auth = new Map<string, AuthObject>();
+	meta: Record<string, ProviderInstanceMeta> = {};
+
+	getConfiguredProviders(): string[] {
+		return Array.from(this.configured);
+	}
+
+	getResolvedAuthState(providerId: string): AuthObject | undefined {
+		return this.auth.get(providerId);
+	}
+
+	getAllProviderMeta(): Record<string, ProviderInstanceMeta> {
+		return this.meta;
+	}
+
+	/** Configures a provider the way a completed Setup modal would. */
+	add(providerId: string, auth: AuthObject = { apiKey: "sk-test" }): void {
+		this.configured.add(providerId);
+		this.auth.set(providerId, auth);
+	}
+
+	/** Removes a provider the way `deleteProvider` would (config + secret both gone). */
+	remove(providerId: string): void {
+		this.configured.delete(providerId);
+		this.auth.delete(providerId);
+	}
+}
+
+describe("registrySync", () => {
+	let data: FakeConfigSource;
+
+	beforeEach(() => {
+		resetRegistry();
+		data = new FakeConfigSource();
+	});
+
+	describe("syncProvider", () => {
+		it("registers a configured built-in provider", () => {
+			data.add("openai");
+
+			expect(syncProvider(data, "openai")).toBe(true);
+			expect(getRegistry().has("openai")).toBe(true);
+			expect(getRegistry().getAuth("openai")).toEqual({ apiKey: "sk-test" });
+		});
+
+		it("registers a template provider using its instance meta", () => {
+			data.meta = { "my-custom": { templateId: "openai-compatible", displayName: "My Custom" } };
+			data.add("my-custom", { apiKey: "sk-custom", baseUrl: "https://example.test/v1" });
+
+			expect(syncProvider(data, "my-custom")).toBe(true);
+			expect(getRegistry().get("my-custom")?.displayName).toBe("My Custom");
+		});
+
+		it("refreshes cached auth when a key is edited", () => {
+			data.add("openai", { apiKey: "sk-old" });
+			syncProvider(data, "openai");
+
+			data.auth.set("openai", { apiKey: "sk-new" });
+			syncProvider(data, "openai");
+
+			expect(getRegistry().getAuth("openai")).toEqual({ apiKey: "sk-new" });
+		});
+
+		it("drops a stale entry when auth can no longer be resolved", () => {
+			data.add("openai");
+			syncProvider(data, "openai");
+
+			// e.g. the underlying secret was cleared.
+			data.auth.delete("openai");
+
+			expect(syncProvider(data, "openai")).toBe(false);
+			expect(getRegistry().has("openai")).toBe(false);
+		});
+
+		it("returns false for an unknown provider ID", () => {
+			data.add("does-not-exist");
+
+			expect(syncProvider(data, "does-not-exist")).toBe(false);
+			expect(getRegistry().has("does-not-exist")).toBe(false);
+		});
+	});
+
+	describe("unsyncProvider", () => {
+		it("removes the provider so it is no longer usable", () => {
+			data.add("openai");
+			syncProvider(data, "openai");
+			expect(getRegistry().has("openai")).toBe(true);
+
+			unsyncProvider("openai");
+
+			expect(getRegistry().has("openai")).toBe(false);
+			expect(getRegistry().getAuth("openai")).toBeUndefined();
+			expect(() => getRegistry().createChatInstance("openai", "gpt-4o")).toThrow();
+		});
+
+		it("is a no-op for a provider that was never registered", () => {
+			expect(() => unsyncProvider("openai")).not.toThrow();
+		});
+	});
+
+	describe("syncAllProviders", () => {
+		it("registers everything configured", () => {
+			data.add("openai");
+			data.add("anthropic");
+
+			syncAllProviders(data);
+
+			expect(getRegistry().list().sort()).toEqual(["anthropic", "openai"]);
+		});
+
+		it("unregisters providers that are no longer configured", () => {
+			data.add("openai");
+			data.add("anthropic");
+			syncAllProviders(data);
+
+			data.remove("anthropic");
+			syncAllProviders(data);
+
+			expect(getRegistry().list()).toEqual(["openai"]);
+		});
+
+		it("handles a rename: old ID dropped, new ID registered", () => {
+			data.meta = { "custom-old": { templateId: "openai-compatible", displayName: "Custom" } };
+			data.add("custom-old");
+			syncAllProviders(data);
+			expect(getRegistry().has("custom-old")).toBe(true);
+
+			// Rename, as `renameProvider` rewrites it.
+			data.remove("custom-old");
+			delete data.meta["custom-old"];
+			data.meta["custom-new"] = { templateId: "openai-compatible", displayName: "Custom" };
+			data.add("custom-new");
+			syncAllProviders(data);
+
+			expect(getRegistry().has("custom-old")).toBe(false);
+			expect(getRegistry().has("custom-new")).toBe(true);
+		});
+	});
+
+	describe("ensureProviderRegistered", () => {
+		it("registers on demand when the provider is missing", () => {
+			data.add("openai");
+
+			expect(getRegistry().has("openai")).toBe(false);
+			expect(ensureProviderRegistered(data, "openai")).toBe(true);
+			expect(getRegistry().has("openai")).toBe(true);
+		});
+
+		it("leaves an already-registered provider untouched", () => {
+			data.add("openai", { apiKey: "sk-registered" });
+			syncProvider(data, "openai");
+
+			// A stale store value must not overwrite the live entry on the fast path.
+			data.auth.set("openai", { apiKey: "sk-stale" });
+
+			expect(ensureProviderRegistered(data, "openai")).toBe(true);
+			expect(getRegistry().getAuth("openai")).toEqual({ apiKey: "sk-registered" });
+		});
+
+		it("returns false for a deleted provider so callers can surface the error", () => {
+			expect(ensureProviderRegistered(data, "openai")).toBe(false);
+			expect(getRegistry().has("openai")).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Problem

The `ProviderRegistry` singleton was only ever written during `AgentManager.runInitialize()` at `onLayoutReady`, so it never learned about provider mutations made after startup. Neither `registry.unregister()` nor `registry.updateAuth()` had a single caller anywhere in the codebase, and `AgentManager.reinitialize()` had none either — its only references were its own definition and a comment.

That produced the two reported symptoms:

**Adding a provider required an Obsidian reload.** The UI updated correctly (model dropdowns are `$derived` off `getConfiguredProviders()`, so the provider *looked* activated), but the registry didn't. At send time `Agent.resolveRun` → `registry.createChatInstance` threw `ProviderNotFoundError`, whose handler then cleared the agent's `chatModel` — so it didn't just fail, it silently wiped the model selection.

**Deleting a provider leaked its entry.** `deleteProvider` cleaned up config and secrets but never touched the registry, so the entry survived — including the resolved `AuthObject` holding the raw API key that had just been removed from SecretStorage. It stayed fully usable: `VectorStoreService.ensureProviderRegistered` short-circuits on `registry.has()` and kept embedding against the deleted provider.

Two smaller leaks found alongside: `renameProvider` left a ghost entry under the old ID (and never registered the new one), and `removeProviderQueries` missed the `["models", provider]` cache key, so re-adding a same-slug provider could be served the deleted one's model list.

## Changes

**Registry now tracks the data store.** New `src/providers/registrySync.ts` owns the diff logic in one place. It declares its data source structurally (`ProviderConfigSource`) rather than importing `dataStore`, which avoids a circular import and keeps the persistence layer free of any dependency on the agent layer. Driven from the mutation points:

- `deleteProvider` → `unsyncProvider`
- `setProviderConfigured` → `syncProvider` on commit — **this is the fix for the reload symptom**, as it's the exact point `ProviderSetup` hits on a successful connection
- `renameProvider` → `syncAllProviders`, since a rename changes two IDs
- `setProviderAuthField` / `assignSecretIdToProviderField` / `setProviderAuthMode` → refresh cached auth, since the registry snapshots the resolved `AuthObject` at registration and would otherwise keep using an edited key's old value

Unconfigured drafts are deliberately skipped — a draft is a half-filled Setup modal that `onClose` may delete.

**Lazy fallback in `AgentManager`.** `prepareAgentForStream` now registers on demand for the chat, summarization and title providers, so a run self-heals rather than clearing the user's model. `VectorStoreService` already had this fallback and chat didn't, which is precisely why only the chat path broke; it now delegates to the shared helper instead of keeping a near-identical copy.

**`removeProviderQueries`** also drops `["models", provider]`.

## Notes for review

- `syncProvider` re-`register`s rather than calling `updateAuth`, because that also refreshes the *definition* — which matters for template providers, whose definition is derived from instance meta via `createTemplateDefinition`.
- The `ProviderNotFoundError` handler that clears `chatModel` is kept: it's still the right response once on-demand registration has had its chance, i.e. the provider really is gone.

## Testing

- `bun run check` — 2757 files, 0 errors
- `bun run test` — 1407 passed
- `bun run build` — clean

New `test/providers/registrySync.test.ts` adds 13 tests covering both leaks, the rename two-ID case, auth refresh, and the fast path not clobbering a live entry with a stale store value. I confirmed they aren't vacuous by temporarily stubbing out `unsyncProvider` — the delete-leak test failed as expected, then restored it.

Not yet verified in a live vault. Worth confirming by hand: add a provider and send a message without reloading, then delete it and check indexing stops using it.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._