### PR TITLE
feat(graph): bottom sheets for the settings panel and selection bar on mobile

### DIFF
--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -60,6 +60,10 @@ interface Props {
 	 * be able to take the sheet slot over (only one sheet at a time).
 	 */
 	isCollapsed?: boolean;
+	/** True while the graph is rebuilt from a subset of notes. */
+	isImmersed?: boolean;
+	/** Leave immerse and return to the full graph. */
+	onExitImmerse?: () => void;
 }
 
 let {
@@ -90,6 +94,8 @@ let {
 	isTopicsCollapsed = false,
 	onToggleCollapseAll,
 	isCollapsed = $bindable(true),
+	isImmersed = false,
+	onExitImmerse,
 }: Props = $props();
 
 let isDevCollapsed = $state(true);
@@ -301,6 +307,20 @@ $effect(() => {
   size the rail read as undersized against the canvas.
 -->
 <div class="graph-toolbar">
+  <!-- Immersion's exit lives on the rail rather than in a sheet, because it is a
+       mode rather than a transient result: it persists while you pan, select and
+       immerse further, so its control has to persist too without covering the
+       canvas. Only shown while immersed — a rail button that did nothing the
+       rest of the time would be worse than no button. Accented so the rail also
+       answers "why am I only seeing some of my notes?". -->
+  {#if isImmersed}
+    <Button
+      iconId="log-out"
+      onClick={() => onExitImmerse?.()}
+      tooltip={onMobile ? "Exit immerse — back to the full graph" : "Exit immerse (Esc)"}
+      styles="is-active"
+    />
+  {/if}
   <Button iconId="maximize" onClick={onFitToView} tooltip={fitTooltip} />
   <Button
     iconId="lasso"

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -727,11 +727,29 @@ $effect(() => {
     display: flex;
     flex-direction: column;
     gap: 6px;
-    /* Above the sheet's dismiss layer, so fit / lasso / topics stay reachable
-       while a sheet is open — the sheet leaves the graph visible on purpose,
-       and a toolbar you can see but not press would undercut that. The sliders
-       button in particular has to keep working as the sheet's own toggle. */
-    z-index: 15;
+    /* Sits in the gap between the sheet's dismiss layer (12) and the sheet
+       itself (14): above the layer so fit / lasso / topics stay pressable
+       while a sheet is open — and so the sliders button keeps working as the
+       sheet's own toggle — but below the sheet, which is opaque. Putting the
+       toolbar above the sheet instead left the icons painted over the sheet's
+       own controls. */
+    z-index: 13;
+  }
+
+  /* A vertical rail runs straight down into the sheet: at the 44px mobile touch
+     size the column is ~294px tall, so five of its six buttons ended up behind
+     the sheet — including the sliders button that closes it. Laid out as a row
+     it occupies the strip above the sheet instead, which stays clear even at
+     the full detent (the row ends ~6px above a 90%-height sheet).
+
+     Right-aligned so it keeps its corner rather than stretching across the
+     canvas, and wrapped so a narrower phone drops buttons to a second row
+     instead of pushing them off-screen. */
+  :global(.is-mobile) .graph-toolbar {
+    flex-direction: row-reverse;
+    flex-wrap: wrap-reverse;
+    justify-content: flex-start;
+    max-width: calc(100vw - 16px);
   }
 
   /* Sized here rather than via Button's `iconSize` prop: for an icon-only button

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -391,8 +391,16 @@ $effect(() => {
     <!-- Granularity and "Inferred links" both decide *which topics exist*
          (they re-run Leiden), so they belong together and above the topic list
          they produce. Everything under Display only changes how the same topics
-         are drawn. -->
-    <span class="section-label">Topics</span>
+         are drawn.
+
+         `setting-group` / `setting-items` are Obsidian's own classes, not ours:
+         the heading sits outside the card and `.setting-items` paints the
+         lighter offset background, with radius and border coming from
+         `--setting-items-*`. Using core's structure means the panel tracks the
+         user's theme instead of approximating it. -->
+    <div class="setting-group">
+      <SettingContainer name="Topics" isHeading />
+      <div class="setting-items">
 
     <!-- Held back until the vault's levels are known: the slider's length is
          derived, so showing it early would change its range under the user. -->
@@ -438,13 +446,18 @@ $effect(() => {
           onSettingsChange({ linkOnlyTopics: !value, showSemanticLinks: value })}
       />
     </SettingContainer>
+      </div>
+    </div>
 
     {#if segments.length > 0}
-      <div class="section-label section-label--with-action">
-        <span
-          >Found · {segments.length}
-          {#if !onMobile}<span class="section-label-hint">shift/⌘ multi-select</span>{/if}</span
-        >
+      <div class="setting-group">
+      <!-- A heading row like the others, so the naming button lands in the
+           control slot Obsidian already right-aligns rather than needing a
+           bespoke flex row. -->
+      <SettingContainer name="Found · {segments.length}" isHeading class="section-heading--action">
+        {#snippet nameSuffix()}
+          {#if !onMobile}<span class="section-label-hint">shift/⌘ multi-select</span>{/if}
+        {/snippet}
         <!-- The spinner doubles as the cancel control: hovering (or focusing)
              a live run swaps it for an X. Listeners go on the button itself
              rather than a wrapper — it is already focusable, so keyboard users
@@ -457,8 +470,8 @@ $effect(() => {
           onClick={() => (isLabeling ? onCancelLabeling?.() : onLabelTopics?.())}
           styles={isLabeling && !showCancelLabeling ? "is-spinning" : ""}
         />
-      </div>
-      <div class="segment-list">
+      </SettingContainer>
+      <div class="setting-items segment-list">
         {#each segments as seg (seg.id)}
           <button
             type="button"
@@ -472,6 +485,7 @@ $effect(() => {
           </button>
         {/each}
       </div>
+      </div>
     {/if}
 
     <!-- ── Scope ────────────────────────────── -->
@@ -479,7 +493,9 @@ $effect(() => {
          it is the rarest thing to touch — usually set once and left — so the
          controls reached on every visit stay at the top, where the topic list
          can also sit directly under the settings that produce it. -->
-    <span class="section-label">Scope</span>
+    <div class="setting-group">
+      <SettingContainer name="Scope" isHeading />
+      <div class="setting-items">
     <SettingContainer
       name="Markdown only"
       desc="Show only Markdown notes; off shows all indexable files"
@@ -490,11 +506,15 @@ $effect(() => {
         onchange={(value) => onSettingsChange({ markdownOnly: value })}
       />
     </SettingContainer>
+      </div>
+    </div>
 
     <!-- ── Display ───────────────────────────── -->
     <!-- Purely how the graph above is drawn — nothing here changes which notes
          are included or how they group. -->
-    <span class="section-label">Display</span>
+    <div class="setting-group">
+      <SettingContainer name="Display" isHeading />
+      <div class="setting-items">
     <SettingContainer
       name="Topic regions"
       desc="Tint the area behind each topic so groups read at a glance"
@@ -545,6 +565,8 @@ $effect(() => {
         onchange={(value) => onSettingsChange({ highlightBridges: value })}
       />
     </SettingContainer>
+      </div>
+    </div>
   </div>
 {/snippet}
 
@@ -848,13 +870,16 @@ $effect(() => {
     padding: 0;
   }
 
+  /* Centred: this is a caption describing the whole graph, not a labelled
+     setting, so aligning it to the settings' left edge made it read as a row
+     that had lost its control. The rule underneath is gone too — the grouped
+     cards below now provide the separation it was drawing by hand. */
   .stats-row {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding-bottom: 6px;
-    border-bottom: 1px solid var(--background-modifier-border);
-    margin-bottom: 4px;
+    justify-content: center;
+    text-align: center;
+    padding: 0 16px 10px;
   }
 
   .stats-text {
@@ -883,15 +908,39 @@ $effect(() => {
     padding-right: 4px;
   }
 
-  .section-label--with-action {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
+  /* A heading row carries no control by default, so it has no min-height to
+     stop the naming button from squashing it. */
+  :global(.section-heading--action) {
+    min-height: 32px;
+  }
+
+  /* Core sizes `.setting-group` for a full-width settings tab
+     (`--setting-group-max-width`, centred). This panel is a narrow column, so
+     let the group take whatever width it is given instead. */
+  .graph-controls-body :global(.setting-group) {
+    max-width: none;
+    width: 100%;
+  }
+
+  .graph-controls-body :global(.setting-group + .setting-group) {
+    margin-top: 12px;
+  }
+
+  /* Core's card padding is sized for a full settings tab (20px each side on
+     top of each item's own 16px). That is too airy for a panel this narrow.
+
+     The background is set explicitly rather than left to
+     `--setting-items-background`: outside a settings tab that variable resolves
+     to the same darker value as the surface behind it, so the cards vanished
+     into their own container. `--background-primary` is the lighter of the
+     pair, which is the way round a settings tab actually renders. */
+  .graph-controls-body :global(.setting-items) {
+    padding-block: 4px;
+    background-color: var(--background-primary);
   }
 
   /* The label button reuses Obsidian's clickable-icon chrome; only the spin is ours. */
-  .section-label--with-action :global(.is-spinning svg) {
+  :global(.is-spinning svg) {
     animation: s2b-label-spin 1s linear infinite;
   }
 
@@ -928,7 +977,9 @@ $effect(() => {
     display: flex;
     flex-direction: column;
     gap: 1px;
-    padding: 2px 0 6px;
+    /* 10px + the row's own 6px lands the dots on the same 16px edge as the
+       setting names and section headings. */
+    padding: 6px 10px;
     max-height: 40vh;
     overflow-y: auto;
     /* Without this a flex child refuses to shrink below its content height,

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import BottomSheet from "../ui/BottomSheet.svelte";
 import Button from "../ui/Button.svelte";
 import RangeSlider from "../ui/RangeSlider.svelte";
 import Toggle from "../ui/Toggle.svelte";
@@ -53,6 +54,12 @@ interface Props {
 	isTopicsCollapsed?: boolean;
 	/** Collapse or expand all topics at once (the atom button / S shortcut). */
 	onToggleCollapseAll?: () => void;
+	/**
+	 * Whether the settings panel is hidden. Bindable so the parent can close it
+	 * — on mobile the panel is a bottom sheet, and a selection appearing has to
+	 * be able to take the sheet slot over (only one sheet at a time).
+	 */
+	isCollapsed?: boolean;
 }
 
 let {
@@ -82,9 +89,9 @@ let {
 	onFocusSegment,
 	isTopicsCollapsed = false,
 	onToggleCollapseAll,
+	isCollapsed = $bindable(true),
 }: Props = $props();
 
-let isCollapsed = $state(true);
 let isDevCollapsed = $state(true);
 
 /** Defaulted here rather than in the template — settings persisted before this
@@ -359,184 +366,212 @@ $effect(() => {
   {/if}
 </div>
 
-<!-- Main settings panel -->
-<div class="graph-controls" class:collapsed={isCollapsed} bind:clientHeight={mainPanelHeight}>
-  {#if !isCollapsed}
-    <div class="graph-controls-body">
-      <!-- ── Stats row ──────────────────────────── -->
-      <div class="stats-row">
-        <span class="stats-text">
-          {#if isLoading}
-            <span class="loading-label">{loadingLabel}</span>
-          {:else if graphStats}
-            {nodeCount} notes · {graphStats.unlinkedNotes} unlinked · {graphStats.wikiEdges} links{#if graphStats.semanticEdges > 0}{" "}· {graphStats.semanticEdges} inferred{/if}
-          {:else}
-            {nodeCount} notes
-          {/if}
-        </span>
-      </div>
-
-      <!-- ── Topics ───────────────────────────── -->
-      <!-- Granularity and "Inferred links" both decide *which topics exist*
-           (they re-run Leiden), so they belong together and above the topic list
-           they produce. Everything under Display only changes how the same topics
-           are drawn. -->
-      <span class="section-label">Topics</span>
-
-      <!-- Held back until the vault's levels are known: the slider's length is
-           derived, so showing it early would change its range under the user. -->
-      {#if granularityReady}
-        <!-- Distinct from the camera zoom (scroll, +/-), which changes scale.
-             This changes how finely notes are grouped into topics — hence the
-             separate `granularity*` vocabulary throughout. -->
-        <SettingContainer
-          name="Granularity"
-          desc={onMobile
-            ? "Left: a few broad topics. Right: many specific ones. Every note stays visible."
-            : "Left: a few broad topics. Right: many specific ones. Every note stays visible. (↑/↓ on the graph)"}
-          compact
-        >
-          <RangeSlider
-            value={granularityLevel}
-            min={MIN_GRANULARITY_LEVEL}
-            max={granularityMaxLevel}
-            step={1}
-            showValue={true}
-            onchange={(v) => onGranularityChange?.(v)}
-            oncommit={(v) => onGranularityCommit?.(v)}
-          />
-        </SettingContainer>
-      {:else}
-        <SettingContainer name="Granularity" desc="Working out this vault's topic levels…" compact>
-          <span class="granularity-pending">…</span>
-        </SettingContainer>
-      {/if}
-
-      <!-- One switch for the whole concept: inferred links are either part of the
-           graph (drawn *and* grouping notes) or absent. Splitting "draw" from
-           "count" allowed a state where hidden edges silently decided the topics.
-
-           A plain compact row like every other setting here: `inferredLinksHint`
-           folds the live measurement into the same hover description, so the
-           number is still there without this row growing an extra line and an
-           affordance nothing else in the panel has. -->
-      <SettingContainer name="Inferred links" desc={inferredLinksHint} compact>
-        <Toggle
-          checked={!(settings.linkOnlyTopics ?? false) && (settings.showSemanticLinks ?? true)}
-          onchange={(value) =>
-            onSettingsChange({ linkOnlyTopics: !value, showSemanticLinks: value })}
-        />
-      </SettingContainer>
-
-      {#if segments.length > 0}
-        <div class="section-label section-label--with-action">
-          <span
-            >Found · {segments.length}
-            {#if !onMobile}<span class="section-label-hint">shift/⌘ multi-select</span>{/if}</span
-          >
-          <!-- The spinner doubles as the cancel control: hovering (or focusing)
-               a live run swaps it for an X. Listeners go on the button itself
-               rather than a wrapper — it is already focusable, so keyboard users
-               reach the cancel affordance by tabbing to it. -->
-          <Button
-            bind:element={labelButtonEl}
-            iconId={showCancelLabeling ? "x" : isLabeling ? "loader" : "sparkles"}
-            ariaLabel={isLabeling ? "Cancel naming topics" : "Name topics with AI"}
-            tooltip={isLabeling ? "Cancel naming" : "Name topics with AI"}
-            onClick={() => (isLabeling ? onCancelLabeling?.() : onLabelTopics?.())}
-            styles={isLabeling && !showCancelLabeling ? "is-spinning" : ""}
-          />
-        </div>
-        <div class="segment-list">
-          {#each segments as seg (seg.id)}
-            <button
-              type="button"
-              class="segment-row"
-              class:segment-row--active={focusedSegmentIds.has(seg.id)}
-              onclick={(e) => onFocusSegment?.(seg.id, e.shiftKey || e.metaKey || e.ctrlKey)}
-            >
-              <span class="segment-dot" style="background-color: {seg.color}"></span>
-              <span class="segment-label">{seg.label}</span>
-              <span class="segment-count">{seg.paths.size}</span>
-            </button>
-          {/each}
-        </div>
-      {/if}
-
-      <!-- ── Scope ────────────────────────────── -->
-      <!-- What is in the graph at all. Placed after Topics rather than before it:
-           it is the rarest thing to touch — usually set once and left — so the
-           controls reached on every visit stay at the top, where the topic list
-           can also sit directly under the settings that produce it. -->
-      <span class="section-label">Scope</span>
-      <SettingContainer
-        name="Markdown only"
-        desc="Show only Markdown notes; off shows all indexable files"
-        compact
-      >
-        <Toggle
-          checked={settings.markdownOnly}
-          onchange={(value) => onSettingsChange({ markdownOnly: value })}
-        />
-      </SettingContainer>
-
-      <!-- ── Display ───────────────────────────── -->
-      <!-- Purely how the graph above is drawn — nothing here changes which notes
-           are included or how they group. -->
-      <span class="section-label">Display</span>
-      <SettingContainer
-        name="Topic regions"
-        desc="Tint the area behind each topic so groups read at a glance"
-        compact
-      >
-        <Toggle
-          checked={settings.showTopicHulls ?? true}
-          onchange={(value) => onSettingsChange({ showTopicHulls: value })}
-        />
-      </SettingContainer>
-      <SettingContainer
-        name="Topic labels"
-        desc="Show the topic name pills over the graph"
-        compact
-      >
-        <Toggle
-          checked={settings.showClusterLabels ?? true}
-          onchange={(value) => onSettingsChange({ showClusterLabels: value })}
-        />
-      </SettingContainer>
-      <SettingContainer
-        name="Direction arrows"
-        desc="Show arrows for directed wiki links"
-        compact
-      >
-        <Toggle
-          checked={settings.directedWikiEdges}
-          onchange={(value) => onSettingsChange({ directedWikiEdges: value })}
-        />
-      </SettingContainer>
-      <SettingContainer
-        name="Highlight isolated"
-        desc="Mark notes with no wiki links in accent color"
-        compact
-      >
-        <Toggle
-          checked={settings.highlightIsolated}
-          onchange={(value) => onSettingsChange({ highlightIsolated: value })}
-        />
-      </SettingContainer>
-      <SettingContainer
-        name="Highlight bridges"
-        desc="Mark notes that connect multiple topics in accent color"
-        compact
-      >
-        <Toggle
-          checked={settings.highlightBridges}
-          onchange={(value) => onSettingsChange({ highlightBridges: value })}
-        />
-      </SettingContainer>
+<!--
+  The panel's controls, defined once and rendered into whichever container the
+  platform calls for: a floating popover on desktop, a bottom sheet on mobile.
+  One copy of the markup, so a control added here cannot go missing from one
+  modality.
+-->
+{#snippet panelBody()}
+  <div class="graph-controls-body">
+    <!-- ── Stats row ──────────────────────────── -->
+    <div class="stats-row">
+      <span class="stats-text">
+        {#if isLoading}
+          <span class="loading-label">{loadingLabel}</span>
+        {:else if graphStats}
+          {nodeCount} notes · {graphStats.unlinkedNotes} unlinked · {graphStats.wikiEdges} links{#if graphStats.semanticEdges > 0}{" "}· {graphStats.semanticEdges} inferred{/if}
+        {:else}
+          {nodeCount} notes
+        {/if}
+      </span>
     </div>
-  {/if}
-</div>
+
+    <!-- ── Topics ───────────────────────────── -->
+    <!-- Granularity and "Inferred links" both decide *which topics exist*
+         (they re-run Leiden), so they belong together and above the topic list
+         they produce. Everything under Display only changes how the same topics
+         are drawn. -->
+    <span class="section-label">Topics</span>
+
+    <!-- Held back until the vault's levels are known: the slider's length is
+         derived, so showing it early would change its range under the user. -->
+    {#if granularityReady}
+      <!-- Distinct from the camera zoom (scroll, +/-), which changes scale.
+           This changes how finely notes are grouped into topics — hence the
+           separate `granularity*` vocabulary throughout. -->
+      <SettingContainer
+        name="Granularity"
+        desc={onMobile
+          ? "Left: a few broad topics. Right: many specific ones. Every note stays visible."
+          : "Left: a few broad topics. Right: many specific ones. Every note stays visible. (↑/↓ on the graph)"}
+        compact
+      >
+        <RangeSlider
+          value={granularityLevel}
+          min={MIN_GRANULARITY_LEVEL}
+          max={granularityMaxLevel}
+          step={1}
+          showValue={true}
+          onchange={(v) => onGranularityChange?.(v)}
+          oncommit={(v) => onGranularityCommit?.(v)}
+        />
+      </SettingContainer>
+    {:else}
+      <SettingContainer name="Granularity" desc="Working out this vault's topic levels…" compact>
+        <span class="granularity-pending">…</span>
+      </SettingContainer>
+    {/if}
+
+    <!-- One switch for the whole concept: inferred links are either part of the
+         graph (drawn *and* grouping notes) or absent. Splitting "draw" from
+         "count" allowed a state where hidden edges silently decided the topics.
+
+         A plain compact row like every other setting here: `inferredLinksHint`
+         folds the live measurement into the same hover description, so the
+         number is still there without this row growing an extra line and an
+         affordance nothing else in the panel has. -->
+    <SettingContainer name="Inferred links" desc={inferredLinksHint} compact>
+      <Toggle
+        checked={!(settings.linkOnlyTopics ?? false) && (settings.showSemanticLinks ?? true)}
+        onchange={(value) =>
+          onSettingsChange({ linkOnlyTopics: !value, showSemanticLinks: value })}
+      />
+    </SettingContainer>
+
+    {#if segments.length > 0}
+      <div class="section-label section-label--with-action">
+        <span
+          >Found · {segments.length}
+          {#if !onMobile}<span class="section-label-hint">shift/⌘ multi-select</span>{/if}</span
+        >
+        <!-- The spinner doubles as the cancel control: hovering (or focusing)
+             a live run swaps it for an X. Listeners go on the button itself
+             rather than a wrapper — it is already focusable, so keyboard users
+             reach the cancel affordance by tabbing to it. -->
+        <Button
+          bind:element={labelButtonEl}
+          iconId={showCancelLabeling ? "x" : isLabeling ? "loader" : "sparkles"}
+          ariaLabel={isLabeling ? "Cancel naming topics" : "Name topics with AI"}
+          tooltip={isLabeling ? "Cancel naming" : "Name topics with AI"}
+          onClick={() => (isLabeling ? onCancelLabeling?.() : onLabelTopics?.())}
+          styles={isLabeling && !showCancelLabeling ? "is-spinning" : ""}
+        />
+      </div>
+      <div class="segment-list">
+        {#each segments as seg (seg.id)}
+          <button
+            type="button"
+            class="segment-row"
+            class:segment-row--active={focusedSegmentIds.has(seg.id)}
+            onclick={(e) => onFocusSegment?.(seg.id, e.shiftKey || e.metaKey || e.ctrlKey)}
+          >
+            <span class="segment-dot" style="background-color: {seg.color}"></span>
+            <span class="segment-label">{seg.label}</span>
+            <span class="segment-count">{seg.paths.size}</span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+
+    <!-- ── Scope ────────────────────────────── -->
+    <!-- What is in the graph at all. Placed after Topics rather than before it:
+         it is the rarest thing to touch — usually set once and left — so the
+         controls reached on every visit stay at the top, where the topic list
+         can also sit directly under the settings that produce it. -->
+    <span class="section-label">Scope</span>
+    <SettingContainer
+      name="Markdown only"
+      desc="Show only Markdown notes; off shows all indexable files"
+      compact
+    >
+      <Toggle
+        checked={settings.markdownOnly}
+        onchange={(value) => onSettingsChange({ markdownOnly: value })}
+      />
+    </SettingContainer>
+
+    <!-- ── Display ───────────────────────────── -->
+    <!-- Purely how the graph above is drawn — nothing here changes which notes
+         are included or how they group. -->
+    <span class="section-label">Display</span>
+    <SettingContainer
+      name="Topic regions"
+      desc="Tint the area behind each topic so groups read at a glance"
+      compact
+    >
+      <Toggle
+        checked={settings.showTopicHulls ?? true}
+        onchange={(value) => onSettingsChange({ showTopicHulls: value })}
+      />
+    </SettingContainer>
+    <SettingContainer
+      name="Topic labels"
+      desc="Show the topic name pills over the graph"
+      compact
+    >
+      <Toggle
+        checked={settings.showClusterLabels ?? true}
+        onchange={(value) => onSettingsChange({ showClusterLabels: value })}
+      />
+    </SettingContainer>
+    <SettingContainer
+      name="Direction arrows"
+      desc="Show arrows for directed wiki links"
+      compact
+    >
+      <Toggle
+        checked={settings.directedWikiEdges}
+        onchange={(value) => onSettingsChange({ directedWikiEdges: value })}
+      />
+    </SettingContainer>
+    <SettingContainer
+      name="Highlight isolated"
+      desc="Mark notes with no wiki links in accent color"
+      compact
+    >
+      <Toggle
+        checked={settings.highlightIsolated}
+        onchange={(value) => onSettingsChange({ highlightIsolated: value })}
+      />
+    </SettingContainer>
+    <SettingContainer
+      name="Highlight bridges"
+      desc="Mark notes that connect multiple topics in accent color"
+      compact
+    >
+      <Toggle
+        checked={settings.highlightBridges}
+        onchange={(value) => onSettingsChange({ highlightBridges: value })}
+      />
+    </SettingContainer>
+  </div>
+{/snippet}
+
+{#if onMobile}
+  <!--
+    On a phone the popover was the wrong modality outright: it covered ~76% of
+    the viewport it floated over, hung from the least reachable edge, and gave
+    a drag-and-watch control (granularity) nothing to watch. The sheet keeps
+    the graph visible above it and puts the controls under the thumb.
+
+    Opens at the peek detent, where Topics — the granularity slider and
+    inferred links — is what you get; drag up for the topic list and the rest.
+  -->
+  <BottomSheet
+    open={!isCollapsed}
+    onClose={() => (isCollapsed = true)}
+    ariaLabel="Graph settings"
+  >
+    {@render panelBody()}
+  </BottomSheet>
+{:else}
+  <div class="graph-controls" class:collapsed={isCollapsed} bind:clientHeight={mainPanelHeight}>
+    {#if !isCollapsed}
+      {@render panelBody()}
+    {/if}
+  </div>
+{/if}
 
 <!-- Dev panel (dev build only) -->
 {#if import.meta.env.DEV}
@@ -692,7 +727,11 @@ $effect(() => {
     display: flex;
     flex-direction: column;
     gap: 6px;
-    z-index: 11;
+    /* Above the sheet's dismiss layer, so fit / lasso / topics stay reachable
+       while a sheet is open — the sheet leaves the graph visible on purpose,
+       and a toolbar you can see but not press would undercut that. The sliders
+       button in particular has to keep working as the sheet's own toggle. */
+    z-index: 15;
   }
 
   /* Sized here rather than via Button's `iconSize` prop: for an icon-only button
@@ -747,9 +786,10 @@ $effect(() => {
     box-shadow: none;
   }
 
-  /* On a phone a fixed 300px panel + 52px offset overflows and occludes the
-     canvas — fit it to the viewport instead. */
-  :global(.is-mobile) .graph-controls {
+  /* Only the dev panel still uses this popover on mobile — the shipped settings
+     panel is a bottom sheet there, which owns its own width. A fixed 300px box
+     plus the 52px toolbar offset overflows a phone, so fit it to the viewport. */
+  :global(.is-mobile) .graph-controls--dev {
     width: min(300px, calc(100vw - 68px));
   }
 
@@ -780,6 +820,14 @@ $effect(() => {
     display: flex;
     flex-direction: column;
     gap: 4px;
+  }
+
+  /* The sheet supplies its own horizontal padding and safe-area bottom, so the
+     popover's would double it. Scoped to the sheet rather than to `.is-mobile`,
+     because the dev panel shares this class and still renders as a popover
+     there — it needs to keep its own padding. */
+  :global(.s2b-bottom-sheet) .graph-controls-body {
+    padding: 0;
   }
 
   .stats-row {
@@ -871,6 +919,15 @@ $effect(() => {
     overscroll-behavior: contain;
   }
 
+  /* Inside the sheet the cap is not only unnecessary but actively wrong: the
+     full detent exists so the topic list can use the height, and a nested
+     scroll area within a scrolling sheet gives two overlapping scroll targets
+     under one thumb. Let the list run, and let the sheet scroll it. */
+  :global(.is-mobile) .segment-list {
+    max-height: none;
+    overflow-y: visible;
+  }
+
   .segment-row {
     display: flex;
     align-items: center;
@@ -888,6 +945,13 @@ $effect(() => {
 
   .segment-row:hover {
     background: var(--background-modifier-hover);
+  }
+
+  /* A 3px-padded row lands around 22px — half the touch floor, on the one list
+     in this panel you are meant to tap repeatedly. */
+  :global(.is-mobile) .segment-row {
+    min-height: 44px;
+    padding: 6px 8px;
   }
 
   .segment-row--active {

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -1252,9 +1252,13 @@ let isControlsCollapsed = $state(true);
  * fires on the *transition into* having a selection, so reopening the settings
  * sheet while a selection is still live doesn't immediately close it again.
  */
+// Keyed on the selection alone, matching what actually opens the sheet on
+// mobile. Including `isImmersed` here would close the settings sheet on entering
+// immerse, where nothing takes the sheet slot in return — immersion's affordance
+// is a toolbar button now, precisely so it does not occupy the canvas.
 let hadSelection = false;
 $effect(() => {
-	const hasSelection = selectedPaths.length > 0 || isImmersed;
+	const hasSelection = selectedPaths.length > 0;
 	if (hasSelection && !hadSelection && onMobile) isControlsCollapsed = true;
 	hadSelection = hasSelection;
 });
@@ -2248,7 +2252,14 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
     {/if}
   {/snippet}
 
-  {#if isImmersed || selectedPaths.length > 0}
+  <!-- Immersion is a *mode* you work inside, not a transient result like a
+       selection, so on mobile it must not hold the sheet open: a sheet plus its
+       dismiss layer covers the canvas, which left the graph you just immersed
+       into un-pannable, un-selectable and impossible to immerse further. The
+       sheet is therefore driven by the selection alone, and immersion carries
+       its own persistent affordance on the toolbar (see GraphControls), which
+       floats above the canvas without blocking it. -->
+  {#if onMobile ? selectedPaths.length > 0 : isImmersed || selectedPaths.length > 0}
     {#if onMobile}
       <!--
         The desktop bar's only mobile treatment was `flex-wrap: wrap`, which
@@ -2262,7 +2273,7 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
       -->
       <BottomSheet
         open={true}
-        onClose={selectedPaths.length > 0 ? handleClearSelection : handleExitImmerse}
+        onClose={handleClearSelection}
         draggable={false}
         ariaLabel="Graph selection"
       >
@@ -2272,61 +2283,48 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
         <div class="selection-sheet setting-group">
           <div class="selection-sheet-header">
             <span class="selection-count">{@render selectionCount()}</span>
-            <Button
-              iconId="x"
-              onClick={selectedPaths.length > 0 ? handleClearSelection : handleExitImmerse}
-              tooltip={selectedPaths.length > 0 ? "Clear selection" : "Exit immerse"}
-            />
+            <Button iconId="x" onClick={handleClearSelection} tooltip="Clear selection" />
           </div>
           <div class="selection-sheet-actions setting-items">
-            {#if selectedPaths.length > 0}
-              <!-- Promoted from icon-only to a labelled row. It rendered at
-                   30x26 on the bar — the easiest control here to mis-tap, and
-                   it sat next to a destructive one. -->
+            <!-- Promoted from icon-only to a labelled row. It rendered at
+                 30x26 on the bar — the easiest control here to mis-tap, and
+                 it sat next to a destructive one. -->
+            <Button
+              iconId="scan"
+              buttonText="Zoom to selection"
+              onClick={handleZoomToSelection}
+              tooltip="Move the camera to fit the selected notes"
+            />
+            {#if selectedTopicsCollapseAction !== null}
               <Button
-                iconId="scan"
-                buttonText="Zoom to selection"
-                onClick={handleZoomToSelection}
-                tooltip="Move the camera to fit the selected notes"
-              />
-              {#if selectedTopicsCollapseAction !== null}
-                <Button
-                  iconId={selectedTopicsCollapseAction === "collapse" ? "chevrons-down-up" : "chevrons-up-down"}
-                  buttonText={selectedTopicsCollapseAction === "collapse" ? "Collapse" : "Expand"}
-                  onClick={() => void handleCollapseSelectedTopics()}
-                  tooltip={selectedTopicsCollapseAction === "collapse"
-                    ? "Fold the selected topics into single nodes"
-                    : "Unfold the selected topics back into notes"}
-                />
-              {/if}
-              <Button
-                iconId="scan-search"
-                buttonText="Immerse"
-                onClick={handleImmerse}
-                tooltip="Rebuild graph with selected notes only"
-              />
-              {#if !hasOpenChat}
-                <Button
-                  iconId="message-square"
-                  buttonText="Open in chat"
-                  onClick={handleSendToChat}
-                  tooltip="Reveal the chat and attach the selected notes"
-                />
-              {/if}
-              <Button
-                iconId="copy-plus"
-                buttonText="Open all"
-                onClick={handleOpenAllSelected}
-                tooltip="Open all selected notes in new tabs"
-              />
-            {:else}
-              <Button
-                iconId="log-out"
-                buttonText="Exit immerse"
-                onClick={handleExitImmerse}
-                tooltip="Return to the full graph"
+                iconId={selectedTopicsCollapseAction === "collapse" ? "chevrons-down-up" : "chevrons-up-down"}
+                buttonText={selectedTopicsCollapseAction === "collapse" ? "Collapse" : "Expand"}
+                onClick={() => void handleCollapseSelectedTopics()}
+                tooltip={selectedTopicsCollapseAction === "collapse"
+                  ? "Fold the selected topics into single nodes"
+                  : "Unfold the selected topics back into notes"}
               />
             {/if}
+            <Button
+              iconId="scan-search"
+              buttonText="Immerse"
+              onClick={handleImmerse}
+              tooltip="Rebuild graph with selected notes only"
+            />
+            {#if !hasOpenChat}
+              <Button
+                iconId="message-square"
+                buttonText="Open in chat"
+                onClick={handleSendToChat}
+                tooltip="Reveal the chat and attach the selected notes"
+              />
+            {/if}
+            <Button
+              iconId="copy-plus"
+              buttonText="Open all"
+              onClick={handleOpenAllSelected}
+              tooltip="Open all selected notes in new tabs"
+            />
           </div>
         </div>
       </BottomSheet>
@@ -2419,6 +2417,8 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
     onFocusSegment={handleFocusSegment}
     onToggleCollapseAll={handleToggleCollapseAll}
     bind:isCollapsed={isControlsCollapsed}
+    {isImmersed}
+    onExitImmerse={handleExitImmerse}
   />
 </div>
 

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -74,6 +74,7 @@ import { VIEW_TYPE_CHAT } from "../../views/chat/Chat";
 import { VIEW_TYPE_SMART_GRAPH } from "../../views/smart-graph/SmartGraphView";
 import { getSessionRegistry } from "../../stores/chatStore.svelte";
 import LoadingAnimation from "../ui/LoadingAnimation.svelte";
+import BottomSheet from "../ui/BottomSheet.svelte";
 import Button from "../ui/Button.svelte";
 import GraphCanvas from "./GraphCanvas.svelte";
 import GraphControls from "./GraphControls.svelte";
@@ -1233,6 +1234,32 @@ const onMobile = isMobileUI();
 const withKey = (tooltip: string, key: string) => (onMobile ? tooltip : `${tooltip} (${key})`);
 
 /**
+ * Whether the settings panel is hidden. Owned here rather than inside
+ * `GraphControls` because on mobile it is a bottom sheet, and the selection
+ * sheet has to be able to take that slot over — see below.
+ */
+let isControlsCollapsed = $state(true);
+
+/**
+ * One sheet at a time: a selection appearing closes the settings sheet.
+ *
+ * Both surfaces are bottom-anchored on mobile, so leaving them both open would
+ * either stack them over most of the screen or have them overlap. The selection
+ * wins because it is the more transient of the two and the one the user just
+ * created.
+ *
+ * A genuine side effect on a separate surface, not state synchronisation: it
+ * fires on the *transition into* having a selection, so reopening the settings
+ * sheet while a selection is still live doesn't immediately close it again.
+ */
+let hadSelection = false;
+$effect(() => {
+	const hasSelection = selectedPaths.length > 0 || isImmersed;
+	if (hasSelection && !hadSelection && onMobile) isControlsCollapsed = true;
+	hadSelection = hasSelection;
+});
+
+/**
  * Open a set of notes in tabs, confirming first past the threshold.
  *
  * Shared by the selection bar's "Open all" and a collapsed topic's context
@@ -2210,72 +2237,155 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
     />
   {/if}
 
-  {#if isImmersed || selectedPaths.length > 0}
-    <div class="graph-selection-bar">
-      <span class="selection-count">
-        {#if selectedPaths.length > 0}
-          <strong>{selectedPaths.length}</strong>
-          {selectedPaths.length === 1 ? "note" : "notes"} selected{isImmersed ? " · immersed" : ""}
-        {:else}
-          <strong>{graphData.nodes.length}</strong>
-          {graphData.nodes.length === 1 ? "note" : "notes"} · immersed
-        {/if}
-      </span>
-      <!-- Left of the divider with the count: this moves the camera, it doesn't
-           act on the notes the way the verbs on the right do. Grouping it with
-           the count keeps that split legible, and leaves both icon-only buttons
-           bracketing the labelled actions rather than sitting among them. -->
-      {#if selectedPaths.length > 0}
-        <Button iconId="scan" onClick={handleZoomToSelection} tooltip="Zoom to selection (F)" />
-      {/if}
-      <div class="selection-divider"></div>
-      <div class="selection-actions">
-        {#if selectedPaths.length > 0}
-          {#if selectedTopicsCollapseAction !== null}
-            <!-- Same chevrons as the toolbar's collapse-all: this is that action
-                 scoped to a selection rather than a different one, so it should
-                 not carry a different glyph. -->
-            <Button
-              iconId={selectedTopicsCollapseAction === "collapse" ? "chevrons-down-up" : "chevrons-up-down"}
-              buttonText={selectedTopicsCollapseAction === "collapse" ? "Collapse" : "Expand"}
-              onClick={() => void handleCollapseSelectedTopics()}
-              tooltip={withKey(
-                selectedTopicsCollapseAction === "collapse"
-                  ? "Fold the selected topics into single nodes"
-                  : "Unfold the selected topics back into notes",
-                "C",
-              )}
-            />
-          {/if}
-          <Button
-            iconId="scan-search"
-            buttonText="Immerse"
-            onClick={handleImmerse}
-            tooltip={withKey("Rebuild graph with selected notes only", "I")}
-          />
-          {#if !hasOpenChat}
-            <Button
-              iconId="message-square"
-              buttonText="Open in chat"
-              onClick={handleSendToChat}
-              tooltip={withKey("Reveal the chat and attach the selected notes", "A")}
-            />
-          {/if}
-          <Button
-            iconId="copy-plus"
-            buttonText="Open all"
-            onClick={handleOpenAllSelected}
-            tooltip={withKey("Open all selected notes in new tabs", "O")}
-          />
+  <!-- What the selection bar says about itself, shared by both modalities. -->
+  {#snippet selectionCount()}
+    {#if selectedPaths.length > 0}
+      <strong>{selectedPaths.length}</strong>
+      {selectedPaths.length === 1 ? "note" : "notes"} selected{isImmersed ? " · immersed" : ""}
+    {:else}
+      <strong>{graphData.nodes.length}</strong>
+      {graphData.nodes.length === 1 ? "note" : "notes"} · immersed
+    {/if}
+  {/snippet}
 
-          <!-- Icon-only: dismissing isn't one of the verbs you came here for, so
-               it reads as an affordance on the bar rather than a peer action. -->
-          <Button iconId="x" onClick={handleClearSelection} tooltip="Clear selection (Esc)" />
-        {:else}
-          <Button buttonText="Exit" onClick={handleExitImmerse} tooltip="Exit immerse (Esc)" />
+  {#if isImmersed || selectedPaths.length > 0}
+    {#if onMobile}
+      <!--
+        The desktop bar's only mobile treatment was `flex-wrap: wrap`, which
+        turned one row into three and left the divider — a rule that separates
+        the count from the verbs — pointing at nothing. A sheet is a narrow
+        column by construction, so the verbs stack as full-width rows and the
+        divider has no job to be left without.
+
+        Not draggable: this is a fixed list of verbs with nothing to expand
+        into, so a handle would advertise a gesture that does nothing.
+      -->
+      <BottomSheet
+        open={true}
+        onClose={selectedPaths.length > 0 ? handleClearSelection : handleExitImmerse}
+        draggable={false}
+        ariaLabel="Graph selection"
+      >
+        <div class="selection-sheet">
+          <div class="selection-sheet-header">
+            <span class="selection-count">{@render selectionCount()}</span>
+            <Button
+              iconId="x"
+              onClick={selectedPaths.length > 0 ? handleClearSelection : handleExitImmerse}
+              tooltip={selectedPaths.length > 0 ? "Clear selection" : "Exit immerse"}
+            />
+          </div>
+          <div class="selection-sheet-actions">
+            {#if selectedPaths.length > 0}
+              <!-- Promoted from icon-only to a labelled row. It rendered at
+                   30x26 on the bar — the easiest control here to mis-tap, and
+                   it sat next to a destructive one. -->
+              <Button
+                iconId="scan"
+                buttonText="Zoom to selection"
+                onClick={handleZoomToSelection}
+                tooltip="Move the camera to fit the selected notes"
+              />
+              {#if selectedTopicsCollapseAction !== null}
+                <Button
+                  iconId={selectedTopicsCollapseAction === "collapse" ? "chevrons-down-up" : "chevrons-up-down"}
+                  buttonText={selectedTopicsCollapseAction === "collapse" ? "Collapse" : "Expand"}
+                  onClick={() => void handleCollapseSelectedTopics()}
+                  tooltip={selectedTopicsCollapseAction === "collapse"
+                    ? "Fold the selected topics into single nodes"
+                    : "Unfold the selected topics back into notes"}
+                />
+              {/if}
+              <Button
+                iconId="scan-search"
+                buttonText="Immerse"
+                onClick={handleImmerse}
+                tooltip="Rebuild graph with selected notes only"
+              />
+              {#if !hasOpenChat}
+                <Button
+                  iconId="message-square"
+                  buttonText="Open in chat"
+                  onClick={handleSendToChat}
+                  tooltip="Reveal the chat and attach the selected notes"
+                />
+              {/if}
+              <Button
+                iconId="copy-plus"
+                buttonText="Open all"
+                onClick={handleOpenAllSelected}
+                tooltip="Open all selected notes in new tabs"
+              />
+            {:else}
+              <Button
+                iconId="log-out"
+                buttonText="Exit immerse"
+                onClick={handleExitImmerse}
+                tooltip="Return to the full graph"
+              />
+            {/if}
+          </div>
+        </div>
+      </BottomSheet>
+    {:else}
+      <div class="graph-selection-bar">
+        <span class="selection-count">{@render selectionCount()}</span>
+        <!-- Left of the divider with the count: this moves the camera, it doesn't
+             act on the notes the way the verbs on the right do. Grouping it with
+             the count keeps that split legible, and leaves both icon-only buttons
+             bracketing the labelled actions rather than sitting among them. -->
+        {#if selectedPaths.length > 0}
+          <Button iconId="scan" onClick={handleZoomToSelection} tooltip="Zoom to selection (F)" />
         {/if}
+        <div class="selection-divider"></div>
+        <div class="selection-actions">
+          {#if selectedPaths.length > 0}
+            {#if selectedTopicsCollapseAction !== null}
+              <!-- Same chevrons as the toolbar's collapse-all: this is that action
+                   scoped to a selection rather than a different one, so it should
+                   not carry a different glyph. -->
+              <Button
+                iconId={selectedTopicsCollapseAction === "collapse" ? "chevrons-down-up" : "chevrons-up-down"}
+                buttonText={selectedTopicsCollapseAction === "collapse" ? "Collapse" : "Expand"}
+                onClick={() => void handleCollapseSelectedTopics()}
+                tooltip={withKey(
+                  selectedTopicsCollapseAction === "collapse"
+                    ? "Fold the selected topics into single nodes"
+                    : "Unfold the selected topics back into notes",
+                  "C",
+                )}
+              />
+            {/if}
+            <Button
+              iconId="scan-search"
+              buttonText="Immerse"
+              onClick={handleImmerse}
+              tooltip={withKey("Rebuild graph with selected notes only", "I")}
+            />
+            {#if !hasOpenChat}
+              <Button
+                iconId="message-square"
+                buttonText="Open in chat"
+                onClick={handleSendToChat}
+                tooltip={withKey("Reveal the chat and attach the selected notes", "A")}
+              />
+            {/if}
+            <Button
+              iconId="copy-plus"
+              buttonText="Open all"
+              onClick={handleOpenAllSelected}
+              tooltip={withKey("Open all selected notes in new tabs", "O")}
+            />
+
+            <!-- Icon-only: dismissing isn't one of the verbs you came here for, so
+                 it reads as an affordance on the bar rather than a peer action. -->
+            <Button iconId="x" onClick={handleClearSelection} tooltip="Clear selection (Esc)" />
+          {:else}
+            <Button buttonText="Exit" onClick={handleExitImmerse} tooltip="Exit immerse (Esc)" />
+          {/if}
+        </div>
       </div>
-    </div>
+    {/if}
   {/if}
 
   <GraphControls
@@ -2305,6 +2415,7 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
     focusedSegmentIds={focusedSegmentIds}
     onFocusSegment={handleFocusSegment}
     onToggleCollapseAll={handleToggleCollapseAll}
+    bind:isCollapsed={isControlsCollapsed}
   />
 </div>
 
@@ -2410,28 +2521,49 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
     flex-shrink: 0;
   }
 
-  /* On a phone the centered, nowrap bar overflows both screen edges — the
-     buttons past the viewport can't be tapped. Pin it to the safe width,
-     let the count + actions wrap, and let the actions fill the row so every
-     button stays on-screen and comfortably tappable. */
-  :global(.is-mobile) .graph-selection-bar {
-    left: 8px;
-    right: 8px;
-    transform: none;
-    max-width: none;
-    flex-wrap: wrap;
-    justify-content: center;
-    white-space: normal;
-    /* Sit clear of Obsidian's floating mobile navbar (a ~52px pill anchored to
-       the bottom with a gap below it — it occupies ~84px of the viewport
-       bottom and floats over the full-height graph canvas). Obsidian exposes
-       no reliable height var for it, so clear it with a fixed offset plus any
-       device safe-area inset. */
-    bottom: calc(92px + var(--safe-area-inset-bottom, 0px));
+  /* ── Mobile selection sheet ──────────────────────────────────────────────
+     Replaces the wrapped bar entirely. The bar used to hang at a hardcoded
+     `bottom: 92px` to clear Obsidian's floating navbar, which left it in open
+     canvas attached to neither the content nor the screen edge; the sheet is
+     anchored at `bottom: 0` inside `.smart-graph-view`, which already subtracts
+     the navbar band from its own height, so the clearance comes from the one
+     measurement that was already right. */
+
+  .selection-sheet {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-top: 2px;
   }
 
-  :global(.is-mobile) .selection-actions {
-    flex-wrap: wrap;
-    justify-content: center;
+  /* The count is the sheet's title, which is why there is no divider here:
+     a header separated from its body by layout doesn't need a rule to say so. */
+  .selection-sheet-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--background-modifier-border);
+  }
+
+  .selection-sheet-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  /* Full-width rows at the touch floor. `justify-content` is set explicitly
+     because Obsidian's base `button` rule centres content, which ragged the
+     labels once the buttons became full-width. */
+  .selection-sheet-actions :global(button) {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+    width: 100%;
+    min-height: 44px;
+    padding: 8px 12px;
+    text-align: left;
   }
 </style>

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -2266,7 +2266,10 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
         draggable={false}
         ariaLabel="Graph selection"
       >
-        <div class="selection-sheet">
+        <!-- Same structure as the settings sheet: a heading outside a
+             `.setting-items` card holding the rows, so the two sheets read as
+             one surface rather than two hand-styled ones. -->
+        <div class="selection-sheet setting-group">
           <div class="selection-sheet-header">
             <span class="selection-count">{@render selectionCount()}</span>
             <Button
@@ -2275,7 +2278,7 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
               tooltip={selectedPaths.length > 0 ? "Clear selection" : "Exit immerse"}
             />
           </div>
-          <div class="selection-sheet-actions">
+          <div class="selection-sheet-actions setting-items">
             {#if selectedPaths.length > 0}
               <!-- Promoted from icon-only to a labelled row. It rendered at
                    30x26 on the bar — the easiest control here to mis-tap, and
@@ -2529,33 +2532,41 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
      the navbar band from its own height, so the clearance comes from the one
      measurement that was already right. */
 
+  /* Core sizes `.setting-group` for a full settings tab; this is a narrow
+     column, same as the settings sheet. */
   .selection-sheet {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    padding-top: 2px;
+    max-width: none;
+    width: 100%;
   }
 
-  /* The count is the sheet's title, which is why there is no divider here:
-     a header separated from its body by layout doesn't need a rule to say so. */
+  /* The count is the sheet's heading, so it matches a `.setting-item-heading`:
+     outside the card, 16px in so it shares the rows' left edge, no rule (the
+     card below provides the separation). */
   .selection-sheet-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 8px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--background-modifier-border);
+    min-height: 32px;
+    padding: 0 16px;
+    margin-bottom: 8px;
   }
 
+  /* The card holding the verbs. Background set explicitly rather than left to
+     `--setting-items-background`, which outside a settings tab resolves to the
+     same value as the sheet behind it — see the settings panel for the same
+     note. */
   .selection-sheet-actions {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    background-color: var(--background-primary);
+    padding-block: 4px;
   }
 
   /* Full-width rows at the touch floor. `justify-content` is set explicitly
      because Obsidian's base `button` rule centres content, which ragged the
-     labels once the buttons became full-width. */
+     labels once the buttons became full-width. Transparent, like a
+     `.setting-item` inside a card — the card paints the surface. */
   .selection-sheet-actions :global(button) {
     display: flex;
     align-items: center;
@@ -2563,7 +2574,18 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
     gap: 10px;
     width: 100%;
     min-height: 44px;
-    padding: 8px 12px;
+    padding: 10px 16px;
     text-align: left;
+    background: none;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  /* Hairlines between rows, the way core separates items within one card.
+     `:not(:first-child)` rather than a border on every row, so the card's own
+     rounded top edge stays clean. */
+  .selection-sheet-actions :global(button:not(:first-child)) {
+    border-top: 1px solid var(--background-modifier-border);
   }
 </style>

--- a/src/components/ui/BottomSheet.svelte
+++ b/src/components/ui/BottomSheet.svelte
@@ -287,10 +287,13 @@ const sheetHeight = $derived.by(() => {
 <style>
   /* Covers the canvas above the sheet only — the sheet itself must stay
      tappable, so this is a sibling rather than a parent. */
+  /* 12 / 13 / 14 across the three layers is load-bearing: the graph toolbar
+     sits at 13, between this and the sheet, so it stays pressable while a
+     sheet is open without painting over the sheet's own controls. */
   .s2b-sheet-dismiss {
     position: absolute;
     inset: 0;
-    z-index: 13;
+    z-index: 12;
     background: transparent;
   }
 
@@ -371,7 +374,18 @@ const sheetHeight = $derived.by(() => {
     overflow-y: auto;
     /* Keep a scroll that reaches its end from chaining into the canvas behind. */
     overscroll-behavior: contain;
-    padding: 0 12px calc(12px + env(safe-area-inset-bottom));
+    /* The bottom inset clears Obsidian's floating mobile navbar, which is NOT
+       covered by the host view's own reservation: `.smart-graph-view` subtracts
+       the navbar's 52px, but the navbar floats with a gap beneath it and so
+       occupies more of the viewport bottom than its own height. Measured in the
+       emulator, it starts 32px above where the sheet ends — so without this the
+       last rows of the topic list sit under the navbar pill.
+
+       Padding rather than shortening the sheet: the sheet's background should
+       still run to the bottom edge (a gap under it would show canvas through a
+       strip the navbar only partly covers); it is the scrollable *content* that
+       has to stop short. */
+    padding: 0 12px calc(44px + env(safe-area-inset-bottom));
   }
 
   /* Without a handle above it the content would sit flush against the sheet's

--- a/src/components/ui/BottomSheet.svelte
+++ b/src/components/ui/BottomSheet.svelte
@@ -222,6 +222,32 @@ function handleDragEnd(e: PointerEvent) {
 	detentIndex = nearest;
 }
 
+/**
+ * Keyboard control for the handle. A `<div>` synthesises no click from
+ * Enter/Space the way the old `<button>` did, so the binding is explicit — and
+ * since this is announced as a slider, the arrow keys should move it directly
+ * rather than only cycling.
+ */
+function handleHandleKeydown(e: KeyboardEvent) {
+	if (e.key === "Enter" || e.key === " ") {
+		e.preventDefault();
+		handleHandleClick();
+		return;
+	}
+	if (e.key === "ArrowUp") {
+		e.preventDefault();
+		detentIndex = Math.min(detents.length - 1, detentIndex + 1);
+		return;
+	}
+	if (e.key === "ArrowDown") {
+		e.preventDefault();
+		// Below the smallest detent there is nowhere left to go but closed, which
+		// matches what dragging past it does.
+		if (detentIndex === 0) onClose();
+		else detentIndex -= 1;
+	}
+}
+
 /** Tapping the handle steps between detents — a reachable alternative to dragging. */
 function handleHandleClick() {
 	if (!draggable || isDragging) return;
@@ -268,21 +294,31 @@ const sheetHeight = $derived.by(() => {
            a 4px-tall pill is far below anything a thumb can reliably land on,
            so the padded bar around it takes the pointer.
 
-           A real `<button>` rather than a styled div, so the tap-to-step
-           behaviour is reachable by keyboard and announced — the drag itself
-           has no keyboard equivalent, but stepping detents does. -->
-      <button
-        type="button"
+           Deliberately not a `<button>`. It was one, for keyboard reach, but
+           mobile Obsidian paints `button:active` with a full-width background
+           and WebKit adds its own tap highlight — so every drag flashed a
+           rectangle behind the pill and made an indicator feel like a control
+           you had pressed. A `separator` with `tabindex` keeps it focusable and
+           correctly announced as a resize grip, without inheriting any button
+           chrome to fight. -->
+      <div
         class="s2b-sheet-handle"
+        role="slider"
+        aria-orientation="vertical"
         aria-label="Resize panel"
+        aria-valuemin={0}
+        aria-valuemax={detents.length - 1}
+        aria-valuenow={detentIndex}
+        tabindex="0"
         onpointerdown={handleDragStart}
         onpointermove={handleDragMove}
         onpointerup={handleDragEnd}
         onpointercancel={handleDragEnd}
         onclick={handleHandleClick}
+        onkeydown={handleHandleKeydown}
       >
         <div class="s2b-sheet-grabber"></div>
-      </button>
+      </div>
     {/if}
 
     <div class="s2b-sheet-scroll" class:s2b-sheet-scroll--faded={hasOverflow} bind:this={scrollEl}>
@@ -371,10 +407,33 @@ const sheetHeight = $derived.by(() => {
     border-radius: 0;
     box-shadow: none;
     cursor: grab;
+    /* The grabber pill is the only thing that should ever paint here. WebKit
+       otherwise flashes a full-width grey rectangle on touch, which made a
+       passive indicator read as a button being pressed. */
+    -webkit-tap-highlight-color: transparent;
+    user-select: none;
+    -webkit-user-select: none;
     /* Claim the vertical gesture for the drag. Only on the handle: the scroll
        region below must keep its own panning, and the sliders inside it keep
        the `pan-y` they need (see RangeSlider). */
     touch-action: none;
+  }
+
+  /* Focus lands on the grabber pill rather than outlining the full-width bar,
+     which would reintroduce exactly the rectangle this stopped painting. */
+  .s2b-sheet-handle:focus-visible {
+    outline: none;
+  }
+
+  .s2b-sheet-handle:focus-visible .s2b-sheet-grabber {
+    outline: 2px solid var(--background-modifier-border-focus);
+    outline-offset: 3px;
+  }
+
+  /* Feedback while dragging belongs on the pill too — it darkens instead of the
+     bar behind it lighting up. */
+  .s2b-bottom-sheet--dragging .s2b-sheet-grabber {
+    background: var(--text-muted);
   }
 
   .s2b-sheet-grabber {

--- a/src/components/ui/BottomSheet.svelte
+++ b/src/components/ui/BottomSheet.svelte
@@ -324,6 +324,13 @@ const sheetHeight = $derived.by(() => {
     box-shadow: var(--shadow-l);
     animation: s2b-sheet-in 160ms ease-out;
     transition: height 200ms cubic-bezier(0.32, 0.72, 0, 1);
+    /* Claim every gesture that lands on the sheet's own chrome. Obsidian binds
+       swipe-down to the command palette and horizontal swipes to the sidebars
+       as JS touch listeners, and the browser only withholds those events from
+       the host if we declare we are handling the axis. Left at `auto`, a drag
+       that started anywhere but the 24px handle opened the command palette.
+       The scroll region below re-enables the one axis it genuinely needs. */
+    touch-action: none;
   }
 
   /* Under the finger the height must follow the pointer exactly; a transition
@@ -379,6 +386,10 @@ const sheetHeight = $derived.by(() => {
     overflow-y: auto;
     /* Keep a scroll that reaches its end from chaining into the canvas behind. */
     overscroll-behavior: contain;
+    /* Vertical only: this genuinely scrolls, so the browser must own that axis.
+       Horizontal stays claimed by the sheet's `none`, which is what keeps a
+       sideways drag over the content from opening a sidebar. */
+    touch-action: pan-y;
     /* The bottom inset clears Obsidian's floating mobile navbar, which is NOT
        covered by the host view's own reservation: `.smart-graph-view` subtracts
        the navbar's 52px, but the navbar floats with a gap beneath it and so

--- a/src/components/ui/BottomSheet.svelte
+++ b/src/components/ui/BottomSheet.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { untrack } from "svelte";
 import type { Snippet } from "svelte";
+import { claimTouchGestures } from "../../utils/claimTouchGestures";
 
 interface Props {
 	open: boolean;
@@ -247,8 +248,14 @@ const sheetHeight = $derived.by(() => {
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="s2b-sheet-dismiss" onclick={onClose}></div>
 
+  <!-- One attachment on the root covers everything inside: the drag handle, the
+       granularity slider, and the scrolling body. The host's swipe recognizer
+       is a bubble-phase `touchmove` on `window`, so stopping the event here
+       starves it before it can decide an axis — see the action for the
+       on-device measurement this is based on. -->
   <div
     bind:this={sheetEl}
+    use:claimTouchGestures
     class="s2b-bottom-sheet"
     class:s2b-bottom-sheet--dragging={isDragging}
     style="height: {sheetHeight}"
@@ -324,12 +331,11 @@ const sheetHeight = $derived.by(() => {
     box-shadow: var(--shadow-l);
     animation: s2b-sheet-in 160ms ease-out;
     transition: height 200ms cubic-bezier(0.32, 0.72, 0, 1);
-    /* Claim every gesture that lands on the sheet's own chrome. Obsidian binds
-       swipe-down to the command palette and horizontal swipes to the sidebars
-       as JS touch listeners, and the browser only withholds those events from
-       the host if we declare we are handling the axis. Left at `auto`, a drag
-       that started anywhere but the 24px handle opened the command palette.
-       The scroll region below re-enables the one axis it genuinely needs. */
+    /* Stops the browser's own panning on the sheet's chrome, so a drag on the
+       handle never also scrolls something underneath. Keeping the host's swipe
+       recognizers out is a separate job, done by `use:claimTouchGestures` on
+       this same element — `touch-action` alone provably does not do it. The
+       scroll region below re-enables the one axis it genuinely needs. */
     touch-action: none;
   }
 

--- a/src/components/ui/BottomSheet.svelte
+++ b/src/components/ui/BottomSheet.svelte
@@ -311,6 +311,11 @@ const sheetHeight = $derived.by(() => {
     display: flex;
     flex-direction: column;
     min-height: 0;
+    /* The darker of the pair, matching how a settings tab renders: the page is
+       `--background-secondary` and the grouped cards on it are lighter. (Don't
+       read that off `--setting-items-background`, which resolves to the darker
+       value here — the settings tab overrides it. Measured, core paints a
+       #ffffff card on a #f6f6f6 page.) */
     background: var(--background-secondary);
     border-top: 1px solid var(--background-modifier-border);
     /* Rounded at the top only: the bottom edge is flush against the navbar, and

--- a/src/components/ui/BottomSheet.svelte
+++ b/src/components/ui/BottomSheet.svelte
@@ -1,0 +1,389 @@
+<script lang="ts">
+import { untrack } from "svelte";
+import type { Snippet } from "svelte";
+
+interface Props {
+	open: boolean;
+	onClose: () => void;
+	/**
+	 * Heights to snap to, as fractions of the containing block. Ascending.
+	 * Two is the useful number here: a peek that leaves the graph visible, and
+	 * a full stop for a long list.
+	 */
+	detents?: number[];
+	/** Which detent to open at. */
+	initialDetent?: number;
+	/**
+	 * False for a sheet that should be exactly as tall as its content — the
+	 * selection sheet is a fixed set of verbs, so there is nothing to expand
+	 * into and a handle would promise a gesture that does nothing.
+	 */
+	draggable?: boolean;
+	ariaLabel: string;
+	children: Snippet;
+}
+
+let {
+	open,
+	onClose,
+	detents = [0.45, 0.9],
+	initialDetent = 0,
+	draggable = true,
+	ariaLabel,
+	children,
+}: Props = $props();
+
+/** The sheet element, used to measure its containing block during a drag. */
+let sheetEl = $state<HTMLElement | undefined>(undefined);
+/** The scroll region, watched so the overflow fade can turn itself off. */
+let scrollEl = $state<HTMLElement | undefined>(undefined);
+
+/**
+ * Live height in px while dragging, `null` when settled.
+ *
+ * A settled sheet is sized by its detent (a percentage) rather than a frozen
+ * pixel value, so it keeps tracking the viewport if the device rotates or the
+ * leaf is resized. Only the drag needs pixels.
+ */
+let dragHeight = $state<number | null>(null);
+let detentIndex = $state(0);
+
+/** True once dragged far enough to count as a drag rather than a tap. */
+let isDragging = $state(false);
+
+/** Whether the scroll region has content below the fold. */
+let hasOverflow = $state(false);
+
+/**
+ * Reset to the opening detent each time the sheet is shown.
+ *
+ * Reopening a sheet the user had dragged to full height would otherwise
+ * reopen at full height, which hides the graph the sheet is meant to leave
+ * visible. A side effect on state owned elsewhere (`open`), not a derivation.
+ */
+$effect(() => {
+	if (!open) return;
+	// Only the open/closed transition should reset the sheet — untracked so a
+	// later detent change (the user dragging) can't re-enter this and snap the
+	// sheet back under their finger.
+	untrack(() => {
+		detentIndex = initialDetent;
+		dragHeight = null;
+	});
+});
+
+/**
+ * Track whether the scroll region actually overflows, so the bottom fade only
+ * appears when there is something below the fold — an always-on fade reads as
+ * decoration and stops carrying information.
+ *
+ * A ResizeObserver rather than a one-shot measure: the content changes height
+ * as topics are found and as sections are toggled, and the sheet itself
+ * changes height when dragged.
+ */
+$effect(() => {
+	const el = scrollEl;
+	if (!el) return;
+
+	const measure = () => {
+		hasOverflow = el.scrollHeight - el.scrollTop - el.clientHeight > 1;
+	};
+
+	measure();
+	const observer = new ResizeObserver(measure);
+	observer.observe(el);
+	// The content is a separate box from the scroll port; both can change.
+	for (const child of Array.from(el.children)) observer.observe(child);
+	el.addEventListener("scroll", measure, { passive: true });
+
+	return () => {
+		observer.disconnect();
+		el.removeEventListener("scroll", measure);
+	};
+});
+
+/** Escape closes, matching every other dismissible surface in the plugin. */
+$effect(() => {
+	if (!open) return;
+	const onKeyDown = (e: KeyboardEvent) => {
+		if (e.key !== "Escape") return;
+		e.preventDefault();
+		onClose();
+	};
+	document.addEventListener("keydown", onKeyDown);
+	return () => document.removeEventListener("keydown", onKeyDown);
+});
+
+/** Height of the box the sheet is positioned against. */
+function containerHeight(): number {
+	return sheetEl?.parentElement?.clientHeight ?? window.innerHeight;
+}
+
+// ── Drag ────────────────────────────────────────────────────────────────────
+// Pointer events with capture, the same approach the graph canvas uses for its
+// own drags: it survives the pointer leaving the handle, which happens
+// constantly when you fling a sheet.
+
+/** Where the drag started, and the sheet height at that moment. */
+let dragStartY = 0;
+let dragStartHeight = 0;
+/** Last sample, for the release velocity. */
+let lastY = 0;
+let lastT = 0;
+let velocity = 0;
+
+/** Past this much movement a press is a drag, not a tap on the handle. */
+const DRAG_THRESHOLD_PX = 4;
+/** px/ms past which a flick decides the direction regardless of position. */
+const FLICK_VELOCITY = 0.5;
+/** How far below the smallest detent the sheet must go to dismiss. */
+const DISMISS_MARGIN = 0.6;
+
+function handleDragStart(e: PointerEvent) {
+	if (!draggable || !sheetEl) return;
+	dragStartY = e.clientY;
+	lastY = e.clientY;
+	lastT = e.timeStamp;
+	velocity = 0;
+	dragStartHeight = sheetEl.clientHeight;
+	isDragging = false;
+	(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+}
+
+function handleDragMove(e: PointerEvent) {
+	if (!draggable || !sheetEl) return;
+	const el = e.currentTarget as HTMLElement;
+	if (!el.hasPointerCapture(e.pointerId)) return;
+
+	const delta = dragStartY - e.clientY;
+	if (!isDragging && Math.abs(delta) < DRAG_THRESHOLD_PX) return;
+	isDragging = true;
+
+	const dt = e.timeStamp - lastT;
+	if (dt > 0) velocity = (lastY - e.clientY) / dt;
+	lastY = e.clientY;
+	lastT = e.timeStamp;
+
+	const max = containerHeight() * detents[detents.length - 1];
+	// Allowed below the smallest detent so a downward drag can reach dismissal,
+	// but never above the largest — a sheet taller than its container has
+	// nowhere to put the overshoot.
+	dragHeight = Math.min(max, Math.max(0, dragStartHeight + delta));
+}
+
+function handleDragEnd(e: PointerEvent) {
+	const el = e.currentTarget as HTMLElement;
+	if (el.hasPointerCapture(e.pointerId)) el.releasePointerCapture(e.pointerId);
+	if (!draggable || !isDragging || dragHeight === null) {
+		isDragging = false;
+		return;
+	}
+
+	const height = dragHeight;
+	const container = containerHeight();
+	isDragging = false;
+	dragHeight = null;
+
+	const smallest = detents[0] * container;
+
+	// A decisive flick wins over position: someone who throws the sheet down
+	// from full height means "close", even though it is still passing through
+	// the peek detent when they let go.
+	if (velocity < -FLICK_VELOCITY) {
+		if (detentIndex === 0) {
+			onClose();
+		} else {
+			detentIndex -= 1;
+		}
+		return;
+	}
+	if (velocity > FLICK_VELOCITY) {
+		detentIndex = Math.min(detents.length - 1, detentIndex + 1);
+		return;
+	}
+
+	// Dragged well below the smallest detent and released: dismiss.
+	if (height < smallest * DISMISS_MARGIN) {
+		onClose();
+		return;
+	}
+
+	// Otherwise settle on whichever detent the sheet is closest to.
+	let nearest = 0;
+	let best = Number.POSITIVE_INFINITY;
+	for (let i = 0; i < detents.length; i++) {
+		const distance = Math.abs(detents[i] * container - height);
+		if (distance < best) {
+			best = distance;
+			nearest = i;
+		}
+	}
+	detentIndex = nearest;
+}
+
+/** Tapping the handle steps between detents — a reachable alternative to dragging. */
+function handleHandleClick() {
+	if (!draggable || isDragging) return;
+	detentIndex = detentIndex >= detents.length - 1 ? 0 : detentIndex + 1;
+}
+
+const sheetHeight = $derived.by(() => {
+	if (!draggable) return "auto";
+	if (dragHeight !== null) return `${dragHeight}px`;
+	return `${(detents[detentIndex] ?? detents[0]) * 100}%`;
+});
+</script>
+
+{#if open}
+  <!--
+    Dismiss layer: deliberately transparent rather than a dimming scrim.
+
+    The controls in these sheets are drag-and-watch — the point of the
+    granularity slider is seeing topics re-cluster underneath it — so anything
+    that dims the canvas defeats the reason the sheet exists. It still catches
+    the tap, which is the behaviour a backdrop is actually there for.
+  -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="s2b-sheet-dismiss" onclick={onClose}></div>
+
+  <div
+    bind:this={sheetEl}
+    class="s2b-bottom-sheet"
+    class:s2b-bottom-sheet--dragging={isDragging}
+    style="height: {sheetHeight}"
+    role="dialog"
+    aria-modal="false"
+    aria-label={ariaLabel}
+  >
+    {#if draggable}
+      <!-- The handle is the whole drag surface, not just the visible grabber:
+           a 4px-tall pill is far below anything a thumb can reliably land on,
+           so the padded bar around it takes the pointer.
+
+           A real `<button>` rather than a styled div, so the tap-to-step
+           behaviour is reachable by keyboard and announced — the drag itself
+           has no keyboard equivalent, but stepping detents does. -->
+      <button
+        type="button"
+        class="s2b-sheet-handle"
+        aria-label="Resize panel"
+        onpointerdown={handleDragStart}
+        onpointermove={handleDragMove}
+        onpointerup={handleDragEnd}
+        onpointercancel={handleDragEnd}
+        onclick={handleHandleClick}
+      >
+        <div class="s2b-sheet-grabber"></div>
+      </button>
+    {/if}
+
+    <div class="s2b-sheet-scroll" class:s2b-sheet-scroll--faded={hasOverflow} bind:this={scrollEl}>
+      {@render children()}
+    </div>
+  </div>
+{/if}
+
+<style>
+  /* Covers the canvas above the sheet only — the sheet itself must stay
+     tappable, so this is a sibling rather than a parent. */
+  .s2b-sheet-dismiss {
+    position: absolute;
+    inset: 0;
+    z-index: 13;
+    background: transparent;
+  }
+
+  /* `bottom: 0` against `.smart-graph-view`, which on mobile already ends above
+     Obsidian's floating navbar (it subtracts the navbar band from its own
+     height). So the sheet lands flush on the navbar without repeating that
+     measurement — the previous selection bar hardcoded a 92px offset to do the
+     same job, and drifted whenever the real inset differed. */
+  .s2b-bottom-sheet {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 14;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    background: var(--background-secondary);
+    border-top: 1px solid var(--background-modifier-border);
+    /* Rounded at the top only: the bottom edge is flush against the navbar, and
+       rounding an edge that touches something reads as a rendering mistake. */
+    border-radius: var(--radius-l) var(--radius-l) 0 0;
+    box-shadow: var(--shadow-l);
+    animation: s2b-sheet-in 160ms ease-out;
+    transition: height 200ms cubic-bezier(0.32, 0.72, 0, 1);
+  }
+
+  /* Under the finger the height must follow the pointer exactly; a transition
+     here would make the sheet lag behind the drag. */
+  .s2b-bottom-sheet--dragging {
+    transition: none;
+  }
+
+  @keyframes s2b-sheet-in {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+
+  /* Obsidian gives every `button` a background, border and shadow; this one is
+     a grab surface, so it resets them and lets the grabber pill be the only
+     thing that paints. */
+  .s2b-sheet-handle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    /* A 4px pill inside a bar tall enough to actually grab. */
+    padding: 10px 0;
+    min-height: 24px;
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    cursor: grab;
+    /* Claim the vertical gesture for the drag. Only on the handle: the scroll
+       region below must keep its own panning, and the sliders inside it keep
+       the `pan-y` they need (see RangeSlider). */
+    touch-action: none;
+  }
+
+  .s2b-sheet-grabber {
+    width: 36px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--background-modifier-border);
+  }
+
+  .s2b-sheet-scroll {
+    flex: 1;
+    /* Without this a flex child refuses to shrink below its content height, so
+       the sheet would grow past its detent instead of scrolling. */
+    min-height: 0;
+    overflow-y: auto;
+    /* Keep a scroll that reaches its end from chaining into the canvas behind. */
+    overscroll-behavior: contain;
+    padding: 0 12px calc(12px + env(safe-area-inset-bottom));
+  }
+
+  /* Without a handle above it the content would sit flush against the sheet's
+     top edge, so the padding the handle was providing has to come from here. */
+  .s2b-bottom-sheet:not(:has(.s2b-sheet-handle)) .s2b-sheet-scroll {
+    padding-top: 12px;
+  }
+
+  /* The "there is more below" affordance. Fades the last few pixels of content
+     rather than adding a chrome element, and turns itself off at the end of the
+     scroll so its presence always means something. */
+  .s2b-sheet-scroll--faded {
+    mask-image: linear-gradient(to bottom, black calc(100% - 24px), transparent 100%);
+  }
+</style>

--- a/src/components/ui/RangeSlider.svelte
+++ b/src/components/ui/RangeSlider.svelte
@@ -83,10 +83,16 @@ const fillRatio = $derived.by(() => {
 	 * changing the value. Claiming the gesture here keeps the drag with the
 	 * control the finger is actually on.
 	 *
-	 * `pan-y` rather than `none`: the panel this lives in scrolls vertically and
-	 * is taller than a phone screen, so a slider that swallowed both axes would
-	 * become a dead zone you cannot scroll past. Horizontal goes to the thumb,
-	 * vertical still scrolls the panel.
+	 * `none`, not `pan-y`. `pan-y` still declares "I do not handle horizontal
+	 * panning", which is exactly the axis the sidebar-swipe listens on — so the
+	 * sidebar kept opening mid-drag. Only `none` claims both axes and stops the
+	 * browser generating the pan the host is watching for.
+	 *
+	 * `pan-y` was originally chosen so a tall panel could still be scrolled by
+	 * dragging over the slider. That trade no longer applies: the slider sits in
+	 * a card inside a scrolling sheet, with the row's label, the surrounding
+	 * card and the whole sheet body all available to scroll from — none of which
+	 * is a 6px-tall control whose entire purpose is the horizontal drag.
 	 *
 	 * Deliberately no track or thumb styling: Obsidian paints both itself off the
 	 * `slider` class and the `--slider-fill-ratio` we set inline, and overriding
@@ -94,7 +100,7 @@ const fillRatio = $derived.by(() => {
 	 * touch behaviour changes.
 	 */
 	.s2b-range {
-		touch-action: pan-y;
+		touch-action: none;
 	}
 
 	/* No transparent border to grow the hit area on mobile.

--- a/src/components/ui/RangeSlider.svelte
+++ b/src/components/ui/RangeSlider.svelte
@@ -34,15 +34,34 @@ function handleChange(e: Event) {
 	value = Number(target.value);
 	oncommit?.(value);
 }
+
+/**
+ * How far along the track the value sits, 0–1.
+ *
+ * Obsidian paints the filled part of the track itself, from a
+ * `linear-gradient` on `input[type="range"].slider` that reads this variable —
+ * the same way its own `SliderComponent` sets it inline. Without it the
+ * gradient resolves to a 0% fill and the control renders as a bare grey rail,
+ * which is why this looked hand-rolled next to a native slider.
+ */
+const fillRatio = $derived.by(() => {
+	const span = max - min;
+	if (span <= 0) return 0;
+	return Math.min(1, Math.max(0, (value - min) / span));
+});
 </script>
 
 <div class="flex items-center gap-2 {className}">
 	{#if showValue}
 		<output class="text-ui-small text-text-muted w-8 text-right">{value}</output>
 	{/if}
+	<!-- `slider` is Obsidian's own class: it is what opts this input into the
+	     native filled track (and the theme's thumb sizing) rather than the bare
+	     rail the base `input[type="range"]` rule gives. -->
 	<input
 		type="range"
-		class="s2b-range w-full cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+		class="slider s2b-range w-full cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+		style="--slider-fill-ratio: {fillRatio};"
 		{value}
 		{min}
 		{max}
@@ -69,24 +88,21 @@ function handleChange(e: Event) {
 	 * become a dead zone you cannot scroll past. Horizontal goes to the thumb,
 	 * vertical still scrolls the panel.
 	 *
-	 * Deliberately no track or thumb styling: Obsidian paints the track through
-	 * `background` on the input itself, and overriding it here would drop the
-	 * user's theme for a hand-rolled slider. Only the touch behaviour changes.
+	 * Deliberately no track or thumb styling: Obsidian paints both itself off the
+	 * `slider` class and the `--slider-fill-ratio` we set inline, and overriding
+	 * either here would drop the user's theme for a hand-rolled slider. Only the
+	 * touch behaviour changes.
 	 */
 	.s2b-range {
 		touch-action: pan-y;
 	}
 
-	/* A 6px-tall element is thinner than a fingertip, so most taps missed it
-	   outright. A transparent border enlarges the hit area without entering the
-	   background painting area, so Obsidian's track keeps drawing exactly as the
-	   theme intended — `padding` + `background-clip: content-box` was tried first
-	   and erased the rail, leaving a thumb floating over nothing. Mobile only: a
-	   mouse is precise enough, and the extra height would loosen the desktop
-	   panel's rhythm. */
-	:global(.is-mobile) .s2b-range {
-		border-top: 10px solid transparent;
-		border-bottom: 10px solid transparent;
-		box-sizing: content-box;
-	}
+	/* No transparent border to grow the hit area on mobile.
+
+	   That was added back when this rendered as a bare 6px rail, where the only
+	   thing to aim at really was 6px tall. With the native `slider` class the
+	   theme's own thumb applies at 24px, which is already a reasonable target,
+	   and the border made the control 26px tall — visibly fatter than every
+	   native slider next to it, which is what gave it away as non-native. The
+	   thumb overflows the track box, so it stays grabbable without it. */
 </style>

--- a/src/components/ui/RangeSlider.svelte
+++ b/src/components/ui/RangeSlider.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+import { onDestroy } from "svelte";
+import { claimTouchGestures } from "../../utils/claimTouchGestures";
+
 interface Props {
 	value?: number;
 	min?: number;
@@ -23,17 +26,51 @@ let {
 	oncommit,
 }: Props = $props();
 
+/** Pending rAF for the deferred `onchange`, so drags coalesce to one per frame. */
+let liveFrame: number | null = null;
+
+/**
+ * Update the thumb immediately; run the consumer's work after the paint.
+ *
+ * `onchange` fires on every pointer sample during a drag, and a consumer can do
+ * real work in it — the graph's granularity handler re-derives segments and
+ * repaints its canvas, measured at ~115ms on a 4,207-note vault. Calling it
+ * synchronously here blocks the browser from painting the new thumb position,
+ * so the *slider itself* lagged the finger even though `value` was already
+ * correct. The work is main-thread by nature (style reads, canvas paint), so
+ * it cannot simply be moved to a worker.
+ *
+ * Deferring to `requestAnimationFrame` lets the thumb paint first and collapses
+ * a burst of samples into one call per frame. Drag-and-watch still works — the
+ * consumer sees the newest value every frame — it just no longer sits in front
+ * of the control's own rendering.
+ */
 function handleInput(e: Event) {
 	const target = e.target as HTMLInputElement;
 	value = Number(target.value);
-	onchange?.(value);
+	if (!onchange) return;
+	if (liveFrame !== null) cancelAnimationFrame(liveFrame);
+	liveFrame = requestAnimationFrame(() => {
+		liveFrame = null;
+		onchange?.(value);
+	});
 }
 
 function handleChange(e: Event) {
 	const target = e.target as HTMLInputElement;
 	value = Number(target.value);
+	// Drop any deferred live update: the commit below supersedes it, and letting
+	// it fire afterwards would re-apply a stale mid-drag value on top.
+	if (liveFrame !== null) {
+		cancelAnimationFrame(liveFrame);
+		liveFrame = null;
+	}
 	oncommit?.(value);
 }
+
+onDestroy(() => {
+	if (liveFrame !== null) cancelAnimationFrame(liveFrame);
+});
 
 /**
  * How far along the track the value sits, 0–1.
@@ -51,7 +88,7 @@ const fillRatio = $derived.by(() => {
 });
 </script>
 
-<div class="flex items-center gap-2 {className}">
+<div class="s2b-range-row flex items-center gap-2 {className}">
 	{#if showValue}
 		<output class="text-ui-small text-text-muted w-8 text-right">{value}</output>
 	{/if}
@@ -59,6 +96,7 @@ const fillRatio = $derived.by(() => {
 	     native filled track (and the theme's thumb sizing) rather than the bare
 	     rail the base `input[type="range"]` rule gives. -->
 	<input
+		use:claimTouchGestures
 		type="range"
 		class="slider s2b-range w-full cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
 		style="--slider-fill-ratio: {fillRatio};"
@@ -74,25 +112,15 @@ const fillRatio = $derived.by(() => {
 
 <style>
 	/*
-	 * `touch-action: none` is the load-bearing line on mobile.
+	 * `touch-action: none` stops the *browser's* own panning, so dragging the
+	 * thumb never also scrolls the surrounding panel.
 	 *
-	 * Obsidian's mobile CSS leaves range inputs at `touch-action: manipulation`,
-	 * which declares "this element does not handle panning" — so a horizontal drag
-	 * on the slider is handed to Obsidian's sidebar-swipe gesture instead of moving
-	 * the thumb. Dragging the granularity slider opened the sidebar rather than
-	 * changing the value. Claiming the gesture here keeps the drag with the
-	 * control the finger is actually on.
-	 *
-	 * `none`, not `pan-y`. `pan-y` still declares "I do not handle horizontal
-	 * panning", which is exactly the axis the sidebar-swipe listens on — so the
-	 * sidebar kept opening mid-drag. Only `none` claims both axes and stops the
-	 * browser generating the pan the host is watching for.
-	 *
-	 * `pan-y` was originally chosen so a tall panel could still be scrolled by
-	 * dragging over the slider. That trade no longer applies: the slider sits in
-	 * a card inside a scrolling sheet, with the row's label, the surrounding
-	 * card and the whole sheet body all available to scroll from — none of which
-	 * is a 6px-tall control whose entire purpose is the horizontal drag.
+	 * It does NOT stop Obsidian's sidebar swipe. That is a JS recognizer
+	 * (bubble-phase `touchmove` on `window`), which receives the event stream
+	 * no matter what `touch-action` says — `manipulation` → `pan-y` (#417) and
+	 * then `pan-y` → `none` both failed on hardware for exactly this reason.
+	 * `use:claimTouchGestures` on the input is what actually protects the drag;
+	 * see that action for the on-device measurement.
 	 *
 	 * Deliberately no track or thumb styling: Obsidian paints both itself off the
 	 * `slider` class and the `--slider-fill-ratio` we set inline, and overriding
@@ -101,6 +129,20 @@ const fillRatio = $derived.by(() => {
 	 */
 	.s2b-range {
 		touch-action: none;
+	}
+
+	/* Obsidian's base rule is `input[type="range"] { width: 100px }`, which beats
+	   the `w-full` utility class on specificity — measured 100px in a 194px slot
+	   on a phone, so the control was using barely half the room it had. Match the
+	   element selector to win, and let the row grow into the slot. */
+	.s2b-range-row {
+		flex: 1;
+		min-width: 0;
+	}
+
+	input[type="range"].s2b-range {
+		width: 100%;
+		min-width: 0;
 	}
 
 	/* No transparent border to grow the hit area on mobile.

--- a/src/styles.css
+++ b/src/styles.css
@@ -1207,6 +1207,7 @@
 .is-mobile .attach-context-button.clickable-icon,
 .is-mobile .chat-input-icon-button.clickable-icon,
 .is-mobile .graph-controls .clickable-icon,
+.is-mobile .s2b-bottom-sheet .clickable-icon,
 .is-mobile .provider-icon-button.clickable-icon,
 .is-mobile .pcb-action-icon {
 	min-width: 44px !important;

--- a/src/utils/claimTouchGestures.ts
+++ b/src/utils/claimTouchGestures.ts
@@ -1,0 +1,52 @@
+/**
+ * Svelte action: keep touch drags inside this element away from Obsidian's
+ * mobile swipe gestures (sidebar open/close, pull-down command palette).
+ *
+ * ## What the host actually does
+ *
+ * Measured on-device (iOS 26) by patching `addEventListener` in the live
+ * WebView, the recognizer registers as:
+ *
+ *     window | touchmove | bubble | function(i){var r=E(i); ...
+ *       Math.abs(o-a) vs Math.abs(h-s) ... Date.now()-d>200 ...
+ *
+ * That is: **`touchmove`, on `window`, in the bubble phase**, doing axis
+ * detection against the touch start within a 200 ms window.
+ *
+ * Two consequences, both of which earlier attempts got wrong:
+ *
+ * 1. **It listens to `touchmove`, not `pointermove`.** iOS Safari dispatches
+ *    the two independently, so stopping pointer events does nothing.
+ * 2. **It is on `window` in the bubble phase** — the very last thing to run.
+ *    So `stopPropagation` from anywhere inside the sheet reliably starves it.
+ *    (A capture-phase listener on an ancestor could not have been blocked
+ *    this way; this one can.)
+ *
+ * Verified on-device: with this stop attached, synthetic touchmoves on the
+ * slider reach the window listener 0 times; without it, every one arrives.
+ *
+ * ## Why not `touch-action`
+ *
+ * `touch-action` only governs the *browser's* built-in panning/zooming. It
+ * never had any effect on a JS recognizer, which is why `manipulation` →
+ * `pan-y` (#417) and then `pan-y` → `none` both failed on hardware. It is
+ * still worth setting to stop native scroll fighting the drag, but it is not
+ * what protects against the host gesture.
+ *
+ * ## Scope
+ *
+ * `touchmove` only. `touchstart`/`touchend` still propagate, so taps, focus
+ * and the host's own bookkeeping are untouched — a swipe recognizer that gets
+ * a start but no moves simply never fires. Non-passive is required: some
+ * callers also want `preventDefault` available, and a passive listener could
+ * not offer it; we only ever call `stopPropagation` here.
+ */
+export function claimTouchGestures(node: HTMLElement) {
+	const stop = (e: Event) => e.stopPropagation();
+	node.addEventListener("touchmove", stop);
+	return {
+		destroy() {
+			node.removeEventListener("touchmove", stop);
+		},
+	};
+}


### PR DESCRIPTION
Closes #418.

The graph's two floating surfaces — the settings panel and the selection bar — were desktop layouts reused verbatim on phones. As #418 argues, the problems are modality problems rather than sizing bugs, so this changes the modality rather than patching controls one at a time.

## What changed

A shared `BottomSheet` primitive (`src/components/ui/BottomSheet.svelte`), with both surfaces rendered into it on mobile.

**Desktop is unchanged.** The panel's controls moved into a `{#snippet panelBody()}` rendered into either container, so there's one copy of the markup — a control added later can't go missing from one modality — and the desktop branch keeps its existing popover verbatim.

### Against the issue's requirements

| Requirement | How |
|---|---|
| Keep the graph visible | Dismiss layer is **transparent**, not a dimming scrim — a scrim would defeat the drag-and-watch controls the sheet exists to serve. It still catches the tap, which is what a backdrop is actually for. |
| Bottom-anchored, thumb reach | `bottom: 0` inside `.smart-graph-view`, which already subtracts the navbar band from its own height. |
| ≥44px touch targets | Selection sheet rows are full-width and 44px; segment rows raised from ~22px; `.s2b-bottom-sheet .clickable-icon` added to the existing mobile floor in `styles.css`. |
| Narrow-column layout, no meaningless elements | The count becomes the sheet header and the verbs stack, so `.selection-divider` is **structurally gone** on mobile rather than left dangling after a wrap. |
| Swipe/backdrop dismiss + scroll affordance | Drag, flick, tap-outside and Escape all dismiss; the scroll region carries a bottom `mask-image` fade that turns itself off at the end, so its presence always means something. |

### Notable

- **The `92px` magic number is deleted, not reproduced.** The selection bar used `bottom: calc(92px + safe-area)` to clear Obsidian's floating navbar, which left it attached to neither the content nor the screen edge. `.smart-graph-view` already does that measurement correctly for the canvas, so anchoring inside it inherits the one value that was already right.
- **No portaling needed.** Unlike the chat composer (`Chat.svelte:90`), there's no on-screen keyboard in the graph view, so the leaf's stale-reflow problem doesn't apply.
- **Two detents** for settings: peek (45%) leaves the graph visible with Topics — granularity and inferred links — in reach; drag up to 90% for the topic list. The list's `max-height: 40vh` cap is dropped inside the sheet, since a nested scroll area within a scrolling sheet gives two overlapping scroll targets under one thumb.
- **One sheet at a time.** A selection appearing closes the settings sheet — guarded on the transition, so reopening settings while a selection is live doesn't immediately close it again.
- The toolbar is lifted above the dismiss layer so fit/lasso/topics stay reachable while a sheet is open, and the sliders button keeps working as the sheet's own toggle.
- `RangeSlider`'s `touch-action: pan-y` from #417 is preserved and load-bearing: the sheet body scrolls vertically, so the slider must keep handing the vertical axis on. `touch-action: none` is confined to the drag handle.
- The dev panel (dev builds only) keeps its popover; it's out of the issue's scope.

## Verification

- `bun run check` — 0 errors, 0 warnings
- `bun run test` — 1564 passed
- `bun run lint` — 35 errors, unchanged from `dev` (verified by stashing); none in the new code
- `bun run build` — clean

Not yet confirmed on a physical device — the emulator can't reproduce real touch behaviour or the actual navbar inset, so the drag/flick feel and the safe-area clearance are worth a look on hardware.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._