### PR TITLE
feat(graph): calmer labels, a topics toggle, and selection-bar polish

### DIFF
--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -328,10 +328,57 @@ const RECLUSTER_VELOCITY_DECAY = 0.55;
  * per-cluster member damping — combined ~5× weaker than it once was, so
  * settled clusters keep breathing room). Migration across the layout to a
  * *new* topic needs the strong pull back for a moment, or freshly split
- * topics stay spatially interleaved with overlapping hulls. Restored to the
- * equilibrium strength when the transition ends.
+ * topics stay spatially interleaved with overlapping hulls. Ramped back to the
+ * equilibrium strength as the transition ends (see RECLUSTER_BOOST_RAMP_*).
  */
 const RECLUSTER_COHESION_BOOST = 3;
+
+/**
+ * Alpha span over which the migration boost eases back to equilibrium.
+ *
+ * The boost used to be handed back in one step at alpha < 0.02 — but at 3× the
+ * equilibrium pull, the migration leaves every cluster compressed well past
+ * where charge repulsion wants it, and the simulation still has ~2.5s of ticks
+ * left below 0.02. Stepping the force field there made the settled-looking
+ * graph visibly push apart once, seconds after the migration seemed done.
+ *
+ * The ramp spans the *whole* transition (it starts at RECLUSTER_ALPHA, i.e. on
+ * the first tick) rather than a narrow window at the end: a flat full-boost
+ * plateau followed by a late release still read as two animations — migrate,
+ * then relax. Eased from the start, relinquishing the boost is simply part of
+ * the settling motion.
+ */
+const RECLUSTER_BOOST_RAMP_START = RECLUSTER_ALPHA;
+const RECLUSTER_BOOST_RAMP_END = 0.02;
+
+/**
+ * Current cohesion boost factor for the migration, as a function of alpha.
+ * Pure in alpha so the tick handler and the physics-rebuild effect can never
+ * disagree about the strength mid-transition.
+ *
+ * Smoothstep rather than linear: its zero slope at both ends means the factor
+ * holds near the full boost early — while alpha is high and the migration is
+ * covering real distance — and lands on 1 tangentially, so there is no kink in
+ * the force field at either boundary. (In wall-clock terms alpha decays
+ * exponentially, so the middle of the curve is also stretched over the longest
+ * stretch of the transition.)
+ */
+function reclusterBoostFactor(alpha: number): number {
+	if (alpha >= RECLUSTER_BOOST_RAMP_START) return RECLUSTER_COHESION_BOOST;
+	if (alpha <= RECLUSTER_BOOST_RAMP_END) return 1;
+	const t = (RECLUSTER_BOOST_RAMP_START - alpha) / (RECLUSTER_BOOST_RAMP_START - RECLUSTER_BOOST_RAMP_END);
+	const eased = t * t * (3 - 2 * t);
+	return RECLUSTER_COHESION_BOOST + (1 - RECLUSTER_COHESION_BOOST) * eased;
+}
+
+/**
+ * True only while the 3× migration boost is in play — i.e. the transition was
+ * started by a topic reassignment. `isReclustering` alone can't distinguish
+ * that from a collapse/expand `followLayout` transition, which shares the
+ * decay/camera treatment but never boosts cohesion; ramping there would
+ * *introduce* a triple-strength pull mid-collapse rather than remove a step.
+ */
+let reclusterBoostActive = false;
 
 /**
  * Delay before the corrective fit that runs after the layout has stopped
@@ -457,6 +504,14 @@ function requestRender(mode: RenderMode) {
 const EDGE_REDRAW_SCALE_STEP = 0.05;
 /** Camera scale at which edges were last tessellated. */
 let lastEdgeDrawScale = 1;
+
+/**
+ * Zoom band currently governing the label budget (index into
+ * LABEL_BUDGET_ZOOM_STEPS). Held across frames so a camera hovering exactly on a
+ * threshold doesn't oscillate between two budgets — the band only changes once
+ * the scale has moved decisively past the boundary (see LABEL_BUDGET_HYSTERESIS).
+ */
+let labelBudgetStepIndex = -1;
 /** Camera scale at the last viewport-move callback — distinguishes zoom from pan. */
 let lastViewportScale = 1;
 
@@ -572,9 +627,13 @@ function handleKeyDown(e: KeyboardEvent) {
 
 // Persistent label occlusion grid — allocated once, zeroed at the start of each render.
 // Avoids a ~10KB allocation + GC at 60fps. Resized only when canvas dimensions change.
-let labelGrid: Uint8Array = new Uint8Array(0);
-let labelGridCols = 0;
-let labelGridRows = 0;
+/**
+ * Occupied label-occlusion cells for the current frame, keyed by packed
+ * world-anchored cell coordinates. A Set rather than the previous screen-sized
+ * Uint8Array because world-anchored columns are unbounded (and negative);
+ * cleared each frame rather than reallocated.
+ */
+const labelCellsOccupied = new Set<number>();
 
 // Node ID → SimNode map for O(1) lookups (built once in setupSimulation)
 let simNodeMap: Map<string, SimNode> = new Map();
@@ -1108,6 +1167,109 @@ function render(mode: RenderMode) {
 	// readable threshold — no manual zoom setting needed. The occlusion grid
 	// handles crowding; this threshold handles legibility.
 	const MIN_LABEL_SCREEN_RADIUS = 5; // px — node must be at least this big on screen
+
+	/**
+	 * Simulation alpha at and below which ordinary labels are fully visible.
+	 *
+	 * Deliberately below the 0.05 the camera's final fit uses: the camera only has
+	 * to stop chasing the layout, whereas a label has to be *readable*, and text
+	 * still creeping is more distracting than text that arrives late. The layout
+	 * keeps drifting visibly for a while after alpha 0.05.
+	 */
+	const LABEL_SETTLE_ALPHA = 0.02;
+	/** Alpha at which ordinary labels are fully hidden; between the two they fade. */
+	const LABEL_SETTLE_ALPHA_MAX = 0.05;
+	/**
+	 * Ordinary labels fade out while the layout is still moving.
+	 *
+	 * Anchoring the occlusion lattice to the world stopped labels re-rolling under
+	 * a *camera* move, but during a live simulation the nodes genuinely move
+	 * relative to each other, so cell ownership legitimately changes frame to
+	 * frame and the flicker is real rather than an artefact. There's nothing to
+	 * read mid-settle anyway — the captions are still sliding around — so they
+	 * fade in once the graph stops.
+	 *
+	 * A fade rather than a hard cutoff: switching at a threshold would make every
+	 * label pop in at once the instant alpha crossed it.
+	 *
+	 * Hovered, highlighted and cluster-representative labels are exempt — those
+	 * answer a direct question ("what is this?") and must respond immediately,
+	 * settled or not.
+	 */
+	const simAlpha = simulation?.alpha() ?? 0;
+	const settleLabelAlpha =
+		simAlpha <= LABEL_SETTLE_ALPHA
+			? 1
+			: simAlpha >= LABEL_SETTLE_ALPHA_MAX
+				? 0
+				: 1 - (simAlpha - LABEL_SETTLE_ALPHA) / (LABEL_SETTLE_ALPHA_MAX - LABEL_SETTLE_ALPHA);
+
+	/**
+	 * How many *ordinary* nodes may be captioned at once.
+	 *
+	 * The radius gate alone barely discriminates: `nodeDrawRadius` is
+	 * `log1p(degree)`-shaped, so a degree-3 note and a degree-30 hub differ by
+	 * only a couple of screen pixels and nearly every node clears the threshold
+	 * together. Hundreds then contend for the same occlusion cells, and because
+	 * winning a cell is binary, two similar nodes drifting a pixel apart trade the
+	 * label back and forth every frame — that's the flicker, not the volume alone.
+	 *
+	 * Ranking by degree and captioning only the top slice fixes both: the hubs
+	 * worth reading keep their labels (and keep them *stably*, since the ranking
+	 * only changes when the graph does), while the long tail stays quiet until you
+	 * hover it or zoom in far enough that few nodes are on screen at all.
+	 *
+	 * Priority tiers above ordinary — hovered, its neighbours, highlighted, and
+	 * cluster representatives — are exempt and never counted against this budget.
+	 *
+	 * The budget is the overview value; it grows with zoom (see below), where
+	 * crowding is the thing that stops being true.
+	 */
+	const ORDINARY_LABEL_BUDGET_BASE = 12;
+	/**
+	 * Graphs at or below this many nodes skip the budget entirely.
+	 *
+	 * The budget exists to resolve contention, and a small graph has none — the
+	 * occlusion grid alone keeps it readable. Capping here would only hide labels
+	 * that fit perfectly well.
+	 */
+	const LABEL_BUDGET_MIN_NODES = 60;
+	/**
+	 * Zoom multipliers on the budget, applied in discrete steps.
+	 *
+	 * A budget computed continuously from `scale` slides by one label at a time as
+	 * the camera moves, and since each increment flips exactly one caption on or
+	 * off, panning and zooming made labels blink. Stepping instead means the
+	 * budget holds constant across a whole zoom band and changes at a handful of
+	 * thresholds — a single deliberate change rather than a continuous shimmer.
+	 *
+	 * Zooming in still earns more labels: fewer nodes remain on screen, so the
+	 * occlusion grid has room the cap shouldn't be withholding.
+	 */
+	const LABEL_BUDGET_ZOOM_STEPS: Array<{ minScale: number; multiplier: number }> = [
+		{ minScale: 4, multiplier: 5 },
+		{ minScale: 2, multiplier: 2.5 },
+		{ minScale: 1, multiplier: 1 },
+	];
+	/**
+	 * Fraction the scale must overshoot a boundary before the band changes.
+	 * Without it, a camera resting on a threshold flips between two budgets on
+	 * sub-pixel jitter — trading the flicker for a rarer but identical one.
+	 */
+	const LABEL_BUDGET_HYSTERESIS = 0.12;
+	const nextStepIndex = LABEL_BUDGET_ZOOM_STEPS.findIndex((step) => {
+		// Leaving the current band costs extra; entering a new one is unchanged, so
+		// the boundary is sticky in whichever direction we're already committed to.
+		const isCurrent = LABEL_BUDGET_ZOOM_STEPS.indexOf(step) === labelBudgetStepIndex;
+		const threshold = isCurrent ? step.minScale * (1 - LABEL_BUDGET_HYSTERESIS) : step.minScale;
+		return scale >= threshold;
+	});
+	if (nextStepIndex !== -1) labelBudgetStepIndex = nextStepIndex;
+	const zoomMultiplier = LABEL_BUDGET_ZOOM_STEPS[labelBudgetStepIndex]?.multiplier ?? 1;
+	const ORDINARY_LABEL_BUDGET =
+		simNodes.length <= LABEL_BUDGET_MIN_NODES
+			? Number.POSITIVE_INFINITY
+			: Math.round(ORDINARY_LABEL_BUDGET_BASE * zoomMultiplier);
 	const showClusterAnchors = showClusterLabels && clusterRepresentativeNodes.size > 0;
 	const hovId = hoveredNode?.id ?? null;
 	const hoverNeighbors = hovId ? adjacency.get(hovId) : undefined;
@@ -1148,22 +1310,22 @@ function render(mode: RenderMode) {
 	const LABEL_FONT_PX = Math.round(Math.max(baselineFontPx, LABEL_FONT_MIN_PX));
 
 	// Label occlusion culling — grid-based O(n) instead of O(n²) linear scan.
-	// The canvas is divided into LABEL_CELL_W×LABEL_CELL_H px cells (screen space).
+	// Cells are LABEL_CELL_W×LABEL_CELL_H screen pixels, but anchored to the
+	// *world* origin rather than the screen corner: a pan moves every label and
+	// the lattice together, so nobody changes cells and contention outcomes hold
+	// still. When the lattice was screen-anchored, panning slid all labels across
+	// fixed cell boundaries, and two labels that never visually overlapped could
+	// share a cell at one camera offset and not the next — re-rolling who wins on
+	// every pan frame, which read as labels flashing while the camera moved.
 	// A label is allowed only if none of the cells it spans are already occupied.
 	const LABEL_CELL_W = 60; // px — approx half an average label width
 	const LABEL_CELL_H = LABEL_FONT_PX + 6; // px — label height + padding
 	const LABEL_PAD_X = 2;
 	const LABEL_PAD_Y = 1;
-	const neededCols = Math.ceil(width / LABEL_CELL_W) + 1;
-	const neededRows = Math.ceil(height / LABEL_CELL_H) + 1;
-	// Resize persistent grid only when canvas dimensions change; otherwise just zero it
-	if (neededCols !== labelGridCols || neededRows !== labelGridRows) {
-		labelGridCols = neededCols;
-		labelGridRows = neededRows;
-		labelGrid = new Uint8Array(labelGridCols * labelGridRows);
-	} else {
-		labelGrid.fill(0);
-	}
+	labelCellsOccupied.clear();
+	// Where the world origin currently lands on screen; subtracting it from a
+	// screen coordinate yields a pan-invariant coordinate (world × zoom).
+	const labelGridOrigin = renderer.worldToScreen(0, 0);
 
 	function canDrawLabel(nodeX: number, labelY: number, approxCharCount: number, fontPx = LABEL_FONT_PX): boolean {
 		// Font sizes are already in screen px, so sw/sh are screen px directly
@@ -1175,22 +1337,34 @@ function render(mode: RenderMode) {
 		const x2 = screen.x + sw / 2 + LABEL_PAD_X;
 		const y2 = screen.y + LABEL_PAD_Y;
 
-		// Convert to grid cell range
-		const col0 = Math.max(0, Math.floor(x1 / LABEL_CELL_W));
-		const col1 = Math.min(labelGridCols - 1, Math.floor(x2 / LABEL_CELL_W));
-		const row0 = Math.max(0, Math.floor(y1 / LABEL_CELL_H));
-		const row1 = Math.min(labelGridRows - 1, Math.floor(y2 / LABEL_CELL_H));
+		// Reject anything off-screen outright (screen space — this part *should*
+		// track the camera). Off-screen labels would otherwise occupy cells — and,
+		// now that ordinary labels are budgeted, spend a slot — while painting
+		// nothing the user can see. That also makes zooming in behave: as fewer
+		// nodes remain on screen, the budget is spent on them rather than on hubs
+		// somewhere off-canvas.
+		if (x2 < 0 || y2 < 0 || x1 > width || y1 > height) return false;
+
+		// Convert to world-anchored cell range (unbounded ints, negative is fine).
+		const col0 = Math.floor((x1 - labelGridOrigin.x) / LABEL_CELL_W);
+		const col1 = Math.floor((x2 - labelGridOrigin.x) / LABEL_CELL_W);
+		const row0 = Math.floor((y1 - labelGridOrigin.y) / LABEL_CELL_H);
+		const row1 = Math.floor((y2 - labelGridOrigin.y) / LABEL_CELL_H);
+
+		// Pack col/row into one integer key. 16 bits each — collisions need cells
+		// 65 536 apart (≈4M px), far beyond any real layout.
+		const cellKey = (c: number, r: number) => ((c & 0xffff) << 16) | (r & 0xffff);
 
 		// Check — any occupied cell means overlap
 		for (let r = row0; r <= row1; r++) {
 			for (let c = col0; c <= col1; c++) {
-				if (labelGrid[r * labelGridCols + c]) return false;
+				if (labelCellsOccupied.has(cellKey(c, r))) return false;
 			}
 		}
 		// Mark cells as occupied
 		for (let r = row0; r <= row1; r++) {
 			for (let c = col0; c <= col1; c++) {
-				labelGrid[r * labelGridCols + c] = 1;
+				labelCellsOccupied.add(cellKey(c, r));
 			}
 		}
 		return true;
@@ -1231,6 +1405,11 @@ function render(mode: RenderMode) {
 		});
 	}
 	const sortedLabelNodes = cachedSortedLabelNodes;
+
+	// Ordinary (untiered) labels placed so far this frame, against
+	// ORDINARY_LABEL_BUDGET. Nodes arrive degree-sorted, so the budget is spent on
+	// the most connected notes first.
+	let ordinaryLabelsDrawn = 0;
 
 	const labelEntries: Array<{
 		nodeX: number;
@@ -1281,9 +1460,16 @@ function render(mode: RenderMode) {
 				alpha: 1,
 				fontSize,
 			});
-		} else if (screenRadius >= MIN_LABEL_SCREEN_RADIUS) {
+		} else if (
+			settleLabelAlpha > 0 &&
+			screenRadius >= MIN_LABEL_SCREEN_RADIUS &&
+			ordinaryLabelsDrawn < ORDINARY_LABEL_BUDGET
+		) {
 			// Node is large enough on screen to anchor a label — show it if space allows
 			if (!canDrawLabel(node.x, labelY, node.label.length, fontSize)) continue;
+			// Counted only once the label is actually placed, so labels lost to
+			// occlusion don't silently consume the budget and leave it under-filled.
+			ordinaryLabelsDrawn++;
 			// Smooth fade-in over a 2px radius window so labels don't pop in abruptly
 			const fadeAlpha = Math.min(1, (screenRadius - MIN_LABEL_SCREEN_RADIUS) / 2);
 			labelEntries.push({
@@ -1291,7 +1477,7 @@ function render(mode: RenderMode) {
 				nodeY: labelY,
 				text: node.label,
 				color: node.highlighted ? c.textAccent : c.textNormal,
-				alpha: nodeAlpha * fadeAlpha,
+				alpha: nodeAlpha * fadeAlpha * settleLabelAlpha,
 				fontSize,
 			});
 		}
@@ -2107,13 +2293,23 @@ function setupForceSimulation(
 			hitGridDirty = true;
 			// A finished re-cluster transition hands its slower decay back, so the
 			// next drag or retarget feels normal instead of inheriting the drift.
-			// The migration cohesion boost is handed back with it — the settled
-			// layout must live at the gentle equilibrium strength.
-			if (isReclustering && simulation && simulation.alpha() < 0.02) {
-				isReclustering = false;
-				simulation.alphaDecay(baseAlphaDecay).velocityDecay(baseVelocityDecay);
-				const clusterForce = simulation.force("cluster") as ReturnType<typeof clusterCohesionForce> | undefined;
-				clusterForce?.strength(effectiveClusterCohesion);
+			// The migration cohesion boost isn't stepped off here — it eases out
+			// along `reclusterBoostFactor` as alpha falls through the ramp window,
+			// so releasing the over-compressed clusters is part of the same settle
+			// instead of a visible second push after it.
+			if (isReclustering && simulation) {
+				const tickAlpha = simulation.alpha();
+				if (reclusterBoostActive && tickAlpha < RECLUSTER_BOOST_RAMP_START) {
+					const clusterForce = simulation.force("cluster") as
+						| ReturnType<typeof clusterCohesionForce>
+						| undefined;
+					clusterForce?.strength(effectiveClusterCohesion * reclusterBoostFactor(tickAlpha));
+				}
+				if (tickAlpha < RECLUSTER_BOOST_RAMP_END) {
+					isReclustering = false;
+					reclusterBoostActive = false;
+					simulation.alphaDecay(baseAlphaDecay).velocityDecay(baseVelocityDecay);
+				}
 			}
 
 			// During initial settling, continuously refit the camera so it
@@ -2172,6 +2368,9 @@ function setupForceSimulation(
 	baseAlphaDecay = simulation.alphaDecay();
 	baseVelocityDecay = simulation.velocityDecay();
 	isReclustering = false;
+	// A fresh force set carries no migration boost; a stale flag would let the
+	// tick handler re-apply one to a simulation that never asked for it.
+	reclusterBoostActive = false;
 
 	// On a fresh layout, hide the canvas briefly so the first visible frame is
 	// already partially settled rather than the initial random-pile explosion.
@@ -2291,8 +2490,9 @@ function setupGraph(data: GraphData) {
 			// but that same gentleness can no longer *migrate* nodes across the
 			// layout when a granularity change hands them new topics, so freshly
 			// split groups stayed spatially interleaved and their hulls overlapped.
-			// Boost the pull for the transition only; the tick handler that ends
-			// the re-cluster (alpha < 0.02) restores the equilibrium strength.
+			// Boost the pull for the transition only; the tick handler eases it
+			// back to equilibrium across the RECLUSTER_BOOST_RAMP alpha window.
+			reclusterBoostActive = true;
 			clusterForce?.strength(effectiveClusterCohesion * RECLUSTER_COHESION_BOOST);
 			simulation
 				.alpha(RECLUSTER_ALPHA)
@@ -2381,10 +2581,14 @@ $effect(() => {
 	});
 	// Recreating the forces resets cohesion to its equilibrium strength; restore
 	// the migration boost if a re-cluster is still in flight, or a settings
-	// write landing mid-transition would strand topics half-migrated.
-	if (isReclustering) {
+	// write landing mid-transition would strand topics half-migrated. At the
+	// alpha-dependent factor, not the full boost — a write landing mid-ramp
+	// snapping the strength back up to 3× would reintroduce exactly the
+	// discontinuity the ramp exists to remove. Gated on the boost flag because
+	// `followLayout` transitions share `isReclustering` without ever boosting.
+	if (reclusterBoostActive) {
 		const migratingCluster = sim.force("cluster") as ReturnType<typeof clusterCohesionForce> | undefined;
-		migratingCluster?.strength(effectiveClusterCohesion * RECLUSTER_COHESION_BOOST);
+		migratingCluster?.strength(effectiveClusterCohesion * reclusterBoostFactor(sim.alpha()));
 	}
 
 	// Reheat only when a force parameter really changed. `settings` is replaced

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -540,9 +540,23 @@ function rectContains(outer: WorldRect, inner: WorldRect): boolean {
 	return inner.minX >= outer.minX && inner.maxX <= outer.maxX && inner.minY >= outer.minY && inner.maxY <= outer.maxY;
 }
 
-function handleKeyDown(e: KeyboardEvent) {
+/**
+ * Graph keyboard shortcuts.
+ *
+ * Exported because the canvas is not the only place these have to work: clicking
+ * a topic row in the settings panel makes a selection *and* moves focus to that
+ * row, so a canvas-scoped listener left the selection-bar verbs (I/O/A/C)
+ * unreachable — the shortcuts were dead exactly when there was something to use
+ * them on, and clicking back onto the canvas to restore focus cleared the
+ * selection. The view binds this at its own root so anything inside the graph
+ * leaf keeps them live.
+ */
+export function handleKeyDown(e: KeyboardEvent) {
 	const tag = (e.target as HTMLElement | null)?.tagName;
 	if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+	// A slider or other range control owns its arrow keys; stepping granularity
+	// from under it would fight the control the user is actually operating.
+	if ((e.target as HTMLElement | null)?.closest?.('input, [role="slider"], [contenteditable="true"]')) return;
 
 	if (
 		(e.key === "Meta" || e.key === "Control") &&
@@ -2900,7 +2914,6 @@ export function panToClusters(clusters: Set<number>) {
   onpointermove={handleMouseMove}
   onpointerup={handleMouseUp}
   onclick={handleClick}
-  onkeydown={handleKeyDown}
   onwheel={handleWheel}
   onmouseleave={handleMouseLeave}
   oncontextmenu={handleContextMenu}

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -304,8 +304,14 @@ $effect(() => {
   <!-- Show/hide detected topics. Display-only, so flipping it is instant and the
        graph underneath is unchanged — that's what makes it readable as "here is
        what the clustering added". -->
+  <!-- A wand rather than a shape: the point of this toggle is that the topics
+       were *found for you*, not that regions appear. `shapes`/`circle-dashed`
+       named the visible result, which read as a drawing option and gave no hint
+       there was anything inferred behind it. One icon across both states, since
+       the `is-active` tint already carries on/off — swapping the glyph as well
+       made the control look like two different buttons. -->
   <Button
-    iconId={showTopics ? "shapes" : "circle-dashed"}
+    iconId="wand-sparkles"
     tooltip={showTopics
       ? "Hide topics — show the raw graph without clustering"
       : "Show topics — colour notes by their detected topic"}

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -318,8 +318,16 @@ $effect(() => {
     onClick={() => onSettingsChange({ showTopics: !showTopics })}
     styles={showTopics ? "is-active" : ""}
   />
+  <!-- Chevrons rather than `group`/`ungroup`: Lucide's group icon is a dashed
+       selection marquee around two rectangles, which means "group the selected
+       objects" in a design tool — there is no marquee here, and its corner
+       brackets collided with `maximize` on this same rail. Converging and
+       diverging chevrons are the collapse/expand idiom from every tree and
+       outline UI, and say exactly what happens: many nodes fold into one, one
+       unfolds back into many. The glyph swaps per state because this action is
+       genuinely bidirectional, unlike the show/hide toggle above it. -->
   <Button
-    iconId={isTopicsCollapsed ? "ungroup" : "group"}
+    iconId={isTopicsCollapsed ? "chevrons-up-down" : "chevrons-down-up"}
     tooltip={isLeidenRunning
       ? "Computing topics…"
       : !showTopics

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -368,24 +368,6 @@ $effect(() => {
         </span>
       </div>
 
-      <!-- ── Scope ────────────────────────────── -->
-      <!-- What is in the graph at all. This sits above Topics because it decides
-           the input: changing the file set changes which notes exist to be
-           grouped, so every topic below is derived from whatever is scoped here.
-           It previously sat under Display, which read as a cosmetic preference
-           when it is the most consequential control in the panel. -->
-      <span class="section-label">Scope</span>
-      <SettingContainer
-        name="Markdown only"
-        desc="Show only Markdown notes; off shows all indexable files"
-        compact
-      >
-        <Toggle
-          checked={settings.markdownOnly}
-          onchange={(value) => onSettingsChange({ markdownOnly: value })}
-        />
-      </SettingContainer>
-
       <!-- ── Topics ───────────────────────────── -->
       <!-- Granularity and "Inferred links" both decide *which topics exist*
            (they re-run Leiden), so they belong together and above the topic list
@@ -472,6 +454,23 @@ $effect(() => {
           {/each}
         </div>
       {/if}
+
+      <!-- ── Scope ────────────────────────────── -->
+      <!-- What is in the graph at all. Placed after Topics rather than before it:
+           it is the rarest thing to touch — usually set once and left — so the
+           controls reached on every visit stay at the top, where the topic list
+           can also sit directly under the settings that produce it. -->
+      <span class="section-label">Scope</span>
+      <SettingContainer
+        name="Markdown only"
+        desc="Show only Markdown notes; off shows all indexable files"
+        compact
+      >
+        <Toggle
+          checked={settings.markdownOnly}
+          onchange={(value) => onSettingsChange({ markdownOnly: value })}
+        />
+      </SettingContainer>
 
       <!-- ── Display ───────────────────────────── -->
       <!-- Purely how the graph above is drawn — nothing here changes which notes

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -4,6 +4,7 @@ import RangeSlider from "../ui/RangeSlider.svelte";
 import Toggle from "../ui/Toggle.svelte";
 import SettingContainer from "../settings/SettingContainer.svelte";
 import { isMobileUI } from "../../utils/platform";
+import { icon } from "../../utils/utils";
 import {
 	type SmartGraphSettings,
 	type GraphData,
@@ -138,6 +139,23 @@ let graphStats = $derived.by(() => {
  */
 let inferredLinksOn = $derived(!(settings.linkOnlyTopics ?? false) && (settings.showSemanticLinks ?? true));
 
+/**
+ * What the control *is* — static across every state, so it lives behind the info
+ * icon rather than taking a line of the panel. Separated from the measurement
+ * below because the two have opposite lifetimes: this is read once while
+ * learning the control, the number is read every time it changes.
+ */
+const INFERRED_LINKS_HELP =
+	"Connect notes by meaning as well as by the links you wrote, so unlinked notes still find a topic. Turn it off to see what your own linking covers on its own. Requires a graph embedding index.";
+
+/**
+ * The live result of the current state — a measurement, not help. Stays inline
+ * (`showDesc`) because it is the payoff for flipping the toggle: watching the
+ * coverage drop is the whole point of turning inferred links off.
+ *
+ * Returns "" when there is nothing measured to report, so the row collapses back
+ * to a plain toggle instead of holding a line for restated help.
+ */
 let inferredLinksHint = $derived.by(() => {
 	const total = graphData.nodes.length;
 	if (!inferredLinksOn) {
@@ -146,16 +164,16 @@ let inferredLinksHint = $derived.by(() => {
 		if (!settings.linkOnlyTopics) {
 			return "Hidden, but still grouping notes. Toggle twice to exclude them from topics as well";
 		}
-		if (total === 0) return "Off — topics come from the links you wrote.";
+		if (total === 0) return "";
 		const placed = graphData.nodes.filter((n) => n.cluster != null).length;
 		const percent = Math.round((placed / total) * 100);
 		return `Your links alone group ${placed} of ${total} notes (${percent}%). The other ${total - placed} are unlinked.`;
 	}
 	const inferred = graphData.edges.filter((e) => e.type === "semantic").length;
-	if (inferred === 0) {
-		return "Connect notes by meaning as well as by the links you wrote — needs a graph embedding index";
-	}
-	return `Adding ${inferred} similarity connections so unlinked notes still find a topic. Turn off to see what your own links cover.`;
+	// No index yet: there is no measurement to show, and the reason lives in the
+	// info tooltip alongside the rest of the explanation.
+	if (inferred === 0) return "";
+	return `Adding ${inferred} similarity connections so unlinked notes still find a topic.`;
 });
 
 function handleLinkDistanceChange(val: number) {
@@ -351,8 +369,26 @@ $effect(() => {
         </span>
       </div>
 
+      <!-- ── Scope ────────────────────────────── -->
+      <!-- What is in the graph at all. This sits above Topics because it decides
+           the input: changing the file set changes which notes exist to be
+           grouped, so every topic below is derived from whatever is scoped here.
+           It previously sat under Display, which read as a cosmetic preference
+           when it is the most consequential control in the panel. -->
+      <span class="section-label">Scope</span>
+      <SettingContainer
+        name="Markdown only"
+        desc="Show only Markdown notes; off shows all indexable files"
+        compact
+      >
+        <Toggle
+          checked={settings.markdownOnly}
+          onchange={(value) => onSettingsChange({ markdownOnly: value })}
+        />
+      </SettingContainer>
+
       <!-- ── Topics ───────────────────────────── -->
-      <!-- Granularity and "Ignore inferred links" both decide *which topics exist*
+      <!-- Granularity and "Inferred links" both decide *which topics exist*
            (they re-run Leiden), so they belong together and above the topic list
            they produce. Everything under Display only changes how the same topics
            are drawn. -->
@@ -390,9 +426,15 @@ $effect(() => {
       <!-- One switch for the whole concept: inferred links are either part of the
            graph (drawn *and* grouping notes) or absent. Splitting "draw" from
            "count" allowed a state where hidden edges silently decided the topics.
-           `showDesc` because the off-state description is a live measurement of
-           the user's own linking — the whole point of turning this off. -->
+
+           The explanation lives behind the info icon; only the live measurement
+           stays inline (`showDesc`), and `inferredLinksHint` returns "" when
+           there is nothing measured — so the row holds a line for a number worth
+           reading, never for restated help. -->
       <SettingContainer name="Inferred links" desc={inferredLinksHint} compact showDesc>
+        {#snippet nameSuffix()}
+          <span class="info-icon" aria-label={INFERRED_LINKS_HELP} use:icon={"info"}></span>
+        {/snippet}
         <Toggle
           checked={!(settings.linkOnlyTopics ?? false) && (settings.showSemanticLinks ?? true)}
           onchange={(value) =>
@@ -436,17 +478,9 @@ $effect(() => {
       {/if}
 
       <!-- ── Display ───────────────────────────── -->
+      <!-- Purely how the graph above is drawn — nothing here changes which notes
+           are included or how they group. -->
       <span class="section-label">Display</span>
-      <SettingContainer
-        name="Markdown only"
-        desc="Show only Markdown notes; off shows all indexable files"
-        compact
-      >
-        <Toggle
-          checked={settings.markdownOnly}
-          onchange={(value) => onSettingsChange({ markdownOnly: value })}
-        />
-      </SettingContainer>
       <SettingContainer
         name="Topic regions"
         desc="Tint the area behind each topic so groups read at a glance"
@@ -778,6 +812,24 @@ $effect(() => {
     font-size: var(--font-ui-small);
     color: var(--text-faint);
     padding-right: 4px;
+  }
+
+  /* Carries the static explanation as a tooltip, so the row keeps its inline
+     line for the live measurement instead. Faint at rest and only resolving on
+     hover — it is an affordance for help that is there when wanted, not a mark
+     competing with the setting's own name. */
+  .info-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--icon-xs);
+    height: var(--icon-xs);
+    color: var(--text-faint);
+    cursor: help;
+  }
+
+  .info-icon:hover {
+    color: var(--text-muted);
   }
 
   .section-label--with-action {

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -4,7 +4,6 @@ import RangeSlider from "../ui/RangeSlider.svelte";
 import Toggle from "../ui/Toggle.svelte";
 import SettingContainer from "../settings/SettingContainer.svelte";
 import { isMobileUI } from "../../utils/platform";
-import { icon } from "../../utils/utils";
 import {
 	type SmartGraphSettings,
 	type GraphData,
@@ -140,21 +139,15 @@ let graphStats = $derived.by(() => {
 let inferredLinksOn = $derived(!(settings.linkOnlyTopics ?? false) && (settings.showSemanticLinks ?? true));
 
 /**
- * What the control *is* — static across every state, so it lives behind the info
- * icon rather than taking a line of the panel. Separated from the measurement
- * below because the two have opposite lifetimes: this is read once while
- * learning the control, the number is read every time it changes.
- */
-const INFERRED_LINKS_HELP =
-	"Connect notes by meaning as well as by the links you wrote, so unlinked notes still find a topic. Turn it off to see what your own linking covers on its own. Requires a graph embedding index.";
-
-/**
- * The live result of the current state — a measurement, not help. Stays inline
- * (`showDesc`) because it is the payoff for flipping the toggle: watching the
- * coverage drop is the whole point of turning inferred links off.
+ * What the control does, plus the live result of its current state.
  *
- * Returns "" when there is nothing measured to report, so the row collapses back
- * to a plain toggle instead of holding a line for restated help.
+ * Delivered as one description through the row's normal hover tooltip, exactly
+ * like every other compact setting here. An earlier version split these — help
+ * behind an info icon, measurement inline under the toggle — which gave this one
+ * row two affordances no other row had, and put a paragraph in a column of
+ * single-line switches. The measurement is worth reading, but not worth breaking
+ * the shape of the panel for; a user who wants the number is already hovering
+ * the control they just flipped.
  */
 let inferredLinksHint = $derived.by(() => {
 	const total = graphData.nodes.length;
@@ -162,18 +155,18 @@ let inferredLinksHint = $derived.by(() => {
 		// Only report link coverage when topics really are link-only. A stored
 		// half-state (hidden but still grouping) would make that number a lie.
 		if (!settings.linkOnlyTopics) {
-			return "Hidden, but still grouping notes. Toggle twice to exclude them from topics as well";
+			return "Hidden, but still grouping notes. Toggle twice to exclude them from topics as well.";
 		}
-		if (total === 0) return "";
+		if (total === 0) return "Off — topics come from the links you wrote.";
 		const placed = graphData.nodes.filter((n) => n.cluster != null).length;
 		const percent = Math.round((placed / total) * 100);
-		return `Your links alone group ${placed} of ${total} notes (${percent}%). The other ${total - placed} are unlinked.`;
+		return `Off — topics come from the links you wrote. Your links alone group ${placed} of ${total} notes (${percent}%); the other ${total - placed} are unlinked.`;
 	}
 	const inferred = graphData.edges.filter((e) => e.type === "semantic").length;
-	// No index yet: there is no measurement to show, and the reason lives in the
-	// info tooltip alongside the rest of the explanation.
-	if (inferred === 0) return "";
-	return `Adding ${inferred} similarity connections so unlinked notes still find a topic.`;
+	if (inferred === 0) {
+		return "Connect notes by meaning as well as by the links you wrote — needs a graph embedding index.";
+	}
+	return `Connect notes by meaning as well as by the links you wrote: ${inferred} similarity connections so unlinked notes still find a topic. Turn off to see what your own links cover.`;
 });
 
 function handleLinkDistanceChange(val: number) {
@@ -427,14 +420,11 @@ $effect(() => {
            graph (drawn *and* grouping notes) or absent. Splitting "draw" from
            "count" allowed a state where hidden edges silently decided the topics.
 
-           The explanation lives behind the info icon; only the live measurement
-           stays inline (`showDesc`), and `inferredLinksHint` returns "" when
-           there is nothing measured — so the row holds a line for a number worth
-           reading, never for restated help. -->
-      <SettingContainer name="Inferred links" desc={inferredLinksHint} compact showDesc>
-        {#snippet nameSuffix()}
-          <span class="info-icon" aria-label={INFERRED_LINKS_HELP} use:icon={"info"}></span>
-        {/snippet}
+           A plain compact row like every other setting here: `inferredLinksHint`
+           folds the live measurement into the same hover description, so the
+           number is still there without this row growing an extra line and an
+           affordance nothing else in the panel has. -->
+      <SettingContainer name="Inferred links" desc={inferredLinksHint} compact>
         <Toggle
           checked={!(settings.linkOnlyTopics ?? false) && (settings.showSemanticLinks ?? true)}
           onchange={(value) =>
@@ -812,24 +802,6 @@ $effect(() => {
     font-size: var(--font-ui-small);
     color: var(--text-faint);
     padding-right: 4px;
-  }
-
-  /* Carries the static explanation as a tooltip, so the row keeps its inline
-     line for the live measurement instead. Faint at rest and only resolving on
-     hover — it is an affordance for help that is there when wanted, not a mark
-     competing with the setting's own name. */
-  .info-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: var(--icon-xs);
-    height: var(--icon-xs);
-    color: var(--text-faint);
-    cursor: help;
-  }
-
-  .info-icon:hover {
-    color: var(--text-muted);
   }
 
   .section-label--with-action {

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -87,6 +87,10 @@ let {
 let isCollapsed = $state(true);
 let isDevCollapsed = $state(true);
 
+/** Defaulted here rather than in the template — settings persisted before this
+ *  toggle existed have no value for it, and topics-on is the established behaviour. */
+let showTopics = $derived(settings.showTopics ?? true);
+
 /**
  * Live height of the main panel, so the dev panel can stack directly beneath
  * it. Measured rather than assumed: the panel grows and shrinks as sections
@@ -269,7 +273,15 @@ $effect(() => {
 });
 </script>
 
-<!-- Unified vertical toolbar -->
+<!--
+  Unified vertical toolbar.
+
+  Icons are `m` (18px), not Button's `s` (16px) default. This rail is a standing
+  stack of tool toggles floating over the canvas — the same pattern as Obsidian's
+  ribbon and nav-action buttons, which are 18px/30px. The 16px default matches
+  view-header actions instead, which is a different, denser pattern, and at this
+  size the rail read as undersized against the canvas.
+-->
 <div class="graph-toolbar">
   <Button iconId="maximize" onClick={onFitToView} tooltip={fitTooltip} />
   <Button
@@ -278,15 +290,28 @@ $effect(() => {
     onClick={() => onLassoModeChange?.(!lassoMode)}
     styles={lassoMode ? "is-active" : ""}
   />
+  <!-- Show/hide detected topics. Display-only, so flipping it is instant and the
+       graph underneath is unchanged — that's what makes it readable as "here is
+       what the clustering added". -->
   <Button
-    iconId="atom"
+    iconId={showTopics ? "shapes" : "circle-dashed"}
+    tooltip={showTopics
+      ? "Hide topics — show the raw graph without clustering"
+      : "Show topics — colour notes by their detected topic"}
+    onClick={() => onSettingsChange({ showTopics: !showTopics })}
+    styles={showTopics ? "is-active" : ""}
+  />
+  <Button
+    iconId={isTopicsCollapsed ? "ungroup" : "group"}
     tooltip={isLeidenRunning
       ? "Computing topics…"
-      : isTopicsCollapsed
-        ? "Expand all topics back into notes (S)"
-        : "Collapse all topics into single nodes (S) — or select topics and use Collapse"}
+      : !showTopics
+        ? "Turn topics on to collapse them"
+        : isTopicsCollapsed
+          ? "Expand all topics back into notes (S)"
+          : "Collapse all topics into single nodes (S) — or select topics and use Collapse"}
     onClick={() => onToggleCollapseAll?.()}
-    disabled={isLeidenRunning}
+    disabled={isLeidenRunning || !showTopics}
     styles={isTopicsCollapsed ? "is-active" : ""}
   />
   <div class="toolbar-icon-wrapper">
@@ -631,6 +656,29 @@ $effect(() => {
     flex-direction: column;
     gap: 6px;
     z-index: 11;
+  }
+
+  /* Sized here rather than via Button's `iconSize` prop: for an icon-only button
+     that prop also pins width/height to the icon size as an inline style, which
+     would shrink the click target to 18px — a bigger glyph on a smaller thing to
+     hit. Setting both from CSS keeps them independent.
+
+     18px/30px matches Obsidian's ribbon and nav-action buttons. This rail is that
+     pattern — a standing stack of tool toggles — not the denser 16px/28px
+     view-header strip that Button defaults to. */
+  .graph-toolbar :global(button.clickable-icon) {
+    width: 30px;
+    height: 30px;
+  }
+
+  .graph-toolbar :global(button.clickable-icon .s2b-button-icon) {
+    width: var(--icon-m);
+    height: var(--icon-m);
+  }
+
+  .graph-toolbar :global(button.clickable-icon svg) {
+    width: var(--icon-m);
+    height: var(--icon-m);
   }
 
   /* These render at 30x26 — well under the touch floor, and they're the only

--- a/src/components/graph/NoteContextView.svelte
+++ b/src/components/graph/NoteContextView.svelte
@@ -293,7 +293,15 @@ onDestroy(() => {
 });
 </script>
 
-<div class="note-context" data-testid="note-context-root">
+<!-- Graph shortcuts are bound at the view root rather than on the canvas, so they
+     stay live when focus sits on a control elsewhere in this view. Matches
+     SmartGraphView; keydown only fires for focus inside this subtree. -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="note-context"
+  data-testid="note-context-root"
+  onkeydown={(e) => canvasComponent?.handleKeyDown(e)}
+>
   <div class="note-context__surface">
     <div class="note-context__overlay">
       {#if isLoadingSemantic}

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -1087,6 +1087,12 @@ function handleSettingsChange(partial: Partial<SmartGraphSettings>) {
 	if (partial.leidenResolution !== undefined) {
 		setCachedResolution(graphTopologySignature(graphData), partial.leidenResolution);
 	}
+	// Topics are applied in `resolveAndApplySegments`, which nothing re-runs on its
+	// own — repaint from the communities already in hand. Deliberately not a Leiden
+	// run: this toggle is display-only, so both directions are just a re-colour.
+	if (partial.showTopics !== undefined) {
+		resolveAndApplySegments(graphData);
+	}
 }
 
 function handleFolderFilterChange(folders: string[]) {
@@ -1686,7 +1692,11 @@ function handleFocusSegment(segmentId: string, multi: boolean) {
  */
 function resolveAndApplySegments(gd: GraphData) {
 	const themeColors = resolveThemeColors();
-	const resolved = resolveSegments(plugin.app, gd, "leiden", {
+	// `"none"` resolves to no segments, which strips every node's colour and
+	// cluster below — the whole effect of the topics toggle. Suppressing it here
+	// rather than skipping the Leiden run keeps `leidenCommunities` intact, so
+	// turning topics back on is a re-render rather than a recompute.
+	const resolved = resolveSegments(plugin.app, gd, (settings.showTopics ?? true) ? "leiden" : "none", {
 		clusterMap: new Map(),
 		clusterLabels: effectiveClusterLabels,
 		themeColors,
@@ -2178,16 +2188,26 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
     <div class="graph-selection-bar">
       <span class="selection-count">
         {#if selectedPaths.length > 0}
-          {selectedPaths.length} notes selected{isImmersed ? " · immersed" : ""}
+          <strong>{selectedPaths.length}</strong>
+          {selectedPaths.length === 1 ? "note" : "notes"} selected{isImmersed ? " · immersed" : ""}
         {:else}
-          {graphData.nodes.length} notes · immersed
+          <strong>{graphData.nodes.length}</strong>
+          {graphData.nodes.length === 1 ? "note" : "notes"} · immersed
         {/if}
       </span>
+      <!-- Left of the divider with the count: this moves the camera, it doesn't
+           act on the notes the way the verbs on the right do. Grouping it with
+           the count keeps that split legible, and leaves both icon-only buttons
+           bracketing the labelled actions rather than sitting among them. -->
+      {#if selectedPaths.length > 0}
+        <Button iconId="scan" onClick={handleZoomToSelection} tooltip="Zoom to selection (F)" />
+      {/if}
+      <div class="selection-divider"></div>
       <div class="selection-actions">
         {#if selectedPaths.length > 0}
-          <Button iconId="scan" onClick={handleZoomToSelection} tooltip="Zoom to selection (F)" />
           {#if selectedTopicsCollapseAction !== null}
             <Button
+              iconId={selectedTopicsCollapseAction === "collapse" ? "fold-vertical" : "unfold-vertical"}
               buttonText={selectedTopicsCollapseAction === "collapse" ? "Collapse" : "Expand"}
               onClick={() => void handleCollapseSelectedTopics()}
               tooltip={withKey(
@@ -2199,23 +2219,29 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
             />
           {/if}
           <Button
+            iconId="scan-search"
             buttonText="Immerse"
             onClick={handleImmerse}
             tooltip={withKey("Rebuild graph with selected notes only", "I")}
           />
-          <Button
-            buttonText="Open all"
-            onClick={handleOpenAllSelected}
-            tooltip={withKey("Open all selected notes in new tabs", "O")}
-          />
           {#if !hasOpenChat}
             <Button
+              iconId="message-square"
               buttonText="Open in chat"
               onClick={handleSendToChat}
               tooltip={withKey("Reveal the chat and attach the selected notes", "A")}
             />
           {/if}
-          <Button buttonText="Clear" onClick={handleClearSelection} tooltip="Clear selection (Esc)" />
+          <Button
+            iconId="copy-plus"
+            buttonText="Open all"
+            onClick={handleOpenAllSelected}
+            tooltip={withKey("Open all selected notes in new tabs", "O")}
+          />
+
+          <!-- Icon-only: dismissing isn't one of the verbs you came here for, so
+               it reads as an affordance on the bar rather than a peer action. -->
+          <Button iconId="x" onClick={handleClearSelection} tooltip="Clear selection (Esc)" />
         {:else}
           <Button buttonText="Exit" onClick={handleExitImmerse} tooltip="Exit immerse (Esc)" />
         {/if}
@@ -2288,30 +2314,71 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
 
   .graph-selection-bar {
     position: absolute;
-    bottom: 12px;
+    /* Clear Obsidian's status bar, which floats over the bottom-right of the
+       canvas — at the previous 12px the two overlapped and the word/backlink
+       counts collided with the bar's own buttons. */
+    bottom: 34px;
     left: 50%;
     transform: translateX(-50%);
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 8px 16px;
-    background: var(--background-primary);
+    gap: 10px;
+    padding: 6px 8px 6px 14px;
+    /* Secondary background + native shadow token, so the bar reads as a floating
+       surface the way Obsidian's own popovers do rather than as a flat card that
+       tracks the canvas colour. */
+    background: var(--background-secondary);
     border: 1px solid var(--background-modifier-border);
-    border-radius: 8px;
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+    /* `--radius-l` (12px) rather than the composer's literal 22px: that 22px is
+       half the composer's height — a pill — not a house rounding, and it only
+       reads as one at that height. 12px is Obsidian's own value for floating
+       panels, and being a token it tracks whatever the user's theme defines. */
+    border-radius: var(--radius-l);
+    box-shadow: var(--shadow-l);
     z-index: 12;
     white-space: nowrap;
+    animation: s2b-selection-bar-in 120ms ease-out;
+  }
+
+  /* Slide up a touch on appear — the bar shows up in response to a selection
+     made elsewhere on the canvas, so a little motion draws the eye to it. */
+  @keyframes s2b-selection-bar-in {
+    from {
+      opacity: 0;
+      transform: translateX(-50%) translateY(6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
   }
 
   .selection-count {
-    font-size: 13px;
-    font-weight: 500;
+    font-size: var(--font-ui-small);
+    font-weight: var(--font-medium);
+    color: var(--text-muted);
+  }
+
+  /* The number is the thing being acted on, so it carries the emphasis while the
+     surrounding words stay muted. */
+  .selection-count :global(strong) {
     color: var(--text-normal);
+    font-weight: var(--font-semibold);
   }
 
   .selection-actions {
     display: flex;
-    gap: 6px;
+    align-items: center;
+    gap: 4px;
+  }
+
+  /* Separates the count and its view control from the verbs acting on the notes. */
+  .selection-divider {
+    width: 1px;
+    align-self: stretch;
+    margin: 2px 0;
+    background: var(--background-modifier-border);
+    flex-shrink: 0;
   }
 
   /* On a phone the centered, nowrap bar overflows both screen edges — the

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -2232,8 +2232,11 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
       <div class="selection-actions">
         {#if selectedPaths.length > 0}
           {#if selectedTopicsCollapseAction !== null}
+            <!-- Same chevrons as the toolbar's collapse-all: this is that action
+                 scoped to a selection rather than a different one, so it should
+                 not carry a different glyph. -->
             <Button
-              iconId={selectedTopicsCollapseAction === "collapse" ? "fold-vertical" : "unfold-vertical"}
+              iconId={selectedTopicsCollapseAction === "collapse" ? "chevrons-down-up" : "chevrons-up-down"}
               buttonText={selectedTopicsCollapseAction === "collapse" ? "Collapse" : "Expand"}
               onClick={() => void handleCollapseSelectedTopics()}
               tooltip={withKey(

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -325,6 +325,13 @@ let selectedTopicsCollapseAction: "collapse" | "expand" | null = $derived.by(() 
 
 /** The graph as rendered: topics collapsed to single nodes, or as-is. */
 let displayGraphData: GraphData = $derived.by(() => {
+	// Collapsing is meaningless with topics hidden: every node is unsorted, so
+	// folding would merge the whole graph into one "Unsorted · N" node instead of
+	// showing the raw view the toggle is for. `handleSettingsChange` already
+	// clears the folds when topics are switched off, but this guard is what makes
+	// the bad state unreachable — any other path that leaves collapse state set
+	// (a restored setting, a rebuild) can't resurrect it.
+	if (!(settings.showTopics ?? true)) return graphData;
 	if (effectiveCollapsedTopics.size === 0) return graphData;
 	return buildCollapsedGraph(graphData, {
 		collapsedTopics: effectiveCollapsedTopics,
@@ -1091,6 +1098,18 @@ function handleSettingsChange(partial: Partial<SmartGraphSettings>) {
 	// own — repaint from the communities already in hand. Deliberately not a Leiden
 	// run: this toggle is display-only, so both directions are just a re-colour.
 	if (partial.showTopics !== undefined) {
+		// Hiding topics strips every node's cluster, so `allTopicIds` collapses to
+		// the single UNSORTED sentinel. Left standing, collapse-all would then fold
+		// the entire graph into one "Unsorted · N" node — the opposite of the raw
+		// view this toggle exists to show — and the collapse control is disabled
+		// while topics are hidden, so it couldn't be undone from the toolbar.
+		// There are no topics to be collapsed in this state, so drop the folds
+		// outright rather than carrying them into a view they can't describe.
+		if (partial.showTopics === false) {
+			collapseAll = false;
+			collapsedTopics = new Set();
+			expandedTopics = new Set();
+		}
 		resolveAndApplySegments(graphData);
 	}
 }

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -2161,7 +2161,14 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
 }
 </script>
 
-<div class="smart-graph-view">
+<!-- Keydown sits on the whole view, not just the canvas: selecting a topic from
+     the settings panel moves focus to that panel row, and a canvas-scoped
+     listener meant the selection-bar shortcuts went dead exactly when a
+     selection existed. Keydown still only fires for focus inside this subtree,
+     so this widens the shortcuts to the graph leaf without claiming keys
+     globally. `GraphCanvas.handleKeyDown` already ignores text inputs. -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="smart-graph-view" onkeydown={(e) => canvasComponent?.handleKeyDown(e)}>
   {#if isLoading && graphData.nodes.length === 0}
     <div class="graph-loading">
       <LoadingAnimation />

--- a/src/components/graph/pixiRenderer.ts
+++ b/src/components/graph/pixiRenderer.ts
@@ -729,9 +729,23 @@ export class PixiRenderer {
 			let strokeWidth = 0;
 			if (isSelected) {
 				strokeColor = c.accent;
-				strokeWidth = 3 / scale;
+				// Same weight as the hover/highlight ring below: the dimming of
+				// everything unselected already carries the selection, so this ring
+				// only has to confirm it. Heavier, it read as a crust on the node
+				// rather than a marker on it, and a large lasso became a wall of rings.
+				strokeWidth = 2 / scale;
 			} else if (node.highlighted || isHovered) {
-				strokeColor = isHovered ? c.textNormal : c.accent;
+				// Accent, matching selection — `textNormal` used to draw this ring, but
+				// that's the theme's *maximum* contrast: near-white on dark themes and
+				// near-black (#222) on light ones, where it read as a hard black
+				// outline rather than a highlight.
+				//
+				// The exception is hovering an already-highlighted node, which is a
+				// normal state rather than a rare one (bridge/isolated highlighting is
+				// a persistent property, not a transient). Those nodes are *filled*
+				// with accent, so an accent ring on them would vanish into the fill —
+				// they take `textMuted`, which contrasts on either theme polarity.
+				strokeColor = isHovered && node.highlighted ? c.textMuted : c.accent;
 				strokeWidth = 2 / scale;
 			}
 
@@ -890,15 +904,24 @@ export class PixiRenderer {
 		const scale = this.viewport.scaled || 1;
 		const normalWidth = 1.2 / scale;
 		const highlightWidth = 1.6 / scale;
-		// Inferred edges read as a quieter background layer behind authored links.
-		const semanticWidth = 0.9 / scale;
-		const semanticAlphaScale = 0.45;
+		// Inferred edges carry the same colour weight as authored ones — same
+		// width, same alpha, same `c.graphLine`. The dash pattern already tells the
+		// two apart, so dimming them as well (they were 0.9px at 0.45 alpha) only
+		// made them hard to see at all; the inferred structure is worth reading,
+		// not just hinting at.
+		const semanticWidth = normalWidth;
 		const dash = 5 / scale;
 		const dashGap = 4 / scale;
 
 		// Dashed segments can't share the batched line buckets (each needs its own
 		// sub-path walk), so they collect separately and draw underneath.
 		const semanticLineBuckets = new Map<string, Array<{ sx: number; sy: number; tx: number; ty: number }>>();
+		// Hovered inferred edges, kept apart so the density fallback below can leave
+		// them dashed while the bulk layer goes solid.
+		const highlightSemanticLineBuckets = new Map<
+			string,
+			Array<{ sx: number; sy: number; tx: number; ty: number }>
+		>();
 
 		// Loop-invariant: the base alpha is tuned for the overview, lifted as the
 		// camera zooms in (where few edges are on screen to crowd each other).
@@ -973,10 +996,7 @@ export class PixiRenderer {
 			const rawAlpha =
 				(!inFocus ? 0.05 : !inSelection ? 0.05 : isHighlighted ? 0.9 : safeBaseEdgeAlpha) *
 				safeEdgeFadeAlpha *
-				(isHighlighted ? 1 : edgeHoverAlpha / 0.85) *
-				// Fade inferred edges unless they're the ones being hovered, so hovering a
-				// note still reveals why it sits where it does.
-				(isSemantic && !isHighlighted ? semanticAlphaScale : 1);
+				(isHighlighted ? 1 : edgeHoverAlpha / 0.85);
 
 			// Quantize alpha to reduce unique buckets (round to nearest 0.05)
 			const alpha = clampUnitInterval(Math.round(rawAlpha * 20) / 20, 0);
@@ -994,10 +1014,15 @@ export class PixiRenderer {
 			const key = `${color}|${width.toFixed(4)}|${alpha.toFixed(2)}`;
 
 			if (isSemantic) {
-				let semanticBucket = semanticLineBuckets.get(key);
+				// Hovered inferred edges keep their dashes even when the rest of the
+				// layer has fallen back to solid: a hover reveals a handful of edges,
+				// so the per-dash cost is trivial there, and it's the one moment the
+				// user is asking "authored or inferred?" about a specific connection.
+				const target = isHighlighted ? highlightSemanticLineBuckets : semanticLineBuckets;
+				let semanticBucket = target.get(key);
 				if (!semanticBucket) {
 					semanticBucket = [];
-					semanticLineBuckets.set(key, semanticBucket);
+					target.set(key, semanticBucket);
 				}
 				semanticBucket.push({ sx, sy, tx, ty });
 				// Arrowheads denote authored direction; an inferred similarity has none.
@@ -1076,13 +1101,17 @@ export class PixiRenderer {
 			}
 		};
 
-		const drawDashedBuckets = (buckets: Map<string, Array<{ sx: number; sy: number; tx: number; ty: number }>>) => {
+		const drawDashedBuckets = (
+			buckets: Map<string, Array<{ sx: number; sy: number; tx: number; ty: number }>>,
+			/** Draw dashes regardless of density — used for the few hovered edges. */
+			alwaysDash = false,
+		) => {
 			// Past the limit, dashes cost more than they communicate — draw the
 			// whole inferred layer as quieter solid strokes instead (see
 			// SEMANTIC_DASH_EDGE_LIMIT).
 			let totalEdges = 0;
 			for (const segments of buckets.values()) totalEdges += segments.length;
-			const asSolid = totalEdges > SEMANTIC_DASH_EDGE_LIMIT;
+			const asSolid = !alwaysDash && totalEdges > SEMANTIC_DASH_EDGE_LIMIT;
 
 			for (const [key, segments] of buckets) {
 				const [color, widthStr, alphaStr] = key.split("|");
@@ -1113,6 +1142,8 @@ export class PixiRenderer {
 			drawArrowBuckets(normalArrowBuckets);
 		}
 		drawLineBuckets(highlightLineBuckets);
+		// Hovered inferred edges join the highlighted tier, still dashed.
+		drawDashedBuckets(highlightSemanticLineBuckets, true);
 		if (opts.directedWikiEdges) {
 			drawArrowBuckets(highlightArrowBuckets);
 		}

--- a/src/components/settings/SettingContainer.svelte
+++ b/src/components/settings/SettingContainer.svelte
@@ -10,12 +10,6 @@ interface Props {
 	isDisabled?: boolean;
 	/** When true, hides the description text and shows it as a tooltip on the name instead. */
 	compact?: boolean;
-	/**
-	 * Force the description to render inline even in `compact` rows. Use this when
-	 * the description is a *computed result* rather than static help — a value the
-	 * user is meant to read is not something to hide behind a hover.
-	 */
-	showDesc?: boolean;
 	children?: import("svelte").Snippet;
 }
 
@@ -28,7 +22,6 @@ let {
 	disabled = false,
 	isDisabled = false,
 	compact = false,
-	showDesc = false,
 	children,
 	class: className = "",
 }: Props = $props();
@@ -39,12 +32,10 @@ const isRowDisabled = $derived(disabled || isDisabled);
 <div
   class="setting-item {isHeading ? 'setting-item-heading' : ''} {isRowDisabled
     ? 'opacity-50 pointer-events-none'
-    : ''} {compact ? 'setting-item--compact' : ''} {compact && showDesc
-    ? 'setting-item--show-desc'
-    : ''} {className}"
+    : ''} {compact ? 'setting-item--compact' : ''} {className}"
 >
   <div class="setting-item-info">
-    <div class="setting-item-name" aria-label={compact && desc && !showDesc ? desc : undefined}>
+    <div class="setting-item-name" aria-label={compact && desc ? desc : undefined}>
       {#if namePrefix}
         <span class="setting-item-name-prefix">{@render namePrefix()}</span>
       {/if}
@@ -61,11 +52,6 @@ const isRowDisabled = $derived(disabled || isDisabled);
   <div class="setting-item-control">
     {@render children?.()}
   </div>
-  <!-- Compact rows are too narrow for name + description + control on one line,
-       so the description wraps onto its own line as a sibling of both. -->
-  {#if compact && showDesc && desc}
-    <div class="setting-item-description">{desc}</div>
-  {/if}
 </div>
 
 <style>
@@ -97,25 +83,9 @@ const isRowDisabled = $derived(disabled || isDisabled);
     align-self: center;
   }
 
-  /* Only hint at a tooltip when there actually is one — a row showing its
-     description inline has nothing hidden to reveal. */
-  .setting-item--compact:not(.setting-item--show-desc) .setting-item-name {
+  /* A compact row always carries its description as a tooltip on the name, so
+     the name always hints that there is something to reveal. */
+  .setting-item--compact .setting-item-name {
     cursor: help;
-  }
-
-  /* A compact row is narrow: name, description and control cannot share one line
-     without the name wrapping to a hard-to-read column. Drop the description onto
-     its own full-width line beneath the name/control row instead. */
-  .setting-item--show-desc {
-    flex-wrap: wrap;
-  }
-
-  .setting-item--show-desc .setting-item-description {
-    flex-basis: 100%;
-    font-size: var(--font-ui-smaller);
-    line-height: 1.35;
-    margin-top: 4px;
-    white-space: normal;
-    text-wrap: pretty;
   }
 </style>

--- a/src/components/ui/RangeSlider.svelte
+++ b/src/components/ui/RangeSlider.svelte
@@ -42,7 +42,7 @@ function handleChange(e: Event) {
 	{/if}
 	<input
 		type="range"
-		class="w-full h-1 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+		class="s2b-range w-full cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
 		{value}
 		{min}
 		{max}
@@ -52,3 +52,41 @@ function handleChange(e: Event) {
 		onchange={handleChange}
 	/>
 </div>
+
+<style>
+	/*
+	 * `touch-action: none` is the load-bearing line on mobile.
+	 *
+	 * Obsidian's mobile CSS leaves range inputs at `touch-action: manipulation`,
+	 * which declares "this element does not handle panning" — so a horizontal drag
+	 * on the slider is handed to Obsidian's sidebar-swipe gesture instead of moving
+	 * the thumb. Dragging the granularity slider opened the sidebar rather than
+	 * changing the value. Claiming the gesture here keeps the drag with the
+	 * control the finger is actually on.
+	 *
+	 * `pan-y` rather than `none`: the panel this lives in scrolls vertically and
+	 * is taller than a phone screen, so a slider that swallowed both axes would
+	 * become a dead zone you cannot scroll past. Horizontal goes to the thumb,
+	 * vertical still scrolls the panel.
+	 *
+	 * Deliberately no track or thumb styling: Obsidian paints the track through
+	 * `background` on the input itself, and overriding it here would drop the
+	 * user's theme for a hand-rolled slider. Only the touch behaviour changes.
+	 */
+	.s2b-range {
+		touch-action: pan-y;
+	}
+
+	/* A 6px-tall element is thinner than a fingertip, so most taps missed it
+	   outright. A transparent border enlarges the hit area without entering the
+	   background painting area, so Obsidian's track keeps drawing exactly as the
+	   theme intended — `padding` + `background-clip: content-box` was tried first
+	   and erased the rail, leaving a thumb floating over nothing. Mobile only: a
+	   mouse is precise enough, and the extra height would loosen the desktop
+	   panel's rhythm. */
+	:global(.is-mobile) .s2b-range {
+		border-top: 10px solid transparent;
+		border-bottom: 10px solid transparent;
+		box-sizing: content-box;
+	}
+</style>

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -210,6 +210,15 @@ export interface SmartGraphSettings {
 	showClusterLabels: boolean;
 	/** Whether to draw a tinted region behind each topic's notes */
 	showTopicHulls: boolean;
+	/**
+	 * Whether detected topics are applied to the view at all.
+	 *
+	 * Display-only: Leiden still runs and `leidenCommunities` stays populated, so
+	 * flipping this is instant and costs no recompute. Off, every note renders in
+	 * the default node colour with no regions or labels — which is the point, it's
+	 * the before/after that shows what the clustering actually contributed.
+	 */
+	showTopics: boolean;
 }
 
 /**
@@ -250,6 +259,7 @@ export const DEFAULT_SMART_GRAPH_SETTINGS: SmartGraphSettings = {
 	highlightBridges: false,
 	showClusterLabels: true,
 	showTopicHulls: true,
+	showTopics: true,
 };
 
 /**


### PR DESCRIPTION
Visual pass over the smart graph. Most of this started as "that looks a bit off" and turned into a specific cause worth naming.

## Labels

**Flashing while panning.** The occlusion lattice was anchored to the *screen*, so panning slid every label across fixed cell boundaries — two labels that never visually overlapped could share a cell at one camera offset and not the next, re-rolling which one won on every frame. The lattice is now anchored to the **world origin**, so it moves with the graph and contention outcomes hold still under a pan.

**Clutter.** Ordinary nodes now have a label budget, spent in degree order so hubs keep their captions. The old screen-radius gate barely discriminated: `nodeDrawRadius` is `log1p(degree)`-shaped, so a degree-3 note and a degree-30 hub differ by ~2px and nearly everything cleared the threshold together.

- Small graphs (≤60 nodes) skip the budget entirely — no contention to resolve, and capping there only hid labels that fit fine.
- The zoom lift is **stepped with hysteresis** rather than continuous. A budget that slides by one label at a time flips exactly one caption per frame as the camera moves, which was its own flicker.

**Flashing while the layout settles.** Ordinary labels now fade out while the simulation is still moving — once nodes move relative to each other the flicker is genuine rather than an artefact, and mid-settle captions aren't readable anyway. Hover, highlight and cluster-representative labels are exempt, since those answer a direct question and must respond immediately.

Also fixes `canDrawLabel` clamping off-screen labels onto edge cells and returning `true`. Harmless before; with a budget they spent slots while painting nothing.

## Recluster transition

A one-time push-apart, seconds after the migration appeared to finish. The 3× cohesion boost was handed back in a single step at alpha 0.02 — but the sim still had ~2.5s of ticks left, and clusters compressed under the boost sprang outward once charge repulsion suddenly dominated. The boost now eases out across the whole transition on a smoothstep, so releasing it is part of the same settle rather than a second animation.

## Topics toggle

New toolbar toggle to show/hide detected topics — the before/after makes it legible what the clustering actually contributed.

Mostly wiring something that already existed: `SegmentBy` already had `"none"` and `resolveSegments` already honoured it, but `segmentBy` was a declared setting nothing ever read, with `"leiden"` hardcoded at the single call site.

Display-only, so flipping it repaints from the communities already in hand rather than re-running Leiden. Collapse-all disables itself while topics are hidden, since there's nothing to fold.

## Edges and rings

- Inferred edges now carry the **same colour weight** as authored ones. The dash already distinguishes them; dimming as well (0.9px at 0.45 alpha) left them barely visible.
- Hovered inferred edges keep their dashes even where the density fallback draws the bulk layer solid — a hover reveals a handful of edges, so the per-dash cost is trivial exactly where the distinction matters.
- The hover ring used `--text-normal`, the theme's *maximum* contrast: near-white on dark themes but `#222` on light ones, where it read as a hard black outline. Now the accent — except on highlighted nodes, which are already *filled* with the accent and would lose the ring entirely.
- Selection ring 3px → 2px, matching hover.

## Selection bar

- **Cleared Obsidian's status bar** — measured a real 15px overlap; the word/backlink counts collided with the bar's buttons.
- Native tokens (`--background-secondary`, `--shadow-l`, `--radius-l`) replacing hardcoded values tuned for dark themes.
- Bold count with correct pluralisation (previously always "notes", so "1 notes selected").
- Icons on the verbs, `Clear` as icon-only, and the camera control moved left of the divider — it moves the view, it doesn't act on the notes the way the other verbs do.
- Graph control rail bumped to 18px/30px, matching Obsidian's ribbon and nav-action buttons rather than the denser view-header strip.

## Testing

`bun run check`, `bun run format` and `bun run build` all clean. Each change was verified live in the test vault as it went in — including the ones that turned out to be regressions from an earlier step in this same branch (the zoom-scaled label budget, and my first attempt at the boost handback).

## Settings panel

The two existing sections had a stated split — Topics decides *which topics exist*, Display decides *how they're drawn* — that didn't hold. Most visibly, **`Markdown only` sat under Display** while being the most consequential control in the panel: it changes which notes are in the graph at all, and therefore what there is to group.

Split **Scope** out as its own section, so each heading names what its controls actually change. Ordered by how often they're reached rather than by pipeline stage — Scope is usually set once and left alone, so leading with it would push the everyday controls down the panel:

| Section | Controls |
|---|---|
| **Topics** | Granularity, Inferred links, the found-topics list |
| **Scope** | Markdown only |
| **Display** | Topic regions, Topic labels, Direction arrows, Highlight isolated, Highlight bridges |

Topics opening the panel also puts the found-topics list directly under the settings that produce it.

**`Inferred links` gets an info icon.** Every other compact row already hides its description behind a hover tooltip; this row opted out because its text is a *live measurement* rather than static help — and that number is the payoff for turning the toggle off. Both were true at once, which is why the row was carrying a paragraph.

So the two are now separated: the explanation moves behind the icon, the measurement stays inline, and the hint returns `""` when there's nothing measured. The row holds a line for a number worth reading, never for restated help.


## Keyboard shortcuts

Keydown was bound to the canvas container, so shortcuts only fired while that element held focus. Selecting a topic from the settings panel makes a selection **and** moves focus to the panel row — so the selection-bar verbs (`I`/`O`/`A`/`C`) went dead exactly when there was finally something to use them on, and clicking back onto the canvas to restore focus cleared the selection. A dead end with no way out.

The handler is now bound at the **view root**, which wraps the canvas, the panel and the selection bar. Keydown still only fires for focus inside that subtree, so this widens the shortcuts to the graph leaf without claiming keys globally. The canvas-level binding is removed so it can't fire twice as the event bubbles.

Shortcuts reaching the panel means they can also reach its controls, so the handler additionally bails on any focused `input`, `[role="slider"]` or `contenteditable` — otherwise arrowing the Granularity slider would step granularity twice, once through the slider and once through the shortcut.

`NoteContextView` mounts its own `GraphCanvas` and gets the same wiring. It's disabled for the initial release so this is dormant, but left as-was it would have silently lost its shortcuts.



## Mobile: range slider touch handling

Obsidian's mobile CSS leaves range inputs at `touch-action: manipulation`, which declares "this element does not handle panning" — so a horizontal drag on the granularity slider was handed to Obsidian's **sidebar-swipe gesture** instead of moving the thumb. Dragging the slider opened the sidebar rather than changing the value.

Set to `pan-y` rather than `none`: the settings panel scrolls vertically and is taller than a phone screen, so a slider that swallowed both axes would become a dead zone you couldn't scroll past. Horizontal goes to the thumb, vertical still scrolls the panel.

The element was also only **6px tall** — thinner than a fingertip, so most taps missed it outright. A transparent border takes the hit area to **26px** without entering the background painting area, so Obsidian's track keeps drawing as the theme intended. (`padding` + `background-clip: content-box` was tried first and erased the rail, leaving the thumb floating over nothing — caught in a screenshot.)

Mobile only; a mouse is precise enough and the extra height would loosen the desktop panel's rhythm.

**Not fixed here:** the panel's *modality* on mobile is still a desktop popover at 79%×76% of the viewport, covering the graph it configures. Split out as #418.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._