### PR TITLE
fix: rebuild cached embeddings after a provider credential change

### DIFF
--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -211,6 +211,16 @@ interface IndexInstance {
 	embeddings: EmbeddingsInterface | null;
 	currentProviderId: string | null;
 	currentModelId: string | null;
+	/**
+	 * Registry credential generation the cached `embeddings` was built at.
+	 *
+	 * The instance snapshots its resolved auth at construction, so provider/model id
+	 * equality is not enough to reuse it — an edited API key or baseUrl produces the
+	 * same ids while invalidating the instance. Mirrors the `authGen` term in
+	 * `AgentManager.buildRunnableCacheKey`, which fixed the identical staleness on
+	 * the chat side.
+	 */
+	currentAuthGeneration: number | null;
 	hasValidatedThisSession: boolean;
 	isIndexing: boolean;
 	progress: IndexingProgress;
@@ -242,6 +252,44 @@ export function formatEta(ms: number): string {
 	const hours = Math.floor(totalMinutes / 60);
 	const minutes = totalMinutes % 60;
 	return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+/**
+ * The subset of a cached embeddings instance's identity that decides reuse.
+ * Structural so the predicate below can be exercised without an IndexInstance.
+ */
+export interface CachedEmbeddingsIdentity {
+	providerId: string | null;
+	modelId: string | null;
+	/** Registry credential generation the instance was built at. */
+	authGeneration: number | null;
+}
+
+/**
+ * Whether a cached embeddings instance can be reused for `want`.
+ *
+ * Extracted from `getEmbeddingsForInstance` so the rule is directly testable:
+ * the method itself is private and reachable only through index initialization,
+ * which made the credential check unverifiable by mutation — the guard could be
+ * deleted without failing a single test.
+ *
+ * The `authGeneration` term is the load-bearing one. An embeddings instance
+ * snapshots its resolved auth at construction, and index instances live for the
+ * whole plugin session, so provider/model equality alone would keep serving an
+ * instance built with a rotated-away API key or a stale baseUrl. That fails
+ * silently — an embed call just 401s or returns nothing — until Obsidian
+ * restarts. Same defect the `authGen` term fixed in the agent's runnable cache.
+ */
+export function canReuseCachedEmbeddings(
+	cached: CachedEmbeddingsIdentity,
+	want: { provider: string; model: string },
+	currentAuthGeneration: number,
+): boolean {
+	return (
+		cached.providerId === want.provider &&
+		cached.modelId === want.model &&
+		cached.authGeneration === currentAuthGeneration
+	);
 }
 
 export interface ValidationProgressCountsInput {
@@ -299,6 +347,7 @@ export class VectorStoreService {
 			embeddings: null,
 			currentProviderId: null,
 			currentModelId: null,
+			currentAuthGeneration: null,
 			hasValidatedThisSession: false,
 			isIndexing: false,
 			progress: {
@@ -593,15 +642,30 @@ export class VectorStoreService {
 	 * Get or create embeddings for a specific instance.
 	 */
 	private getEmbeddingsForInstance(inst: IndexInstance, model: DefaultEmbedModel): EmbeddingsInterface | null {
-		if (inst.embeddings && inst.currentProviderId === model.provider && inst.currentModelId === model.model) {
+		const registry = getRegistry();
+		const authGeneration = registry.getAuthGeneration();
+		// Reuse rule lives in `canReuseCachedEmbeddings` — see there for why the
+		// credential generation has to participate.
+		if (
+			inst.embeddings &&
+			canReuseCachedEmbeddings(
+				{
+					providerId: inst.currentProviderId,
+					modelId: inst.currentModelId,
+					authGeneration: inst.currentAuthGeneration,
+				},
+				model,
+				authGeneration,
+			)
+		) {
 			return inst.embeddings;
 		}
 
 		try {
-			const registry = getRegistry();
 			inst.embeddings = registry.createEmbeddingInstance(model.provider, model.model);
 			inst.currentProviderId = model.provider;
 			inst.currentModelId = model.model;
+			inst.currentAuthGeneration = authGeneration;
 			return inst.embeddings;
 		} catch (error) {
 			Logger.error(`[VectorStore] Failed to create embeddings for ${inst.indexId}:`, error);

--- a/test/providers/registrySync.test.ts
+++ b/test/providers/registrySync.test.ts
@@ -220,5 +220,43 @@ describe("registrySync", () => {
 			unsyncProvider("never-registered");
 			expect(getRegistry().getAuthGeneration()).toBe(before);
 		});
+
+		/**
+		 * The generation is the shared invalidation signal for every cache whose values
+		 * embed resolved credentials. Two consumers rely on it today — the agent's
+		 * runnable cache and VectorStoreService's per-index embeddings instance — and
+		 * both compare a stored generation against the live one. Pin the property they
+		 * both depend on: a credential edit must make a previously-captured generation
+		 * compare unequal, while an unrelated read must not.
+		 */
+		it("makes a captured generation stale after a credential edit", () => {
+			data.add("openai", { apiKey: "sk-old" });
+			syncProvider(data, "openai");
+
+			// What a cache stores alongside the instance it just built.
+			const capturedAtBuild = getRegistry().getAuthGeneration();
+			// A plain read must not invalidate anything.
+			expect(getRegistry().getAuthGeneration()).toBe(capturedAtBuild);
+
+			data.auth.set("openai", { apiKey: "sk-new" });
+			syncProvider(data, "openai");
+
+			// The cache's reuse check now fails, so it rebuilds against the new key.
+			expect(getRegistry().getAuthGeneration()).not.toBe(capturedAtBuild);
+		});
+
+		it("survives a baseUrl-only edit (no key change)", () => {
+			data.add("my-local", { apiKey: "sk", baseUrl: "http://localhost:1234" });
+			data.meta = { "my-local": { templateId: "openai-compatible", displayName: "Local" } };
+			syncProvider(data, "my-local");
+			const captured = getRegistry().getAuthGeneration();
+
+			// Repointing at a different endpoint invalidates cached instances just as a
+			// rotated key does — same provider id, entirely different destination.
+			data.auth.set("my-local", { apiKey: "sk", baseUrl: "http://localhost:9999" });
+			syncProvider(data, "my-local");
+
+			expect(getRegistry().getAuthGeneration()).not.toBe(captured);
+		});
 	});
 });

--- a/test/vectorstore/VectorStoreService.test.ts
+++ b/test/vectorstore/VectorStoreService.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { formatEta, summarizeValidationProgressCounts } from "../../src/vectorstore/VectorStoreService";
+import {
+	canReuseCachedEmbeddings,
+	formatEta,
+	summarizeValidationProgressCounts,
+} from "../../src/vectorstore/VectorStoreService";
 import { getDefaultEmbeddingBatchSize, normalizeEmbeddingBatchSize } from "../../src/vectorstore/batchSize";
 
 describe("embedding batch size helpers", () => {
@@ -61,5 +65,52 @@ describe("formatEta", () => {
 		expect(formatEta(90_000)).toBe("2m");
 		expect(formatEta(60 * 60_000)).toBe("1h");
 		expect(formatEta(72 * 60_000)).toBe("1h 12m");
+	});
+});
+
+/*
+ * The embeddings instance is cached per index for the whole plugin session, and
+ * it bakes in the credentials it was built with. Reuse therefore has to consider
+ * the registry's credential generation, not just provider/model ids — otherwise a
+ * rotated API key or an edited baseUrl keeps being used until Obsidian restarts,
+ * failing silently (an embed call just 401s).
+ *
+ * This is the same defect the `authGen` term fixed in the agent's runnable cache.
+ * `getEmbeddingsForInstance` is private and only reachable through index init, so
+ * the rule is extracted here to be directly assertable — without a seam the guard
+ * could be deleted without failing anything.
+ */
+describe("canReuseCachedEmbeddings", () => {
+	const cached = { providerId: "openai", modelId: "text-embedding-3-small", authGeneration: 7 };
+	const want = { provider: "openai", model: "text-embedding-3-small" };
+
+	it("reuses when provider, model and credentials are all unchanged", () => {
+		expect(canReuseCachedEmbeddings(cached, want, 7)).toBe(true);
+	});
+
+	it("rebuilds after a credential change, even with identical ids", () => {
+		// The rotation case: same provider, same model, new key.
+		expect(canReuseCachedEmbeddings(cached, want, 8)).toBe(false);
+	});
+
+	it("rebuilds when the provider changes", () => {
+		expect(canReuseCachedEmbeddings(cached, { provider: "ollama", model: want.model }, 7)).toBe(false);
+	});
+
+	it("rebuilds when the model changes", () => {
+		expect(canReuseCachedEmbeddings(cached, { provider: want.provider, model: "other" }, 7)).toBe(false);
+	});
+
+	it("never reuses a never-populated cache slot", () => {
+		// A fresh IndexInstance starts with all three null.
+		expect(canReuseCachedEmbeddings({ providerId: null, modelId: null, authGeneration: null }, want, 0)).toBe(
+			false,
+		);
+	});
+
+	it("does not treat a null generation as matching generation 0", () => {
+		// Guards the sentinel: `null` means "never built", which must not collide with
+		// the registry's initial generation of 0.
+		expect(canReuseCachedEmbeddings({ ...cached, authGeneration: null }, want, 0)).toBe(false);
 	});
 });


### PR DESCRIPTION
Follow-up to #411. That PR fixed a stale-credential bug in the agent's runnable cache and introduced a registry `authGeneration` as the invalidation signal. Reviewing it raised the obvious question — *what else caches something built from provider credentials?* — so I swept every cache in the codebase. This is the one other place with the same shape.

## The bug

`getEmbeddingsForInstance` reused its cached embeddings instance whenever the provider and model **ids** matched:

```ts
if (inst.embeddings && inst.currentProviderId === model.provider && inst.currentModelId === model.model) {
    return inst.embeddings;
}
```

But the instance snapshots its resolved auth at construction, and an `IndexInstance` lives for the **whole plugin session** (created once, cleared only on cleanup). So rotating an embedding provider's API key — or editing its baseUrl — produced identical ids, hit the cache, and kept using the old credentials until Obsidian restarted.

It fails silently: the embed call just 401s or returns nothing. Five call sites read this, covering both indexing and search.

Reuse now also requires the registry's credential generation to be unchanged.

## Test seam

The reuse rule is extracted as `canReuseCachedEmbeddings` rather than left inline, because **the guard was otherwise unverifiable**. `getEmbeddingsForInstance` is private and only reachable through index initialization — I could delete the credential check and not a single test would fail. That's a bad property for a fix whose entire purpose is a check.

With the seam, mutation testing works:

| Mutation | Result |
|---|---|
| Drop the `authGeneration` term (the original bug, verbatim) | **2 tests fail** |
| Drop the `providerId` term | **1 test fails** |
| Drop the `modelId` term | **1 test fails** |

It follows the file's existing convention of exported pure helpers (`formatEta`, `summarizeValidationProgressCounts`), so it adds no new pattern. I verified there's one definition and one call site — no parallel copy that could drift from the live path.

Two of the six new cases cover sentinel hazards worth having: a never-populated slot (all-`null`, as `createInstance` produces), and `authGeneration: null` not comparing equal to the registry's initial generation of `0`.

Also pins the property both consumers depend on, in `registrySync`: a credential edit makes a previously-captured generation compare unequal, a plain read does not, and a baseUrl-only edit counts as a change.

## Swept and cleared

Recorded so the next person doesn't redo it:

| Cache | Verdict |
|---|---|
| `resolvedVisionSupportCache` | Vision support is a **model capability** — identical for any key. Correctly keyed `provider::model`. |
| `modelsDevApi`, `openrouterModels` | Public model catalogues (pricing, context windows). Not credential-derived, TTL-bounded. |
| `ollamaModels` | Already checks `cachedResponse.baseUrl === baseUrl` — the one auth field that matters for it. |
| `topicLabeler` | Builds its chat instance fresh per call. |
| `AgentManager` image/PDF processors | Rebuilt per `buildToolsForAgent` and land in the runnable — covered transitively by the `authGen` cache key from #411. |

## Verification

- `bun run check` — 2761 files, 0 errors
- `bun run test` — **1554 passed** in isolation (1548 → 1554)

Verified against a working tree containing **only** these changes: unrelated in-progress work was stashed for the run, so these numbers reflect this branch alone.

## Scope

Three files: `VectorStoreService.ts` plus two test files. No behaviour change when credentials are unchanged — the cache still hits exactly as before.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._