### PR TITLE
refactor: drop the "Spaces" name from privacy membership rules

### DIFF
--- a/src/components/modal/PrivacyListModal.svelte
+++ b/src/components/modal/PrivacyListModal.svelte
@@ -2,15 +2,15 @@
 import { getAllTags, type App } from "obsidian";
 import type { ViewFilter } from "../../types/viewFilter";
 import {
-	buildSpaceMembershipRulesEditorFilter,
-	cloneSpaceMembershipDraft,
+	buildPrivacyMembershipRulesEditorFilter,
+	clonePrivacyMembershipDraft,
 	cloneViewFilter,
-	compileSpaceMembershipDraft,
-	createEmptySpaceFilter,
-	extractSpaceMembershipRulesFilter,
-	parseSpaceMembershipFilter,
+	compilePrivacyMembershipDraft,
+	createEmptyPrivacyFilter,
+	extractPrivacyMembershipRulesFilter,
+	parsePrivacyMembershipFilter,
 	resolveViewFilter,
-	resolveSpaceMembershipDraft,
+	resolvePrivacyMembershipDraft,
 	rewriteViewFilterForRename,
 } from "../../lib/views";
 import { getData } from "../../stores/dataStore.svelte";
@@ -81,8 +81,8 @@ function ensureGroup(filter: ViewFilter): ViewFilter {
 	return { type: "all", conditions: [filter] };
 }
 
-const initialParsed = parseSpaceMembershipFilter(data.privacyFilter);
-let privacyFilter = $state<ViewFilter>(ensureGroup(data.privacyFilter ?? createEmptySpaceFilter()));
+const initialParsed = parsePrivacyMembershipFilter(data.privacyFilter);
+let privacyFilter = $state<ViewFilter>(ensureGroup(data.privacyFilter ?? createEmptyPrivacyFilter()));
 let showFilters = $state(initialParsed.draft.autoIncludeRules.length > 0);
 /** Whether the mode explanation + path-visibility caveat are expanded. */
 let showModeDetails = $state(false);
@@ -118,7 +118,7 @@ $effect(() => {
 	});
 	return () => app.vault.offref(ref);
 });
-const parsedMembership = $derived.by(() => parseSpaceMembershipFilter(privacyFilter));
+const parsedMembership = $derived.by(() => parsePrivacyMembershipFilter(privacyFilter));
 const privacyUniverse = $derived.by(
 	() =>
 		new Set(
@@ -135,7 +135,7 @@ const resolvedPrivacy = $derived.by(() =>
 				provenance: new Map<string, string[]>(),
 				excludedPaths: new Set<string>(),
 			}
-		: resolveSpaceMembershipDraft(app, parsedMembership.draft, privacyUniverse),
+		: resolvePrivacyMembershipDraft(app, parsedMembership.draft, privacyUniverse),
 );
 const includedFiles = $derived.by(() => [...resolvedPrivacy.paths].sort((left, right) => left.localeCompare(right)));
 const excludedFiles = $derived.by(() =>
@@ -213,12 +213,12 @@ function saveChanges() {
 	modal.close();
 }
 
-function updateDraft(mutator: (draft: ReturnType<typeof cloneSpaceMembershipDraft>) => void) {
-	const currentParsedMembership = parseSpaceMembershipFilter(privacyFilter);
-	const draft = cloneSpaceMembershipDraft(currentParsedMembership.draft);
+function updateDraft(mutator: (draft: ReturnType<typeof clonePrivacyMembershipDraft>) => void) {
+	const currentParsedMembership = parsePrivacyMembershipFilter(privacyFilter);
+	const draft = clonePrivacyMembershipDraft(currentParsedMembership.draft);
 	mutator(draft);
 	showFilters = showFilters || draft.autoIncludeRules.length > 0;
-	updatePrivacyFilter(compileSpaceMembershipDraft(draft));
+	updatePrivacyFilter(compilePrivacyMembershipDraft(draft));
 }
 
 function getParentPath(path: string): string {
@@ -248,7 +248,7 @@ function restoreExcludedPath(path: string) {
 }
 
 function handleRulesFilterChange(nextFilter: ViewFilter) {
-	const simpleRules = extractSpaceMembershipRulesFilter(nextFilter);
+	const simpleRules = extractPrivacyMembershipRulesFilter(nextFilter);
 	if (!simpleRules) {
 		showFilters = true;
 		updatePrivacyFilter(cloneViewFilter(nextFilter));
@@ -465,7 +465,7 @@ const excludedTitle = $derived.by(() => (privacyMode === "private-by-default" ? 
       filterPanelLabel="Filters"
       filterBuilderFilter={parsedMembership.isAdvanced
   		? ensureGroup(cloneViewFilter(privacyFilter))
-  		: buildSpaceMembershipRulesEditorFilter(parsedMembership.draft.autoIncludeRules)}
+  		: buildPrivacyMembershipRulesEditorFilter(parsedMembership.draft.autoIncludeRules)}
       {availableFolders}
       {availableTags}
       {availableProperties}

--- a/src/lib/views.ts
+++ b/src/lib/views.ts
@@ -27,25 +27,25 @@ export interface ResolvedView {
 	stalePaths: string[];
 }
 
-export type SpaceMembershipRule =
+export type PrivacyMembershipRule =
 	| { type: "folder"; value: string }
 	| { type: "tag"; value: string }
 	| { type: "extension"; value: string }
 	| { type: "query"; value: string; algorithm: "lexical" | "semantic" | "hybrid" }
 	| { type: "property"; value: string; values?: string[] };
 
-export interface SpaceMembershipDraft {
+export interface PrivacyMembershipDraft {
 	manualPaths: string[];
-	autoIncludeRules: SpaceMembershipRule[];
+	autoIncludeRules: PrivacyMembershipRule[];
 	excludedPaths: string[];
 }
 
-export interface ParsedSpaceMembershipDraft {
-	draft: SpaceMembershipDraft;
+export interface ParsedPrivacyMembershipDraft {
+	draft: PrivacyMembershipDraft;
 	isAdvanced: boolean;
 }
 
-export interface ResolvedSpaceMembership extends ResolvedView {
+export interface ResolvedPrivacyMembership extends ResolvedView {
 	provenance: Map<string, string[]>;
 	excludedPaths: Set<string>;
 }
@@ -189,10 +189,10 @@ export function rewriteViewFilterForRename(filter: ViewFilter, oldPath: string, 
 	return changed ? { type: filter.type, conditions } : filter;
 }
 
-export function cloneSpaceMembershipDraft(draft: SpaceMembershipDraft): SpaceMembershipDraft {
+export function clonePrivacyMembershipDraft(draft: PrivacyMembershipDraft): PrivacyMembershipDraft {
 	return {
 		manualPaths: [...draft.manualPaths],
-		autoIncludeRules: draft.autoIncludeRules.map((rule) => cloneSpaceMembershipRule(rule)),
+		autoIncludeRules: draft.autoIncludeRules.map((rule) => clonePrivacyMembershipRule(rule)),
 		excludedPaths: [...draft.excludedPaths],
 	};
 }
@@ -212,12 +212,12 @@ export function resolveViewFilter(app: App, filter: ViewFilter, universe?: Set<s
 	return resolveNode(app, filter, allPaths);
 }
 
-export function createEmptySpaceFilter(): ViewFilter {
+export function createEmptyPrivacyFilter(): ViewFilter {
 	return { type: "paths", value: [] };
 }
 
-export function compileSpaceMembershipDraft(draft: SpaceMembershipDraft): ViewFilter {
-	const normalized = normalizeSpaceMembershipDraft(draft);
+export function compilePrivacyMembershipDraft(draft: PrivacyMembershipDraft): ViewFilter {
+	const normalized = normalizePrivacyMembershipDraft(draft);
 	const includeLeaves: ViewFilterLeaf[] = [];
 
 	if (normalized.manualPaths.length > 0) {
@@ -225,11 +225,11 @@ export function compileSpaceMembershipDraft(draft: SpaceMembershipDraft): ViewFi
 	}
 
 	for (const rule of normalized.autoIncludeRules) {
-		includeLeaves.push(cloneSpaceMembershipRule(rule));
+		includeLeaves.push(clonePrivacyMembershipRule(rule));
 	}
 
 	if (includeLeaves.length === 0) {
-		return createEmptySpaceFilter();
+		return createEmptyPrivacyFilter();
 	}
 
 	const includeNode: ViewFilter =
@@ -245,41 +245,41 @@ export function compileSpaceMembershipDraft(draft: SpaceMembershipDraft): ViewFi
 	};
 }
 
-export function buildSpaceMembershipRulesEditorFilter(rules: SpaceMembershipRule[]): ViewFilter {
+export function buildPrivacyMembershipRulesEditorFilter(rules: PrivacyMembershipRule[]): ViewFilter {
 	return {
 		type: "any",
-		conditions: rules.map((rule) => cloneSpaceMembershipRule(rule)),
+		conditions: rules.map((rule) => clonePrivacyMembershipRule(rule)),
 	};
 }
 
-export function extractSpaceMembershipRulesFilter(filter: ViewFilter): SpaceMembershipRule[] | null {
+export function extractPrivacyMembershipRulesFilter(filter: ViewFilter): PrivacyMembershipRule[] | null {
 	if (isLeaf(filter)) {
-		return isSpaceMembershipRule(filter) ? [cloneSpaceMembershipRule(filter)] : null;
+		return isPrivacyMembershipRule(filter) ? [clonePrivacyMembershipRule(filter)] : null;
 	}
 
 	if (filter.type !== "any") {
 		return null;
 	}
 
-	const rules: SpaceMembershipRule[] = [];
+	const rules: PrivacyMembershipRule[] = [];
 	for (const condition of filter.conditions) {
-		if (!isLeaf(condition) || !isSpaceMembershipRule(condition)) {
+		if (!isLeaf(condition) || !isPrivacyMembershipRule(condition)) {
 			return null;
 		}
-		rules.push(cloneSpaceMembershipRule(condition));
+		rules.push(clonePrivacyMembershipRule(condition));
 	}
 
 	return rules;
 }
 
-export function parseSpaceMembershipFilter(filter: ViewFilter): ParsedSpaceMembershipDraft {
-	const draft: SpaceMembershipDraft = {
+export function parsePrivacyMembershipFilter(filter: ViewFilter): ParsedPrivacyMembershipDraft {
+	const draft: PrivacyMembershipDraft = {
 		manualPaths: [],
 		autoIncludeRules: [],
 		excludedPaths: [],
 	};
 
-	if (!extractSimpleSpaceMembership(filter, draft)) {
+	if (!extractSimplePrivacyMembership(filter, draft)) {
 		return {
 			draft: {
 				manualPaths: [],
@@ -291,17 +291,17 @@ export function parseSpaceMembershipFilter(filter: ViewFilter): ParsedSpaceMembe
 	}
 
 	return {
-		draft: normalizeSpaceMembershipDraft(draft),
+		draft: normalizePrivacyMembershipDraft(draft),
 		isAdvanced: false,
 	};
 }
 
-export function resolveSpaceMembershipDraft(
+export function resolvePrivacyMembershipDraft(
 	app: App,
-	draft: SpaceMembershipDraft,
+	draft: PrivacyMembershipDraft,
 	universe?: Set<string>,
-): ResolvedSpaceMembership {
-	const normalized = normalizeSpaceMembershipDraft(draft);
+): ResolvedPrivacyMembership {
+	const normalized = normalizePrivacyMembershipDraft(draft);
 	const resolvedPaths = new Set<string>();
 	const provenance = new Map<string, string[]>();
 	const stalePaths = new Set<string>();
@@ -339,8 +339,8 @@ export function resolveSpaceMembershipDraft(
 	};
 }
 
-export function matchesSpaceMembershipDraftPath(app: App, draft: SpaceMembershipDraft, filePath: string): boolean {
-	const normalized = normalizeSpaceMembershipDraft(draft);
+export function matchesPrivacyMembershipDraftPath(app: App, draft: PrivacyMembershipDraft, filePath: string): boolean {
+	const normalized = normalizePrivacyMembershipDraft(draft);
 
 	if (normalized.excludedPaths.includes(filePath)) {
 		return false;
@@ -350,7 +350,7 @@ export function matchesSpaceMembershipDraftPath(app: App, draft: SpaceMembership
 		return true;
 	}
 
-	return normalized.autoIncludeRules.some((rule) => matchesSpaceMembershipRulePath(app, rule, filePath));
+	return normalized.autoIncludeRules.some((rule) => matchesPrivacyMembershipRulePath(app, rule, filePath));
 }
 
 /**
@@ -402,15 +402,15 @@ export function describeViewFilter(filter: ViewFilter): string {
 	return `${filter.type}(${inner})`;
 }
 
-function normalizeSpaceMembershipDraft(draft: SpaceMembershipDraft): SpaceMembershipDraft {
+function normalizePrivacyMembershipDraft(draft: PrivacyMembershipDraft): PrivacyMembershipDraft {
 	return {
 		manualPaths: dedupeStrings(draft.manualPaths),
-		autoIncludeRules: draft.autoIncludeRules.map((rule) => cloneSpaceMembershipRule(rule)),
+		autoIncludeRules: draft.autoIncludeRules.map((rule) => clonePrivacyMembershipRule(rule)),
 		excludedPaths: dedupeStrings(draft.excludedPaths),
 	};
 }
 
-function extractSimpleSpaceMembership(filter: ViewFilter, draft: SpaceMembershipDraft): boolean {
+function extractSimplePrivacyMembership(filter: ViewFilter, draft: PrivacyMembershipDraft): boolean {
 	if (isLeaf(filter)) {
 		return extractSimpleIncludeNode(filter, draft);
 	}
@@ -443,15 +443,15 @@ function extractSimpleSpaceMembership(filter: ViewFilter, draft: SpaceMembership
 	return includeCount === 1;
 }
 
-function extractSimpleIncludeNode(filter: ViewFilter, draft: SpaceMembershipDraft): boolean {
+function extractSimpleIncludeNode(filter: ViewFilter, draft: PrivacyMembershipDraft): boolean {
 	if (isLeaf(filter)) {
 		if (filter.type === "paths") {
 			draft.manualPaths.push(...filter.value);
 			return true;
 		}
 
-		if (isSpaceMembershipRule(filter)) {
-			draft.autoIncludeRules.push(cloneSpaceMembershipRule(filter));
+		if (isPrivacyMembershipRule(filter)) {
+			draft.autoIncludeRules.push(clonePrivacyMembershipRule(filter));
 			return true;
 		}
 
@@ -482,7 +482,7 @@ function collectExcludedPaths(filter: ViewFilterGroup): string[] {
 	return paths;
 }
 
-function isSpaceMembershipRule(filter: ViewFilter): filter is SpaceMembershipRule {
+function isPrivacyMembershipRule(filter: ViewFilter): filter is PrivacyMembershipRule {
 	return (
 		filter.type === "folder" ||
 		filter.type === "tag" ||
@@ -512,7 +512,7 @@ function mergeResolvedMembership(
 	}
 }
 
-function describeMembershipRule(rule: SpaceMembershipRule): string {
+function describeMembershipRule(rule: PrivacyMembershipRule): string {
 	switch (rule.type) {
 		case "folder":
 			return `Folder: ${rule.value}`;
@@ -529,7 +529,7 @@ function describeMembershipRule(rule: SpaceMembershipRule): string {
 	}
 }
 
-function matchesSpaceMembershipRulePath(app: App, rule: SpaceMembershipRule, filePath: string): boolean {
+function matchesPrivacyMembershipRulePath(app: App, rule: PrivacyMembershipRule, filePath: string): boolean {
 	switch (rule.type) {
 		case "folder":
 			// See `resolveFolder`: a blank folder is an unfinished condition and
@@ -560,7 +560,7 @@ function matchesSpaceMembershipRulePath(app: App, rule: SpaceMembershipRule, fil
 	}
 }
 
-function cloneSpaceMembershipRule(rule: SpaceMembershipRule): SpaceMembershipRule {
+function clonePrivacyMembershipRule(rule: PrivacyMembershipRule): PrivacyMembershipRule {
 	switch (rule.type) {
 		case "folder":
 			return { type: "folder", value: rule.value };

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -1,9 +1,9 @@
 import { normalizePath } from "obsidian";
 import { SHIPPED_BASE_PROMPTS, SHIPPED_MEMORY_PROMPTS } from "../agent/prompts";
 import {
-	createEmptySpaceFilter,
-	matchesSpaceMembershipDraftPath,
-	parseSpaceMembershipFilter,
+	createEmptyPrivacyFilter,
+	matchesPrivacyMembershipDraftPath,
+	parsePrivacyMembershipFilter,
 	resolveViewFilter,
 	rewriteViewFilterForRename,
 } from "../lib/views";
@@ -588,7 +588,7 @@ export const DEFAULT_SETTINGS: PluginData = {
 
 	// Privacy
 	privacyMode: "private-by-default",
-	privacyFilter: createEmptySpaceFilter(),
+	privacyFilter: createEmptyPrivacyFilter(),
 
 	// UI state
 	isVerbose: false,
@@ -770,13 +770,13 @@ export class PluginDataStore {
 	}
 
 	private isFileListedInPrivacyFilter(filePath: string): boolean {
-		const parsed = parseSpaceMembershipFilter(this.#data.privacyFilter);
+		const parsed = parsePrivacyMembershipFilter(this.#data.privacyFilter);
 		if (parsed.isAdvanced) {
 			return resolveViewFilter(this._plugin.app, this.#data.privacyFilter, this.getAllVaultPaths()).paths.has(
 				filePath,
 			);
 		}
-		return matchesSpaceMembershipDraftPath(this._plugin.app, parsed.draft, filePath);
+		return matchesPrivacyMembershipDraftPath(this._plugin.app, parsed.draft, filePath);
 	}
 
 	/** Check whether a provider is trusted to process private/sensitive files. */

--- a/src/types/viewFilter.ts
+++ b/src/types/viewFilter.ts
@@ -2,8 +2,8 @@
  * View Filter Types
  *
  * A recursive filter tree that describes a re-resolvable set of vault files.
- * Used by the privacy list and by Spaces membership rules — not by the graph,
- * despite having originally lived in `types/graph.ts` alongside saved views.
+ * Used by the privacy list's membership rules — not by the graph, despite
+ * having originally lived in `types/graph.ts` alongside saved views.
  *
  * Resolution lives in `lib/views.ts`; the editor UI is
  * `components/settings/ViewFilterBuilder.svelte`.

--- a/test/lib/views.test.ts
+++ b/test/lib/views.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-	compileSpaceMembershipDraft,
-	createEmptySpaceFilter,
+	compilePrivacyMembershipDraft,
+	createEmptyPrivacyFilter,
 	describeViewFilter,
 	getAllMarkdownPaths,
-	matchesSpaceMembershipDraftPath,
-	parseSpaceMembershipFilter,
-	resolveSpaceMembershipDraft,
+	matchesPrivacyMembershipDraftPath,
+	parsePrivacyMembershipFilter,
+	resolvePrivacyMembershipDraft,
 	resolveViewFilter,
 	rewriteViewFilterForRename,
 } from "../../src/lib/views";
@@ -492,17 +492,17 @@ describe("getAllMarkdownPaths", () => {
 describe("space membership draft helpers", () => {
 	it("compiles an empty draft to an empty paths filter", () => {
 		expect(
-			compileSpaceMembershipDraft({
+			compilePrivacyMembershipDraft({
 				manualPaths: [],
 				autoIncludeRules: [],
 				excludedPaths: [],
 			}),
-		).toEqual(createEmptySpaceFilter());
+		).toEqual(createEmptyPrivacyFilter());
 	});
 
 	it("compiles manual paths, auto rules, and exclusions into the existing filter shape", () => {
 		expect(
-			compileSpaceMembershipDraft({
+			compilePrivacyMembershipDraft({
 				manualPaths: ["Manual/a.md"],
 				autoIncludeRules: [{ type: "folder", value: "Research" }],
 				excludedPaths: ["Research/old.md"],
@@ -523,7 +523,7 @@ describe("space membership draft helpers", () => {
 	});
 
 	it("parses a simple compiled filter back into a file-first draft", () => {
-		const parsed = parseSpaceMembershipFilter({
+		const parsed = parsePrivacyMembershipFilter({
 			type: "all",
 			conditions: [
 				{
@@ -546,7 +546,7 @@ describe("space membership draft helpers", () => {
 	});
 
 	it("marks non-simple all-groups as advanced", () => {
-		const parsed = parseSpaceMembershipFilter({
+		const parsed = parsePrivacyMembershipFilter({
 			type: "all",
 			conditions: [
 				{ type: "folder", value: "Work" },
@@ -571,7 +571,7 @@ describe("space membership draft helpers", () => {
 			},
 		);
 
-		const result = resolveSpaceMembershipDraft(app, {
+		const result = resolvePrivacyMembershipDraft(app, {
 			manualPaths: ["Manual/a.md", "missing.md"],
 			autoIncludeRules: [
 				{ type: "folder", value: "Research" },
@@ -603,11 +603,11 @@ describe("space membership draft helpers", () => {
 			excludedPaths: ["Research/skip.md"],
 		};
 
-		expect(matchesSpaceMembershipDraftPath(app, draft, "Work/manual.md")).toBe(true);
-		expect(matchesSpaceMembershipDraftPath(app, draft, "Research/ml-paper.md")).toBe(true);
-		expect(matchesSpaceMembershipDraftPath(app, draft, "Assets/diagram.pdf")).toBe(true);
-		expect(matchesSpaceMembershipDraftPath(app, draft, "Research/skip.md")).toBe(false);
-		expect(matchesSpaceMembershipDraftPath(app, draft, "Other/file.md")).toBe(false);
+		expect(matchesPrivacyMembershipDraftPath(app, draft, "Work/manual.md")).toBe(true);
+		expect(matchesPrivacyMembershipDraftPath(app, draft, "Research/ml-paper.md")).toBe(true);
+		expect(matchesPrivacyMembershipDraftPath(app, draft, "Assets/diagram.pdf")).toBe(true);
+		expect(matchesPrivacyMembershipDraftPath(app, draft, "Research/skip.md")).toBe(false);
+		expect(matchesPrivacyMembershipDraftPath(app, draft, "Other/file.md")).toBe(false);
 	});
 });
 
@@ -740,7 +740,7 @@ describe("property leaf", () => {
 			excludedPaths: [],
 		};
 
-		const parsed = parseSpaceMembershipFilter(compileSpaceMembershipDraft(draft));
+		const parsed = parsePrivacyMembershipFilter(compilePrivacyMembershipDraft(draft));
 
 		expect(parsed.isAdvanced).toBe(false);
 		expect(parsed.draft.autoIncludeRules).toEqual([{ type: "property", value: "client", values: ["Acme"] }]);
@@ -754,7 +754,7 @@ describe("property leaf", () => {
 		// isFilePrivate() uses the sync matcher in tool loops; it must not
 		// disagree with the set-based resolver used to render the UI.
 		for (const path of FILES) {
-			expect(matchesSpaceMembershipDraftPath(app(), draft, path)).toBe(resolved.paths.has(path));
+			expect(matchesPrivacyMembershipDraftPath(app(), draft, path)).toBe(resolved.paths.has(path));
 		}
 	});
 
@@ -792,7 +792,7 @@ describe("empty leaf values", () => {
 		};
 
 		for (const path of FILES) {
-			expect(matchesSpaceMembershipDraftPath(app, draft, path)).toBe(false);
+			expect(matchesPrivacyMembershipDraftPath(app, draft, path)).toBe(false);
 		}
 	});
 

--- a/test/stores/dataStore.test.ts
+++ b/test/stores/dataStore.test.ts
@@ -38,7 +38,7 @@ import {
 	SetChatModelError,
 	SetEmbedModelError,
 } from "../../src/stores/dataStore.svelte";
-import { compileSpaceMembershipDraft } from "../../src/lib/views";
+import { compilePrivacyMembershipDraft } from "../../src/lib/views";
 import type { StoredProviderState } from "../../src/stores/dataStore.svelte";
 import type { PromptFileReader } from "../../src/types/plugin";
 import { BASE_SYSTEM_PROMPT, DEFAULT_MEMORY_PROMPT } from "../../src/agent/prompts";
@@ -806,7 +806,7 @@ describe("PluginDataStore – Privacy List", () => {
 
 	it("should treat unlisted files as private in private-by-default mode", () => {
 		store.setPrivacyFilter(
-			compileSpaceMembershipDraft({
+			compilePrivacyMembershipDraft({
 				manualPaths: ["shared.md"],
 				autoIncludeRules: [],
 				excludedPaths: [],
@@ -820,7 +820,7 @@ describe("PluginDataStore – Privacy List", () => {
 	it("should treat listed files as private in public-by-default mode", () => {
 		store.setPrivacyMode("public-by-default");
 		store.setPrivacyFilter(
-			compileSpaceMembershipDraft({
+			compilePrivacyMembershipDraft({
 				manualPaths: ["secret.md"],
 				autoIncludeRules: [],
 				excludedPaths: [],


### PR DESCRIPTION
## Why

Spaces was an experiment that got abandoned, but its vocabulary outlived it. The filter-tree helpers that back the **privacy list** were still named `SpaceMembership*`, and the header comment in `types/viewFilter.ts` still claimed the tree was used by *"the privacy list and Spaces membership rules"* — describing a consumer that no longer exists.

Nothing was dead code: every one of these helpers has live callers. The privacy list absorbed the machinery when Spaces went away; only the name was left behind.

## What

Renamed 17 identifiers across 86 call sites, so they match the `privacyFilter` / `setPrivacyFilter` / `isFileListedInPrivacyFilter` names they already sit beside:

| Old | New |
|---|---|
| `SpaceMembershipRule` | `PrivacyMembershipRule` |
| `SpaceMembershipDraft` | `PrivacyMembershipDraft` |
| `ParsedSpaceMembershipDraft` | `ParsedPrivacyMembershipDraft` |
| `ResolvedSpaceMembership` | `ResolvedPrivacyMembership` |
| `createEmptySpaceFilter` | `createEmptyPrivacyFilter` |
| `parseSpaceMembershipFilter` | `parsePrivacyMembershipFilter` |
| `compileSpaceMembershipDraft` | `compilePrivacyMembershipDraft` |
| `resolveSpaceMembershipDraft` | `resolvePrivacyMembershipDraft` |
| `matchesSpaceMembershipDraftPath` | `matchesPrivacyMembershipDraftPath` |
| + 8 internal helpers | `*Privacy*` |

Plus the stale header comment in `types/viewFilter.ts`.

## Not touched

`SpaceSegment` in `types/graph.ts` — there "space" means coordinate space for the graph's visual partitions (`"folder:Work"`, `"cluster:3"`). Unrelated to the removed feature, and still live in `GraphControls`, `SmartGraphView`, and five `graphDataBuilder` resolvers.

## Verification

Pure rename — **88 insertions, 88 deletions**, symmetric. Audited per-file: **0 non-rename changed lines** in all five code/test files; `viewFilter.ts` is the comment only.

- `bun run check` — 2761 files, 0 errors, 0 warnings
- `bun run test` — 96 files, 1564 tests passing
- `bun run format` — no fixes applied

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._