### PR TITLE
fix(graph): consistent cursors across the graph view

### DIFF
--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -459,6 +459,26 @@ function isOverClusterPill(x: number, y: number): boolean {
 	return clusterPillAt(x, y) !== undefined;
 }
 
+// ── Cursor ──────────────────────────────────────────────────
+//
+// One function owns the canvas cursor, and it is a pure function of the
+// present state — never of a transition. The previous code assigned the
+// cursor inside the "did the hovered node change?" guard, so moving from a
+// topic pill (which forces hoveredNode = null) onto empty canvas compared
+// null to null, skipped the assignment, and left `pointer` stuck on the
+// canvas. Deriving from current position instead makes that class of bug
+// unrepresentable.
+//
+// Clickable things resolve to `var(--cursor)` rather than a literal
+// `pointer` so the graph tracks Obsidian's "Use pointer cursor for clickable
+// elements" setting, exactly like the native `.clickable-icon` buttons on the
+// toolbar rail. Grab/grabbing stay literal: panning is direct manipulation of
+// a surface, not a click target, so it is not what that setting governs.
+function applyCursor(overInteractive: boolean) {
+	if (!pixi) return;
+	pixi.canvas.style.cursor = overInteractive ? "var(--cursor)" : lassoMode ? "crosshair" : "grab";
+}
+
 // ── On-demand render scheduling ─────────────────────────────
 //
 // Every render trigger funnels through requestRender, which coalesces any
@@ -1768,7 +1788,7 @@ function handleMouseMove(e: PointerEvent) {
 	} else {
 		// Hover detection: check cluster legend first, then nodes
 		if (isOverClusterPill(x, y)) {
-			canvas.style.cursor = "pointer";
+			applyCursor(true);
 			if (hoveredNode) {
 				hoveredNode = null;
 				requestRender("world");
@@ -1777,10 +1797,12 @@ function handleMouseMove(e: PointerEvent) {
 		}
 
 		const node = findNodeAt(x, y);
+		// Outside the guard below: the cursor follows the pointer's current
+		// position, while the guard gates only the expensive re-render.
+		applyCursor(node !== null);
 		if (node !== hoveredNode) {
 			hoveredNode = node;
 			previewTriggeredForNode = null;
-			canvas.style.cursor = node ? "pointer" : lassoMode ? "crosshair" : "grab";
 			requestRender("world");
 		}
 		// Cmd/Ctrl+hover triggers note preview (fire once per node)
@@ -1922,6 +1944,9 @@ function handleMouseLeave() {
 	cancelLongPress();
 	hoveredNode = null;
 	previewTriggeredForNode = null;
+	// Leaving while over a node or pill would otherwise strand `var(--cursor)`
+	// on the canvas, so re-entering over empty space starts out wrong.
+	applyCursor(false);
 	requestRender("world");
 }
 
@@ -2558,6 +2583,23 @@ $effect(() => {
 	// nodeSize feeds node radii, which the hit grid bakes in at build time.
 	hitGridDirty = true;
 	if (pixi) requestRender("world");
+});
+
+// Lasso is toggled from the toolbar, so the pointer is over the rail — not the
+// canvas — when the mode flips, and no pointermove follows to refresh the
+// cursor. Without this the crosshair only appears once you happen to move over
+// a node and back off it. DOM manipulation in response to a prop, which is what
+// $effect is for.
+$effect(() => {
+	const _lasso = lassoMode;
+	void _lasso;
+	// Mid-gesture the cursor belongs to the drag, not to hover state. Untracked
+	// so this effect keys on lassoMode alone and isn't also re-run by the
+	// lasso's own start/end.
+	untrack(() => {
+		if (isLassoing || dragSimNode) return;
+		applyCursor(false);
+	});
 });
 
 // Hot-update force parameters without full rebuild.

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -474,8 +474,13 @@ function isOverClusterPill(x: number, y: number): boolean {
 // elements" setting, exactly like the native `.clickable-icon` buttons on the
 // toolbar rail. Grab/grabbing stay literal: panning is direct manipulation of
 // a surface, not a click target, so it is not what that setting governs.
+// Guarded on `ready`, not just non-null: `pixi` is assigned before
+// `renderer.init()` is awaited, and the `canvas` getter reads `this.app`, which
+// only exists once that init has run. The lasso effect below fires on mount and
+// can land inside exactly that window, where a non-null `pixi` would still
+// throw. This is the hazard `PixiRenderer.ready` already exists to describe.
 function applyCursor(overInteractive: boolean) {
-	if (!pixi) return;
+	if (!pixi?.ready) return;
 	pixi.canvas.style.cursor = overInteractive ? "var(--cursor)" : lassoMode ? "crosshair" : "grab";
 }
 

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -2758,6 +2758,12 @@ onMount(() => {
 				requestRender("world");
 			}
 
+			// Same "catch up on what was missed while initializing" idea as the fit
+			// above: applyCursor is a no-op until the renderer is ready, so anything
+			// that set the cursor during init was dropped. Replay it once here so the
+			// canvas doesn't wait for the first pointermove to show the right cursor.
+			applyCursor(false);
+
 			const resizeObserver = new ResizeObserver(() => {
 				const rect = containerEl.getBoundingClientRect();
 				renderer.resize(rect.width, rect.height);

--- a/src/components/graph/GraphControls.svelte
+++ b/src/components/graph/GraphControls.svelte
@@ -1027,7 +1027,10 @@ $effect(() => {
     background: none;
     border: none;
     border-radius: 4px;
-    cursor: pointer;
+    /* Not a literal `pointer`: Obsidian's base `button` rule already resolves
+       to var(--cursor), and hardcoding here made these rows disagree with the
+       toolbar rail whenever "Use pointer cursor for clickable elements" is off. */
+    cursor: var(--cursor);
     color: var(--text-normal);
     text-align: left;
     transition: background-color 0.1s ease;
@@ -1089,7 +1092,7 @@ $effect(() => {
     width: 100%;
     background: none;
     border: none;
-    cursor: pointer;
+    cursor: var(--cursor);
     padding: 0;
   }
 

--- a/src/components/graph/NoteContextView.svelte
+++ b/src/components/graph/NoteContextView.svelte
@@ -692,7 +692,7 @@ onDestroy(() => {
     border-radius: 0;
     background: transparent;
     text-align: left;
-    cursor: pointer;
+    cursor: var(--cursor);
     color: inherit;
   }
 


### PR DESCRIPTION
Fixes two cursor inconsistencies in the smart graph view. Both come from the same underlying problem: the graph decided cursors in three places that didn't agree with each other, and none of them respected the user's Obsidian appearance setting.

## The clickable cursor stuck after hovering a topic label

`handleMouseMove` set `pointer` unconditionally in the cluster-pill branch, but the reset lived *inside* the `node !== hoveredNode` guard — and the pill branch had already forced `hoveredNode = null`. So moving from a pill onto empty canvas compared `null` to `null`, skipped the assignment, and left the pointer stuck.

The root cause is that the cursor was derived from a *change in hover identity* rather than from where the pointer currently is. Every canvas cursor now goes through one `applyCursor()` that reads present state, called on every move instead of inside the guard — the guard still gates the expensive `requestRender("world")`, so this costs nothing.

Two related gaps closed alongside it:
- `handleMouseLeave` cleared `hoveredNode` but not the cursor, so leaving the canvas while over a pill stranded the value for the next entry.
- `lassoMode` was only read inside that same guard, so toggling lasso from the toolbar didn't show the crosshair until you happened to hover a node and move off it. There's now a small `$effect` for it (DOM manipulation in response to a prop, per CLAUDE.md).

## The toolbar showed the arrow, not the clickable cursor

This one turned out to be Obsidian behaving correctly. Verified by extracting `obsidian.asar`:

```css
:root { --cursor: default; }          /* pointer only under .is-mobile, or when
                                         "Use pointer cursor for clickable
                                         elements" is enabled */
.clickable-icon { cursor: var(--cursor); }
button          { cursor: var(--cursor); }
```

The rail's `Button`s render as `button.clickable-icon` and set no cursor of their own, so they were already tracking the user's preference. The actual inconsistency was the opposite direction — the graph hardcoded `cursor: pointer` in a few places and thereby *ignored* that preference, which is what made the toolbar look wrong by comparison.

Those now resolve to `var(--cursor)` as well (`.segment-row`, `.section-label--collapsible`, `NoteContextView`'s list row, and the canvas's node/pill cursor), so the rail, topic rows, cluster labels and nodes all agree in either setting state.

`grab`/`grabbing` on the canvas container stay literal: panning is direct manipulation of a surface, not a click target, so it isn't what that setting governs.

## Verification

- `bun run check` — 2763 files, 0 errors, 0 warnings
- `bun run format` — clean
- Unit tests were run but aren't a meaningful signal here: this is hover-state behaviour with no coverage, and the suite doesn't resolve cleanly from a git worktree. All 1261 tests that executed passed.

Worth checking by hand, since that's where the bug lives:
- Hover a topic label → move onto empty canvas → cursor must return to `grab`. Also pill → node → pill → empty, and pill → off-canvas → back on.
- Toggle lasso from the rail *without moving the mouse* → crosshair appears immediately; exit → back to `grab`.
- Press and hold empty canvas → still `grabbing`.
- Flip *Appearance → Use pointer cursor for clickable elements*: with it off, toolbar / topic rows / labels / nodes should all show the arrow; with it on, all should show the pointer. The point is that they agree either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._