### PR TITLE
fix: correctness and privacy fixes from a core-subsystem review

### DIFF
--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -38,6 +38,14 @@ import {
 } from "./summarization";
 import type { Telemetry } from "./telemetry/Telemetry";
 
+/**
+ * Upper bound on memoized runnables. Sized well above the number of agent configs a
+ * vault realistically runs concurrently (each open chat pins at most one), so steady-state
+ * hit rate is unaffected — it only trims the trail of superseded entries left behind by
+ * prompt/tool edits.
+ */
+const RUNNABLE_CACHE_MAX = 16;
+
 const MAX_IMAGE_ATTACHMENT_BYTES = 15 * 1024 * 1024;
 const MAX_TEXT_ATTACHMENT_CHARS = 120_000;
 const MAX_PDF_EXTRACT_CHARS = 180_000;
@@ -279,7 +287,8 @@ export class Agent {
 	private readonly threadStore?: ThreadStore;
 	private readonly registry: ProviderRegistry;
 	private readonly defaultPrompt: string;
-	/** Runnables memoized by agent-config cacheKey (built by AgentManager). */
+	/** Runnables memoized by agent-config cacheKey (built by AgentManager).
+	 *  Insertion-ordered, and used as an LRU — see {@link RUNNABLE_CACHE_MAX}. */
 	private readonly runnableCache = new Map<string, AgentRunnable>();
 
 	constructor(options: AgentOptions) {
@@ -312,6 +321,57 @@ export class Agent {
 	 *  (e.g. the set of loaded skills) changes and can affect any agent's prompt. */
 	invalidateAllRunnables(): void {
 		this.runnableCache.clear();
+	}
+
+	/**
+	 * Drops cache entries whose credential generation is stale.
+	 *
+	 * The cacheKey carries an `authGen` term (see `AgentManager.buildRunnableCacheKey`)
+	 * so a credential change can't be served a runnable holding the old key. That alone
+	 * is correct but leaky: superseded entries would never be read again, yet each pins
+	 * a LangGraph agent, a model instance, and a full tool array. Pruning on insert
+	 * keeps the cache bounded by the number of live agent configs rather than by how
+	 * many times the user has edited a key.
+	 */
+	private pruneStaleAuthGenerations(currentKey: string): void {
+		const match = /"authGen":(\d+)/.exec(currentKey);
+		if (!match) return;
+		const currentGen = match[1];
+		for (const key of this.runnableCache.keys()) {
+			const keyGen = /"authGen":(\d+)/.exec(key)?.[1];
+			if (keyGen !== undefined && keyGen !== currentGen) this.runnableCache.delete(key);
+		}
+	}
+
+	/** Reads a cached runnable, marking it most-recently-used. */
+	private getCachedRunnable(cacheKey: string): AgentRunnable | undefined {
+		const cached = this.runnableCache.get(cacheKey);
+		if (!cached) return undefined;
+		// Map iterates in insertion order, so re-inserting moves this key to the end
+		// (the MRU position) and keeps `evictLeastRecentlyUsed` honest.
+		this.runnableCache.delete(cacheKey);
+		this.runnableCache.set(cacheKey, cached);
+		return cached;
+	}
+
+	/**
+	 * Stores a runnable, evicting the least-recently-used entries past the cap.
+	 *
+	 * The cacheKey covers the whole agent config — system prompt, skills, per-tool
+	 * overrides, subagent revisions — so every prompt edit or tool toggle mints a new
+	 * key while the superseded entry stays resident, each pinning a LangGraph agent, a
+	 * model instance and a full tool array. Nothing evicted it: `invalidateRunnable`
+	 * only fires on explicit config-change hooks. An LRU bound is the cheap fix; a
+	 * wrongly-evicted entry costs one rebuild, not a correctness bug.
+	 */
+	private setCachedRunnable(cacheKey: string, runnable: AgentRunnable): void {
+		this.runnableCache.set(cacheKey, runnable);
+		while (this.runnableCache.size > RUNNABLE_CACHE_MAX) {
+			const oldest = this.runnableCache.keys().next();
+			if (oldest.done) break;
+			this.runnableCache.delete(oldest.value);
+			Logger.debug("agent.runnableCache.evict", { evicted: oldest.value, size: this.runnableCache.size });
+		}
 	}
 	/**
 	 * Builds the message content for a HumanMessage, supporting multimodal attachments.
@@ -513,7 +573,7 @@ export class Agent {
 				}
 			: undefined;
 
-		let runnable = this.runnableCache.get(cacheKey);
+		let runnable = this.getCachedRunnable(cacheKey);
 		if (!runnable) {
 			runnable = createAgent({
 				model: selectedModel.instance,
@@ -525,7 +585,8 @@ export class Agent {
 					...this.buildSubAgentMiddleware(selectedModel, subAgents, tools),
 				] as never,
 			});
-			this.runnableCache.set(cacheKey, runnable);
+			this.pruneStaleAuthGenerations(cacheKey);
+			this.setCachedRunnable(cacheKey, runnable);
 			Logger.debug("agent.resolveRun.build", { provider, chatModel, cacheKey });
 		}
 
@@ -763,8 +824,7 @@ export class Agent {
 
 		const finishedAt = new Date();
 		const messages = this.extractMessagesFromResult(rawResult);
-		await this.persistThreadMetadata(threadId, runId, messages, selectedModel.name);
-		await this.flushThreadPersistence(threadId);
+		await this.finalizeThreadPersistence(threadId, runId, messages, selectedModel.name);
 
 		const result: AgentResult = {
 			runId,
@@ -786,55 +846,53 @@ export class Agent {
 		return result;
 	}
 
-	async *streamTokens(options: AgentStreamOptions): AsyncGenerator<AgentStreamChunk> {
-		const { query, resolved } = options;
+	/**
+	 * The one streaming implementation behind {@link streamTokens},
+	 * {@link editFromCheckpoint} and {@link regenerateFromCheckpoint}.
+	 *
+	 * Those three used to carry a verbatim copy of this ~200-line loop each. The
+	 * copies were not free: `regenerateFromCheckpoint` silently lost its
+	 * `flushThreadPersistence` call (a run's thread metadata could be dropped on
+	 * quit), and two other cosmetic divergences accumulated. The methods differ in
+	 * only three real ways, all parameters here:
+	 *
+	 *  - `input` — a fresh `{ messages: [humanMessage] }` for a query/edit, or `null`
+	 *    to continue from a checkpoint without adding a message (regenerate);
+	 *  - `checkpointId` — present to fork from a checkpoint, absent to append;
+	 *  - `label` — the `agent.*` prefix for this run's debug logs, and the wording of
+	 *    the "no final output" error.
+	 */
+	private async *runStream(params: {
+		options: {
+			resolved: ResolvedRun;
+			signal?: AbortSignal;
+			metadata?: Record<string, unknown>;
+			configurable?: Record<string, unknown>;
+		};
+		threadId: string;
+		runId: string;
+		input: { messages: BaseMessage[] } | null;
+		checkpointId?: string;
+		label: string;
+		noOutputError: string;
+		logStart: Record<string, unknown>;
+	}): AsyncGenerator<AgentStreamChunk> {
+		const { options, threadId, runId, input, checkpointId, label, noOutputError, logStart } = params;
+		const { resolved } = options;
 		const { runnable: agent, selectedModel } = resolved;
-		const hasAttachments = Boolean(options.attachments?.length);
-
-		if ((!query || query.trim().length === 0) && !hasAttachments) {
-			throw new Error("Query must be a non-empty string when no attachments are provided.");
-		}
-
-		const runId = this.generateId();
-		const threadId = options.threadId;
-		if (!threadId) throw new Error("threadId is required");
 		const startedAt = new Date();
-		Logger.debug("agent.streamTokens.start", {
-			runId,
-			threadId,
-			provider: selectedModel.provider,
-			model: selectedModel.name,
-			queryPreview: query.slice(0, 200),
-		});
 
-		const invokeConfig = this.buildRunnableConfig(options, threadId);
+		Logger.debug(`${label}.start`, { runId, threadId, ...logStart });
 
-		const normalizedQuery = query.trim().length > 0 ? query : "Please analyze the attached files.";
-		const messageContent = await this.buildMessageContent(
-			normalizedQuery,
-			resolved.supportsVision,
-			resolved.currentProvider,
-			options.attachments,
-		);
-		const humanMessage = this.createHumanMessage(
-			messageContent,
-			options.attachments,
-			options.visibleNotes,
-			options.selection,
-			options.graphNotes,
-			options.lcSource,
-		);
+		const invokeConfig = this.buildRunnableConfig(options, threadId, checkpointId);
+		const transportContext = createAiTransportContext("default", `${label}:${runId}`);
 
-		const transportLabel = `agent.streamTokens:${runId}`;
-		const transportContext = createAiTransportContext("default", transportLabel);
-
-		const streamInput = { messages: [humanMessage] };
 		// Bind the LangChain stream so each pull runs inside this run's transport
 		// context (run()-scoped, concurrency-safe). Without this the fetch issued
 		// deep inside the stream would read whichever context another concurrent
 		// run last set.
 		const stream = bindAsyncIterableToTransportContext(
-			await agent.stream(streamInput, {
+			await agent.stream(input, {
 				...invokeConfig,
 				streamMode: ["messages", "tools", "values"] as const,
 			}),
@@ -866,7 +924,7 @@ export class Agent {
 			for await (const chunk of stream) {
 				// Check if aborted before processing
 				if (options.signal?.aborted) {
-					Logger.debug("agent.streamTokens.aborted", { runId, threadId });
+					Logger.debug(`${label}.aborted`, { runId, threadId });
 					break;
 				}
 
@@ -881,11 +939,11 @@ export class Agent {
 					if (tp.event === "on_tool_start") {
 						const toolCallId = tp.toolCallId ?? "";
 						const toolName = tp.name;
-						const toolInput = (tp as { event: "on_tool_start"; input: unknown }).input;
-						const input = this.normalizeStreamToolInput(toolInput);
+						const rawToolInput = (tp as { event: "on_tool_start"; input: unknown }).input;
+						const toolInput = this.normalizeStreamToolInput(rawToolInput);
 						const attribution = this.resolveToolAttribution(
 							"on_tool_start",
-							input,
+							toolInput,
 							toolName,
 							toolCallId,
 							taskCallStack,
@@ -896,13 +954,13 @@ export class Agent {
 						);
 						const preamble = toolCallPreambles.get(toolCallId);
 						toolCallPreambles.delete(toolCallId);
-						pendingToolCalls.set(toolCallId, { name: toolName, input });
-						Logger.debug("agent.streamTokens.tool_start", { runId, toolCallId, toolName });
+						pendingToolCalls.set(toolCallId, { name: toolName, input: toolInput });
+						Logger.debug(`${label}.tool_start`, { runId, toolCallId, toolName });
 						yield {
 							type: "tool_start",
 							toolCallId,
 							toolName,
-							input,
+							input: toolInput,
 							preamble,
 							...attribution,
 							runId,
@@ -930,7 +988,7 @@ export class Agent {
 							lastAiMessageId,
 						);
 						pendingToolCalls.delete(toolCallId);
-						Logger.debug("agent.streamTokens.tool_end", { runId, toolCallId, toolName });
+						Logger.debug(`${label}.tool_end`, { runId, toolCallId, toolName });
 						yield {
 							type: "tool_end",
 							toolCallId,
@@ -998,7 +1056,7 @@ export class Agent {
 		} catch (error) {
 			// Don't log or rethrow abort errors - they're expected during cancellation
 			if (error instanceof Error && error.name === "AbortError") {
-				Logger.debug("agent.streamTokens.aborted", { runId, threadId });
+				Logger.debug(`${label}.aborted`, { runId, threadId });
 				return;
 			}
 
@@ -1006,29 +1064,29 @@ export class Agent {
 			if (downgradeError) {
 				rawResult = await this.invokeBufferedFallback(
 					agent,
-					streamInput,
+					input,
 					invokeConfig,
 					runId,
 					threadId,
-					"agent.streamTokens",
+					label,
 					downgradeError,
 				);
 			} else {
 				// Wrap connection errors in ProviderEndpointError for consistent handling
 				if (error instanceof TypeError && error.message.includes("fetch")) {
 					const provider = selectedModel.provider;
-					Logger.debug("agent.streamTokens.error", { runId, message: `Connection failed to ${provider}` });
+					Logger.debug(`${label}.error`, { runId, message: `Connection failed to ${provider}` });
 					throw new ProviderEndpointError(provider, "Connection refused - service may not be running");
 				}
 
-				Logger.debug("agent.streamTokens.error", {
+				Logger.debug(`${label}.error`, {
 					runId,
 					message: error instanceof Error ? error.message : String(error),
 				});
 				throw error;
 			}
 		} finally {
-			Logger.debug("agent.streamTokens.cleanup", { runId, threadId });
+			Logger.debug(`${label}.cleanup`, { runId, threadId });
 		}
 
 		// If aborted, don't process final result
@@ -1037,13 +1095,12 @@ export class Agent {
 		}
 
 		if (!rawResult) {
-			throw new Error("Agent streaming completed without producing a final output.");
+			throw new Error(noOutputError);
 		}
 
 		const finishedAt = new Date();
 		const messages = this.extractMessagesFromResult(rawResult);
-		await this.persistThreadMetadata(threadId, runId, messages, selectedModel.name);
-		await this.flushThreadPersistence(threadId);
+		await this.finalizeThreadPersistence(threadId, runId, messages, selectedModel.name);
 
 		const result: AgentResult = {
 			runId,
@@ -1055,7 +1112,7 @@ export class Agent {
 		};
 
 		await this.telemetry?.onRunComplete?.(result);
-		Logger.debug("agent.streamTokens.complete", {
+		Logger.debug(`${label}.complete`, {
 			runId,
 			durationMs: result.durationMs,
 			responsePreview:
@@ -1073,7 +1130,7 @@ export class Agent {
 		// This ensures UI stays in sync with the database
 		const checkpointMessage = await this.getLastAssistantMessageFromCheckpoint(threadId);
 		if (checkpointMessage) {
-			Logger.debug("agent.streamTokens.checkpoint_message", {
+			Logger.debug(`${label}.checkpoint_message`, {
 				runId,
 				threadId,
 				messageId: checkpointMessage.id,
@@ -1087,13 +1144,54 @@ export class Agent {
 		}
 	}
 
+	async *streamTokens(options: AgentStreamOptions): AsyncGenerator<AgentStreamChunk> {
+		const { query, resolved } = options;
+		const hasAttachments = Boolean(options.attachments?.length);
+
+		if ((!query || query.trim().length === 0) && !hasAttachments) {
+			throw new Error("Query must be a non-empty string when no attachments are provided.");
+		}
+
+		const threadId = options.threadId;
+		if (!threadId) throw new Error("threadId is required");
+
+		const normalizedQuery = query.trim().length > 0 ? query : "Please analyze the attached files.";
+		const messageContent = await this.buildMessageContent(
+			normalizedQuery,
+			resolved.supportsVision,
+			resolved.currentProvider,
+			options.attachments,
+		);
+		const humanMessage = this.createHumanMessage(
+			messageContent,
+			options.attachments,
+			options.visibleNotes,
+			options.selection,
+			options.graphNotes,
+			options.lcSource,
+		);
+
+		yield* this.runStream({
+			options,
+			threadId,
+			runId: this.generateId(),
+			input: { messages: [humanMessage] },
+			label: "agent.streamTokens",
+			noOutputError: "Agent streaming completed without producing a final output.",
+			logStart: {
+				provider: resolved.selectedModel.provider,
+				model: resolved.selectedModel.name,
+				queryPreview: query.slice(0, 200),
+			},
+		});
+	}
+
 	/**
 	 * Edit a message by forking from a checkpoint with a new user message.
 	 * This creates a new branch from the given checkpoint.
 	 */
 	async *editFromCheckpoint(options: AgentEditOptions): AsyncGenerator<AgentStreamChunk> {
 		const { query, threadId, checkpointId, resolved } = options;
-		const { runnable: agent, selectedModel } = resolved;
 
 		if (!query || query.trim().length === 0) {
 			throw new Error("Query must be a non-empty string.");
@@ -1102,19 +1200,6 @@ export class Agent {
 		if (!checkpointId) {
 			throw new Error("checkpointId is required for editing.");
 		}
-
-		const runId = this.generateId();
-		const startedAt = new Date();
-		Logger.debug("agent.editFromCheckpoint.start", {
-			runId,
-			threadId,
-			checkpointId,
-			provider: selectedModel.provider,
-			model: selectedModel.name,
-			queryPreview: query.slice(0, 200),
-		});
-
-		const invokeConfig = this.buildRunnableConfig(options, threadId, checkpointId);
 
 		const messageContent = await this.buildMessageContent(
 			query,
@@ -1131,241 +1216,21 @@ export class Agent {
 			options.lcSource,
 		);
 
-		const input = {
-			messages: [humanMessage],
-		};
-
-		const transportLabel = `agent.editFromCheckpoint:${runId}`;
-		const transportContext = createAiTransportContext("default", transportLabel);
-
-		const stream = bindAsyncIterableToTransportContext(
-			await agent.stream(input, {
-				...invokeConfig,
-				streamMode: ["messages", "tools", "values"] as const,
-			}),
-			transportContext,
-		);
-
-		let rawResult: unknown;
-		const pendingToolCalls = new Map<string, { name: string; input: unknown }>();
-		const taskCallStack: string[] = [];
-		const taskAiMessageIds = new Map<string, string | undefined>();
-		const taskSubAgentNames = new Map<string, string | undefined>();
-		const taskChildCounts = new Map<string, number>();
-		let lastAiMessageId: string | undefined;
-		const toolCallPreambles = new Map<string, string>();
-		let preambleAccumulator = "";
-		try {
-			for await (const chunk of stream) {
-				if (options.signal?.aborted) {
-					Logger.debug("agent.editFromCheckpoint.aborted", { runId, threadId });
-					break;
-				}
-
-				const [mode, payload] = chunk as ["messages" | "tools" | "values", unknown];
-
-				if (mode === "tools") {
-					const tp = payload as
-						| { event: "on_tool_start"; toolCallId?: string; name: string; input: unknown }
-						| { event: "on_tool_end"; toolCallId?: string; name: string; output: unknown }
-						| { event: string; toolCallId?: string; name: string };
-
-					if (tp.event === "on_tool_start") {
-						const toolCallId = tp.toolCallId ?? "";
-						const toolName = tp.name;
-						const toolInput = (tp as { event: "on_tool_start"; input: unknown }).input;
-						const toolInputNorm = this.normalizeStreamToolInput(toolInput);
-						const attribution = this.resolveToolAttribution(
-							"on_tool_start",
-							toolInputNorm,
-							toolName,
-							toolCallId,
-							taskCallStack,
-							taskAiMessageIds,
-							taskSubAgentNames,
-							taskChildCounts,
-							lastAiMessageId,
-						);
-						const preamble = toolCallPreambles.get(toolCallId);
-						toolCallPreambles.delete(toolCallId);
-						pendingToolCalls.set(toolCallId, { name: toolName, input: toolInputNorm });
-						Logger.debug("agent.editFromCheckpoint.tool_start", { runId, toolCallId, toolName });
-						yield {
-							type: "tool_start",
-							toolCallId,
-							toolName,
-							input: toolInputNorm,
-							preamble,
-							...attribution,
-							runId,
-							threadId,
-						};
-						continue;
-					}
-
-					if (tp.event === "on_tool_end") {
-						const toolCallId = tp.toolCallId ?? "";
-						const pending = pendingToolCalls.get(toolCallId);
-						const toolName = pending?.name ?? tp.name;
-						const output = this.normalizeStreamToolOutput(
-							(tp as { event: "on_tool_end"; output: unknown }).output,
-						);
-						const attribution = this.resolveToolAttribution(
-							"on_tool_end",
-							undefined,
-							toolName,
-							toolCallId,
-							taskCallStack,
-							taskAiMessageIds,
-							taskSubAgentNames,
-							taskChildCounts,
-							lastAiMessageId,
-						);
-						pendingToolCalls.delete(toolCallId);
-						Logger.debug("agent.editFromCheckpoint.tool_end", { runId, toolCallId, toolName });
-						yield {
-							type: "tool_end",
-							toolCallId,
-							toolName,
-							output,
-							...attribution,
-							runId,
-							threadId,
-						};
-						continue;
-					}
-
-					continue;
-				}
-
-				if (mode === "messages") {
-					const [message, msgMeta] = payload as [BaseMessage, Record<string, unknown>];
-					if (message.getType() === "ai") {
-						// Subagent tokens carry `lc_agent_name` — suppress them from the parent's
-						// main content (they're delivered via the `task` ToolMessage). See the
-						// streamTokens loop for the full rationale.
-						if (typeof msgMeta?.lc_agent_name === "string") continue;
-						if (message.id && message.id !== lastAiMessageId) {
-							lastAiMessageId = message.id;
-							preambleAccumulator = "";
-						}
-						const token = this.normalizeContentToString(message.content);
-						if (token && token.length > 0) {
-							preambleAccumulator += token;
-							yield {
-								type: "token",
-								token,
-								aiMessageId: lastAiMessageId,
-								runId,
-								threadId,
-							};
-						}
-						const msgToolCalls = (message as { tool_calls?: { id?: string }[] }).tool_calls;
-						if (Array.isArray(msgToolCalls) && msgToolCalls.length > 0 && preambleAccumulator) {
-							for (const tc of msgToolCalls) {
-								if (tc.id && !toolCallPreambles.has(tc.id)) {
-									toolCallPreambles.set(tc.id, preambleAccumulator);
-								}
-							}
-						}
-					}
-					continue;
-				}
-
-				if (mode === "values") {
-					if (this.isAgentOutputCandidate(payload)) {
-						rawResult = payload;
-					}
-				}
-			}
-		} catch (error) {
-			if (error instanceof Error && error.name === "AbortError") {
-				Logger.debug("agent.editFromCheckpoint.aborted", { runId, threadId });
-				return;
-			}
-
-			const downgradeError = findAiTransportDowngradeRequiredError(error);
-			if (downgradeError) {
-				rawResult = await this.invokeBufferedFallback(
-					agent,
-					input,
-					invokeConfig,
-					runId,
-					threadId,
-					"agent.editFromCheckpoint",
-					downgradeError,
-				);
-			} else {
-				if (error instanceof TypeError && error.message.includes("fetch")) {
-					const provider = selectedModel.provider;
-					Logger.debug("agent.editFromCheckpoint.error", {
-						runId,
-						message: `Connection failed to ${provider}`,
-					});
-					throw new ProviderEndpointError(provider, "Connection refused - service may not be running");
-				}
-
-				Logger.debug("agent.editFromCheckpoint.error", {
-					runId,
-					message: error instanceof Error ? error.message : String(error),
-				});
-				throw error;
-			}
-		} finally {
-			Logger.debug("agent.editFromCheckpoint.cleanup", { runId, threadId });
-		}
-
-		if (options.signal?.aborted) {
-			return;
-		}
-
-		if (!rawResult) {
-			throw new Error("Agent edit completed without producing a final output.");
-		}
-
-		const finishedAt = new Date();
-		const messages = this.extractMessagesFromResult(rawResult);
-		await this.persistThreadMetadata(threadId, runId, messages, selectedModel.name);
-		await this.flushThreadPersistence(threadId);
-
-		const result: AgentResult = {
-			runId,
+		yield* this.runStream({
+			options,
 			threadId,
-			durationMs: finishedAt.getTime() - startedAt.getTime(),
-			messages,
-			response: this.extractResponse(messages),
-			raw: rawResult,
-		};
-
-		await this.telemetry?.onRunComplete?.(result);
-		Logger.debug("agent.editFromCheckpoint.complete", {
-			runId,
-			durationMs: result.durationMs,
-			responsePreview:
-				typeof result.response === "string" ? (result.response as string).slice(0, 200) : undefined,
+			runId: this.generateId(),
+			input: { messages: [humanMessage] },
+			checkpointId,
+			label: "agent.editFromCheckpoint",
+			noOutputError: "Agent edit completed without producing a final output.",
+			logStart: {
+				checkpointId,
+				provider: resolved.selectedModel.provider,
+				model: resolved.selectedModel.name,
+				queryPreview: query.slice(0, 200),
+			},
 		});
-
-		yield {
-			type: "result",
-			result,
-			runId,
-			threadId,
-		};
-
-		const checkpointMessage = await this.getLastAssistantMessageFromCheckpoint(threadId);
-		if (checkpointMessage) {
-			Logger.debug("agent.editFromCheckpoint.checkpoint_message", {
-				runId,
-				threadId,
-				messageId: checkpointMessage.id,
-			});
-			yield {
-				type: "checkpoint_message",
-				message: checkpointMessage,
-				runId,
-				threadId,
-			};
-		}
 	}
 
 	/**
@@ -1374,257 +1239,26 @@ export class Agent {
 	 */
 	async *regenerateFromCheckpoint(options: AgentRegenerateOptions): AsyncGenerator<AgentStreamChunk> {
 		const { threadId, checkpointId, resolved } = options;
-		const { runnable: agent, selectedModel } = resolved;
 
 		if (!checkpointId) {
 			throw new Error("checkpointId is required for regeneration.");
 		}
 
-		const runId = this.generateId();
-		const startedAt = new Date();
-		Logger.debug("agent.regenerateFromCheckpoint.start", {
-			runId,
+		yield* this.runStream({
+			options,
 			threadId,
+			runId: this.generateId(),
+			// null → continue from the checkpoint without adding a new message.
+			input: null,
 			checkpointId,
-			provider: selectedModel.provider,
-			model: selectedModel.name,
+			label: "agent.regenerateFromCheckpoint",
+			noOutputError: "Agent regeneration completed without producing a final output.",
+			logStart: {
+				checkpointId,
+				provider: resolved.selectedModel.provider,
+				model: resolved.selectedModel.name,
+			},
 		});
-
-		const invokeConfig = this.buildRunnableConfig(options, threadId, checkpointId);
-
-		// Pass null to continue from checkpoint without adding a new message
-		const input = null;
-
-		const transportLabel = `agent.regenerateFromCheckpoint:${runId}`;
-		const transportContext = createAiTransportContext("default", transportLabel);
-
-		const stream = bindAsyncIterableToTransportContext(
-			await agent.stream(input, {
-				...invokeConfig,
-				streamMode: ["messages", "tools", "values"] as const,
-			}),
-			transportContext,
-		);
-
-		let rawResult: unknown;
-		const pendingToolCalls = new Map<string, { name: string; input: unknown }>();
-		const taskCallStack: string[] = [];
-		const taskAiMessageIds = new Map<string, string | undefined>();
-		const taskSubAgentNames = new Map<string, string | undefined>();
-		const taskChildCounts = new Map<string, number>();
-		let lastAiMessageId: string | undefined;
-		const toolCallPreambles = new Map<string, string>();
-		let preambleAccumulator = "";
-		try {
-			for await (const chunk of stream) {
-				if (options.signal?.aborted) {
-					Logger.debug("agent.regenerateFromCheckpoint.aborted", { runId, threadId });
-					break;
-				}
-
-				const [mode, payload] = chunk as ["messages" | "tools" | "values", unknown];
-
-				if (mode === "tools") {
-					const tp = payload as
-						| { event: "on_tool_start"; toolCallId?: string; name: string; input: unknown }
-						| { event: "on_tool_end"; toolCallId?: string; name: string; output: unknown }
-						| { event: string; toolCallId?: string; name: string };
-
-					if (tp.event === "on_tool_start") {
-						const toolCallId = tp.toolCallId ?? "";
-						const toolName = tp.name;
-						const toolInput = (tp as { event: "on_tool_start"; input: unknown }).input;
-						const toolInputNorm = this.normalizeStreamToolInput(toolInput);
-						const attribution = this.resolveToolAttribution(
-							"on_tool_start",
-							toolInputNorm,
-							toolName,
-							toolCallId,
-							taskCallStack,
-							taskAiMessageIds,
-							taskSubAgentNames,
-							taskChildCounts,
-							lastAiMessageId,
-						);
-						pendingToolCalls.set(toolCallId, { name: toolName, input: toolInputNorm });
-						const preamble = toolCallPreambles.get(toolCallId);
-						toolCallPreambles.delete(toolCallId);
-						Logger.debug("agent.regenerateFromCheckpoint.tool_start", { runId, toolCallId, toolName });
-						yield {
-							type: "tool_start",
-							toolCallId,
-							toolName,
-							input: toolInputNorm,
-							preamble,
-							...attribution,
-							runId,
-							threadId,
-						};
-						continue;
-					}
-
-					if (tp.event === "on_tool_end") {
-						const toolCallId = tp.toolCallId ?? "";
-						const pending = pendingToolCalls.get(toolCallId);
-						const toolName = pending?.name ?? tp.name;
-						const output = this.normalizeStreamToolOutput(
-							(tp as { event: "on_tool_end"; output: unknown }).output,
-						);
-						const attribution = this.resolveToolAttribution(
-							"on_tool_end",
-							undefined,
-							toolName,
-							toolCallId,
-							taskCallStack,
-							taskAiMessageIds,
-							taskSubAgentNames,
-							taskChildCounts,
-							lastAiMessageId,
-						);
-						pendingToolCalls.delete(toolCallId);
-						Logger.debug("agent.regenerateFromCheckpoint.tool_end", { runId, toolCallId, toolName });
-						yield {
-							type: "tool_end",
-							toolCallId,
-							toolName,
-							output,
-							...attribution,
-							runId,
-							threadId,
-						};
-						continue;
-					}
-
-					continue;
-				}
-
-				if (mode === "messages") {
-					const [message, msgMeta] = payload as [BaseMessage, Record<string, unknown>];
-					if (message.getType() === "ai") {
-						// Subagent tokens carry `lc_agent_name` — suppress them from the parent's
-						// main content (they're delivered via the `task` ToolMessage). See the
-						// streamTokens loop for the full rationale.
-						if (typeof msgMeta?.lc_agent_name === "string") continue;
-						if (message.id && message.id !== lastAiMessageId) {
-							lastAiMessageId = message.id;
-							preambleAccumulator = "";
-						}
-						const token = this.normalizeContentToString(message.content);
-						if (token && token.length > 0) {
-							preambleAccumulator += token;
-							yield {
-								type: "token",
-								token,
-								aiMessageId: lastAiMessageId,
-								runId,
-								threadId,
-							};
-						}
-						const msgToolCalls = (message as { tool_calls?: { id?: string }[] }).tool_calls;
-						if (Array.isArray(msgToolCalls) && msgToolCalls.length > 0 && preambleAccumulator) {
-							for (const tc of msgToolCalls) {
-								if (tc.id && !toolCallPreambles.has(tc.id)) {
-									toolCallPreambles.set(tc.id, preambleAccumulator);
-								}
-							}
-						}
-					}
-					continue;
-				}
-
-				if (mode === "values") {
-					if (this.isAgentOutputCandidate(payload)) {
-						rawResult = payload;
-					}
-				}
-			}
-		} catch (error) {
-			if (error instanceof Error && error.name === "AbortError") {
-				Logger.debug("agent.regenerateFromCheckpoint.aborted", { runId, threadId });
-				return;
-			}
-
-			const downgradeError = findAiTransportDowngradeRequiredError(error);
-			if (downgradeError) {
-				rawResult = await this.invokeBufferedFallback(
-					agent,
-					input,
-					invokeConfig,
-					runId,
-					threadId,
-					"agent.regenerateFromCheckpoint",
-					downgradeError,
-				);
-			} else {
-				if (error instanceof TypeError && error.message.includes("fetch")) {
-					const provider = selectedModel.provider;
-					Logger.debug("agent.regenerateFromCheckpoint.error", {
-						runId,
-						message: `Connection failed to ${provider}`,
-					});
-					throw new ProviderEndpointError(provider, "Connection refused - service may not be running");
-				}
-
-				Logger.debug("agent.regenerateFromCheckpoint.error", {
-					runId,
-					message: error instanceof Error ? error.message : String(error),
-				});
-				throw error;
-			}
-		} finally {
-			Logger.debug("agent.regenerateFromCheckpoint.cleanup", { runId, threadId });
-		}
-
-		if (options.signal?.aborted) {
-			return;
-		}
-
-		if (!rawResult) {
-			throw new Error("Agent regeneration completed without producing a final output.");
-		}
-
-		const finishedAt = new Date();
-		const messages = this.extractMessagesFromResult(rawResult);
-		await this.persistThreadMetadata(threadId, runId, messages, selectedModel.name);
-
-		const result: AgentResult = {
-			runId,
-			threadId,
-			durationMs: finishedAt.getTime() - startedAt.getTime(),
-			messages,
-			response: this.extractResponse(messages),
-			raw: rawResult,
-		};
-
-		await this.telemetry?.onRunComplete?.(result);
-		Logger.debug("agent.regenerateFromCheckpoint.complete", {
-			runId,
-			durationMs: result.durationMs,
-			responsePreview:
-				typeof result.response === "string" ? (result.response as string).slice(0, 200) : undefined,
-		});
-
-		yield {
-			type: "result",
-			result,
-			runId,
-			threadId,
-		};
-
-		const checkpointMessage = await this.getLastAssistantMessageFromCheckpoint(threadId);
-		if (checkpointMessage) {
-			Logger.debug("agent.regenerateFromCheckpoint.checkpoint_message", {
-				runId,
-				threadId,
-				messageId: checkpointMessage.id,
-			});
-			yield {
-				type: "checkpoint_message",
-				message: checkpointMessage,
-				runId,
-				threadId,
-			};
-		}
 	}
 
 	async getThreadHistory(threadId: string): Promise<ThreadHistory | undefined> {
@@ -2117,6 +1751,26 @@ export class Agent {
 			return;
 		}
 		await this.threadStore.flush(threadId);
+	}
+
+	/**
+	 * Records this run's thread metadata and forces it to disk.
+	 *
+	 * The two must stay paired: `threadStore.write` only marks the thread dirty and
+	 * schedules a 2s debounced save, so without the flush a quit or crash inside that
+	 * window loses the run's metadata. Every run-completion path calls this rather than
+	 * the two methods separately — `regenerateFromCheckpoint` previously called only
+	 * `persistThreadMetadata`, which is the kind of drift three near-identical
+	 * stream loops invite.
+	 */
+	private async finalizeThreadPersistence(
+		threadId: string,
+		runId: string,
+		messages: BaseMessage[],
+		modelName?: string,
+	): Promise<void> {
+		await this.persistThreadMetadata(threadId, runId, messages, modelName);
+		await this.flushThreadPersistence(threadId);
 	}
 
 	async generateTitle(userMessage: string, resolved: ResolvedRun): Promise<string | undefined> {

--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -837,16 +837,16 @@ export class AgentManager {
 
 		// Built-in tool registry: maps tool IDs to their factory functions
 		const builtInTools: [BuiltInToolId, () => StructuredToolInterface][] = [
-			["search_notes", () => createSearchNotesTool(this.plugin.app)],
-			["list_directory", () => createListDirectoryTool(this.plugin.app)],
-			["get_all_tags", () => createGetAllTagsTool(this.plugin.app)],
-			["execute_javascript", () => createExecuteJavaScriptTool()],
-			["get_properties", () => createGetPropertiesTool(this.plugin.app)],
+			["search_notes", () => createSearchNotesTool(this.plugin.app, agentCfg.id)],
+			["list_directory", () => createListDirectoryTool(this.plugin.app, agentCfg.id)],
+			["get_all_tags", () => createGetAllTagsTool(this.plugin.app, agentCfg.id)],
+			["execute_javascript", () => createExecuteJavaScriptTool(agentCfg.id)],
+			["get_properties", () => createGetPropertiesTool(this.plugin.app, agentCfg.id)],
 			[
 				"read_content",
-				() => createReadContentTool(this.plugin.app, imageProcessorInstance, pdfProcessorInstance),
+				() => createReadContentTool(this.plugin.app, imageProcessorInstance, pdfProcessorInstance, agentCfg.id),
 			],
-			["grep_notes", () => createGrepNotesTool(this.plugin.app)],
+			["grep_notes", () => createGrepNotesTool(this.plugin.app, agentCfg.id)],
 			["manage_notes", () => createManageNotesTool(this.plugin.app, agentCfg.id)],
 			["fetch_url", () => createFetchUrlTool()],
 			["web_search", () => createWebSearchTool()],
@@ -1395,6 +1395,16 @@ export class AgentManager {
 			summ: `${summarizationModel.provider}:${summarizationModel.model}`,
 			agentId: agent.id,
 			agentRev: this.agentConfigRevision(agent),
+			// A cached runnable holds the model instance it was BUILT with, and that
+			// instance has the resolved credentials baked in — `resolveRun` mints a fresh
+			// instance every call but only uses it on a cache miss. Without this term,
+			// rotating an API key (or editing a baseUrl) leaves the key unchanged, hits
+			// the cache, and keeps issuing requests with the OLD credential until
+			// Obsidian restarts — silently, with no error. The data store already
+			// re-registers the provider on such an edit (see `setProviderAuthField`),
+			// which bumps this counter. Not the auth itself: a counter can't leak a
+			// secret if a cache key is ever logged.
+			authGen: this.registry.getAuthGeneration(),
 		});
 	}
 

--- a/src/agent/tools/executeJavaScript.ts
+++ b/src/agent/tools/executeJavaScript.ts
@@ -1,9 +1,10 @@
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
-import { DEFAULT_TOOLS_CONFIG, getData } from "../../stores/dataStore.svelte";
+import { DEFAULT_TOOLS_CONFIG } from "../../stores/dataStore.svelte";
 import { formatExecutionResult, type JavaScriptExecutionResult } from "./executeJavaScriptShared";
 import type { ExecuteJavaScriptWorkerRequest, ExecuteJavaScriptWorkerResponse } from "./executeJavaScriptWorker";
 import ExecuteJavaScriptWorkerConstructor from "./executeJavaScriptWorker?worker&inline";
+import { resolveToolAgent } from "./toolAgentContext";
 
 const EXECUTION_TIMEOUT_MS = 3_000;
 
@@ -56,8 +57,8 @@ async function executeInWorker(code: string, input?: unknown): Promise<JavaScrip
 	});
 }
 
-export function createExecuteJavaScriptTool() {
-	const getToolConfig = () => getData().getSelectedAgent().toolsConfig.execute_javascript;
+export function createExecuteJavaScriptTool(agentId = "") {
+	const getToolConfig = () => resolveToolAgent(agentId).toolsConfig.execute_javascript;
 	const defaultToolConfig = DEFAULT_TOOLS_CONFIG.execute_javascript;
 
 	return tool(

--- a/src/agent/tools/executePluginApi.ts
+++ b/src/agent/tools/executePluginApi.ts
@@ -19,6 +19,15 @@ const EXECUTION_TIMEOUT_MS = 5_000;
  * approval gate (the tool is only bound when the user enables the integration),
  * a timeout on awaited work, output truncation, and error-to-string. This is NOT
  * a sandbox: a call into a plugin's api can do anything that plugin can.
+ *
+ * **The timeout bounds waiting, not execution.** It is a `Promise.race`, which
+ * settles the wrapper but cannot cancel what is already running — there is no way
+ * to interrupt a main-thread call. So it covers a snippet that *awaits* too long
+ * (a slow api call), and does nothing for one that blocks synchronously: a
+ * `while (true) {}` freezes Obsidian's UI and the race never gets a turn to run.
+ * Escaping that needs a worker, which cannot reach `app` — the constraint this
+ * tool exists to work around. The per-plugin approval gate is what actually
+ * carries the risk here; treat the timeout as a courtesy, not a control.
  */
 export function createPluginApiExecTool(app: App, pluginId: string, displayName: string) {
 	const execFn = async ({ code, input }: { code: string; input?: unknown }): Promise<string> => {
@@ -54,7 +63,7 @@ export function createPluginApiExecTool(app: App, pluginId: string, displayName:
 
 	return tool(execFn, {
 		name: toRuntimeToolName(pluginId),
-		description: `Run JavaScript against the "${displayName}" plugin's public API on the main thread. The plugin's api object is in scope as \`api\`, and the Obsidian \`app\` is available. Use \`return\` for the final value and \`console.log\` for intermediate output. Awaited work times out after ${EXECUTION_TIMEOUT_MS}ms; this is not sandboxed, so keep snippets simple and read-only unless the user asked otherwise. Load the "${displayName}" skill (if available) to learn the API's shape before calling it.`,
+		description: `Run JavaScript against the "${displayName}" plugin's public API on the main thread. The plugin's api object is in scope as \`api\`, and the Obsidian \`app\` is available. Use \`return\` for the final value and \`console.log\` for intermediate output. Awaited work times out after ${EXECUTION_TIMEOUT_MS}ms, but the timeout CANNOT interrupt synchronous code — an unbounded loop will freeze the app, so always bound your iteration. This is not sandboxed, so keep snippets simple and read-only unless the user asked otherwise. Load the "${displayName}" skill (if available) to learn the API's shape before calling it.`,
 		schema: z.object({
 			code: z
 				.string()

--- a/src/agent/tools/getAllTags.ts
+++ b/src/agent/tools/getAllTags.ts
@@ -1,21 +1,35 @@
 import { type App, getAllTags } from "obsidian";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
-import { getData } from "../../stores/dataStore.svelte";
+import { getPendingChangesStore } from "../../stores/pendingChangesStore.svelte";
 import { isAgentFilePath } from "../../utils/fileFiltering";
+import { resolveToolAgent, resolveToolProvider } from "./toolAgentContext";
 
 /**
  * Tool for retrieving all tags from the Obsidian vault
  */
-export function createGetAllTagsTool(app: App) {
-	const pluginData = getData();
-	const toolConfig = pluginData.getSelectedAgent().toolsConfig.get_all_tags;
+export function createGetAllTagsTool(app: App, agentId = "") {
+	const getToolConfig = () => resolveToolAgent(agentId).toolsConfig.get_all_tags;
+	const toolConfig = getToolConfig();
 
 	const getTagsFn = async (): Promise<string> => {
+		// Tags are content: a tag that exists only in a private note names something
+		// about that note (`#therapy`, `#client/acme`). Filter the same way every
+		// other read tool does, so the vault's tag vocabulary can't reach an
+		// untrusted provider through a tool that happens to return no note bodies.
+		// Resolved per invocation — the agent's model can change between calls.
+		const currentProvider = resolveToolProvider(agentId);
+		const store = getPendingChangesStore();
+
 		const files = app.vault.getMarkdownFiles().filter((file) => !isAgentFilePath(file.path));
 		const tags = new Set<string>();
+		let skippedPrivateFiles = 0;
 
 		for (const file of files) {
+			if (currentProvider && store.shouldBlockFile(file.path, currentProvider)) {
+				skippedPrivateFiles++;
+				continue;
+			}
 			const cache = app.metadataCache.getFileCache(file);
 			if (cache) {
 				const fileTags = getAllTags(cache);
@@ -28,12 +42,19 @@ export function createGetAllTagsTool(app: App) {
 		}
 
 		const sortedTags = Array.from(tags).sort();
+		// Surface the skip rather than silently returning a partial vocabulary —
+		// otherwise the model reads an empty/short list as "this vault has no tags"
+		// and reasons from it. Mirrors search_notes' skippedPrivateFiles notice.
+		const privacyNote =
+			skippedPrivateFiles > 0
+				? `\n\n(${skippedPrivateFiles} note(s) were skipped because they are private for the current provider.)`
+				: "";
 
 		if (sortedTags.length === 0) {
-			return "No tags found in the vault.";
+			return `No tags found in the vault.${privacyNote}`;
 		}
 
-		return `Found ${sortedTags.length} tags:\n${sortedTags.join("\n")}`;
+		return `Found ${sortedTags.length} tags:\n${sortedTags.join("\n")}${privacyNote}`;
 	};
 
 	return tool(getTagsFn, {

--- a/src/agent/tools/getProperties.ts
+++ b/src/agent/tools/getProperties.ts
@@ -1,11 +1,11 @@
 import type { App } from "obsidian";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
-import { getData } from "../../stores/dataStore.svelte";
 import { getPendingChangesStore } from "../../stores/pendingChangesStore.svelte";
 import { isAgentFilePath } from "../../utils/fileFiltering";
+import { resolveToolAgent, resolveToolProvider } from "./toolAgentContext";
 
-function getNoteProperties(app: App, noteName: string): string {
+function getNoteProperties(app: App, noteName: string, agentId: string): string {
 	const file = app.vault
 		.getMarkdownFiles()
 		.find(
@@ -17,8 +17,7 @@ function getNoteProperties(app: App, noteName: string): string {
 		return `Note "${noteName}" not found.`;
 	}
 
-	const pluginData = getData();
-	const currentProvider = pluginData.getSelectedAgent().chatModel?.provider;
+	const currentProvider = resolveToolProvider(agentId);
 	if (currentProvider) {
 		const store = getPendingChangesStore();
 		if (store.shouldBlockFile(file.path, currentProvider)) {
@@ -35,11 +34,22 @@ function getNoteProperties(app: App, noteName: string): string {
 	return JSON.stringify(properties);
 }
 
-function getAllPropertyKeys(app: App): string {
+function getAllPropertyKeys(app: App, agentId: string): string {
+	// Property keys are content for the same reason tags are — a key that appears
+	// only in private notes (`therapist`, `salary`) names something about them. Apply
+	// the same filter the single-note branch above already applies.
+	const currentProvider = resolveToolProvider(agentId);
+	const store = getPendingChangesStore();
+
 	const allKeys = new Set<string>();
+	let skippedPrivateFiles = 0;
 
 	for (const file of app.vault.getMarkdownFiles()) {
 		if (isAgentFilePath(file.path)) continue;
+		if (currentProvider && store.shouldBlockFile(file.path, currentProvider)) {
+			skippedPrivateFiles++;
+			continue;
+		}
 		const cache = app.metadataCache.getFileCache(file);
 		if (cache?.frontmatter) {
 			for (const key of Object.keys(cache.frontmatter)) {
@@ -51,23 +61,27 @@ function getAllPropertyKeys(app: App): string {
 	}
 
 	const sortedKeys = Array.from(allKeys).sort((left, right) => left.localeCompare(right));
+	const privacyNote =
+		skippedPrivateFiles > 0
+			? `\n\n(${skippedPrivateFiles} note(s) were skipped because they are private for the current provider.)`
+			: "";
+
 	if (sortedKeys.length === 0) {
-		return "No properties found in the vault.";
+		return `No properties found in the vault.${privacyNote}`;
 	}
 
-	return `Found ${sortedKeys.length} unique properties:\n${sortedKeys.join("\n")}`;
+	return `Found ${sortedKeys.length} unique properties:\n${sortedKeys.join("\n")}${privacyNote}`;
 }
 
 /**
  * Tool for retrieving properties (frontmatter) from Obsidian.
  * Can retrieve all unique property keys across the vault, or properties for a specific note.
  */
-export function createGetPropertiesTool(app: App) {
-	const pluginData = getData();
-	const toolConfig = pluginData.getSelectedAgent().toolsConfig.get_properties;
+export function createGetPropertiesTool(app: App, agentId = "") {
+	const toolConfig = resolveToolAgent(agentId).toolsConfig.get_properties;
 
 	const getPropertiesFn = async ({ note_name }: { note_name?: string }) => {
-		return note_name ? getNoteProperties(app, note_name) : getAllPropertyKeys(app);
+		return note_name ? getNoteProperties(app, note_name, agentId) : getAllPropertyKeys(app, agentId);
 	};
 
 	return tool(getPropertiesFn, {

--- a/src/agent/tools/grepNotes.ts
+++ b/src/agent/tools/grepNotes.ts
@@ -1,7 +1,7 @@
 import { tool } from "@langchain/core/tools";
 import type { App, TFile } from "obsidian";
 import { z } from "zod";
-import { DEFAULT_TOOLS_CONFIG, getData } from "../../stores/dataStore.svelte";
+import { DEFAULT_TOOLS_CONFIG } from "../../stores/dataStore.svelte";
 import { getPendingChangesStore } from "../../stores/pendingChangesStore.svelte";
 import type { GrepNotesSettings } from "../../types/plugin";
 import { getIndexableVaultFiles, isTextIndexableFile, shouldProcessVaultPath } from "../../utils/fileFiltering";
@@ -9,6 +9,7 @@ import { Logger } from "../../utils/logging";
 import { normalizeVaultPath } from "../../utils/pathUtils";
 import { resolveFileReferenceDetailed } from "../../utils/pathResolution";
 import { buildGrepMatcher, MAX_SCANNED_LINE_LENGTH } from "./grepMatcher";
+import { resolveToolAgent, resolveToolProvider } from "./toolAgentContext";
 
 const DEFAULT_LIMIT = 50;
 
@@ -62,9 +63,8 @@ function buildContextBlock(lines: string[], hitIndex: number, contextLines: numb
  * to a single note. Results are paged via `offset`/`limit` over a flat, stable
  * (path-sorted) match list so nothing is silently dropped.
  */
-export function createGrepNotesTool(app: App) {
-	const pluginData = getData();
-	const getConfig = () => pluginData.getSelectedAgent().toolsConfig.grep_notes;
+export function createGrepNotesTool(app: App, agentId = "") {
+	const getConfig = () => resolveToolAgent(agentId).toolsConfig.grep_notes;
 	const toolConfig = getConfig();
 
 	const grepFn = async ({
@@ -131,7 +131,7 @@ export function createGrepNotesTool(app: App) {
 		// vault-wide grep reads every eligible note — the search is exhaustive.
 		// Freeze protection comes from the per-line length guard below (pathological
 		// lines are skipped and reported), not from bounding the file count.
-		const currentProvider = pluginData.getSelectedAgent().chatModel?.provider;
+		const currentProvider = resolveToolProvider(agentId);
 		const store = getPendingChangesStore();
 		const flat: FlatMatch[] = [];
 		let filesSearched = 0;

--- a/src/agent/tools/listDirectory.ts
+++ b/src/agent/tools/listDirectory.ts
@@ -1,10 +1,11 @@
 import { tool } from "@langchain/core/tools";
 import type { App } from "obsidian";
 import { z } from "zod";
-import { DEFAULT_TOOLS_CONFIG, getData } from "../../stores/dataStore.svelte";
+import { DEFAULT_TOOLS_CONFIG } from "../../stores/dataStore.svelte";
 import { getPendingChangesStore } from "../../stores/pendingChangesStore.svelte";
 import { isPathInFolder, normalizeFolderPrefix, normalizeVaultPath } from "../../utils/pathUtils";
 import { isAgentFilePath } from "../../utils/fileFiltering";
+import { resolveToolAgent, resolveToolProvider } from "./toolAgentContext";
 
 interface DirectoryTreeFileEntry {
 	name: string;
@@ -76,8 +77,8 @@ const listDirectorySchema = z.object({
 
 type ListDirectoryInput = z.infer<typeof listDirectorySchema>;
 
-function getListDirectoryToolConfig(): { name: string; description: string } {
-	const selectedConfig = getData().getSelectedAgent().toolsConfig.list_directory;
+function getListDirectoryToolConfig(agentId: string): { name: string; description: string } {
+	const selectedConfig = resolveToolAgent(agentId).toolsConfig.list_directory;
 	const defaultConfig = DEFAULT_TOOLS_CONFIG.list_directory;
 
 	return {
@@ -281,8 +282,8 @@ function buildDirectoryListResult(
 	};
 }
 
-export function createListDirectoryTool(app: App) {
-	const toolConfig = getListDirectoryToolConfig();
+export function createListDirectoryTool(app: App, agentId = "") {
+	const toolConfig = getListDirectoryToolConfig(agentId);
 
 	return tool(
 		async ({ path, recursive, maxDepth, includeFiles = true, includeFolders = true }: ListDirectoryInput) => {
@@ -309,7 +310,7 @@ export function createListDirectoryTool(app: App) {
 			}
 
 			const store = getPendingChangesStore();
-			const currentProvider = getData().getSelectedAgent().chatModel?.provider;
+			const currentProvider = resolveToolProvider(agentId);
 			const scanOptions: DirectoryScanOptions = {
 				rootPath,
 				recursive: effectiveRecursive,

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -441,13 +441,16 @@ export async function stageNoteOperations(
 			continue;
 		}
 
-		if (!settings.allowDelete) {
-			if (operation.type === "delete") {
+		if (operation.type === "delete") {
+			// Permission check inside the type branch, matching create/update/move below.
+			// This used to be an outer `if (!settings.allowDelete)` wrapping an inner
+			// `if (operation.type === "delete")` — correct, but only because the inner
+			// condition carried all the logic; hoisting the outer branch during a later
+			// edit would have silently blocked move/replace too.
+			if (!settings.allowDelete) {
 				return `Error in operation ${operationNumber}: Delete operations are disabled for this agent.`;
 			}
-		}
 
-		if (operation.type === "delete") {
 			const result = validateExistingMarkdownFile(app, operation.path, operationNumber, "delete", agentId);
 			if ("error" in result) return result.error;
 

--- a/src/agent/tools/readContent.ts
+++ b/src/agent/tools/readContent.ts
@@ -17,12 +17,13 @@ import { extractPdfPages, extractTextFromPdf, extractTextFromPdfPages } from "..
 import { Logger } from "../../utils/logging";
 import { extractReferenceInfo, resolveFileReferenceDetailed } from "../../utils/pathResolution";
 import { READ_CONTENT_BUDGET_FRACTION, contextWindowToCharBudget, truncateToBudget } from "../../utils/contentBudget";
+import { resolveToolAgent, resolveToolProvider } from "./toolAgentContext";
 
 /** Conservative cap for whole-PDF vision sends — well under Anthropic's 32 MB native-PDF limit. */
 const MAX_PDF_VISION_BYTES = 20 * 1024 * 1024;
 
-function resolveMaxContentLength(): number {
-	const contextWindow = getData().getSelectedAgent().chatModel?.modelConfig?.contextWindow;
+function resolveMaxContentLength(agentId: string): number {
+	const contextWindow = resolveToolAgent(agentId).chatModel?.modelConfig?.contextWindow;
 	return contextWindowToCharBudget(contextWindow, READ_CONTENT_BUDGET_FRACTION);
 }
 
@@ -331,6 +332,11 @@ export interface ReadNoteContentOptions {
 	pdfProcessor?: BaseChatModel;
 	offset?: number;
 	length?: number;
+	/** The agent that owns this run. Determines which provider the privacy filter is
+	 *  evaluated against, and which agent's context window sizes the content budget.
+	 *  Omitted by the public api path, which has no run to attribute — that falls back
+	 *  to the selected agent (see `resolveToolAgent`). */
+	agentId?: string;
 }
 
 /**
@@ -340,6 +346,7 @@ export interface ReadNoteContentOptions {
  * uses the provided vision/PDF processors when the target needs analysis.
  */
 export async function readNoteContent(app: App, path: string, opts: ReadNoteContentOptions = {}): Promise<string> {
+	const agentId = opts.agentId ?? "";
 	const { imageProcessor, pdfProcessor, offset, length } = opts;
 	const pluginData = getData();
 
@@ -363,7 +370,7 @@ export async function readNoteContent(app: App, path: string, opts: ReadNoteCont
 		const ext = file.extension.toLowerCase();
 
 		// Privacy check
-		const currentProvider = pluginData.getSelectedAgent().chatModel?.provider;
+		const currentProvider = resolveToolProvider(agentId);
 		if (currentProvider) {
 			const store = getPendingChangesStore();
 			if (store.shouldBlockFile(file.path, currentProvider)) {
@@ -378,7 +385,7 @@ export async function readNoteContent(app: App, path: string, opts: ReadNoteCont
 				}
 
 				// Privacy check against the image processor's provider
-				const processorSettings = pluginData.getSelectedAgent().toolsConfig.read_content?.settings as
+				const processorSettings = resolveToolAgent(agentId).toolsConfig.read_content?.settings as
 					| { imageProcessor?: { provider?: string } }
 					| undefined;
 				const processorProvider = processorSettings?.imageProcessor?.provider;
@@ -421,7 +428,7 @@ export async function readNoteContent(app: App, path: string, opts: ReadNoteCont
 
 				if (pdfProcessor) {
 					// Privacy check against the PDF processor's provider
-					const processorSettings = pluginData.getSelectedAgent().toolsConfig.read_content?.settings as
+					const processorSettings = resolveToolAgent(agentId).toolsConfig.read_content?.settings as
 						| { pdfProcessor?: { provider?: string } }
 						| undefined;
 					const processorProvider = processorSettings?.pdfProcessor?.provider;
@@ -529,12 +536,12 @@ export async function readNoteContent(app: App, path: string, opts: ReadNoteCont
 					return `PDF "${file.name}" contains ${totalPages} page(s) but no extractable text. The PDF may contain only images/scans.`;
 				}
 
-				const truncated = truncateContent(text, resolveMaxContentLength());
+				const truncated = truncateContent(text, resolveMaxContentLength(agentId));
 				return `Content of PDF "${file.name}" (${totalPages} pages):\n\n${truncated}`;
 			}
 
 			if (isExcalidrawFile(file)) {
-				const maxLength = resolveMaxContentLength();
+				const maxLength = resolveMaxContentLength(agentId);
 				return await readExcalidrawContent(app, file, maxLength);
 			}
 
@@ -545,7 +552,7 @@ export async function readNoteContent(app: App, path: string, opts: ReadNoteCont
 					const sectionResult = extractSubpathContent(app, file, content, subpath);
 					if (!sectionResult.ok) return sectionResult.error;
 					const { text: sectionText, label: sectionLabel } = sectionResult;
-					const maxLength = length ?? resolveMaxContentLength();
+					const maxLength = length ?? resolveMaxContentLength(agentId);
 					const start = Math.min(offset ?? 0, sectionText.length);
 					const slice = sectionText.slice(start, maxLength > 0 ? start + maxLength : undefined);
 					const remaining = sectionText.length - (start + slice.length);
@@ -557,7 +564,7 @@ export async function readNoteContent(app: App, path: string, opts: ReadNoteCont
 					return `${header}:\n\n${slice}${suffix}`;
 				}
 
-				const maxLength = length ?? resolveMaxContentLength();
+				const maxLength = length ?? resolveMaxContentLength(agentId);
 				const start = Math.min(offset ?? 0, content.length);
 				const slice = content.slice(start, maxLength > 0 ? start + maxLength : undefined);
 				const remaining = content.length - (start + slice.length);
@@ -576,17 +583,22 @@ export async function readNoteContent(app: App, path: string, opts: ReadNoteCont
 	}
 }
 
-export function createReadContentTool(app: App, imageProcessor?: BaseChatModel, pdfProcessor?: BaseChatModel) {
+export function createReadContentTool(
+	app: App,
+	imageProcessor?: BaseChatModel,
+	pdfProcessor?: BaseChatModel,
+	agentId = "",
+) {
 	const pluginData = getData();
 	const defaultToolConfig = DEFAULT_TOOLS_CONFIG.read_content;
-	const getToolConfig = () => pluginData.getSelectedAgent().toolsConfig.read_content;
+	const getToolConfig = () => resolveToolAgent(agentId).toolsConfig.read_content;
 
 	const readContentFn = ({
 		path,
 		offset,
 		length,
 	}: { path: string; offset?: number; length?: number }): Promise<string> =>
-		readNoteContent(app, path, { imageProcessor, pdfProcessor, offset, length });
+		readNoteContent(app, path, { imageProcessor, pdfProcessor, offset, length, agentId });
 
 	const toolConfig = getToolConfig();
 

--- a/src/agent/tools/searchNotes.ts
+++ b/src/agent/tools/searchNotes.ts
@@ -11,6 +11,7 @@ import { normalizeVaultPath } from "../../utils/pathUtils";
 import { getVectorStoreService, type SearchFilter, type SearchResult, waitForVectorStore } from "../../vectorstore";
 import type { SearchMatchBadge, SearchMatchExplanation } from "../../vectorstore/types";
 import { Logger } from "../../utils/logging";
+import { resolveToolAgent, resolveToolProvider } from "./toolAgentContext";
 
 export type { SearchResult } from "../../vectorstore/types";
 
@@ -358,9 +359,9 @@ async function browseWithFilter(filter: SearchFilter): Promise<SearchResult[]> {
  * Tool for searching through Obsidian notes
  * Uses the search algorithm configured in plugin settings
  */
-export function createSearchNotesTool(app: App) {
+export function createSearchNotesTool(app: App, agentId = "") {
 	const pluginData = getData();
-	const getSearchNotesConfig = () => pluginData.getSelectedAgent().toolsConfig.search_notes;
+	const getSearchNotesConfig = () => resolveToolAgent(agentId).toolsConfig.search_notes;
 	const toolConfig = getSearchNotesConfig();
 	/**
 	 * The four display flags are hardcoded on for the agent.
@@ -432,7 +433,7 @@ export function createSearchNotesTool(app: App) {
 		const results = recentOnly
 			? getRecentNotes(app, filter)
 			: await performSearch(app, query, algorithm ?? "lexical", filter);
-		const currentProvider = pluginData.getSelectedAgent().chatModel?.provider;
+		const currentProvider = resolveToolProvider(agentId);
 		const store = getPendingChangesStore();
 
 		let skippedPrivateFiles = 0;

--- a/src/agent/tools/toolAgentContext.ts
+++ b/src/agent/tools/toolAgentContext.ts
@@ -1,0 +1,38 @@
+import type { AgentConfig } from "../../types/plugin";
+import { getData } from "../../stores/dataStore.svelte";
+
+/**
+ * Resolves the agent a tool call is running *for*.
+ *
+ * Tools are built per-agent by `AgentManager.buildToolsForAgent`, which knows the
+ * owning `AgentConfig` — but a tool that reads `getData().getSelectedAgent()` instead
+ * reads the *globally selected* agent, which is a different thing in two cases that
+ * both matter:
+ *
+ *  - **Subagents.** `resolveSubAgentSpecs` builds a referenced agent's tools from that
+ *    agent's own config, including its own `chatModel` (and therefore its own provider
+ *    trust). Reading the global selection would apply the parent's trust decision to
+ *    the subagent's provider.
+ *  - **Multiple chat tabs.** Each session captures its own `selectedAgentId` at open
+ *    time, but the global selection follows whatever the user last picked. A run in
+ *    tab A must not change behavior because the user switched agents in tab B.
+ *
+ * Falls back to the selected agent when no id was threaded through (the public api
+ * path, which has no run to attribute), keeping existing behavior for that caller.
+ */
+export function resolveToolAgent(agentId: string): AgentConfig {
+	const data = getData();
+	return (agentId ? data.getAgent(agentId) : undefined) ?? data.getSelectedAgent();
+}
+
+/**
+ * The provider the privacy filter must be evaluated against for this run: the
+ * chat provider of the agent that owns the run, not of the global selection.
+ *
+ * Always call this at *tool-invocation* time, never at factory time — a tool
+ * instance outlives any single model choice, so a provider captured at build time
+ * goes stale the moment the user switches models.
+ */
+export function resolveToolProvider(agentId: string): string | undefined {
+	return resolveToolAgent(agentId).chatModel?.provider;
+}

--- a/src/components/chat/PendingChangesBar.svelte
+++ b/src/components/chat/PendingChangesBar.svelte
@@ -4,6 +4,7 @@ import { firstChangedLine, revealAndScroll } from "../../lib/pendingChangeNaviga
 import { getPlugin } from "../../stores/state.svelte";
 import { getPendingChangesStore } from "../../stores/pendingChangesStore.svelte";
 import type { PendingChangeEntry } from "../../types/shared";
+import type { RevertSkip } from "../../stores/pendingChangesStore.svelte";
 import { icon } from "../../utils/utils";
 import { VIEW_TYPE_CHAT } from "../../views/chat/Chat";
 import MarkdownRenderer from "../ui/MarkdownRenderer.svelte";
@@ -136,10 +137,22 @@ function handleReject(entry: PendingChangeEntry) {
  *  no longer pending (so accept/reject would both be no-ops on it). */
 async function handleUndoApplied(entry: PendingChangeEntry) {
 	const skipped = await store.undoAppliedGroups(entry.id);
-	if (skipped) {
-		new Notice(`Left "${changePathLabel(entry)}" as-is — it changed after the change was partially applied.`);
-	} else {
+	if (!skipped) {
 		new Notice(`Restored: ${changePathLabel(entry)}`);
+		return;
+	}
+	new Notice(describeSkip(skipped));
+}
+
+/** A restore that didn't happen, phrased for the reason it didn't. */
+function describeSkip(skip: RevertSkip): string {
+	switch (skip.reason) {
+		case "conflict":
+			return `Left "${skip.path}" as-is — it changed after the change was partially applied.`;
+		case "missing":
+			return `Could not restore "${skip.path}" — that note no longer exists. Any applied content moved with it.`;
+		case "failed":
+			return `Failed to restore "${skip.path}". See the console for details.`;
 	}
 }
 
@@ -166,12 +179,11 @@ async function handleRejectAll() {
 	if (skipped.length === 0) {
 		new Notice(hadPending ? "Rejected all pending changes" : "Restored the partially applied notes");
 	} else {
-		// A partially-accepted note that changed on disk since is left alone rather
-		// than overwritten. Say so — otherwise "Rejected all" reads as "everything
-		// was undone" while those files still hold the accepted groups.
-		new Notice(
-			`Rejected all pending changes. ${skipped.length} note(s) were left as-is because they changed after being partially applied: ${skipped.join(", ")}`,
-		);
+		// A partially-accepted note that couldn't be restored is left as it is. Say
+		// so per reason — otherwise "Rejected all" reads as "everything was undone"
+		// while those files still hold the accepted groups.
+		const head = hadPending ? "Rejected all pending changes." : "Finished undoing applied changes.";
+		new Notice(`${head} ${skipped.map(describeSkip).join(" ")}`);
 	}
 }
 

--- a/src/components/chat/PendingChangesBar.svelte
+++ b/src/components/chat/PendingChangesBar.svelte
@@ -127,8 +127,17 @@ async function handleAcceptAll() {
 
 async function handleRejectAll() {
 	if (!threadId) return;
-	await store.rejectAll(threadId);
-	new Notice("Rejected all pending changes");
+	const skipped = await store.rejectAll(threadId);
+	if (skipped.length === 0) {
+		new Notice("Rejected all pending changes");
+	} else {
+		// A partially-accepted note that changed on disk since is left alone rather
+		// than overwritten. Say so — otherwise "Rejected all" reads as "everything
+		// was undone" while those files still hold the accepted groups.
+		new Notice(
+			`Rejected all pending changes. ${skipped.length} note(s) were left as-is because they changed after being partially applied: ${skipped.join(", ")}`,
+		);
+	}
 }
 
 /** Jump to this change's position in the target note (its first changed line).

--- a/src/components/chat/PendingChangesBar.svelte
+++ b/src/components/chat/PendingChangesBar.svelte
@@ -16,11 +16,33 @@ const { threadPath }: Props = $props();
 const store = getPendingChangesStore();
 
 const threadId = $derived(threadPath);
-const pendingEntries = $derived.by(() => {
+/**
+ * Everything in this thread that still needs the user — pending proposals, plus
+ * any entry whose groups were all resolved individually but whose applied text is
+ * still written to the note.
+ *
+ * The bar used to render only `status === "pending"` entries. Accepting one diff
+ * group and then rejecting the rest leaves an entry marked `rejected` with its
+ * accepted content on disk; if that was the thread's only entry the bar vanished,
+ * stranding the change with no way to reach "Reject All".
+ */
+const actionableEntries = $derived.by(() => {
 	void store.revision;
-	return threadId ? store.getEntriesForThread(threadId).filter((e) => e.status === "pending") : [];
+	return threadId ? store.getActionableForThread(threadId) : [];
 });
+const pendingEntries = $derived(actionableEntries.filter((e) => e.status === "pending"));
 const pendingCount = $derived(pendingEntries.length);
+/** Entries holding applied-but-unreverted content (never also `pending`). */
+const appliedEntries = $derived(actionableEntries.filter((e) => e.status !== "pending"));
+const appliedCount = $derived(appliedEntries.length);
+
+/** Headline for the summary row, which now covers two distinct kinds of entry. */
+const summaryLabel = $derived.by(() => {
+	const parts: string[] = [];
+	if (pendingCount > 0) parts.push(`${pendingCount} pending change${pendingCount !== 1 ? "s" : ""}`);
+	if (appliedCount > 0) parts.push(`${appliedCount} partially applied`);
+	return parts.join(", ");
+});
 
 let isExpanded = $state(false);
 
@@ -110,6 +132,17 @@ function handleReject(entry: PendingChangeEntry) {
 	new Notice(`Rejected: ${changePathLabel(entry)}`);
 }
 
+/** Restore a note whose diff groups were partially accepted, for an entry that is
+ *  no longer pending (so accept/reject would both be no-ops on it). */
+async function handleUndoApplied(entry: PendingChangeEntry) {
+	const skipped = await store.undoAppliedGroups(entry.id);
+	if (skipped) {
+		new Notice(`Left "${changePathLabel(entry)}" as-is — it changed after the change was partially applied.`);
+	} else {
+		new Notice(`Restored: ${changePathLabel(entry)}`);
+	}
+}
+
 async function handleAcceptAll() {
 	if (!threadId) return;
 	const count = pendingCount;
@@ -127,9 +160,11 @@ async function handleAcceptAll() {
 
 async function handleRejectAll() {
 	if (!threadId) return;
+	// Capture before the call — both counts are zero afterwards.
+	const hadPending = pendingCount > 0;
 	const skipped = await store.rejectAll(threadId);
 	if (skipped.length === 0) {
-		new Notice("Rejected all pending changes");
+		new Notice(hadPending ? "Rejected all pending changes" : "Restored the partially applied notes");
 	} else {
 		// A partially-accepted note that changed on disk since is left alone rather
 		// than overwritten. Say so — otherwise "Rejected all" reads as "everything
@@ -166,7 +201,7 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
 }
 </script>
 
-{#if pendingCount > 0}
+{#if actionableEntries.length > 0}
   <div class="pcb-container">
     <!-- Summary bar -->
     <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -175,33 +210,37 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
       <div class="pcb-summary-left">
         <div class="pcb-icon" use:icon={"file-diff"} style="--icon-size: var(--icon-xs)"></div>
         <span class="pcb-count">
-          {pendingCount} pending change{pendingCount !== 1 ? "s" : ""}
+          {summaryLabel}
         </span>
       </div>
       <div class="pcb-summary-right">
-        <button
-          class="pcb-action pcb-action-accept"
-          onclick={(e) => {
-            e.stopPropagation();
-            handleAcceptAll();
-          }}
-          title="Accept all changes"
-          type="button"
-        >
-          <div use:icon={"check"} style="--icon-size: 12px"></div>
-          <span>Accept All</span>
-        </button>
+        {#if pendingCount > 0}
+          <button
+            class="pcb-action pcb-action-accept"
+            onclick={(e) => {
+              e.stopPropagation();
+              handleAcceptAll();
+            }}
+            title="Accept all changes"
+            type="button"
+          >
+            <div use:icon={"check"} style="--icon-size: 12px"></div>
+            <span>Accept All</span>
+          </button>
+        {/if}
         <button
           class="pcb-action pcb-action-reject"
           onclick={(e) => {
             e.stopPropagation();
             handleRejectAll();
           }}
-          title="Reject all changes"
+          title={pendingCount > 0
+            ? "Reject all changes, restoring any partially applied notes"
+            : "Restore the partially applied notes to their original content"}
           type="button"
         >
           <div use:icon={"x"} style="--icon-size: 12px"></div>
-          <span>Reject All</span>
+          <span>{pendingCount > 0 ? "Reject All" : "Undo Applied"}</span>
         </button>
         <div class="pcb-chevron" class:pcb-chevron-open={isExpanded}>▸</div>
       </div>
@@ -210,7 +249,7 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
     <!-- Expanded change list -->
     {#if isExpanded}
       <div class="pcb-list">
-        {#each pendingEntries as entry (entry.id)}
+        {#each actionableEntries as entry (entry.id)}
           {@const previewContent = previewContentOf(entry)}
           {@const isPreviewOpen = previewedEntryIds.has(entry.id)}
           <div class="pcb-entry">
@@ -234,6 +273,17 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
                 <span class="pcb-badge {changeTypeBadgeClass(entry.change.type)}">
                   {changeTypeLabel(entry)}
                 </span>
+                {#if entry.status !== "pending"}
+                  <!-- Not a proposal awaiting review: its groups were all resolved
+                       individually and some accepted text is still in the note. -->
+                  <span
+                    class="pcb-applied"
+                    title="Some of this change was applied to the note. Undo it to restore the note's original content."
+                  >
+                    <span use:icon={"circle-alert"} style="--icon-size: 11px"></span>
+                    Partly applied
+                  </span>
+                {/if}
                 {#if entry.change.type === "update"}
                   <!-- svelte-ignore a11y_mouse_events_have_key_events -->
                   <a
@@ -270,30 +320,48 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
                 {/if}
               </div>
               <div class="pcb-entry-actions">
-                <button
-                  class="pcb-action-icon pcb-action-accept"
-                  onclick={(e) => {
-                    e.stopPropagation();
-                    handleAccept(entry);
-                  }}
-                  title="Accept change"
-                  aria-label="Accept change to {entry.change.path}"
-                  type="button"
-                >
-                  <div use:icon={"check"} style="--icon-size: 12px"></div>
-                </button>
-                <button
-                  class="pcb-action-icon pcb-action-reject"
-                  onclick={(e) => {
-                    e.stopPropagation();
-                    handleReject(entry);
-                  }}
-                  title="Reject change"
-                  aria-label="Reject change to {entry.change.path}"
-                  type="button"
-                >
-                  <div use:icon={"x"} style="--icon-size: 12px"></div>
-                </button>
+                {#if entry.status === "pending"}
+                  <button
+                    class="pcb-action-icon pcb-action-accept"
+                    onclick={(e) => {
+                      e.stopPropagation();
+                      handleAccept(entry);
+                    }}
+                    title="Accept change"
+                    aria-label="Accept change to {entry.change.path}"
+                    type="button"
+                  >
+                    <div use:icon={"check"} style="--icon-size: 12px"></div>
+                  </button>
+                  <button
+                    class="pcb-action-icon pcb-action-reject"
+                    onclick={(e) => {
+                      e.stopPropagation();
+                      handleReject(entry);
+                    }}
+                    title="Reject change"
+                    aria-label="Reject change to {entry.change.path}"
+                    type="button"
+                  >
+                    <div use:icon={"x"} style="--icon-size: 12px"></div>
+                  </button>
+                {:else}
+                  <!-- Already resolved at group level: accept/reject are no-ops on it
+                       (both early-return on non-pending), so offer the one action that
+                       still does something — undoing the text left in the note. -->
+                  <button
+                    class="pcb-action-icon pcb-action-reject"
+                    onclick={(e) => {
+                      e.stopPropagation();
+                      handleUndoApplied(entry);
+                    }}
+                    title="Restore this note to its content from before the proposal"
+                    aria-label="Undo applied change to {entry.change.path}"
+                    type="button"
+                  >
+                    <div use:icon={"undo-2"} style="--icon-size: 12px"></div>
+                  </button>
+                {/if}
               </div>
             </div>
 
@@ -513,6 +581,22 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
     font-weight: var(--font-semibold);
     background: color-mix(in srgb, var(--color-red) 20%, transparent);
     color: var(--color-red);
+    cursor: help;
+  }
+
+  /* Shares the deprivatizing badge's shape; amber rather than red — this is a
+     "needs your attention" state, not a privacy warning. */
+  .pcb-applied {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    flex-shrink: 0;
+    padding: 1px 5px;
+    border-radius: var(--radius-s);
+    font-size: 10px;
+    font-weight: var(--font-semibold);
+    background: color-mix(in srgb, var(--color-yellow) 20%, transparent);
+    color: var(--color-yellow);
     cursor: help;
   }
 

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -2427,98 +2427,118 @@ onMount(() => {
 	const renderer = new PixiRenderer();
 	pixi = renderer;
 
-	renderer.init(containerEl, theme).then(() => {
-		lastViewportScale = renderer.scale;
-		// Re-render when the viewport moves. A zoom must refresh counter-scaled
-		// strokes and label visibility; a pure pan only needs the screen-space
-		// overlay (labels, pills, tooltip) re-laid-out.
-		renderer.onViewportMoved(() => {
-			const scale = renderer.scale;
-			if (scale !== lastViewportScale) {
-				lastViewportScale = scale;
-				requestRender("zoom");
-			} else {
-				requestRender("overlay");
-			}
-			// A pan can carry the view outside the margin edges were culled to —
-			// re-tessellate before the missing region scrolls fully into view.
-			if (lastEdgeCullRect && !rectContains(lastEdgeCullRect, viewWorldRect(renderer, 0))) {
-				edgesViewportStale = true;
-				requestRender("zoom");
-			}
-			if (pendingUserViewportMove || pendingUserViewportZoom) {
-				pendingUserViewportMove = false;
-				pendingUserViewportZoom = false;
-				onUserViewportChange?.();
-			}
-		});
+	// `renderer.init()` awaits WebGL context creation, so the cleanup below can run
+	// before it resolves (the user closes the graph tab while it is starting up).
+	// The cleanup is synchronous and would find `__graphCleanup` still unassigned,
+	// after which this continuation would register a ResizeObserver, a
+	// MutationObserver on document.body and a `css-change` listener that nothing
+	// owns — leaking them plus `containerEl` and the destroyed renderer. Bail here
+	// instead; the cleanup has already released everything that existed at its turn.
+	let mountDisposed = false;
 
-		// If graphData arrived before pixi was ready (happens when GraphCanvas
-		// mounts while a build completes, e.g. on first open), do the initial
-		// snap/fit that setupForceSimulation missed.
-		if (simNodes.length > 0) {
-			// Force mode: simulation is already running.
-			// If it has already settled (alpha low), snap the camera immediately
-			// since the tick loop won't fire again to do the initial fit.
-			const alpha = simulation?.alpha() ?? 0;
-			if (alpha < 0.05) {
-				const bounds = computeNodeBounds(simNodes);
-				if (bounds) {
-					const frame = framingFocus(
-						bounds,
-						{ width: renderer.width, height: renderer.height },
-						GRAPH_FIT_PADDING,
-						GRAPH_FIT_MAX_SCALE,
-						computeCoreNodeBounds(simNodes),
-					);
-					renderer.snapToFrame(frame.centerX, frame.centerY, frame.scale);
+	renderer
+		.init(containerEl, theme)
+		.then(() => {
+			if (mountDisposed) return;
+			lastViewportScale = renderer.scale;
+			// Re-render when the viewport moves. A zoom must refresh counter-scaled
+			// strokes and label visibility; a pure pan only needs the screen-space
+			// overlay (labels, pills, tooltip) re-laid-out.
+			renderer.onViewportMoved(() => {
+				const scale = renderer.scale;
+				if (scale !== lastViewportScale) {
+					lastViewportScale = scale;
+					requestRender("zoom");
+				} else {
+					requestRender("overlay");
 				}
-			} else {
-				// Simulation still running — tick loop will handle fitting.
-				needsInitialFit = true;
-				forceTickCount = 0;
-			}
-			requestRender("world");
-		}
-
-		const resizeObserver = new ResizeObserver(() => {
-			const rect = containerEl.getBoundingClientRect();
-			renderer.resize(rect.width, rect.height);
-			requestRender("world");
-		});
-		resizeObserver.observe(containerEl);
-
-		// Listen for Obsidian theme changes — covers both "css-change" events (CSS
-		// snippets) and class mutations on body (.theme-dark / .theme-light toggle).
-		const handleCssChange = () => {
-			const newTheme = readThemeColors(containerEl);
-			renderer.updateTheme(newTheme);
-			requestRender("world");
-		};
-		document.body.addEventListener("css-change", handleCssChange);
-
-		const themeMutationObserver = new MutationObserver((mutations) => {
-			for (const m of mutations) {
-				if (m.type === "attributes" && m.attributeName === "class") {
-					handleCssChange();
-					break;
+				// A pan can carry the view outside the margin edges were culled to —
+				// re-tessellate before the missing region scrolls fully into view.
+				if (lastEdgeCullRect && !rectContains(lastEdgeCullRect, viewWorldRect(renderer, 0))) {
+					edgesViewportStale = true;
+					requestRender("zoom");
 				}
-			}
-		});
-		themeMutationObserver.observe(document.body, {
-			attributes: true,
-			attributeFilter: ["class"],
-		});
+				if (pendingUserViewportMove || pendingUserViewportZoom) {
+					pendingUserViewportMove = false;
+					pendingUserViewportZoom = false;
+					onUserViewportChange?.();
+				}
+			});
 
-		// Store cleanup references
-		(containerEl as any).__graphCleanup = () => {
-			resizeObserver.disconnect();
-			document.body.removeEventListener("css-change", handleCssChange);
-			themeMutationObserver.disconnect();
-		};
-	});
+			// If graphData arrived before pixi was ready (happens when GraphCanvas
+			// mounts while a build completes, e.g. on first open), do the initial
+			// snap/fit that setupForceSimulation missed.
+			if (simNodes.length > 0) {
+				// Force mode: simulation is already running.
+				// If it has already settled (alpha low), snap the camera immediately
+				// since the tick loop won't fire again to do the initial fit.
+				const alpha = simulation?.alpha() ?? 0;
+				if (alpha < 0.05) {
+					const bounds = computeNodeBounds(simNodes);
+					if (bounds) {
+						const frame = framingFocus(
+							bounds,
+							{ width: renderer.width, height: renderer.height },
+							GRAPH_FIT_PADDING,
+							GRAPH_FIT_MAX_SCALE,
+							computeCoreNodeBounds(simNodes),
+						);
+						renderer.snapToFrame(frame.centerX, frame.centerY, frame.scale);
+					}
+				} else {
+					// Simulation still running — tick loop will handle fitting.
+					needsInitialFit = true;
+					forceTickCount = 0;
+				}
+				requestRender("world");
+			}
+
+			const resizeObserver = new ResizeObserver(() => {
+				const rect = containerEl.getBoundingClientRect();
+				renderer.resize(rect.width, rect.height);
+				requestRender("world");
+			});
+			resizeObserver.observe(containerEl);
+
+			// Listen for Obsidian theme changes — covers both "css-change" events (CSS
+			// snippets) and class mutations on body (.theme-dark / .theme-light toggle).
+			const handleCssChange = () => {
+				const newTheme = readThemeColors(containerEl);
+				renderer.updateTheme(newTheme);
+				requestRender("world");
+			};
+			document.body.addEventListener("css-change", handleCssChange);
+
+			const themeMutationObserver = new MutationObserver((mutations) => {
+				for (const m of mutations) {
+					if (m.type === "attributes" && m.attributeName === "class") {
+						handleCssChange();
+						break;
+					}
+				}
+			});
+			themeMutationObserver.observe(document.body, {
+				attributes: true,
+				attributeFilter: ["class"],
+			});
+
+			// Store cleanup references
+			(containerEl as any).__graphCleanup = () => {
+				resizeObserver.disconnect();
+				document.body.removeEventListener("css-change", handleCssChange);
+				themeMutationObserver.disconnect();
+			};
+		})
+		.catch((error) => {
+			// A WebGL context failure would otherwise surface only as an unhandled
+			// rejection. Nothing is registered yet at this point, so there is nothing
+			// to unwind — report it and leave the canvas blank.
+			console.error("[GraphCanvas] Failed to initialize the graph renderer:", error);
+		});
 
 	return () => {
+		// Tell a still-pending `renderer.init()` continuation to bail — see above.
+		mountDisposed = true;
 		(containerEl as any).__graphCleanup?.();
 		visibilityObserver.disconnect();
 		if (renderRafId != null) {

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -1913,8 +1913,7 @@ async function runTopicLabeling(options: { force?: boolean } = {}) {
 		).length;
 		if (withheld > 0) {
 			new Notice(
-				`Private note titles were withheld from ${withheld} ${withheld === 1 ? "topic" : "topics"}. ` +
-					"Trust the graph model's provider in Settings to include them.",
+				`Private note titles were withheld from ${withheld} ${withheld === 1 ? "topic" : "topics"}. Trust the graph model's provider in Settings to include them.`,
 			);
 		}
 	}

--- a/src/components/graph/pixiRenderer.ts
+++ b/src/components/graph/pixiRenderer.ts
@@ -288,6 +288,13 @@ export class PixiRenderer {
 	private _height = 0;
 	private _destroyed = false;
 	private _ready = false;
+	/**
+	 * Whether `app.init()` has resolved. `this.app` is assigned synchronously by
+	 * `new Application()` but is not usable — and must not be destroyed — until its
+	 * async `init()` completes. Distinct from `_ready`, which additionally requires
+	 * the scene graph to be built.
+	 */
+	private _appInitialized = false;
 
 	// Callback fired whenever the viewport moves (pan/zoom/pinch)
 	private _onViewportMoved: (() => void) | null = null;
@@ -338,6 +345,17 @@ export class PixiRenderer {
 			// actually changed, so a settled graph costs no GPU work at idle.
 			autoStart: false,
 		});
+
+		// `app.init()` creates a WebGL context — a real async gap, longer on a cold
+		// GPU. If the owner tore us down inside it, `destroy()` already ran and found
+		// nothing to release (`_appInitialized` was still false). Undo the context we
+		// just finished creating and stop, rather than building a full scene graph and
+		// registering a shared-ticker callback that nothing will ever remove.
+		if (this._destroyed) {
+			this.app.destroy(true, { children: true });
+			return;
+		}
+		this._appInitialized = true;
 
 		// Style the canvas
 		const canvas = this.app.canvas as HTMLCanvasElement;
@@ -495,7 +513,14 @@ export class PixiRenderer {
 		// Sprites share this render texture, so it isn't covered by the
 		// children-destroy below.
 		this.nodeTexture?.destroy(true);
-		this.app.destroy(true, { children: true });
+		// Only tear down a pixi Application whose async `init()` actually resolved.
+		// `new Application()` assigns `this.app` synchronously, so a destroy during
+		// init would otherwise call `destroy()` on a renderer that was never created
+		// — which throws, aborting the caller's remaining cleanup. `init()` checks
+		// `_destroyed` after its await and releases the context itself in that case.
+		if (this._appInitialized) {
+			this.app.destroy(true, { children: true });
+		}
 	}
 
 	/**

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -42,6 +42,21 @@ class ProviderRegistry {
 	/** Configured providers with their definition and auth */
 	private readonly providers = new Map<string, RegisteredProvider>();
 
+	/**
+	 * Monotonic counter bumped on every mutation of a provider's credentials
+	 * (register / updateAuth / unregister). Consumers that *cache artifacts built
+	 * from* an auth state — most importantly `Agent`'s runnable cache, whose cached
+	 * runnable holds a model instance with the credentials baked in — mix
+	 * {@link authGeneration} into their cache key so a rotated API key or an edited
+	 * baseUrl produces a fresh key instead of a stale hit.
+	 *
+	 * A counter rather than a hash of the auth object: the value ends up inside
+	 * long-lived in-memory cache keys, and a counter cannot leak anything about the
+	 * secret even if such a key is logged. Over-invalidation (a no-op re-register
+	 * still bumps) is harmless — the cost is one rebuilt runnable.
+	 */
+	private authGeneration = 0;
+
 	private constructor() {
 		// Private constructor for singleton
 	}
@@ -76,19 +91,25 @@ class ProviderRegistry {
 	 */
 	register(id: string, definition: BaseProviderDefinition, auth: AuthObject): void {
 		this.providers.set(id, { definition, auth });
+		this.authGeneration++;
 	}
 
 	/**
 	 * Unregisters a provider.
 	 */
 	unregister(id: string): void {
-		this.providers.delete(id);
+		if (this.providers.delete(id)) {
+			this.authGeneration++;
+		}
 	}
 
 	/**
 	 * Clears all registered providers.
 	 */
 	clear(): void {
+		if (this.providers.size > 0) {
+			this.authGeneration++;
+		}
 		this.providers.clear();
 	}
 
@@ -127,6 +148,7 @@ class ProviderRegistry {
 		const entry = this.providers.get(id);
 		if (entry) {
 			entry.auth = auth;
+			this.authGeneration++;
 		}
 	}
 
@@ -135,6 +157,14 @@ class ProviderRegistry {
 	 */
 	list(): string[] {
 		return Array.from(this.providers.keys());
+	}
+
+	/**
+	 * Current credential generation — see {@link authGeneration}. Include this in any
+	 * cache key whose cached value embeds resolved provider credentials.
+	 */
+	getAuthGeneration(): number {
+		return this.authGeneration;
 	}
 
 	// =========================================================================

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -328,8 +328,16 @@ export class PendingChangesStore {
 	 * note could interleave read→modify and clobber each other.) The stored
 	 * promise is the tail of the chain; the map entry is cleared only when this
 	 * op is still the tail, so a later arrival that already chained onto us keeps
-	 * the entry alive. */
-	private async withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+	 * the entry alive.
+	 *
+	 * The key is normalized here rather than at the call sites: `#fileLocks` is a
+	 * plain string map, so `"a//b.md"` and `"a/b.md"` would occupy *different*
+	 * chains for one file and let two ops interleave read→modify — exactly the
+	 * clobbering the queue exists to prevent. Callers pass whatever path they hold;
+	 * making the invariant structural means a future call site can't reintroduce
+	 * the split by forgetting to normalize. */
+	private async withFileLock<T>(rawPath: string, fn: () => Promise<T>): Promise<T> {
+		const filePath = normalizePath(rawPath);
 		const previous = this.#fileLocks.get(filePath) ?? Promise.resolve();
 
 		// Run only after everything already queued for this path settles. Swallow
@@ -442,9 +450,15 @@ export class PendingChangesStore {
 		}
 	}
 
-	/** Reject all pending changes for a thread, reverting any partially-applied group writes. */
-	async rejectAll(threadId: string): Promise<void> {
+	/** Reject all pending changes for a thread, reverting any partially-applied group writes.
+	 *
+	 *  Returns the paths whose revert was skipped because the file no longer matched what
+	 *  we wrote — the entries are still rejected (the proposal is dead either way), but the
+	 *  file keeps its current content. Callers should surface these: a silent skip reads as
+	 *  "everything was undone" when it wasn't. */
+	async rejectAll(threadId: string): Promise<string[]> {
 		const pending = this.#entries.filter((e) => e.threadId === threadId && e.status === "pending");
+		const skippedReverts: string[] = [];
 		for (const entry of pending) {
 			// Revert vault file if groups were partially accepted
 			if (entry.change.type === "update" && entry.change.initialOriginalContent !== undefined) {
@@ -452,20 +466,45 @@ export class PendingChangesStore {
 				const initialOriginalContent = change.initialOriginalContent;
 				if (initialOriginalContent === undefined) continue;
 				try {
-					await this.withFileLock(change.path, async () => {
+					const skippedPath = await this.withFileLock(change.path, async () => {
 						const file = this.#plugin.app.vault.getAbstractFileByPath(change.path);
-						if (file instanceof TFile) {
-							await this.#plugin.app.vault.modify(file, initialOriginalContent);
+						if (!(file instanceof TFile)) return undefined;
+
+						// Conflict check, matching acceptChange/acceptChangeGroup. Rejecting
+						// is not a licence to discard the user's own work: between the group
+						// accept and this reject they may have edited the note by hand, and
+						// `vault.modify` does not go through trash, so an unconditional
+						// overwrite destroys those edits with no way back.
+						//
+						// `originalContent` is the right baseline, not `initialOriginalContent`:
+						// acceptChangeGroup advances `originalContent` to exactly what it wrote
+						// (see its `change.originalContent = newVaultContent`), so it tracks what
+						// we last put on disk. If the file still matches it, our writes are the
+						// only ones there and undoing them is safe.
+						const currentContent = await this.#plugin.app.vault.read(file);
+						if (currentContent !== change.originalContent) {
+							return change.path;
 						}
+
+						await this.#plugin.app.vault.modify(file, initialOriginalContent);
+						return undefined;
 					});
+					if (skippedPath) {
+						Logger.warn(
+							`[PendingChanges] Skipped reverting "${skippedPath}" — it was modified after the group accept; leaving the file as-is.`,
+						);
+						skippedReverts.push(skippedPath);
+					}
 				} catch (e) {
 					Logger.error(`[PendingChanges] Failed to revert ${entry.change.path}:`, e);
+					skippedReverts.push(entry.change.path);
 				}
 			}
 			entry.status = "rejected";
 		}
 		this.scheduleSave();
 		this.notifyChange();
+		return skippedReverts;
 	}
 
 	/** Get all entries for a thread. */

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -306,6 +306,10 @@ export class PendingChangesStore {
 		});
 
 		entry.status = "accepted";
+		// The whole proposal is applied with the user's approval, so any partial-write
+		// snapshot from earlier group accepts is settled — see `hasUnrevertedApplication`.
+		// Leaving it set would let `rejectAll` revert a change they just accepted.
+		if (change.type === "update") change.initialOriginalContent = undefined;
 		this.scheduleSave();
 		this.notifyChange();
 	}
@@ -395,6 +399,13 @@ export class PendingChangesStore {
 				change.originalContent = newVaultContent;
 				if (change.originalContent === change.newContent) {
 					entry.status = "accepted";
+					// Every group is now applied and the user approved each one, so the
+					// note's content is theirs — not an unreviewed partial write. Drop the
+					// pre-proposal snapshot: it exists to mark "there is applied content
+					// here the user has not signed off on", and keeping it would make
+					// `rejectAll` treat this completed acceptance as something to undo,
+					// silently reverting a change they explicitly accepted.
+					change.initialOriginalContent = undefined;
 				}
 			});
 
@@ -561,15 +572,22 @@ export class PendingChangesStore {
 	}
 
 	/**
-	 * Whether this entry has partially-applied content still written to the note.
+	 * Whether this entry has applied content in the note that the user has NOT
+	 * signed off on.
 	 *
-	 * True from the first `acceptChangeGroup` until a revert clears the snapshot —
-	 * *independently of status*. An entry whose groups were all resolved individually
-	 * is `accepted` or `rejected` while its applied text is still on disk, so status
-	 * alone cannot answer "is there anything left to undo here".
+	 * `initialOriginalContent` is the invariant: set on the first
+	 * `acceptChangeGroup`, and cleared the moment the outcome is settled — either
+	 * every group was accepted (the content is now theirs) or the applied text was
+	 * reverted (there is nothing left on disk). So it means "unreviewed partial
+	 * write present", not merely "a group was once accepted".
 	 *
-	 * Single source of truth for the two callers that must agree: `rejectAll` (what to
-	 * revert) and `PendingChangesBar` (whether to stay visible so the user can ask).
+	 * Status alone cannot answer this. Resolving the last group individually flips
+	 * the entry to `accepted`/`rejected` while partial text may still be on disk,
+	 * which is why this is keyed on the snapshot rather than on status.
+	 *
+	 * Single source of truth for the callers that must agree: `rejectAll` (what to
+	 * revert), `PendingChangesBar` (whether to stay visible), and `cleanupResolved`
+	 * (what is safe to forget).
 	 */
 	hasUnrevertedApplication(entry: PendingChangeEntry): boolean {
 		return entry.change.type === "update" && entry.change.initialOriginalContent !== undefined;

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -38,6 +38,19 @@ const pendingChangesArraySchema = z.array(pendingChangeEntrySchema);
 let _store: PendingChangesStore | null = null;
 
 /**
+ * Why a partially-applied note was not restored.
+ *
+ * - `conflict` — it changed after the group accept, so we left the user's work alone.
+ * - `missing`  — nothing exists at that path any more (deleted, or moved while the
+ *                plugin was unloaded); there is nothing to restore.
+ * - `failed`   — the write itself threw.
+ */
+export interface RevertSkip {
+	path: string;
+	reason: "conflict" | "missing" | "failed";
+}
+
+/**
  * Determine whether to include a removed or added part in the output.
  */
 function shouldIncludePart(part: Change, isTarget: boolean, targetUsesNew: boolean): boolean {
@@ -465,9 +478,11 @@ export class PendingChangesStore {
 	 * Restore a note whose diff groups were partially accepted back to its
 	 * pre-proposal content. No-op for anything with nothing applied.
 	 *
-	 * @returns the path when the revert was SKIPPED (conflict or failure), else undefined.
+	 * @returns a {@link RevertSkip} when the revert did NOT happen, else undefined.
+	 *   The reason is carried so callers can say which it was — "we left your edits
+	 *   alone" and "that note is gone" are very different messages to receive.
 	 */
-	private async revertAppliedGroups(entry: PendingChangeEntry): Promise<string | undefined> {
+	private async revertAppliedGroups(entry: PendingChangeEntry): Promise<RevertSkip | undefined> {
 		if (!this.hasUnrevertedApplication(entry)) return undefined;
 		// Narrowed by hasUnrevertedApplication, which TS can't see through.
 		const change = entry.change as Extract<PendingChange, { type: "update" }>;
@@ -477,7 +492,21 @@ export class PendingChangesStore {
 		try {
 			return await this.withFileLock(change.path, async () => {
 				const file = this.#plugin.app.vault.getAbstractFileByPath(change.path);
-				if (!(file instanceof TFile)) return undefined;
+				if (!(file instanceof TFile)) {
+					// Nothing at this path to restore. Reporting success would tell the
+					// user the note was put back when it wasn't — and, because the
+					// snapshot below is only cleared on an actual write, the entry would
+					// stay actionable forever with no way to resolve it. Renames are now
+					// tracked for these entries (see #handleFileRename), so reaching here
+					// means the note was deleted, or moved while the plugin was unloaded.
+					Logger.warn(
+						`[PendingChanges] Cannot restore "${change.path}" — the note no longer exists at that path.`,
+					);
+					// Clear the snapshot: there is no file left to undo, so keeping it
+					// would strand the entry as permanently unresolvable.
+					change.initialOriginalContent = undefined;
+					return { path: change.path, reason: "missing" as const };
+				}
 
 				// Conflict check, matching acceptChange/acceptChangeGroup. Rejecting
 				// is not a licence to discard the user's own work: between the group
@@ -495,7 +524,9 @@ export class PendingChangesStore {
 					Logger.warn(
 						`[PendingChanges] Skipped reverting "${change.path}" — it was modified after the group accept; leaving the file as-is.`,
 					);
-					return change.path;
+					// Snapshot deliberately kept: the note is still there, so the user can
+					// resolve the conflict and undo later.
+					return { path: change.path, reason: "conflict" as const };
 				}
 
 				await this.#plugin.app.vault.modify(file, initialOriginalContent);
@@ -509,7 +540,7 @@ export class PendingChangesStore {
 			});
 		} catch (e) {
 			Logger.error(`[PendingChanges] Failed to revert ${change.path}:`, e);
-			return change.path;
+			return { path: change.path, reason: "failed" as const };
 		}
 	}
 
@@ -519,15 +550,15 @@ export class PendingChangesStore {
 	 *
 	 * @returns the path when the revert was skipped, else undefined.
 	 */
-	async undoAppliedGroups(entryId: string): Promise<string | undefined> {
+	async undoAppliedGroups(entryId: string): Promise<RevertSkip | undefined> {
 		const entry = this.#entries.find((e) => e.id === entryId);
 		if (!entry) return undefined;
 
-		const skippedPath = await this.revertAppliedGroups(entry);
+		const skipped = await this.revertAppliedGroups(entry);
 		entry.status = "rejected";
 		this.scheduleSave();
 		this.notifyChange();
-		return skippedPath;
+		return skipped;
 	}
 
 	/** Reject all pending changes for a thread, reverting any partially-applied group writes.
@@ -536,7 +567,7 @@ export class PendingChangesStore {
 	 *  we wrote — the entries are still rejected (the proposal is dead either way), but the
 	 *  file keeps its current content. Callers should surface these: a silent skip reads as
 	 *  "everything was undone" when it wasn't. */
-	async rejectAll(threadId: string): Promise<string[]> {
+	async rejectAll(threadId: string): Promise<RevertSkip[]> {
 		// Two distinct sets, deliberately:
 		//
 		//  - anything still `pending`, which must be marked rejected; and
@@ -550,10 +581,10 @@ export class PendingChangesStore {
 		// on `pending` alone skipped exactly those entries, leaving the applied text in
 		// the vault while the UI reported that everything had been rejected.
 		const targets = this.getActionableForThread(threadId);
-		const skippedReverts: string[] = [];
+		const skippedReverts: RevertSkip[] = [];
 		for (const entry of targets) {
-			const skippedPath = await this.revertAppliedGroups(entry);
-			if (skippedPath) skippedReverts.push(skippedPath);
+			const skipped = await this.revertAppliedGroups(entry);
+			if (skipped) skippedReverts.push(skipped);
 			entry.status = "rejected";
 		}
 		this.scheduleSave();
@@ -694,7 +725,13 @@ export class PendingChangesStore {
 	#handleFileRename(oldPath: string, newPath: string): void {
 		let changed = false;
 		for (const entry of this.#entries) {
-			if (entry.status !== "pending") continue;
+			// Track renames for pending proposals AND for anything still holding
+			// unreverted applied content. The latter is not pending — its groups were
+			// resolved individually — but its path is still a live pointer to text in
+			// the vault that Undo Applied / Reject All must reach. Skipping it left a
+			// stale path, so the revert looked up a file that no longer existed and
+			// reported success while the applied content sat at the new path.
+			if (entry.status !== "pending" && !this.hasUnrevertedApplication(entry)) continue;
 			if (entry.change.path === oldPath) {
 				entry.change.path = newPath;
 				changed = true;

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -450,6 +450,75 @@ export class PendingChangesStore {
 		}
 	}
 
+	/**
+	 * Restore a note whose diff groups were partially accepted back to its
+	 * pre-proposal content. No-op for anything with nothing applied.
+	 *
+	 * @returns the path when the revert was SKIPPED (conflict or failure), else undefined.
+	 */
+	private async revertAppliedGroups(entry: PendingChangeEntry): Promise<string | undefined> {
+		if (!this.hasUnrevertedApplication(entry)) return undefined;
+		// Narrowed by hasUnrevertedApplication, which TS can't see through.
+		const change = entry.change as Extract<PendingChange, { type: "update" }>;
+		const initialOriginalContent = change.initialOriginalContent;
+		if (initialOriginalContent === undefined) return undefined;
+
+		try {
+			return await this.withFileLock(change.path, async () => {
+				const file = this.#plugin.app.vault.getAbstractFileByPath(change.path);
+				if (!(file instanceof TFile)) return undefined;
+
+				// Conflict check, matching acceptChange/acceptChangeGroup. Rejecting
+				// is not a licence to discard the user's own work: between the group
+				// accept and this reject they may have edited the note by hand, and
+				// `vault.modify` does not go through trash, so an unconditional
+				// overwrite destroys those edits with no way back.
+				//
+				// `originalContent` is the right baseline, not `initialOriginalContent`:
+				// acceptChangeGroup advances `originalContent` to exactly what it wrote
+				// (see its `change.originalContent = newVaultContent`), so it tracks what
+				// we last put on disk. If the file still matches it, our writes are the
+				// only ones there and undoing them is safe.
+				const currentContent = await this.#plugin.app.vault.read(file);
+				if (currentContent !== change.originalContent) {
+					Logger.warn(
+						`[PendingChanges] Skipped reverting "${change.path}" — it was modified after the group accept; leaving the file as-is.`,
+					);
+					return change.path;
+				}
+
+				await this.#plugin.app.vault.modify(file, initialOriginalContent);
+				// The note is back to its pre-proposal state, so there is nothing left
+				// to undo. Clearing this makes the revert idempotent: a later revert
+				// (or one after the user edits the note again) must not re-apply this
+				// stale snapshot over their newer content.
+				change.originalContent = initialOriginalContent;
+				change.initialOriginalContent = undefined;
+				return undefined;
+			});
+		} catch (e) {
+			Logger.error(`[PendingChanges] Failed to revert ${change.path}:`, e);
+			return change.path;
+		}
+	}
+
+	/**
+	 * Undo the partially-applied content of a single entry (the per-row counterpart
+	 * of `rejectAll`'s revert), marking it rejected.
+	 *
+	 * @returns the path when the revert was skipped, else undefined.
+	 */
+	async undoAppliedGroups(entryId: string): Promise<string | undefined> {
+		const entry = this.#entries.find((e) => e.id === entryId);
+		if (!entry) return undefined;
+
+		const skippedPath = await this.revertAppliedGroups(entry);
+		entry.status = "rejected";
+		this.scheduleSave();
+		this.notifyChange();
+		return skippedPath;
+	}
+
 	/** Reject all pending changes for a thread, reverting any partially-applied group writes.
 	 *
 	 *  Returns the paths whose revert was skipped because the file no longer matched what
@@ -469,60 +538,11 @@ export class PendingChangesStore {
 		// `rejected` — while the accepted group is still written to the note. Filtering
 		// on `pending` alone skipped exactly those entries, leaving the applied text in
 		// the vault while the UI reported that everything had been rejected.
-		const targets = this.#entries.filter(
-			(e) =>
-				e.threadId === threadId &&
-				(e.status === "pending" ||
-					(e.change.type === "update" && e.change.initialOriginalContent !== undefined)),
-		);
+		const targets = this.getActionableForThread(threadId);
 		const skippedReverts: string[] = [];
 		for (const entry of targets) {
-			// Revert vault file if groups were partially accepted
-			if (entry.change.type === "update" && entry.change.initialOriginalContent !== undefined) {
-				const change = entry.change;
-				const initialOriginalContent = change.initialOriginalContent;
-				if (initialOriginalContent === undefined) continue;
-				try {
-					const skippedPath = await this.withFileLock(change.path, async () => {
-						const file = this.#plugin.app.vault.getAbstractFileByPath(change.path);
-						if (!(file instanceof TFile)) return undefined;
-
-						// Conflict check, matching acceptChange/acceptChangeGroup. Rejecting
-						// is not a licence to discard the user's own work: between the group
-						// accept and this reject they may have edited the note by hand, and
-						// `vault.modify` does not go through trash, so an unconditional
-						// overwrite destroys those edits with no way back.
-						//
-						// `originalContent` is the right baseline, not `initialOriginalContent`:
-						// acceptChangeGroup advances `originalContent` to exactly what it wrote
-						// (see its `change.originalContent = newVaultContent`), so it tracks what
-						// we last put on disk. If the file still matches it, our writes are the
-						// only ones there and undoing them is safe.
-						const currentContent = await this.#plugin.app.vault.read(file);
-						if (currentContent !== change.originalContent) {
-							return change.path;
-						}
-
-						await this.#plugin.app.vault.modify(file, initialOriginalContent);
-						// The note is back to its pre-proposal state, so there is nothing
-						// left to undo. Clearing this makes the revert idempotent: a second
-						// rejectAll (or one after the user edits the note again) must not
-						// re-apply this stale snapshot over their newer content.
-						change.originalContent = initialOriginalContent;
-						change.initialOriginalContent = undefined;
-						return undefined;
-					});
-					if (skippedPath) {
-						Logger.warn(
-							`[PendingChanges] Skipped reverting "${skippedPath}" — it was modified after the group accept; leaving the file as-is.`,
-						);
-						skippedReverts.push(skippedPath);
-					}
-				} catch (e) {
-					Logger.error(`[PendingChanges] Failed to revert ${entry.change.path}:`, e);
-					skippedReverts.push(entry.change.path);
-				}
-			}
+			const skippedPath = await this.revertAppliedGroups(entry);
+			if (skippedPath) skippedReverts.push(skippedPath);
 			entry.status = "rejected";
 		}
 		this.scheduleSave();
@@ -538,6 +558,31 @@ export class PendingChangesStore {
 	/** Get only pending entries for a thread. */
 	getPendingForThread(threadId: string): PendingChangeEntry[] {
 		return this.#entries.filter((e) => e.threadId === threadId && e.status === "pending");
+	}
+
+	/**
+	 * Whether this entry has partially-applied content still written to the note.
+	 *
+	 * True from the first `acceptChangeGroup` until a revert clears the snapshot —
+	 * *independently of status*. An entry whose groups were all resolved individually
+	 * is `accepted` or `rejected` while its applied text is still on disk, so status
+	 * alone cannot answer "is there anything left to undo here".
+	 *
+	 * Single source of truth for the two callers that must agree: `rejectAll` (what to
+	 * revert) and `PendingChangesBar` (whether to stay visible so the user can ask).
+	 */
+	hasUnrevertedApplication(entry: PendingChangeEntry): boolean {
+		return entry.change.type === "update" && entry.change.initialOriginalContent !== undefined;
+	}
+
+	/**
+	 * Entries for a thread that still need the user: pending proposals, plus any
+	 * entry holding partially-applied content that has not been reverted.
+	 */
+	getActionableForThread(threadId: string): PendingChangeEntry[] {
+		return this.#entries.filter(
+			(e) => e.threadId === threadId && (e.status === "pending" || this.hasUnrevertedApplication(e)),
+		);
 	}
 
 	/** Get a single entry by ID. */
@@ -605,7 +650,12 @@ export class PendingChangesStore {
 	/** Remove all resolved (accepted/rejected) entries for a thread. */
 	cleanupResolved(threadId: string): void {
 		const beforeLength = this.#entries.length;
-		this.#entries = this.#entries.filter((e) => e.threadId !== threadId || e.status === "pending");
+		// Keep anything still holding unreverted content on disk: dropping it would
+		// discard the only record of what the note looked like before, leaving the
+		// applied text with no way to undo it. Same rule the bar uses to stay visible.
+		this.#entries = this.#entries.filter(
+			(e) => e.threadId !== threadId || e.status === "pending" || this.hasUnrevertedApplication(e),
+		);
 		this.scheduleSave();
 		if (this.#entries.length !== beforeLength) {
 			this.notifyChange();

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -457,9 +457,26 @@ export class PendingChangesStore {
 	 *  file keeps its current content. Callers should surface these: a silent skip reads as
 	 *  "everything was undone" when it wasn't. */
 	async rejectAll(threadId: string): Promise<string[]> {
-		const pending = this.#entries.filter((e) => e.threadId === threadId && e.status === "pending");
+		// Two distinct sets, deliberately:
+		//
+		//  - anything still `pending`, which must be marked rejected; and
+		//  - anything with `initialOriginalContent` set, which has partially-applied
+		//    content ON DISK that must be undone regardless of its status.
+		//
+		// The second set is not a subset of the first. Accepting one diff group and
+		// then rejecting the remaining ones drives `newContent` back to
+		// `originalContent`, so `rejectChangeGroup` already flipped the entry to
+		// `rejected` — while the accepted group is still written to the note. Filtering
+		// on `pending` alone skipped exactly those entries, leaving the applied text in
+		// the vault while the UI reported that everything had been rejected.
+		const targets = this.#entries.filter(
+			(e) =>
+				e.threadId === threadId &&
+				(e.status === "pending" ||
+					(e.change.type === "update" && e.change.initialOriginalContent !== undefined)),
+		);
 		const skippedReverts: string[] = [];
-		for (const entry of pending) {
+		for (const entry of targets) {
 			// Revert vault file if groups were partially accepted
 			if (entry.change.type === "update" && entry.change.initialOriginalContent !== undefined) {
 				const change = entry.change;
@@ -487,6 +504,12 @@ export class PendingChangesStore {
 						}
 
 						await this.#plugin.app.vault.modify(file, initialOriginalContent);
+						// The note is back to its pre-proposal state, so there is nothing
+						// left to undo. Clearing this makes the revert idempotent: a second
+						// rejectAll (or one after the user edits the note again) must not
+						// re-apply this stale snapshot over their newer content.
+						change.originalContent = initialOriginalContent;
+						change.initialOriginalContent = undefined;
 						return undefined;
 					});
 					if (skippedPath) {

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -711,9 +711,27 @@ export class PendingChangesStore {
 		}
 	}
 
-	/** Remove all entries for a thread (e.g., when thread is deleted). */
+	/**
+	 * Remove all entries for a thread (e.g. when the thread is deleted).
+	 *
+	 * Unlike {@link cleanupResolved} this drops everything, including entries still
+	 * holding unreverted applied content: the chat is gone, so there is no surface
+	 * left to review them on and keeping them would leak rows into a thread that no
+	 * longer exists. But that content stays in the vault with its only undo record
+	 * discarded, so warn rather than doing it silently — the note is left as the
+	 * agent partially wrote it, and the user gets no other signal.
+	 */
 	removeThread(threadId: string): void {
 		const beforeLength = this.#entries.length;
+		const strandedPaths = this.#entries
+			.filter((e) => e.threadId === threadId && this.hasUnrevertedApplication(e))
+			.map((e) => e.change.path);
+		if (strandedPaths.length > 0) {
+			Logger.warn(
+				`[PendingChanges] Discarding ${strandedPaths.length} partially-applied change(s) with the deleted thread. ` +
+					`These notes keep the content that was already applied: ${strandedPaths.join(", ")}`,
+			);
+		}
 		this.#entries = this.#entries.filter((e) => e.threadId !== threadId);
 		this.scheduleSave();
 		if (this.#entries.length !== beforeLength) {

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -64,7 +64,14 @@ export interface PendingNoteUpdate {
 	/** Proposed new content */
 	newContent: string;
 	/** Snapshot of originalContent before any group-level accepts mutated it.
-	 *  Set on the first `acceptChangeGroup` call so `rejectAll` can restore the file. */
+	 *
+	 *  Presence means "applied content is in the note that the user has not signed
+	 *  off on", which is what `rejectAll` / the pending-changes bar key off (see
+	 *  `PendingChangesStore.hasUnrevertedApplication`). Set on the first
+	 *  `acceptChangeGroup`, and cleared once the outcome settles: every group
+	 *  accepted (or the whole entry accepted), or the applied text reverted.
+	 *  Leaving it set past that point would make a completed acceptance look like
+	 *  something to undo. */
 	initialOriginalContent?: string;
 }
 

--- a/src/vectorstore/HNSWVectorStore.ts
+++ b/src/vectorstore/HNSWVectorStore.ts
@@ -33,6 +33,14 @@ const ID_MAPPING_STORE = "id_mapping";
 const DB_VERSION = 2; // Bumped for ID mapping store
 
 /**
+ * How long to wait on a blocked `indexedDB.open` before failing with a real error.
+ * A blocked open fires neither `success` nor `error`, so without a bound it hangs
+ * forever. Generous enough that the normal case — the other connection yielding via
+ * its `versionchange` handler — always wins the race.
+ */
+const OPEN_BLOCKED_TIMEOUT_MS = 10_000;
+
+/**
  * Internal representation stored in IndexedDB.
  * Uses number[] since IndexedDB doesn't efficiently store Float32Array.
  */
@@ -66,6 +74,81 @@ interface StoredMetadata {
 interface IdMapping {
 	numericId: number;
 	stringId: string;
+}
+
+/**
+ * Runs a single read request inside `tx` and settles a promise on it, covering the
+ * transaction-level failures a bare `request.onerror` misses.
+ *
+ * An IndexedDB transaction can abort without ever firing `error` on its request —
+ * the connection being force-closed (which our `versionchange` handler now does),
+ * storage eviction, or the browser tearing the tx down. In those cases only
+ * `tx.onabort` fires, so a promise wired solely to `request.onerror`/`onsuccess`
+ * never settles and its caller hangs indefinitely with no error surfaced.
+ *
+ * For the read paths only; the write paths already settle on `tx.oncomplete` /
+ * `tx.onerror`, which covers them. `map` turns the raw request result into the
+ * caller's shape, and may be called more than once for cursor-driven reads —
+ * return a value only when the read is complete (see `awaitCursor`).
+ */
+function awaitRequest<T>(tx: IDBTransaction, request: IDBRequest, map: (result: never) => T): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		let settled = false;
+		const fail = (reason: unknown) => {
+			if (settled) return;
+			settled = true;
+			reject(reason);
+		};
+
+		request.onerror = () => fail(request.error);
+		tx.onerror = () => fail(tx.error);
+		tx.onabort = () => fail(tx.error ?? new Error("IndexedDB transaction aborted before the request completed."));
+		request.onsuccess = () => {
+			if (settled) return;
+			settled = true;
+			try {
+				resolve(map(request.result as never));
+			} catch (error) {
+				reject(error);
+			}
+		};
+	});
+}
+
+/**
+ * Cursor variant of {@link awaitRequest}: `step` runs on every `onsuccess` and
+ * resolves the promise by returning a value once the cursor is exhausted
+ * (returning `undefined` keeps iterating). Same transaction-abort guards.
+ */
+function awaitCursor<T>(
+	tx: IDBTransaction,
+	request: IDBRequest,
+	step: (cursor: IDBCursor | null) => { done: true; value: T } | undefined,
+): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		let settled = false;
+		const fail = (reason: unknown) => {
+			if (settled) return;
+			settled = true;
+			reject(reason);
+		};
+
+		request.onerror = () => fail(request.error);
+		tx.onerror = () => fail(tx.error);
+		tx.onabort = () => fail(tx.error ?? new Error("IndexedDB transaction aborted before the cursor completed."));
+		request.onsuccess = () => {
+			if (settled) return;
+			try {
+				const outcome = step((request.result as IDBCursor | null) ?? null);
+				if (outcome) {
+					settled = true;
+					resolve(outcome.value);
+				}
+			} catch (error) {
+				fail(error);
+			}
+		};
+	});
 }
 
 /**
@@ -140,8 +223,44 @@ export class HNSWVectorStore implements VectorStore {
 	private async openIndexedDB(): Promise<void> {
 		return new Promise((resolve, reject) => {
 			const request = indexedDB.open(this.dbName, DB_VERSION);
+			let settled = false;
+			let blockedTimer: ReturnType<typeof setTimeout> | null = null;
 
-			request.onerror = () => reject(request.error);
+			const finish = (fn: () => void) => {
+				if (settled) return;
+				settled = true;
+				if (blockedTimer !== null) clearTimeout(blockedTimer);
+				fn();
+			};
+
+			request.onerror = () => finish(() => reject(request.error));
+
+			// The DB name is per-vault, so a second Obsidian window on the same vault
+			// opens the *same* database. When this open needs a version upgrade and
+			// that other connection is still open, IndexedDB fires `blocked` and then
+			// fires NEITHER `success` NOR `error` — the promise would hang forever, and
+			// with it the whole VectorStoreService init, with no error surfaced anywhere.
+			//
+			// The other window normally yields via the `versionchange` handler installed
+			// below (added in the same change), so `blocked` should resolve on its own
+			// within a moment. Time-bounded rather than rejecting immediately so that
+			// normal case still succeeds; if the wait elapses, fail loudly with an
+			// actionable message instead of hanging.
+			request.onblocked = () => {
+				Logger.warn(
+					`${LOG_PREFIX} open blocked on "${this.dbName}" — another connection is still open (a second Obsidian window on this vault?). Waiting ${OPEN_BLOCKED_TIMEOUT_MS}ms for it to close.`,
+				);
+				if (blockedTimer !== null) clearTimeout(blockedTimer);
+				blockedTimer = setTimeout(() => {
+					finish(() =>
+						reject(
+							new Error(
+								`Timed out opening the vector index database "${this.dbName}": another Obsidian window has it open with an older version. Close the other window and reload.`,
+							),
+						),
+					);
+				}, OPEN_BLOCKED_TIMEOUT_MS);
+			};
 
 			request.onupgradeneeded = (event) => {
 				const db = (event.target as IDBOpenDBRequest).result;
@@ -167,8 +286,23 @@ export class HNSWVectorStore implements VectorStore {
 			};
 
 			request.onsuccess = (event) => {
-				this.db = (event.target as IDBOpenDBRequest).result;
-				resolve();
+				const db = (event.target as IDBOpenDBRequest).result;
+				// The other half of the deadlock: if a *future* connection (another
+				// window, or this plugin after an update) needs a version upgrade, it
+				// blocks until every existing connection closes. Without this handler
+				// we would be the connection that never yields, hanging the other side
+				// exactly the way `onblocked` above guards against.
+				db.onversionchange = () => {
+					Logger.warn(
+						`${LOG_PREFIX} another connection requested a version upgrade of "${this.dbName}" — closing ours to let it proceed.`,
+					);
+					db.close();
+					if (this.db === db) this.db = null;
+				};
+				finish(() => {
+					this.db = db;
+					resolve();
+				});
 			};
 		});
 	}
@@ -177,22 +311,15 @@ export class HNSWVectorStore implements VectorStore {
 		if (!this.db) return;
 		const db = this.db;
 
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction(ID_MAPPING_STORE, "readonly");
-			const store = tx.objectStore(ID_MAPPING_STORE);
-			const request = store.getAll();
-
-			request.onerror = () => reject(request.error);
-			request.onsuccess = () => {
-				const mappings = request.result as IdMapping[];
-				this.idToNumeric.clear();
-				this.numericToId.clear();
-				for (const mapping of mappings) {
-					this.idToNumeric.set(mapping.stringId, mapping.numericId);
-					this.numericToId.set(mapping.numericId, mapping.stringId);
-				}
-				resolve();
-			};
+		const tx = db.transaction(ID_MAPPING_STORE, "readonly");
+		const request = tx.objectStore(ID_MAPPING_STORE).getAll();
+		return awaitRequest<void>(tx, request, (mappings: IdMapping[]) => {
+			this.idToNumeric.clear();
+			this.numericToId.clear();
+			for (const mapping of mappings) {
+				this.idToNumeric.set(mapping.stringId, mapping.numericId);
+				this.numericToId.set(mapping.numericId, mapping.stringId);
+			}
 		});
 	}
 
@@ -449,22 +576,11 @@ export class HNSWVectorStore implements VectorStore {
 	async getByPath(path: string): Promise<DocumentVector | undefined> {
 		const db = this.requireDb();
 
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction(DOCUMENTS_STORE, "readonly");
-			const store = tx.objectStore(DOCUMENTS_STORE);
-			const index = store.index("path");
-			const request = index.get(path);
-
-			request.onerror = () => reject(request.error);
-			request.onsuccess = () => {
-				const stored = request.result as StoredDocument | undefined;
-				if (!stored) {
-					resolve(undefined);
-				} else {
-					resolve(this.toDocumentVector(stored));
-				}
-			};
-		});
+		const tx = db.transaction(DOCUMENTS_STORE, "readonly");
+		const request = tx.objectStore(DOCUMENTS_STORE).index("path").get(path);
+		return awaitRequest(tx, request, (stored: StoredDocument | undefined) =>
+			stored ? this.toDocumentVector(stored) : undefined,
+		);
 	}
 
 	/**
@@ -627,14 +743,9 @@ export class HNSWVectorStore implements VectorStore {
 	async count(): Promise<number> {
 		const db = this.requireDb();
 
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction(DOCUMENTS_STORE, "readonly");
-			const store = tx.objectStore(DOCUMENTS_STORE);
-			const request = store.count();
-
-			request.onerror = () => reject(request.error);
-			request.onsuccess = () => resolve(request.result);
-		});
+		const tx = db.transaction(DOCUMENTS_STORE, "readonly");
+		const request = tx.objectStore(DOCUMENTS_STORE).count();
+		return awaitRequest(tx, request, (n: number) => n);
 	}
 
 	/**
@@ -644,23 +755,15 @@ export class HNSWVectorStore implements VectorStore {
 	async countNotes(): Promise<number> {
 		const db = this.requireDb();
 
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction(DOCUMENTS_STORE, "readonly");
-			const store = tx.objectStore(DOCUMENTS_STORE);
-			const index = store.index("path");
-			const request = index.openKeyCursor(null, "nextunique");
+		const tx = db.transaction(DOCUMENTS_STORE, "readonly");
+		const request = tx.objectStore(DOCUMENTS_STORE).index("path").openKeyCursor(null, "nextunique");
 
-			let notes = 0;
-			request.onerror = () => reject(request.error);
-			request.onsuccess = () => {
-				const cursor = request.result;
-				if (cursor) {
-					notes++;
-					cursor.continue();
-				} else {
-					resolve(notes);
-				}
-			};
+		let notes = 0;
+		return awaitCursor(tx, request, (cursor) => {
+			if (!cursor) return { done: true, value: notes };
+			notes++;
+			cursor.continue();
+			return undefined;
 		});
 	}
 
@@ -738,27 +841,17 @@ export class HNSWVectorStore implements VectorStore {
 		if (!this.db) return null;
 		const db = this.db;
 
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction(DOCUMENTS_STORE, "readonly");
-			const store = tx.objectStore(DOCUMENTS_STORE);
-			const request = store.get(id);
-
-			request.onerror = () => reject(request.error);
-			request.onsuccess = () => resolve(request.result ?? null);
-		});
+		const tx = db.transaction(DOCUMENTS_STORE, "readonly");
+		const request = tx.objectStore(DOCUMENTS_STORE).get(id);
+		return awaitRequest(tx, request, (doc: StoredDocument | undefined) => doc ?? null);
 	}
 
 	private async getMetadataInternal(): Promise<StoredMetadata | null> {
 		const db = this.requireDb();
 
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction(METADATA_STORE, "readonly");
-			const store = tx.objectStore(METADATA_STORE);
-			const request = store.get("metadata");
-
-			request.onerror = () => reject(request.error);
-			request.onsuccess = () => resolve((request.result as StoredMetadata) ?? null);
-		});
+		const tx = db.transaction(METADATA_STORE, "readonly");
+		const request = tx.objectStore(METADATA_STORE).get("metadata");
+		return awaitRequest(tx, request, (meta: StoredMetadata | undefined) => meta ?? null);
 	}
 
 	private async putInStore<T>(storeName: string, value: T): Promise<void> {
@@ -778,29 +871,18 @@ export class HNSWVectorStore implements VectorStore {
 	private async getAllStored(): Promise<StoredDocument[]> {
 		const db = this.requireDb();
 
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction(DOCUMENTS_STORE, "readonly");
-			const store = tx.objectStore(DOCUMENTS_STORE);
-			const request = store.getAll();
-
-			request.onerror = () => reject(request.error);
-			request.onsuccess = () => resolve(request.result as StoredDocument[]);
-		});
+		const tx = db.transaction(DOCUMENTS_STORE, "readonly");
+		const request = tx.objectStore(DOCUMENTS_STORE).getAll();
+		return awaitRequest(tx, request, (docs: StoredDocument[]) => docs);
 	}
 
 	/** Get every stored chunk row for a given note path. */
 	private async getAllStoredForPath(path: string): Promise<StoredDocument[]> {
 		const db = this.requireDb();
 
-		return new Promise((resolve, reject) => {
-			const tx = db.transaction(DOCUMENTS_STORE, "readonly");
-			const store = tx.objectStore(DOCUMENTS_STORE);
-			const index = store.index("path");
-			const request = index.getAll(IDBKeyRange.only(path));
-
-			request.onerror = () => reject(request.error);
-			request.onsuccess = () => resolve(request.result as StoredDocument[]);
-		});
+		const tx = db.transaction(DOCUMENTS_STORE, "readonly");
+		const request = tx.objectStore(DOCUMENTS_STORE).index("path").getAll(IDBKeyRange.only(path));
+		return awaitRequest(tx, request, (docs: StoredDocument[]) => docs);
 	}
 
 	private async clearStore(storeName: string): Promise<void> {

--- a/src/vectorstore/MiniSearchService.ts
+++ b/src/vectorstore/MiniSearchService.ts
@@ -48,6 +48,13 @@ const LEXICAL_PATH_MAX = 35;
 const DB_NAME_PREFIX = "s2b-minisearch";
 const DB_VERSION = 5;
 const STORE_NAME = "index";
+
+/**
+ * How long to wait on a blocked `indexedDB.open` before failing with a real error.
+ * A blocked open fires neither `success` nor `error`, so without a bound it hangs
+ * forever. Mirrors the same constant in HNSWVectorStore.
+ */
+const OPEN_BLOCKED_TIMEOUT_MS = 10_000;
 const INDEX_KEY = "main";
 /** Bump whenever the indexed file set or field schema changes to force a full reindex. */
 const STORAGE_SCHEMA_VERSION = 7;
@@ -283,15 +290,57 @@ export class MiniSearchService {
 	async open(): Promise<void> {
 		return new Promise((resolve, reject) => {
 			const request = indexedDB.open(this.dbName, DB_VERSION);
+			let settled = false;
+			let blockedTimer: ReturnType<typeof setTimeout> | null = null;
+
+			const finish = (fn: () => void) => {
+				if (settled) return;
+				settled = true;
+				if (blockedTimer !== null) clearTimeout(blockedTimer);
+				fn();
+			};
 
 			request.onerror = () => {
 				Logger.error("[MiniSearch] Failed to open database:", request.error);
-				reject(request.error);
+				finish(() => reject(request.error));
+			};
+
+			// A blocked open (another connection holds an older version of this
+			// per-vault DB — e.g. a second Obsidian window) fires neither `success`
+			// nor `error`, so without this the promise hangs forever and takes the
+			// lexical-search init with it, silently. See the matching guard in
+			// HNSWVectorStore.openIndexedDB.
+			request.onblocked = () => {
+				Logger.warn(
+					`[MiniSearch] open blocked on "${this.dbName}" — another connection is still open (a second Obsidian window on this vault?). Waiting ${OPEN_BLOCKED_TIMEOUT_MS}ms for it to close.`,
+				);
+				if (blockedTimer !== null) clearTimeout(blockedTimer);
+				blockedTimer = setTimeout(() => {
+					finish(() =>
+						reject(
+							new Error(
+								`Timed out opening the lexical index database "${this.dbName}": another Obsidian window has it open with an older version. Close the other window and reload.`,
+							),
+						),
+					);
+				}, OPEN_BLOCKED_TIMEOUT_MS);
 			};
 
 			request.onsuccess = () => {
-				this.db = request.result;
-				resolve();
+				const db = request.result;
+				// Yield to a future upgrade from another connection rather than being
+				// the connection that blocks it indefinitely.
+				db.onversionchange = () => {
+					Logger.warn(
+						`[MiniSearch] another connection requested a version upgrade of "${this.dbName}" — closing ours to let it proceed.`,
+					);
+					db.close();
+					if (this.db === db) this.db = null;
+				};
+				finish(() => {
+					this.db = db;
+					resolve();
+				});
 			};
 
 			request.onupgradeneeded = (event) => {

--- a/src/views/smart-graph/topicCaches.ts
+++ b/src/views/smart-graph/topicCaches.ts
@@ -581,17 +581,68 @@ const STORE_NAME = "caches";
 const RECORD_KEY = "topic-caches";
 const SAVE_DEBOUNCE_MS = 3000;
 
+/**
+ * How long to wait on a blocked `indexedDB.open` before failing with a real error.
+ * Mirrors the constant in HNSWVectorStore / MiniSearchService.
+ */
+const OPEN_BLOCKED_TIMEOUT_MS = 10_000;
+
 function openDatabase(): Promise<IDBDatabase> {
 	const dbName = `${DB_NAME_PREFIX}-${getData().vaultSlug}`;
 	return new Promise((resolve, reject) => {
 		const request = indexedDB.open(dbName, DB_VERSION);
+		let settled = false;
+		let blockedTimer: ReturnType<typeof setTimeout> | null = null;
+
+		const finish = (fn: () => void) => {
+			if (settled) return;
+			settled = true;
+			if (blockedTimer !== null) clearTimeout(blockedTimer);
+			fn();
+		};
+
 		request.onupgradeneeded = () => {
 			if (!request.result.objectStoreNames.contains(STORE_NAME)) {
 				request.result.createObjectStore(STORE_NAME);
 			}
 		};
-		request.onsuccess = () => resolve(request.result);
-		request.onerror = () => reject(request.error);
+
+		// A blocked open fires neither `success` nor `error`, so without this the
+		// promise never settles — hanging whichever caller awaited it. Latent while
+		// DB_VERSION is 1 (no upgrade has ever run, so `blocked` cannot fire), but it
+		// arms itself the day the version is bumped. Matches the guards in
+		// HNSWVectorStore.openIndexedDB and MiniSearchService.open.
+		request.onblocked = () => {
+			Logger.warn(
+				`[SmartGraph] Topic-cache DB open blocked on "${dbName}" — another connection is still open. ` +
+					`Waiting ${OPEN_BLOCKED_TIMEOUT_MS}ms for it to close.`,
+			);
+			if (blockedTimer !== null) clearTimeout(blockedTimer);
+			blockedTimer = setTimeout(() => {
+				finish(() =>
+					reject(
+						new Error(
+							`Timed out opening the topic-cache database "${dbName}": another Obsidian window has it open with an older version.`,
+						),
+					),
+				);
+			}, OPEN_BLOCKED_TIMEOUT_MS);
+		};
+
+		request.onsuccess = () => {
+			const db = request.result;
+			// Yield to a future upgrade from another connection instead of being the
+			// one that blocks it. Every caller opens, uses and closes the handle, so
+			// there is no long-lived state to reconcile on close.
+			db.onversionchange = () => {
+				Logger.warn(
+					`[SmartGraph] Another connection requested a version upgrade of "${dbName}" — closing ours to let it proceed.`,
+				);
+				db.close();
+			};
+			finish(() => resolve(db));
+		};
+		request.onerror = () => finish(() => reject(request.error));
 	});
 }
 

--- a/test/agent/staleCredentialCache.test.ts
+++ b/test/agent/staleCredentialCache.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+
+const createdRunnables: Array<{ model: { apiKey?: string } }> = [];
+const { createAgentMock, summarizationMiddlewareMock } = vi.hoisted(() => ({
+	createAgentMock: vi.fn((opts: { model: unknown }) => {
+		const runnable = { invoke: vi.fn(), streamEvents: vi.fn(), _model: opts.model };
+		createdRunnables.push({ model: opts.model as { apiKey?: string } });
+		return runnable;
+	}),
+	summarizationMiddlewareMock: vi.fn(() => ({ kind: "summary" })),
+}));
+
+vi.mock("langchain", () => ({
+	createAgent: createAgentMock,
+	summarizationMiddleware: summarizationMiddlewareMock,
+}));
+
+vi.mock("../../src/stores/dataStore.svelte", () => ({
+	getData: vi.fn(() => ({
+		targetFolder: "Chats",
+		isFilePrivate: vi.fn(() => false),
+		isProviderTrusted: vi.fn(() => false),
+	})),
+}));
+
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { Agent } from "../../src/agent/Agent";
+
+/**
+ * Registry stand-in whose credentials can be rotated between calls, mirroring what
+ * `registrySync.syncProvider` does when the user edits an API key: the registry
+ * starts minting instances with the new key, but nothing about the agent *config*
+ * changes.
+ */
+function makeRotatableRegistry(initialKey: string) {
+	const state = { key: initialKey, generation: 0 };
+	return {
+		state,
+		rotate(newKey: string) {
+			state.key = newKey;
+			state.generation++;
+		},
+		registry: {
+			createChatInstance: vi.fn((p: string, m: string) => ({ _provider: p, _model: m, apiKey: state.key })),
+		} as unknown as { createChatInstance: (p: string, m: string, o?: unknown) => BaseChatModel },
+	};
+}
+
+/** Mirrors AgentManager.buildRunnableCacheKey's shape, including the authGen term. */
+function buildCacheKey(agentId: string, authGen: number): string {
+	return JSON.stringify({ provider: "openai", model: "gpt-4o", agentId, authGen });
+}
+
+function makeParams(cacheKey: string) {
+	return {
+		provider: "openai",
+		chatModel: "gpt-4o",
+		options: { contextWindow: 128_000 },
+		cacheKey,
+		systemPrompt: "You are helpful.",
+		tools: [] as const,
+		subAgents: [] as const,
+	};
+}
+
+beforeEach(() => {
+	createAgentMock.mockClear();
+	createdRunnables.length = 0;
+});
+
+describe("runnable cache — credential rotation", () => {
+	it("rebuilds the runnable with the NEW key after a credential change", async () => {
+		const { rotate, state, registry } = makeRotatableRegistry("sk-OLD");
+		const agent = new Agent({ registry: registry as never });
+
+		const first = await agent.resolveRun(makeParams(buildCacheKey("agent-1", state.generation)));
+		expect(createdRunnables[0].model.apiKey).toBe("sk-OLD");
+
+		// User rotates the key: the registry re-registers, bumping authGeneration.
+		rotate("sk-NEW");
+
+		const second = await agent.resolveRun(makeParams(buildCacheKey("agent-1", state.generation)));
+
+		// The cache key changed, so a fresh runnable was built around the new key.
+		// Regression: without the authGen term this was a cache hit and the request
+		// kept going out with sk-OLD until Obsidian restarted.
+		expect(second.runnable).not.toBe(first.runnable);
+		expect(createAgentMock).toHaveBeenCalledTimes(2);
+		expect(createdRunnables[1].model.apiKey).toBe("sk-NEW");
+	});
+
+	it("still reuses the cached runnable when credentials are unchanged", async () => {
+		const { state, registry } = makeRotatableRegistry("sk-SAME");
+		const agent = new Agent({ registry: registry as never });
+		const key = buildCacheKey("agent-1", state.generation);
+
+		const first = await agent.resolveRun(makeParams(key));
+		const second = await agent.resolveRun(makeParams(key));
+
+		expect(second.runnable).toBe(first.runnable);
+		expect(createAgentMock).toHaveBeenCalledTimes(1);
+	});
+
+	/**
+	 * The cacheKey covers the whole agent config, so every prompt edit or tool toggle
+	 * mints a new key while the superseded entry stayed resident forever — each pinning
+	 * a LangGraph agent, a model instance and a tool array.
+	 */
+	it("evicts least-recently-used entries past the cap", async () => {
+		const { state, registry } = makeRotatableRegistry("sk-0");
+		const agent = new Agent({ registry: registry as never });
+
+		// 20 distinct agent configs at one generation — past the cap of 16.
+		for (let i = 0; i < 20; i++) {
+			await agent.resolveRun(makeParams(buildCacheKey(`agent-${i}`, state.generation)));
+		}
+		expect(createAgentMock).toHaveBeenCalledTimes(20);
+
+		// The most recent config is still cached (no rebuild).
+		await agent.resolveRun(makeParams(buildCacheKey("agent-19", state.generation)));
+		expect(createAgentMock).toHaveBeenCalledTimes(20);
+
+		// The oldest was evicted, so it rebuilds.
+		await agent.resolveRun(makeParams(buildCacheKey("agent-0", state.generation)));
+		expect(createAgentMock).toHaveBeenCalledTimes(21);
+	});
+
+	it("keeps a repeatedly-used entry alive regardless of insertion age", async () => {
+		const { state, registry } = makeRotatableRegistry("sk-0");
+		const agent = new Agent({ registry: registry as never });
+		const hotKey = buildCacheKey("hot-agent", state.generation);
+
+		// Insert the hot key FIRST, so it is the oldest by insertion order.
+		await agent.resolveRun(makeParams(hotKey));
+
+		// Push exactly `cap` distinct fillers through, reading the hot key after each.
+		for (let i = 0; i < 16; i++) {
+			await agent.resolveRun(makeParams(buildCacheKey(`filler-${i}`, state.generation)));
+			await agent.resolveRun(makeParams(hotKey));
+		}
+
+		// Assert on the TOTAL build count, not on whether a final probe rebuilds. Under
+		// a plain insertion-order cap the hot key ages out mid-loop and is rebuilt
+		// there — which re-inserts it, so a probe afterwards would hit under either
+		// scheme and the two would look identical. 1 hot + 16 fillers = 17 builds means
+		// the hot key was never evicted; a naive cap yields 18.
+		expect(createAgentMock).toHaveBeenCalledTimes(17);
+	});
+
+	it("prunes superseded generations so the cache doesn't grow per key edit", async () => {
+		const { rotate, state, registry } = makeRotatableRegistry("sk-0");
+		const agent = new Agent({ registry: registry as never });
+
+		await agent.resolveRun(makeParams(buildCacheKey("agent-1", state.generation)));
+		await agent.resolveRun(makeParams(buildCacheKey("agent-2", state.generation)));
+
+		rotate("sk-1");
+		await agent.resolveRun(makeParams(buildCacheKey("agent-1", state.generation)));
+
+		// Both old-generation entries are gone; re-resolving agent-2 at the current
+		// generation must rebuild rather than serve a stale-key runnable.
+		const agent2After = await agent.resolveRun(makeParams(buildCacheKey("agent-2", state.generation)));
+		expect(createdRunnables.at(-1)?.model.apiKey).toBe("sk-1");
+		expect(agent2After.runnable).toBe(
+			(await agent.resolveRun(makeParams(buildCacheKey("agent-2", state.generation)))).runnable,
+		);
+		expect(createAgentMock).toHaveBeenCalledTimes(4);
+	});
+});

--- a/test/agent/streamLoopParity.test.ts
+++ b/test/agent/streamLoopParity.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+
+/*
+ * `streamTokens`, `editFromCheckpoint` and `regenerateFromCheckpoint` used to each
+ * carry a verbatim copy of the same ~200-line stream loop. They now share one
+ * implementation (`runStream`). These tests pin the observable behaviour that
+ * copy provided — token emission, tool start/end correlation, preamble capture,
+ * subagent token suppression, and abort handling — so the shared loop can't
+ * regress any single caller.
+ */
+
+const STREAM_CHUNKS: unknown[] = [];
+
+const { createAgentMock, summarizationMiddlewareMock } = vi.hoisted(() => ({
+	createAgentMock: vi.fn(() => ({
+		invoke: vi.fn(),
+		streamEvents: vi.fn(),
+		stream: vi.fn(async () => {
+			async function* gen() {
+				for (const c of STREAM_CHUNKS) yield c;
+			}
+			return gen();
+		}),
+	})),
+	summarizationMiddlewareMock: vi.fn(() => ({ kind: "summary" })),
+}));
+
+vi.mock("langchain", () => ({
+	createAgent: createAgentMock,
+	summarizationMiddleware: summarizationMiddlewareMock,
+}));
+
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { Agent, type AgentStreamChunk, type ResolvedRun } from "../../src/agent/Agent";
+
+const THREAD_ID = "Chats/thread.chat";
+
+function makeAgent() {
+	const registry = {
+		createChatInstance: vi.fn((provider: string, model: string) => ({ provider, model, invoke: vi.fn() })),
+	} as unknown as { createChatInstance: (p: string, m: string, o?: unknown) => BaseChatModel };
+	return new Agent({ registry: registry as never });
+}
+
+async function makeResolved(agent: Agent): Promise<ResolvedRun> {
+	return agent.resolveRun({
+		provider: "openai",
+		chatModel: "gpt-4o",
+		options: { contextWindow: 128_000 },
+		cacheKey: `parity-${Math.random()}`,
+		systemPrompt: "You are helpful.",
+		tools: [] as const,
+		subAgents: [] as const,
+	});
+}
+
+/** An AI message delta as the `messages` stream mode delivers it. */
+function aiDelta(id: string, content: string, toolCalls?: { id: string }[]) {
+	return [
+		"messages",
+		[{ getType: () => "ai", id, content, tool_calls: toolCalls }, {} as Record<string, unknown>],
+	];
+}
+
+const FINAL_VALUES = ["values", { messages: [{ getType: () => "ai", text: "final", content: "final" }] }];
+
+async function collect(stream: AsyncGenerator<AgentStreamChunk>): Promise<AgentStreamChunk[]> {
+	const out: AgentStreamChunk[] = [];
+	for await (const c of stream) out.push(c);
+	return out;
+}
+
+/** Drive each of the three public streaming methods over the same fake stream. */
+async function runAllThree(): Promise<Record<string, AgentStreamChunk[]>> {
+	const results: Record<string, AgentStreamChunk[]> = {};
+
+	const a = makeAgent();
+	results.streamTokens = await collect(
+		a.streamTokens({ query: "hi", resolved: await makeResolved(a), threadId: THREAD_ID }),
+	);
+
+	const b = makeAgent();
+	results.editFromCheckpoint = await collect(
+		b.editFromCheckpoint({
+			query: "hi",
+			resolved: await makeResolved(b),
+			threadId: THREAD_ID,
+			checkpointId: "cp-1",
+		}),
+	);
+
+	const c = makeAgent();
+	results.regenerateFromCheckpoint = await collect(
+		c.regenerateFromCheckpoint({
+			resolved: await makeResolved(c),
+			threadId: THREAD_ID,
+			checkpointId: "cp-1",
+		}),
+	);
+
+	return results;
+}
+
+beforeEach(() => {
+	createAgentMock.mockClear();
+	STREAM_CHUNKS.length = 0;
+});
+
+describe("stream loop parity across the three entry points", () => {
+	it("emits the same token sequence", async () => {
+		STREAM_CHUNKS.push(aiDelta("m1", "Hello "), aiDelta("m1", "world"), FINAL_VALUES);
+
+		for (const [name, chunks] of Object.entries(await runAllThree())) {
+			const tokens = chunks.filter((c) => c.type === "token").map((c) => (c as { token: string }).token);
+			expect(tokens, name).toEqual(["Hello ", "world"]);
+		}
+	});
+
+	it("correlates tool start/end and carries the preamble", async () => {
+		STREAM_CHUNKS.push(
+			// Text first, then a delta carrying the tool call — the preamble is the
+			// accumulated text stamped onto that call id.
+			aiDelta("m1", "Let me look. "),
+			aiDelta("m1", "", [{ id: "tc-1" }]),
+			["tools", { event: "on_tool_start", toolCallId: "tc-1", name: "search_notes", input: { query: "x" } }],
+			["tools", { event: "on_tool_end", toolCallId: "tc-1", name: "search_notes", output: "result" }],
+			FINAL_VALUES,
+		);
+
+		for (const [name, chunks] of Object.entries(await runAllThree())) {
+			const start = chunks.find((c) => c.type === "tool_start") as
+				| { toolName: string; toolCallId: string; preamble?: string; input: unknown }
+				| undefined;
+			const end = chunks.find((c) => c.type === "tool_end") as
+				| { toolName: string; toolCallId: string; output: unknown }
+				| undefined;
+
+			expect(start, name).toBeDefined();
+			expect(start?.toolName, name).toBe("search_notes");
+			expect(start?.preamble, name).toBe("Let me look. ");
+			expect(start?.input, name).toEqual({ query: "x" });
+			// tool_end resolves its name from the pending map, not the raw event.
+			expect(end?.toolName, name).toBe("search_notes");
+			expect(end?.toolCallId, name).toBe("tc-1");
+			expect(end?.output, name).toBe("result");
+		}
+	});
+
+	it("suppresses subagent tokens from the parent's content", async () => {
+		STREAM_CHUNKS.push(
+			aiDelta("m1", "parent "),
+			// A subagent token is tagged with lc_agent_name and must not append to the
+			// parent message — otherwise the subagent's answer leaks into it twice.
+			["messages", [{ getType: () => "ai", id: "m2", content: "SUBAGENT" }, { lc_agent_name: "worker" }]],
+			aiDelta("m1", "tail"),
+			FINAL_VALUES,
+		);
+
+		for (const [name, chunks] of Object.entries(await runAllThree())) {
+			const tokens = chunks.filter((c) => c.type === "token").map((c) => (c as { token: string }).token);
+			expect(tokens, name).toEqual(["parent ", "tail"]);
+		}
+	});
+
+	it("yields a result chunk carrying the final messages", async () => {
+		STREAM_CHUNKS.push(aiDelta("m1", "done"), FINAL_VALUES);
+
+		for (const [name, chunks] of Object.entries(await runAllThree())) {
+			const result = chunks.find((c) => c.type === "result");
+			expect(result, name).toBeDefined();
+			expect((result as { result: { threadId: string } }).result.threadId, name).toBe(THREAD_ID);
+		}
+	});
+
+	it("stops early and yields no result when the signal is already aborted", async () => {
+		STREAM_CHUNKS.push(aiDelta("m1", "ignored"), FINAL_VALUES);
+		const controller = new AbortController();
+		controller.abort();
+
+		const agent = makeAgent();
+		const chunks = await collect(
+			agent.streamTokens({
+				query: "hi",
+				resolved: await makeResolved(agent),
+				threadId: THREAD_ID,
+				signal: controller.signal,
+			}),
+		);
+
+		expect(chunks.find((c) => c.type === "result")).toBeUndefined();
+	});
+
+	it("throws a method-specific error when the stream produces no final output", async () => {
+		// No values-mode payload at all.
+		STREAM_CHUNKS.push(aiDelta("m1", "text only"));
+
+		const a = makeAgent();
+		await expect(
+			collect(a.streamTokens({ query: "hi", resolved: await makeResolved(a), threadId: THREAD_ID })),
+		).rejects.toThrow(/streaming completed without producing a final output/i);
+
+		const c = makeAgent();
+		await expect(
+			collect(
+				c.regenerateFromCheckpoint({
+					resolved: await makeResolved(c),
+					threadId: THREAD_ID,
+					checkpointId: "cp-1",
+				}),
+			),
+		).rejects.toThrow(/regeneration completed without producing a final output/i);
+	});
+});
+
+describe("stream input shape per entry point", () => {
+	it("passes a human message for query/edit and null for regenerate", async () => {
+		STREAM_CHUNKS.push(FINAL_VALUES);
+
+		const a = makeAgent();
+		const resolvedA = await makeResolved(a);
+		await collect(a.streamTokens({ query: "hi", resolved: resolvedA, threadId: THREAD_ID }));
+		const streamA = (resolvedA.runnable as unknown as { stream: ReturnType<typeof vi.fn> }).stream;
+		expect((streamA.mock.calls[0][0] as { messages: unknown[] }).messages).toHaveLength(1);
+
+		const c = makeAgent();
+		const resolvedC = await makeResolved(c);
+		await collect(
+			c.regenerateFromCheckpoint({ resolved: resolvedC, threadId: THREAD_ID, checkpointId: "cp-1" }),
+		);
+		const streamC = (resolvedC.runnable as unknown as { stream: ReturnType<typeof vi.fn> }).stream;
+		// Regenerate continues from the checkpoint without adding a message.
+		expect(streamC.mock.calls[0][0]).toBeNull();
+		expect((streamC.mock.calls[0][1] as { configurable: { checkpoint_id: string } }).configurable.checkpoint_id).toBe(
+			"cp-1",
+		);
+	});
+});

--- a/test/agent/threadPersistenceFlush.test.ts
+++ b/test/agent/threadPersistenceFlush.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+
+/**
+ * Fake runnable whose `stream` yields a minimal values-mode payload so every
+ * streaming method reaches its run-completion tail (where thread metadata is
+ * persisted). `createAgent` is memoized by cacheKey, so one instance serves all.
+ */
+const { createAgentMock, summarizationMiddlewareMock } = vi.hoisted(() => ({
+	createAgentMock: vi.fn(() => ({
+		invoke: vi.fn(),
+		streamEvents: vi.fn(),
+		stream: vi.fn(async () => {
+			async function* gen() {
+				yield ["values", { messages: [{ getType: () => "ai", text: "done", content: "done" }] }];
+			}
+			return gen();
+		}),
+	})),
+	summarizationMiddlewareMock: vi.fn(() => ({ kind: "summary" })),
+}));
+
+vi.mock("langchain", () => ({
+	createAgent: createAgentMock,
+	summarizationMiddleware: summarizationMiddlewareMock,
+}));
+
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { Agent, type ResolvedRun } from "../../src/agent/Agent";
+import type { ThreadStore } from "../../src/agent/memory/ThreadStore";
+
+const THREAD_ID = "Chats/thread.chat";
+
+function makeRegistry() {
+	return {
+		createChatInstance: vi.fn((provider: string, model: string) => ({ provider, model, invoke: vi.fn() })),
+	} as unknown as { createChatInstance: (p: string, m: string, o?: unknown) => BaseChatModel };
+}
+
+/**
+ * Stand-in for ObsidianChatManager.asThreadStore(). `write` is debounced there —
+ * it only marks the thread dirty — so `flush` is what actually gets the run's
+ * metadata onto disk. Recording both lets us assert the pairing.
+ */
+function makeThreadStore() {
+	const writes: string[] = [];
+	const flushes: (string | undefined)[] = [];
+	const store: ThreadStore = {
+		read: vi.fn(async () => undefined),
+		write: vi.fn(async (snapshot) => {
+			writes.push(snapshot.threadId);
+		}),
+		delete: vi.fn(async () => {}),
+		list: vi.fn(async () => []),
+		clear: vi.fn(async () => {}),
+		flush: vi.fn(async (threadId?: string) => {
+			flushes.push(threadId);
+		}),
+	};
+	return { store, writes, flushes };
+}
+
+async function drain(stream: AsyncGenerator<unknown>): Promise<void> {
+	for await (const _ of stream) {
+		// exhaust
+	}
+}
+
+async function makeResolved(agent: Agent): Promise<ResolvedRun> {
+	return agent.resolveRun({
+		provider: "openai",
+		chatModel: "gpt-4o",
+		options: { contextWindow: 128_000 },
+		cacheKey: "flush-test-key",
+		systemPrompt: "You are helpful.",
+		tools: [] as const,
+		subAgents: [] as const,
+	});
+}
+
+describe("run-completion thread persistence", () => {
+	beforeEach(() => {
+		createAgentMock.mockClear();
+		summarizationMiddlewareMock.mockClear();
+	});
+
+	it("streamTokens flushes thread metadata", async () => {
+		const { store, writes, flushes } = makeThreadStore();
+		const agent = new Agent({ registry: makeRegistry() as never, threadStore: store });
+
+		await drain(agent.streamTokens({ query: "hi", resolved: await makeResolved(agent), threadId: THREAD_ID }));
+
+		expect(writes).toContain(THREAD_ID);
+		expect(flushes).toContain(THREAD_ID);
+	});
+
+	it("editFromCheckpoint flushes thread metadata", async () => {
+		const { store, writes, flushes } = makeThreadStore();
+		const agent = new Agent({ registry: makeRegistry() as never, threadStore: store });
+
+		await drain(
+			agent.editFromCheckpoint({
+				query: "hi",
+				resolved: await makeResolved(agent),
+				threadId: THREAD_ID,
+				checkpointId: "cp-1",
+			}),
+		);
+
+		expect(writes).toContain(THREAD_ID);
+		expect(flushes).toContain(THREAD_ID);
+	});
+
+	/**
+	 * Regression: this path called `persistThreadMetadata` but not
+	 * `flushThreadPersistence`, unlike the other three run-completion paths. Since
+	 * the real store's `write` is a 2s-debounced save, a quit inside that window
+	 * lost the regenerated run's metadata.
+	 */
+	it("regenerateFromCheckpoint flushes thread metadata", async () => {
+		const { store, writes, flushes } = makeThreadStore();
+		const agent = new Agent({ registry: makeRegistry() as never, threadStore: store });
+
+		await drain(
+			agent.regenerateFromCheckpoint({
+				resolved: await makeResolved(agent),
+				threadId: THREAD_ID,
+				checkpointId: "cp-1",
+			}),
+		);
+
+		expect(writes).toContain(THREAD_ID);
+		expect(flushes).toContain(THREAD_ID);
+	});
+
+	it("run() flushes thread metadata", async () => {
+		const { store, writes, flushes } = makeThreadStore();
+		const agent = new Agent({ registry: makeRegistry() as never, threadStore: store });
+		const resolved = await makeResolved(agent);
+		(resolved.runnable as unknown as { invoke: ReturnType<typeof vi.fn> }).invoke = vi.fn(async () => ({
+			messages: [{ getType: () => "ai", text: "done", content: "done" }],
+		}));
+
+		await agent.run({ query: "hi", resolved, threadId: THREAD_ID });
+
+		expect(writes).toContain(THREAD_ID);
+		expect(flushes).toContain(THREAD_ID);
+	});
+
+	it("tolerates a thread store with no flush implementation", async () => {
+		const { store } = makeThreadStore();
+		const noFlush: ThreadStore = { ...store, flush: undefined };
+		const agent = new Agent({ registry: makeRegistry() as never, threadStore: noFlush });
+
+		await expect(
+			drain(
+				agent.regenerateFromCheckpoint({
+					resolved: await makeResolved(agent),
+					threadId: THREAD_ID,
+					checkpointId: "cp-1",
+				}),
+			),
+		).resolves.toBeUndefined();
+	});
+});

--- a/test/agent/toolAgentScoping.test.ts
+++ b/test/agent/toolAgentScoping.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian", async () => {
+	const actual = await import("../__mocks__/obsidian");
+	return { ...actual, getAllTags: (cache: { tags?: string[] }) => cache.tags ?? null };
+});
+
+const mockShouldBlockFile = vi.fn().mockReturnValue(false);
+vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({
+	getPendingChangesStore: () => ({
+		shouldBlockFile: (...args: unknown[]) => mockShouldBlockFile(...args),
+	}),
+}));
+
+/**
+ * Two agents on different providers. `trusted-agent` is the *globally selected*
+ * one; `untrusted-agent` is the one actually running (as a subagent, or as the
+ * agent a background chat tab captured at open time).
+ */
+const AGENTS: Record<string, { id: string; chatModel: { provider: string } | null; toolsConfig: object }> = {
+	"trusted-agent": { id: "trusted-agent", chatModel: { provider: "trusted-local" }, toolsConfig: {} },
+	"untrusted-agent": { id: "untrusted-agent", chatModel: { provider: "untrusted-cloud" }, toolsConfig: {} },
+};
+
+vi.mock("../../src/stores/dataStore.svelte", () => ({
+	getData: () => ({
+		getAgent: (id: string) => AGENTS[id],
+		getSelectedAgent: () => AGENTS["trusted-agent"],
+	}),
+	DEFAULT_TOOLS_CONFIG: {},
+}));
+
+vi.mock("../../src/utils/fileFiltering", () => ({
+	isAgentFilePath: () => false,
+}));
+
+import type { App } from "obsidian";
+import { createGetAllTagsTool } from "../../src/agent/tools/getAllTags";
+import { createGetPropertiesTool } from "../../src/agent/tools/getProperties";
+import { resolveToolAgent, resolveToolProvider } from "../../src/agent/tools/toolAgentContext";
+
+function makeApp(): App {
+	const files = [
+		{ path: "public/notes.md", basename: "notes" },
+		{ path: "private/diary.md", basename: "diary" },
+	];
+	return {
+		vault: { getMarkdownFiles: () => files },
+		metadataCache: {
+			getFileCache: (file: { path: string }) =>
+				file.path === "private/diary.md"
+					? { tags: ["#therapy"], frontmatter: { therapist: "x", position: {} } }
+					: { tags: ["#recipes"], frontmatter: { author: "y", position: {} } },
+		},
+	} as unknown as App;
+}
+
+beforeEach(() => {
+	mockShouldBlockFile.mockReset().mockReturnValue(false);
+});
+
+describe("resolveToolAgent / resolveToolProvider", () => {
+	it("resolves the run's own agent, not the global selection", () => {
+		expect(resolveToolAgent("untrusted-agent").id).toBe("untrusted-agent");
+		expect(resolveToolProvider("untrusted-agent")).toBe("untrusted-cloud");
+	});
+
+	it("falls back to the selected agent when no id is threaded through (public api path)", () => {
+		expect(resolveToolAgent("").id).toBe("trusted-agent");
+		expect(resolveToolProvider("")).toBe("trusted-local");
+	});
+
+	it("falls back to the selected agent for a stale/deleted agent id", () => {
+		expect(resolveToolAgent("deleted-agent").id).toBe("trusted-agent");
+	});
+});
+
+describe("get_all_tags — privacy", () => {
+	it("filters tags from private notes instead of returning the whole vocabulary", async () => {
+		// Every note is private for this provider (private-by-default + untrusted).
+		mockShouldBlockFile.mockImplementation((_path: string, provider: string) => provider === "untrusted-cloud");
+
+		const tool = createGetAllTagsTool(makeApp(), "untrusted-agent");
+		const result = (await tool.invoke({})) as string;
+
+		expect(result).not.toContain("#therapy");
+		expect(result).not.toContain("#recipes");
+		expect(result).toContain("2 note(s) were skipped");
+	});
+
+	it("evaluates trust against the RUNNING agent, not the globally selected one", async () => {
+		mockShouldBlockFile.mockImplementation((_path: string, provider: string) => provider === "untrusted-cloud");
+
+		const result = (await createGetAllTagsTool(makeApp(), "untrusted-agent").invoke({})) as string;
+
+		// Regression: before the fix this read getSelectedAgent() -> "trusted-local",
+		// so nothing was blocked and every tag reached the untrusted provider.
+		expect(mockShouldBlockFile).toHaveBeenCalledWith(expect.any(String), "untrusted-cloud");
+		expect(mockShouldBlockFile).not.toHaveBeenCalledWith(expect.any(String), "trusted-local");
+		expect(result).not.toContain("#therapy");
+	});
+
+	it("returns tags normally when the provider is trusted", async () => {
+		const result = (await createGetAllTagsTool(makeApp(), "trusted-agent").invoke({})) as string;
+		expect(result).toContain("#therapy");
+		expect(result).toContain("#recipes");
+		expect(result).not.toContain("skipped");
+	});
+});
+
+describe("get_properties — privacy", () => {
+	it("filters property keys from private notes", async () => {
+		mockShouldBlockFile.mockImplementation((_path: string, provider: string) => provider === "untrusted-cloud");
+
+		const result = (await createGetPropertiesTool(makeApp(), "untrusted-agent").invoke({})) as string;
+
+		expect(result).not.toContain("therapist");
+		expect(result).toContain("2 note(s) were skipped");
+	});
+
+	it("uses the running agent's provider for the single-note check", async () => {
+		mockShouldBlockFile.mockImplementation((_path: string, provider: string) => provider === "untrusted-cloud");
+
+		const result = (await createGetPropertiesTool(makeApp(), "untrusted-agent").invoke({
+			note_name: "diary",
+		})) as string;
+
+		expect(result).toContain("private for the current provider");
+		expect(mockShouldBlockFile).toHaveBeenCalledWith("private/diary.md", "untrusted-cloud");
+	});
+
+	it("returns property keys normally when the provider is trusted", async () => {
+		const result = (await createGetPropertiesTool(makeApp(), "trusted-agent").invoke({})) as string;
+		expect(result).toContain("therapist");
+		expect(result).toContain("author");
+	});
+});

--- a/test/components/pixiRendererLifecycle.test.ts
+++ b/test/components/pixiRendererLifecycle.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/*
+ * `PixiRenderer.init()` awaits `app.init()`, which creates a WebGL context — a
+ * real async gap. Two defects lived in that window:
+ *
+ *  1. `destroy()` called `this.app.destroy()` unconditionally. `new Application()`
+ *     assigns `this.app` synchronously, so tearing down mid-init destroyed a
+ *     renderer that was never created, which throws and aborts the caller's
+ *     remaining cleanup.
+ *  2. `init()` kept building after the await even when the owner had already
+ *     destroyed it — registering a shared-ticker callback nothing would remove.
+ */
+
+/** Resolves only when the test says so, standing in for WebGL context creation. */
+const { appDestroy, appInit, tickerAdd, tickerRemove, ctl } = vi.hoisted(() => {
+	const ctl: { release?: () => void } = {};
+	return {
+		ctl,
+		appDestroy: vi.fn(),
+		appInit: vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					ctl.release = resolve;
+				}),
+		),
+		tickerAdd: vi.fn(),
+		tickerRemove: vi.fn(),
+	};
+});
+
+vi.mock("pixi.js", () => {
+	class Application {
+		init = appInit;
+		destroy = appDestroy;
+		canvas = document.createElement("canvas");
+		stage = { addChild: vi.fn(), removeChild: vi.fn() };
+		renderer = { resize: vi.fn(), render: vi.fn() };
+	}
+	class Container {
+		children: unknown[] = [];
+		addChild = vi.fn();
+		removeChild = vi.fn();
+		destroy = vi.fn();
+	}
+	return {
+		Application,
+		Container,
+		Graphics: Container,
+		Sprite: Container,
+		Text: Container,
+		Texture: { WHITE: {} },
+		Ticker: { shared: { add: tickerAdd, remove: tickerRemove } },
+	};
+});
+
+vi.mock("pixi-viewport", () => ({
+	Viewport: class {
+		dirty = false;
+		x = 0;
+		y = 0;
+		scaled = 1;
+		scale = { x: 1, y: 1 };
+		plugins = { get: vi.fn(), remove: vi.fn() };
+		drag = () => this;
+		pinch = () => this;
+		wheel = () => this;
+		decelerate = () => this;
+		clampZoom = () => this;
+		animate = () => this;
+		moveCenter = vi.fn();
+		setZoom = vi.fn();
+		resize = vi.fn();
+		toScreen = (x: number, y: number) => ({ x, y });
+		toWorld = (x: number, y: number) => ({ x, y });
+		addChild = vi.fn();
+		on = vi.fn();
+	},
+}));
+
+import { PixiRenderer } from "../../src/components/graph/pixiRenderer";
+
+const THEME = {} as never;
+
+function makeContainer(): HTMLElement {
+	const el = document.createElement("div");
+	el.getBoundingClientRect = () => ({ width: 800, height: 600 }) as DOMRect;
+	return el;
+}
+
+beforeEach(() => {
+	appInit.mockClear();
+	appDestroy.mockClear();
+	tickerAdd.mockClear();
+	tickerRemove.mockClear();
+	ctl.release = undefined;
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("PixiRenderer teardown during init", () => {
+	it("does not destroy a pixi Application whose init never resolved", () => {
+		const renderer = new PixiRenderer();
+		void renderer.init(makeContainer(), THEME);
+
+		// The owner tears down while `app.init()` is still pending.
+		expect(() => renderer.destroy()).not.toThrow();
+		// Regression: this used to call destroy() on an uninitialized Application.
+		expect(appDestroy).not.toHaveBeenCalled();
+	});
+
+	it("releases the context itself when init resolves after a destroy", async () => {
+		const renderer = new PixiRenderer();
+		const initPromise = renderer.init(makeContainer(), THEME);
+
+		renderer.destroy();
+		ctl.release?.();
+		await initPromise;
+
+		// The context finished being created after we gave up on it, so init()
+		// unwinds it rather than leaving a live WebGL context orphaned.
+		expect(appDestroy).toHaveBeenCalledTimes(1);
+		// And it must not have gone on to build the scene graph / register a
+		// shared-ticker callback that nothing would ever remove.
+		expect(tickerAdd).not.toHaveBeenCalled();
+	});
+
+	it("stays idempotent when torn down twice during init", () => {
+		const renderer = new PixiRenderer();
+		void renderer.init(makeContainer(), THEME);
+
+		renderer.destroy();
+		renderer.destroy();
+
+		expect(appDestroy).not.toHaveBeenCalled();
+	});
+
+	it("unwinds the context exactly once after repeated destroys", async () => {
+		const renderer = new PixiRenderer();
+		const initPromise = renderer.init(makeContainer(), THEME);
+
+		renderer.destroy();
+		renderer.destroy();
+		ctl.release?.();
+		await initPromise;
+
+		// init()'s post-await unwind runs once, not once per destroy() call.
+		expect(appDestroy).toHaveBeenCalledTimes(1);
+	});
+
+	// Note: the fully-initialized teardown path (scene graph built, then destroy)
+	// is not unit-tested here. Driving `init()` past its await pulls in most of
+	// pixi's surface (CanvasSource, RenderTexture, filters, …); mocking all of it
+	// would make the test a test of the mock. That path is exercised for real
+	// whenever the graph view opens and closes — the defects fixed here were
+	// specifically about the window BEFORE init resolves, which is what the cases
+	// above pin down.
+});

--- a/test/providers/registrySync.test.ts
+++ b/test/providers/registrySync.test.ts
@@ -184,4 +184,41 @@ describe("registrySync", () => {
 			expect(getRegistry().has("openai")).toBe(false);
 		});
 	});
+
+	/**
+	 * The generation counter is what lets caches whose entries embed resolved
+	 * credentials (notably `Agent`'s runnable cache) notice a key rotation. Without
+	 * it, editing an API key produced an unchanged cache key, a cache hit, and
+	 * requests that kept using the old credential until Obsidian restarted.
+	 */
+	describe("auth generation", () => {
+		it("bumps when a provider's credentials are edited", () => {
+			data.add("openai", { apiKey: "sk-old" });
+			syncProvider(data, "openai");
+			const before = getRegistry().getAuthGeneration();
+
+			// What `setProviderAuthField` does after writing the new secret.
+			data.auth.set("openai", { apiKey: "sk-new" });
+			syncProvider(data, "openai");
+
+			expect(getRegistry().getAuthGeneration()).toBeGreaterThan(before);
+			expect(getRegistry().getAuth("openai")).toEqual({ apiKey: "sk-new" });
+		});
+
+		it("bumps when a provider is removed", () => {
+			data.add("openai");
+			syncProvider(data, "openai");
+			const before = getRegistry().getAuthGeneration();
+
+			unsyncProvider("openai");
+
+			expect(getRegistry().getAuthGeneration()).toBeGreaterThan(before);
+		});
+
+		it("does not bump when unregistering a provider that was never registered", () => {
+			const before = getRegistry().getAuthGeneration();
+			unsyncProvider("never-registered");
+			expect(getRegistry().getAuthGeneration()).toBe(before);
+		});
+	});
 });

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -505,6 +505,60 @@ describe("PendingChangesStore", () => {
 				expect(plugin.app.vault.modify).not.toHaveBeenCalled();
 			});
 
+			/**
+			 * Regression (review of PR #411): `#handleFileRename` skipped non-pending
+			 * entries, so a group-resolved entry kept a stale path after its note was
+			 * renamed. The revert then looked up a file that no longer existed there and
+			 * reported success while the applied content sat at the new path.
+			 */
+			it("follows a rename of a note that still has applied content", async () => {
+				// `load()` is what registers the vault rename handler.
+				await store.load();
+				const { id, original, afterGroupAccept } = await stagePartiallyAccepted();
+				store.rejectChangeGroup(id, 0);
+				expect(store.getEntry(id)?.status).toBe("rejected");
+
+				// The vault rename handler fires for the non-pending entry too.
+				const renameCb = (plugin.app.vault.on as ReturnType<typeof vi.fn>).mock.calls.find(
+					(c) => c[0] === "rename",
+				)?.[1] as (file: { path: string }, oldPath: string) => void;
+				renameCb({ path: "renamed.md" }, "note.md");
+
+				expect(store.getEntry(id)?.change.path).toBe("renamed.md");
+
+				// The undo now targets the note where it actually lives.
+				plugin.app.vault.getAbstractFileByPath = vi.fn().mockReturnValue(makeTFile("renamed.md"));
+				plugin.app.vault.read = vi.fn().mockResolvedValue(afterGroupAccept);
+				(plugin.app.vault.modify as ReturnType<typeof vi.fn>).mockClear();
+
+				const skipped = await store.undoAppliedGroups(id);
+
+				expect(skipped).toBeUndefined();
+				expect(plugin.app.vault.modify).toHaveBeenCalledWith(expect.anything(), original);
+			});
+
+			/**
+			 * Regression (same review): a missing target returned `undefined` — the
+			 * "success" signal — so the UI said the note was restored when nothing had
+			 * been written, and the entry stayed actionable forever because the snapshot
+			 * is only cleared on a real write.
+			 */
+			it("reports a missing note instead of claiming it was restored", async () => {
+				const { id } = await stagePartiallyAccepted();
+				store.rejectChangeGroup(id, 0);
+
+				// The note was deleted (or moved while the plugin was unloaded).
+				plugin.app.vault.getAbstractFileByPath = vi.fn().mockReturnValue(null);
+				(plugin.app.vault.modify as ReturnType<typeof vi.fn>).mockClear();
+
+				const skipped = await store.undoAppliedGroups(id);
+
+				expect(skipped).toEqual({ path: "note.md", reason: "missing" });
+				expect(plugin.app.vault.modify).not.toHaveBeenCalled();
+				// And it must not remain permanently unresolvable.
+				expect(store.getActionableForThread("thread-1")).toEqual([]);
+			});
+
 			it("reports a group-resolved entry as still actionable", async () => {
 				const { id } = await stagePartiallyAccepted();
 				store.rejectChangeGroup(id, 0);
@@ -547,7 +601,7 @@ describe("PendingChangesStore", () => {
 
 				const skipped = await store.undoAppliedGroups(id);
 
-				expect(skipped).toBe("note.md");
+				expect(skipped).toEqual({ path: "note.md", reason: "conflict" });
 				expect(plugin.app.vault.modify).not.toHaveBeenCalled();
 			});
 
@@ -587,7 +641,7 @@ describe("PendingChangesStore", () => {
 				// Regression: this used to unconditionally modify() back to the
 				// pre-proposal content, destroying the user's edits.
 				expect(plugin.app.vault.modify).not.toHaveBeenCalled();
-				expect(skipped).toEqual(["note.md"]);
+				expect(skipped).toEqual([{ path: "note.md", reason: "conflict" }]);
 				// The proposal is still dead either way.
 				expect(store.getEntry(id)?.status).toBe("rejected");
 			});
@@ -604,7 +658,7 @@ describe("PendingChangesStore", () => {
 
 				const skipped = await store.rejectAll("thread-1");
 
-				expect(skipped).toEqual(["note.md"]);
+				expect(skipped).toEqual([{ path: "note.md", reason: "conflict" }]);
 				expect(store.getEntry(id)?.status).toBe("rejected");
 				expect(store.getEntry(plainId)?.status).toBe("rejected");
 				expect(store.getPendingCount("thread-1")).toBe(0);
@@ -618,7 +672,7 @@ describe("PendingChangesStore", () => {
 
 				const skipped = await store.rejectAll("thread-1");
 
-				expect(skipped).toEqual(["note.md"]);
+				expect(skipped).toEqual([{ path: "note.md", reason: "failed" }]);
 			});
 		});
 	});

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../src/stores/dataStore.svelte", () => ({
 import { PendingChangesStore } from "../../src/stores/pendingChangesStore.svelte";
 import { getData } from "../../src/stores/dataStore.svelte";
 import { TFile } from "obsidian";
+import { Logger } from "../../src/utils/logging";
 
 /* --------------------------------------------------------------------------
  * Helpers
@@ -557,6 +558,75 @@ describe("PendingChangesStore", () => {
 				expect(plugin.app.vault.modify).not.toHaveBeenCalled();
 				// And it must not remain permanently unresolvable.
 				expect(store.getActionableForThread("thread-1")).toEqual([]);
+			});
+
+			/*
+			 * Audit of every path that resolves or discards an entry, to pin down the
+			 * `initialOriginalContent` invariant ("applied content the user has not
+			 * signed off on"). Three consecutive review escapes came from changing what
+			 * that flag was used for without re-checking every reader, so each site is
+			 * asserted here rather than reasoned about.
+			 */
+			it("keeps an entry actionable after a row-level reject", async () => {
+				const { id } = await stagePartiallyAccepted();
+
+				// rejectChange writes nothing to the vault, so the applied text remains.
+				store.rejectChange(id);
+
+				expect(store.getEntry(id)?.status).toBe("rejected");
+				expect(store.hasUnrevertedApplication(store.getEntry(id)!)).toBe(true);
+				expect(store.getActionableForThread("thread-1").map((e) => e.id)).toContain(id);
+			});
+
+			it("keeps an entry actionable when superseded by a newer proposal", async () => {
+				const { id } = await stagePartiallyAccepted();
+
+				// addChanges auto-rejects an older pending update for the same path+thread.
+				store.addChanges(
+					[{ type: "update", path: "note.md", originalContent: "x", newContent: "y" }],
+					"tc-2",
+					"thread-1",
+				);
+
+				expect(store.getEntry(id)?.status).toBe("rejected");
+				// Its applied content is still on disk, so the undo must stay reachable.
+				expect(store.getActionableForThread("thread-1").map((e) => e.id)).toContain(id);
+			});
+
+			it("survives a save/load round-trip", async () => {
+				const { id } = await stagePartiallyAccepted();
+				store.rejectChangeGroup(id, 0);
+
+				// Persist, then rehydrate into a fresh store from the same serialized blob.
+				let written = "";
+				plugin.app.vault.adapter.write = vi.fn(async (_p: string, data: string) => {
+					written = data;
+				});
+				await (store as unknown as { saveToDisk(): Promise<void> }).saveToDisk();
+
+				plugin.app.vault.adapter.exists = vi.fn().mockResolvedValue(true);
+				plugin.app.vault.adapter.read = vi.fn(async () => written);
+				const reloaded = new PendingChangesStore(plugin);
+				await reloaded.load();
+
+				// The applied content is still in the vault after a restart, so the entry
+				// must come back actionable rather than being forgotten.
+				expect(reloaded.hasUnrevertedApplication(reloaded.getEntry(id)!)).toBe(true);
+				expect(reloaded.getActionableForThread("thread-1").map((e) => e.id)).toContain(id);
+			});
+
+			it("removeThread discards stranded content but says so", async () => {
+				const warn = vi.spyOn(Logger, "warn").mockImplementation(() => {});
+				const { id } = await stagePartiallyAccepted();
+				store.rejectChangeGroup(id, 0);
+
+				// Deleting the chat removes its rows — there is no surface left to review
+				// them on — but the note keeps the applied text, so that must not be silent.
+				store.removeThread("thread-1");
+
+				expect(store.getEntry(id)).toBeUndefined();
+				expect(warn).toHaveBeenCalledWith(expect.stringContaining("note.md"));
+				warn.mockRestore();
 			});
 
 			it("reports a group-resolved entry as still actionable", async () => {

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -380,6 +380,95 @@ describe("PendingChangesStore", () => {
 
 			expect(store.getEntry(id2)?.status).toBe("pending");
 		});
+
+		/**
+		 * `rejectAll` restores a note that had groups partially accepted. That restore
+		 * used to be an unconditional `vault.modify`, which silently destroyed any edit
+		 * the user made by hand in between — `modify` doesn't go through trash, so the
+		 * work was unrecoverable.
+		 */
+		describe("rejectAll revert of partially-accepted groups", () => {
+			/** Stage a 2-group update and accept the first group, leaving the file
+			 *  partially applied (the state that arms the revert path). */
+			async function stagePartiallyAccepted() {
+				const original = "line1\nline2\nline3\n";
+				const proposed = "CHANGED1\nline2\nCHANGED3\n";
+				const file = makeTFile("note.md");
+				plugin.app.vault.getAbstractFileByPath = vi.fn().mockReturnValue(file);
+				plugin.app.vault.read = vi.fn().mockResolvedValue(original);
+
+				const [id] = store.addChanges(
+					[{ type: "update", path: "note.md", originalContent: original, newContent: proposed }],
+					"tc-1",
+					"thread-1",
+				);
+
+				await store.acceptChangeGroup(id, 0);
+
+				const afterGroupAccept = (plugin.app.vault.modify as ReturnType<typeof vi.fn>).mock.calls[0][1];
+				return { id, original, afterGroupAccept, file };
+			}
+
+			it("reverts to the pre-proposal content when the file is untouched since", async () => {
+				const { id, original, afterGroupAccept } = await stagePartiallyAccepted();
+
+				// File still holds exactly what the group accept wrote.
+				plugin.app.vault.read = vi.fn().mockResolvedValue(afterGroupAccept);
+				(plugin.app.vault.modify as ReturnType<typeof vi.fn>).mockClear();
+
+				const skipped = await store.rejectAll("thread-1");
+
+				expect(skipped).toEqual([]);
+				expect(plugin.app.vault.modify).toHaveBeenCalledWith(expect.anything(), original);
+				expect(store.getEntry(id)?.status).toBe("rejected");
+			});
+
+			it("does NOT overwrite a note the user edited after the group accept", async () => {
+				const { id } = await stagePartiallyAccepted();
+
+				// User hand-edits the note in the editor after accepting the group.
+				plugin.app.vault.read = vi.fn().mockResolvedValue("my own precious edits\n");
+				(plugin.app.vault.modify as ReturnType<typeof vi.fn>).mockClear();
+
+				const skipped = await store.rejectAll("thread-1");
+
+				// Regression: this used to unconditionally modify() back to the
+				// pre-proposal content, destroying the user's edits.
+				expect(plugin.app.vault.modify).not.toHaveBeenCalled();
+				expect(skipped).toEqual(["note.md"]);
+				// The proposal is still dead either way.
+				expect(store.getEntry(id)?.status).toBe("rejected");
+			});
+
+			it("rejects every entry even when one revert is skipped", async () => {
+				const { id } = await stagePartiallyAccepted();
+				const [plainId] = store.addChanges(
+					[{ type: "create", path: "other.md", content: "X" }],
+					"tc-2",
+					"thread-1",
+				);
+
+				plugin.app.vault.read = vi.fn().mockResolvedValue("conflicting content\n");
+
+				const skipped = await store.rejectAll("thread-1");
+
+				expect(skipped).toEqual(["note.md"]);
+				expect(store.getEntry(id)?.status).toBe("rejected");
+				expect(store.getEntry(plainId)?.status).toBe("rejected");
+				expect(store.getPendingCount("thread-1")).toBe(0);
+			});
+
+			it("reports the path when the revert write itself throws", async () => {
+				const { afterGroupAccept } = await stagePartiallyAccepted();
+
+				plugin.app.vault.read = vi.fn().mockResolvedValue(afterGroupAccept);
+				plugin.app.vault.modify = vi.fn().mockRejectedValue(new Error("disk full"));
+
+				const skipped = await store.rejectAll("thread-1");
+
+				expect(skipped).toEqual(["note.md"]);
+			});
+		});
 	});
 
 	/* --------------------------------------------------------------------------

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -409,6 +409,52 @@ describe("PendingChangesStore", () => {
 				return { id, original, afterGroupAccept, file };
 			}
 
+			/**
+			 * Regression (review of PR #411): accepting one group and then rejecting the
+			 * remaining ones drives `newContent` back to `originalContent`, so
+			 * `rejectChangeGroup` flips the entry to `rejected` — while the accepted group
+			 * is still written to the note. `rejectAll` filtered on `status === "pending"`
+			 * and therefore skipped exactly those entries, stranding the applied text on
+			 * disk while reporting that everything had been rejected.
+			 */
+			it("reverts an entry already marked rejected by group-level rejections", async () => {
+				const { id, original, afterGroupAccept } = await stagePartiallyAccepted();
+
+				// Reject the one remaining group. Groups are recomputed from the advanced
+				// originalContent, so the remaining change is index 0.
+				store.rejectChangeGroup(id, 0);
+				expect(store.getEntry(id)?.status).toBe("rejected");
+				expect(store.getPendingCount("thread-1")).toBe(0);
+
+				// The accepted group is still on disk at this point.
+				plugin.app.vault.read = vi.fn().mockResolvedValue(afterGroupAccept);
+				(plugin.app.vault.modify as ReturnType<typeof vi.fn>).mockClear();
+
+				const skipped = await store.rejectAll("thread-1");
+
+				expect(skipped).toEqual([]);
+				expect(plugin.app.vault.modify).toHaveBeenCalledWith(expect.anything(), original);
+			});
+
+			it("does not re-revert on a second rejectAll", async () => {
+				const { id, original, afterGroupAccept } = await stagePartiallyAccepted();
+				store.rejectChangeGroup(id, 0);
+
+				plugin.app.vault.read = vi.fn().mockResolvedValue(afterGroupAccept);
+				await store.rejectAll("thread-1");
+
+				// The user edits the note after the revert. A second rejectAll must not
+				// clobber that with the now-stale pre-proposal snapshot.
+				plugin.app.vault.read = vi.fn().mockResolvedValue("my own later edits\n");
+				(plugin.app.vault.modify as ReturnType<typeof vi.fn>).mockClear();
+
+				const skipped = await store.rejectAll("thread-1");
+
+				expect(plugin.app.vault.modify).not.toHaveBeenCalled();
+				expect(skipped).toEqual([]);
+				void original;
+			});
+
 			it("reverts to the pre-proposal content when the file is untouched since", async () => {
 				const { id, original, afterGroupAccept } = await stagePartiallyAccepted();
 

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -455,6 +455,67 @@ describe("PendingChangesStore", () => {
 				void original;
 			});
 
+			/**
+			 * The bar renders `getActionableForThread`. If that returned only pending
+			 * entries, a thread whose sole entry was fully resolved at group level would
+			 * render nothing — stranding the applied text with no way to reach the undo.
+			 */
+			it("reports a group-resolved entry as still actionable", async () => {
+				const { id } = await stagePartiallyAccepted();
+				store.rejectChangeGroup(id, 0);
+
+				expect(store.getPendingCount("thread-1")).toBe(0);
+				// ...but the note still holds the accepted group, so the UI must show it.
+				expect(store.getActionableForThread("thread-1").map((e) => e.id)).toEqual([id]);
+				expect(store.hasUnrevertedApplication(store.getEntry(id)!)).toBe(true);
+			});
+
+			it("stops reporting it once the content has been undone", async () => {
+				const { id, afterGroupAccept } = await stagePartiallyAccepted();
+				store.rejectChangeGroup(id, 0);
+				plugin.app.vault.read = vi.fn().mockResolvedValue(afterGroupAccept);
+
+				await store.rejectAll("thread-1");
+
+				expect(store.getActionableForThread("thread-1")).toEqual([]);
+				expect(store.hasUnrevertedApplication(store.getEntry(id)!)).toBe(false);
+			});
+
+			it("undoAppliedGroups restores a single entry", async () => {
+				const { id, original, afterGroupAccept } = await stagePartiallyAccepted();
+				store.rejectChangeGroup(id, 0);
+				plugin.app.vault.read = vi.fn().mockResolvedValue(afterGroupAccept);
+				(plugin.app.vault.modify as ReturnType<typeof vi.fn>).mockClear();
+
+				const skipped = await store.undoAppliedGroups(id);
+
+				expect(skipped).toBeUndefined();
+				expect(plugin.app.vault.modify).toHaveBeenCalledWith(expect.anything(), original);
+				expect(store.getActionableForThread("thread-1")).toEqual([]);
+			});
+
+			it("undoAppliedGroups reports a skip without overwriting user edits", async () => {
+				const { id } = await stagePartiallyAccepted();
+				store.rejectChangeGroup(id, 0);
+				plugin.app.vault.read = vi.fn().mockResolvedValue("my own later edits\n");
+				(plugin.app.vault.modify as ReturnType<typeof vi.fn>).mockClear();
+
+				const skipped = await store.undoAppliedGroups(id);
+
+				expect(skipped).toBe("note.md");
+				expect(plugin.app.vault.modify).not.toHaveBeenCalled();
+			});
+
+			it("cleanupResolved keeps an entry that still has content on disk", async () => {
+				const { id } = await stagePartiallyAccepted();
+				store.rejectChangeGroup(id, 0);
+
+				store.cleanupResolved("thread-1");
+
+				// Dropping it would discard the only record of the pre-proposal content.
+				expect(store.getEntry(id)).toBeDefined();
+			});
+
 			it("reverts to the pre-proposal content when the file is untouched since", async () => {
 				const { id, original, afterGroupAccept } = await stagePartiallyAccepted();
 

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -460,6 +460,51 @@ describe("PendingChangesStore", () => {
 			 * entries, a thread whose sole entry was fully resolved at group level would
 			 * render nothing — stranding the applied text with no way to reach the undo.
 			 */
+			/**
+			 * Regression (review of PR #411): accepting EVERY group flips the entry to
+			 * `accepted` while `initialOriginalContent` stayed set, so `rejectAll` — which
+			 * selects on that snapshot — reverted a change the user had explicitly
+			 * accepted, silently discarding it. The snapshot is now cleared the moment the
+			 * outcome settles, so it only ever means "unreviewed partial write present".
+			 */
+			it("does not revert an update whose groups were ALL accepted", async () => {
+				const { id, afterGroupAccept } = await stagePartiallyAccepted();
+
+				// Accept the one remaining group; the entry completes.
+				plugin.app.vault.read = vi.fn().mockResolvedValue(afterGroupAccept);
+				await store.acceptChangeGroup(id, 0);
+				expect(store.getEntry(id)?.status).toBe("accepted");
+
+				// A second, unrelated entry keeps the thread's Reject All live.
+				store.addChanges([{ type: "create", path: "other.md", content: "X" }], "tc-2", "thread-1");
+
+				expect(store.hasUnrevertedApplication(store.getEntry(id)!)).toBe(false);
+				expect(store.getActionableForThread("thread-1").map((e) => e.id)).not.toContain(id);
+
+				(plugin.app.vault.modify as ReturnType<typeof vi.fn>).mockClear();
+				await store.rejectAll("thread-1");
+
+				// The accepted note must be left exactly as the user accepted it.
+				expect(plugin.app.vault.modify).not.toHaveBeenCalled();
+			});
+
+			it("does not revert after a whole-entry accept following a group accept", async () => {
+				const { id, afterGroupAccept } = await stagePartiallyAccepted();
+
+				// Accept the rest of the entry via the row-level action rather than groups.
+				plugin.app.vault.read = vi.fn().mockResolvedValue(afterGroupAccept);
+				await store.acceptChange(id);
+				expect(store.getEntry(id)?.status).toBe("accepted");
+
+				store.addChanges([{ type: "create", path: "other.md", content: "X" }], "tc-2", "thread-1");
+				expect(store.hasUnrevertedApplication(store.getEntry(id)!)).toBe(false);
+
+				(plugin.app.vault.modify as ReturnType<typeof vi.fn>).mockClear();
+				await store.rejectAll("thread-1");
+
+				expect(plugin.app.vault.modify).not.toHaveBeenCalled();
+			});
+
 			it("reports a group-resolved entry as still actionable", async () => {
 				const { id } = await stagePartiallyAccepted();
 				store.rejectChangeGroup(id, 0);

--- a/test/vectorstore/HNSWVectorStore.open.test.ts
+++ b/test/vectorstore/HNSWVectorStore.open.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/*
+ * Regression: `indexedDB.open` fires `blocked` — and then NEITHER `success` NOR
+ * `error` — when another connection holds the same database at an older version.
+ * The DB name is per-vault, so a second Obsidian window on the same vault hits
+ * exactly this. Without an `onblocked` handler the open promise never settled,
+ * hanging VectorStoreService init forever with no error surfaced anywhere.
+ *
+ * The mirror image is `versionchange`: without that handler *we* are the
+ * connection that never yields, blocking the other window indefinitely.
+ */
+
+vi.mock("hnsw", () => ({
+	HNSWWithDB: { create: vi.fn() },
+}));
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+
+import { HNSWVectorStore } from "../../src/vectorstore/HNSWVectorStore";
+
+type OpenRequest = {
+	onerror: null | (() => void);
+	onsuccess: null | ((event: unknown) => void);
+	onblocked: null | (() => void);
+	onupgradeneeded: null | ((event: unknown) => void);
+	error: unknown;
+	result: unknown;
+};
+
+let openRequest: OpenRequest;
+let fakeDbInstance: { onversionchange: null | (() => void); close: ReturnType<typeof vi.fn> };
+
+/** Minimal object-store/transaction stand-in for the reads `open()` performs. */
+function makeConnection() {
+	return {
+		onversionchange: null as null | (() => void),
+		close: vi.fn(),
+		objectStoreNames: { contains: () => true },
+		transaction: () => {
+			const tx = {
+				objectStore: () => ({
+					getAll: () => makeReq([]),
+					get: () => makeReq(undefined),
+				}),
+				onerror: null as null | (() => void),
+				onabort: null as null | (() => void),
+				error: null,
+			};
+			return tx;
+		},
+	};
+}
+
+function makeReq(result: unknown) {
+	const req = {
+		onsuccess: null as null | (() => void),
+		onerror: null as null | (() => void),
+		result,
+		error: null,
+	};
+	queueMicrotask(() => req.onsuccess?.());
+	return req;
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	openRequest = {
+		onerror: null,
+		onsuccess: null,
+		onblocked: null,
+		onupgradeneeded: null,
+		error: null,
+		result: null,
+	};
+	fakeDbInstance = makeConnection();
+	openRequest.result = fakeDbInstance;
+	vi.stubGlobal("indexedDB", { open: vi.fn(() => openRequest) });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
+
+describe("HNSWVectorStore.open — blocked handling", () => {
+	it("rejects with an actionable error when the open stays blocked", async () => {
+		const store = new HNSWVectorStore("vault-1");
+		// Settle-or-hang probe rather than a bare `rejects` assertion: without the
+		// onblocked handler this promise never settles at all, and awaiting it
+		// directly would hang the whole test run instead of failing. Tracking
+		// settlement in a variable turns "never settles" into a legible failure.
+		let outcome: string | undefined;
+		void store.open().then(
+			() => {
+				outcome = "resolved";
+			},
+			(e: unknown) => {
+				outcome = e instanceof Error ? e.message : String(e);
+			},
+		);
+
+		// Another connection holds an older version: `blocked` fires, and crucially
+		// neither `success` nor `error` ever will.
+		openRequest.onblocked?.();
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		expect(outcome).toMatch(/another Obsidian window has it open/i);
+	});
+
+	it("still succeeds when the blocking connection closes before the timeout", async () => {
+		const store = new HNSWVectorStore("vault-1");
+		const opened = store.open();
+
+		openRequest.onblocked?.();
+		// The other window's versionchange handler closes its connection, so the
+		// upgrade proceeds and `success` arrives normally.
+		await vi.advanceTimersByTimeAsync(2_000);
+		openRequest.onsuccess?.({ target: { result: fakeDbInstance } });
+		await vi.advanceTimersByTimeAsync(0);
+
+		await expect(opened).resolves.toBeUndefined();
+	});
+
+	it("does not reject after a late timer fires post-success", async () => {
+		const store = new HNSWVectorStore("vault-1");
+		const opened = store.open();
+
+		openRequest.onblocked?.();
+		openRequest.onsuccess?.({ target: { result: fakeDbInstance } });
+		await vi.advanceTimersByTimeAsync(0);
+		await expect(opened).resolves.toBeUndefined();
+
+		// The blocked timer must have been cancelled; advancing past it changes nothing.
+		await vi.advanceTimersByTimeAsync(30_000);
+		await expect(opened).resolves.toBeUndefined();
+	});
+
+	it("propagates a genuine open error", async () => {
+		const store = new HNSWVectorStore("vault-1");
+		const opened = store.open();
+
+		openRequest.error = new Error("quota exceeded");
+		openRequest.onerror?.();
+
+		await expect(opened).rejects.toThrow(/quota exceeded/);
+	});
+});
+
+describe("HNSWVectorStore reads — transaction abort", () => {
+	/**
+	 * A transaction can abort without ever firing `error` on its request — the
+	 * connection being force-closed (which our own versionchange handler now does),
+	 * or storage eviction. Only `tx.onabort` fires, so a read wired solely to
+	 * `request.onerror`/`onsuccess` would hang its caller forever.
+	 */
+	it("rejects a pending read when the transaction aborts", async () => {
+		let capturedTx: { onabort: null | (() => void); onerror: null | (() => void); error: unknown } | null = null;
+		const connection = {
+			onversionchange: null as null | (() => void),
+			close: vi.fn(),
+			objectStoreNames: { contains: () => true },
+			transaction: () => {
+				const tx = {
+					// A request that never fires success or error on its own.
+					objectStore: () => ({
+						getAll: () => ({ onsuccess: null, onerror: null, result: undefined, error: null }),
+						get: () => ({ onsuccess: null, onerror: null, result: undefined, error: null }),
+					}),
+					onerror: null as null | (() => void),
+					onabort: null as null | (() => void),
+					error: null as unknown,
+				};
+				capturedTx = tx;
+				return tx;
+			},
+		};
+		openRequest.result = connection;
+
+		const store = new HNSWVectorStore("vault-1");
+		const opened = store.open();
+		openRequest.onsuccess?.({ target: { result: connection } });
+		await vi.advanceTimersByTimeAsync(0);
+
+		// open() awaits loadIdMappings, whose transaction we now abort.
+		expect(capturedTx).not.toBeNull();
+		(capturedTx as unknown as { onabort: () => void }).onabort();
+
+        await expect(opened).rejects.toThrow(/aborted/i);
+	});
+});
+
+describe("HNSWVectorStore.open — versionchange", () => {
+	it("closes our connection so another window's upgrade can proceed", async () => {
+		const store = new HNSWVectorStore("vault-1");
+		const opened = store.open();
+
+		openRequest.onsuccess?.({ target: { result: fakeDbInstance } });
+		await vi.advanceTimersByTimeAsync(0);
+		await opened;
+
+		// Regression: without this handler we'd be the connection that blocks the
+		// other window forever — the deadlock's other half.
+		expect(fakeDbInstance.onversionchange).toBeTypeOf("function");
+		fakeDbInstance.onversionchange?.();
+		expect(fakeDbInstance.close).toHaveBeenCalled();
+	});
+});

--- a/test/vectorstore/MiniSearchService.open.test.ts
+++ b/test/vectorstore/MiniSearchService.open.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/*
+ * Same defect as HNSWVectorStore.open: a blocked `indexedDB.open` fires neither
+ * `success` nor `error`, so without an `onblocked` handler the promise never
+ * settles and lexical-search init hangs silently. This DB is at version 5, so the
+ * upgrade path (and therefore the blocked path) is well-travelled.
+ */
+
+import { MiniSearchService } from "../../src/vectorstore/MiniSearchService";
+
+type OpenRequest = {
+	onerror: null | (() => void);
+	onsuccess: null | (() => void);
+	onblocked: null | (() => void);
+	onupgradeneeded: null | ((event: unknown) => void);
+	error: unknown;
+	result: unknown;
+};
+
+let openRequest: OpenRequest;
+let connection: { onversionchange: null | (() => void); close: ReturnType<typeof vi.fn> };
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	connection = {
+		onversionchange: null,
+		close: vi.fn(),
+		objectStoreNames: { contains: () => true },
+	} as unknown as typeof connection;
+	openRequest = {
+		onerror: null,
+		onsuccess: null,
+		onblocked: null,
+		onupgradeneeded: null,
+		error: null,
+		result: connection,
+	};
+	vi.stubGlobal("indexedDB", { open: vi.fn(() => openRequest) });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
+
+describe("MiniSearchService.open — blocked handling", () => {
+	it("rejects with an actionable error when the open stays blocked", async () => {
+		const service = new MiniSearchService("test-vault", "blocked");
+		// Track settlement rather than awaiting: without the onblocked handler this
+		// never settles, which would hang the run instead of failing.
+		let outcome: string | undefined;
+		void service.open().then(
+			() => {
+				outcome = "resolved";
+			},
+			(e: unknown) => {
+				outcome = e instanceof Error ? e.message : String(e);
+			},
+		);
+
+		openRequest.onblocked?.();
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		expect(outcome).toMatch(/another Obsidian window has it open/i);
+	});
+
+	it("succeeds when the blocking connection closes before the timeout", async () => {
+		const service = new MiniSearchService("test-vault", "unblocked");
+		const opened = service.open();
+
+		openRequest.onblocked?.();
+		await vi.advanceTimersByTimeAsync(1_000);
+		openRequest.onsuccess?.();
+
+		await expect(opened).resolves.toBeUndefined();
+	});
+
+	it("installs a versionchange handler that yields to another window's upgrade", async () => {
+		const service = new MiniSearchService("test-vault", "versionchange");
+		const opened = service.open();
+
+		openRequest.onsuccess?.();
+		await opened;
+
+		expect(connection.onversionchange).toBeTypeOf("function");
+		connection.onversionchange?.();
+		expect(connection.close).toHaveBeenCalled();
+	});
+
+	it("propagates a genuine open error", async () => {
+		const service = new MiniSearchService("test-vault", "errored");
+		const opened = service.open();
+
+		openRequest.error = new Error("quota exceeded");
+		openRequest.onerror?.();
+
+		await expect(opened).rejects.toThrow(/quota exceeded/);
+	});
+});

--- a/test/views/topicCachesOpen.test.ts
+++ b/test/views/topicCachesOpen.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/*
+ * Third `indexedDB.open` in the codebase (after HNSWVectorStore and
+ * MiniSearchService). A blocked open fires neither `success` nor `error`, so
+ * without an `onblocked` handler the promise never settles and whichever caller
+ * awaited it hangs.
+ *
+ * Latent while DB_VERSION is 1 — no upgrade has ever run, so `blocked` cannot
+ * fire today — but it arms itself the moment the version is bumped. Both callers
+ * wrap this in `.catch()`, so the fix turns a hang into a logged warning.
+ */
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+
+vi.mock("../../src/stores/dataStore.svelte", () => ({
+	getData: () => ({ vaultSlug: "test-vault" }),
+}));
+
+type OpenRequest = {
+	onerror: null | (() => void);
+	onsuccess: null | (() => void);
+	onblocked: null | (() => void);
+	onupgradeneeded: null | (() => void);
+	error: unknown;
+	result: unknown;
+};
+
+let openRequest: OpenRequest;
+let connection: { onversionchange: null | (() => void); close: ReturnType<typeof vi.fn> };
+
+beforeEach(() => {
+	vi.resetModules();
+	vi.useFakeTimers();
+	connection = {
+		onversionchange: null,
+		close: vi.fn(),
+		objectStoreNames: { contains: () => true },
+		transaction: () => ({
+			objectStore: () => ({
+				get: () => {
+					const req = { onsuccess: null as null | (() => void), onerror: null, result: undefined };
+					queueMicrotask(() => req.onsuccess?.());
+					return req;
+				},
+			}),
+		}),
+	} as unknown as typeof connection;
+	openRequest = {
+		onerror: null,
+		onsuccess: null,
+		onblocked: null,
+		onupgradeneeded: null,
+		error: null,
+		result: connection,
+	};
+	vi.stubGlobal("indexedDB", { open: vi.fn(() => openRequest) });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
+
+describe("topicCaches — blocked IndexedDB open", () => {
+	it("settles (rather than hanging) when the open stays blocked", async () => {
+		const { loadPersistedTopicCaches } = await import("../../src/views/smart-graph/topicCaches");
+
+		// Track settlement rather than awaiting: pre-fix this never settles, which
+		// would hang the run instead of failing.
+		let settled = false;
+		void loadPersistedTopicCaches().then(() => {
+			settled = true;
+		});
+
+		openRequest.onblocked?.();
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		// The caller wraps this in .catch(), so a timeout resolves the hydration
+		// promise — what matters is that it settles at all.
+		expect(settled).toBe(true);
+	});
+
+	it("installs a versionchange handler that yields to another window's upgrade", async () => {
+		const { loadPersistedTopicCaches } = await import("../../src/views/smart-graph/topicCaches");
+
+		const hydration = loadPersistedTopicCaches();
+		openRequest.onsuccess?.();
+		await vi.advanceTimersByTimeAsync(0);
+		await hydration;
+
+		expect(connection.onversionchange).toBeTypeOf("function");
+		connection.onversionchange?.();
+		expect(connection.close).toHaveBeenCalled();
+	});
+
+	it("settles on a genuine open error", async () => {
+		const { loadPersistedTopicCaches } = await import("../../src/views/smart-graph/topicCaches");
+
+		let settled = false;
+		void loadPersistedTopicCaches().then(() => {
+			settled = true;
+		});
+
+		openRequest.error = new Error("quota exceeded");
+		openRequest.onerror?.();
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(settled).toBe(true);
+	});
+});


### PR DESCRIPTION
Review of the whole codebase, weighted toward correctness, in two passes:

1. **Core subsystems** — `agent/`, `stores/`, `vectorstore/`, `providers/`, `search/`, `skills/` (~31k lines): 11 findings.
2. **UI, utils, lifecycle** — `components/`, `views/`, `utils/`, `lib/`, `hooks/`, `editor/`, `main.ts` (~56k lines): 3 findings.

All 14 are fixed here.

Each fix is **mutation-tested**: reverting a guard fails exactly the intended test, no more and no fewer.

## Security / privacy

### Rotating an API key had no effect until restart

`resolveRun` mints a fresh model instance every call but only uses it on a cache *miss*, and the runnable cache key carried provider/model/agent-config but nothing derived from auth. An edited key produced an identical key, hit the cache, and kept issuing requests with the **old credential** — silently, no error. Same for an edited `baseUrl`.

`setProviderAuthField` already had a comment showing this class of bug was found and fixed once at the *registry* layer; the same snapshot problem existed one layer up and wasn't covered.

The registry now carries a monotonic `authGeneration`, bumped on every credential mutation, mixed into the cache key. **A counter, not a hash of the auth object** — the value lands in long-lived in-memory cache keys, and a counter can't leak anything about a secret if such a key is ever logged.

### Privacy filter evaluated against the wrong agent

The filter's trust decision read `getSelectedAgent()` — the *globally selected* agent, not the one running the request. Two ways that misfires:

- **Subagents** run with their own `chatModel`. A subagent on an untrusted provider inherited the parent's trust decision, so private content could flow to it.
- **Multiple tabs** — sessions capture their own `selectedAgentId`, but these tools read the global selection at call time.

`search_notes`, `read_content`, `list_directory`, `grep_notes` and `get_properties` now resolve the owning agent at *invocation* time through a shared `toolAgentContext` helper. `get_properties` was worst: it captured the provider at construction time, stale from the moment it was bound.

### `get_all_tags` had no privacy filter at all

It excluded agent-machinery files but not private ones. Tags are content — under the shipped `private-by-default` mode, *every* note is private unless listed, so the vault's full tag vocabulary reached untrusted providers while every sibling tool was correctly blocking. Tag names routinely encode sensitive structure.

`get_properties`' vault-wide branch had the identical gap (property keys like `therapist`, `salary`); fixed in the same pass.

## Correctness

### `rejectAll` destroyed concurrent user edits

Reverting partially-accepted notes was an unconditional `vault.modify`. Accept one diff group → hand-edit the note → "Reject all" overwrote your edits with pre-proposal content. `vault.modify` skips trash, so it was unrecoverable, and the UI reported plain success.

Now conflict-checks against `change.originalContent` (which `acceptChangeGroup` keeps in lockstep with disk — *not* `initialOriginalContent`, which would flag every partially-accepted file), and returns skipped paths so the caller can surface them.

### IndexedDB `open()` could hang forever

Both stores handled `error`/`success`/`upgradeneeded` but not **`blocked`**, which fires without a following `success` *or* `error` — the promise never settled and index init hung with no diagnostic.

Investigating surfaced the other half: no `versionchange` handler existed anywhere, so our connection was the one that never yields, blocking other windows indefinitely. Fixing only the reported side would have converted a hang into a guaranteed timeout. The DB name is per-vault, so two Obsidian windows collide exactly; MiniSearch is at `DB_VERSION = 5`, so the upgrade path is well-travelled.

Auditing the `getByPath` sub-finding turned up **eight** read paths that could hang on a transaction abort (only `tx.onabort` fires — including when our own new `versionchange` handler force-closes). Consolidated behind `awaitRequest`/`awaitCursor`.

### `regenerateFromCheckpoint` never flushed thread metadata

`threadStore.write` only marks dirty and schedules a **2s debounced** save; `flush` forces it. Three run-completion paths paired the two calls; regenerate called only the first, so a quit inside that window lost the run's metadata. All four now go through one `finalizeThreadPersistence`.

## Maintainability

- **Three ~200-line stream loops deduplicated.** `streamTokens`, `editFromCheckpoint` and `regenerateFromCheckpoint` each carried a verbatim copy — that duplication is precisely what let the missing flush above go unnoticed. Extracted to one `runStream` differing in three parameters. **Agent.ts: 2291 → 1866 lines.**
- **Bounded the runnable cache** (LRU, cap 16). Every prompt edit or tool toggle minted a new key while the superseded entry stayed resident, each pinning a LangGraph agent, model instance and tool array.
- **Corrected `execute_plugin_api`'s timeout docs.** No behaviour change — the design is sound given the constraint (a worker can't reach `app`). But `Promise.race` bounds *waiting*, not execution: a synchronous loop freezes Obsidian and the race never runs. Now stated plainly, including in the tool description, since the model writes the loops.
- **Flattened a dead nested branch** in `manage_notes`' `allowDelete` guard — correct only because the inner condition carried the logic; hoisting the outer branch later would have silently blocked `move`/`replace`.
- **Moved lock-key normalization inside `withFileLock`** so `#fileLocks` can't split one file across two chains.

## Second sweep: UI, utils, lifecycle

The remaining ~56k lines turned up 3 findings — a much lower density than the core, and the patterns that usually break UI code are handled correctly and consistently (monotonic request tokens in `SearchModal`, paired `destroy()` on the trackers, the pixi shared-ticker callback correctly added/removed, destroy guards after every await in `SmartGraphView`).

### `PixiRenderer.destroy()` threw when called before `init()` resolved

`init()` awaits `app.init()`, which creates a WebGL context — a real async gap. `new Application()` assigns `this.app` **synchronously**, so a teardown inside that window called `destroy()` on a renderer that was never created. Pixi throws on that, aborting the caller's remaining cleanup. Now guarded on a new `_appInitialized`, distinct from `_ready` (which additionally requires the scene graph to be built).

### `init()` kept building after being destroyed

Same window: the continuation went on to construct the scene graph and register a `Ticker.shared` callback that nothing would ever remove. It now unwinds the context it just finished creating and returns.

### GraphCanvas leaked three observers if the tab closed during init

`ResizeObserver`, a `MutationObserver` on `document.body`, and a `css-change` listener were all registered *inside* `renderer.init().then(...)`, and `__graphCleanup` was only assigned there. The `onMount` cleanup is synchronous, so closing the graph tab mid-init found `__graphCleanup` unassigned — the optional-chain no-opped, and the continuation then registered all three with no owner, holding `containerEl` and the dead renderer alive.

A `mountDisposed` flag makes the continuation bail. The chain also gains the `.catch()` it lacked, so a WebGL init failure is reported rather than surfacing as an unhandled rejection.

### A third blocked `indexedDB.open`

`topicCaches.ts` holds a third one, missed by the first sweep because it lives under `views/`. Same defect this PR fixes in `HNSWVectorStore` and `MiniSearchService`.

**Lower severity, stated plainly:** `DB_VERSION` is `1`, so no upgrade has ever run and `blocked` cannot fire today; both callers wrap it in `.catch()`. This closes a trap that arms itself on the next version bump, not a live hang.

## Verification

- `bun run check` — 2761 files, 0 errors
- `bun run test` — **1531 passed**, up from 1481 (94 files)
- `bun run lint` — 35 errors, **all pre-existing** (verified by stashing; the two in a file I touched are in `openInChatLeaf`/`loadMCPTools`, untouched code)

The stream-loop extraction is covered by **seven parity tests that also pass against the pre-refactor implementation** — direct evidence the refactor preserves behaviour, rather than the new code merely being self-consistent.

One deliberate gap: the *fully-initialized* pixi teardown path is not unit-tested. Driving `init()` past its await pulls in most of pixi's surface (`CanvasSource`, render textures, filters), and mocking all of it would make the test a test of the mock. The defects fixed here are specifically about the window **before** init resolves, which is what the four new cases pin down.

## Note on scope

Includes one unrelated line in `SmartGraphView.svelte`: a `bun run format` reflow produced while running the formatter on this branch. Not a fix, but caused by this work, so it's here rather than left dangling.

The `GraphCanvas.svelte` diff looks large (186 lines) but is almost entirely re-indentation from wrapping the promise chain — `git diff -w` reduces it to the three edits described above.

## Not addressed

Pre-existing lint errors (35) and the `noNonNullAssertion` cluster in `graphDataBuilder.ts` / `ContextUsageCircle.svelte` are untouched — out of scope for this review.

The retrieval layer was reviewed and found **notably strong** — `chunkAggregation.ts` and `finalSearchRanking.ts` document failed experiments with measurements and record overturned prior conclusions. No changes made there.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._