### PR TITLE
fix(providers): clear references on delete, and load models without a reload

### DIFF
--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -1281,7 +1281,7 @@ async function handleOpenPaths(paths: string[]) {
 			`Open ${paths.length} tabs`,
 		);
 		modal.open();
-		if (!(await modal.promise)) return;
+		if (!(await modal.promise).confirmed) return;
 	}
 
 	for (const path of paths) {

--- a/src/components/modal/ConfirmModal.ts
+++ b/src/components/modal/ConfirmModal.ts
@@ -1,22 +1,41 @@
 import { type App, Modal } from "obsidian";
 
+/** An optional opt-in checkbox rendered between the message and the buttons. */
+export interface ConfirmCheckbox {
+	label: string;
+	/** Sub-label under the checkbox, for spelling out the cost of opting in. */
+	description?: string;
+	/** Unchecked by default — an extra destructive step should never be pre-armed. */
+	initial?: boolean;
+}
+
+export interface ConfirmResult {
+	confirmed: boolean;
+	/** State of the opt-in checkbox. Always false when no checkbox was configured. */
+	checked: boolean;
+}
+
 /**
  * Obsidian-native confirmation modal that replaces `window.confirm()`.
- * Returns a promise that resolves to `true` (confirm) or `false` (cancel/close).
+ * `promise` resolves to a {@link ConfirmResult}; cancel and close (Esc, backdrop) both
+ * resolve `{ confirmed: false, checked: false }`, so a caller can never hang on it.
  */
 export class ConfirmModal extends Modal {
 	private resolved = false;
-	private resolve!: (value: boolean) => void;
-	readonly promise: Promise<boolean>;
+	private resolve!: (value: ConfirmResult) => void;
+	private checked: boolean;
+	readonly promise: Promise<ConfirmResult>;
 
 	constructor(
 		app: App,
 		private readonly title: string,
 		private readonly message: string,
 		private readonly confirmLabel = "Delete",
+		private readonly checkbox?: ConfirmCheckbox,
 	) {
 		super(app);
-		this.promise = new Promise<boolean>((resolve) => {
+		this.checked = checkbox?.initial ?? false;
+		this.promise = new Promise<ConfirmResult>((resolve) => {
 			this.resolve = resolve;
 		});
 	}
@@ -26,11 +45,28 @@ export class ConfirmModal extends Modal {
 
 		this.contentEl.createEl("p", { text: this.message });
 
+		if (this.checkbox) {
+			const wrapper = this.contentEl.createDiv({ cls: "s2b-confirm-checkbox" });
+			const label = wrapper.createEl("label");
+			const input = label.createEl("input", { type: "checkbox" });
+			input.checked = this.checked;
+			label.createSpan({ text: this.checkbox.label });
+			input.addEventListener("change", () => {
+				this.checked = input.checked;
+			});
+			if (this.checkbox.description) {
+				wrapper.createDiv({
+					cls: "s2b-confirm-checkbox-desc",
+					text: this.checkbox.description,
+				});
+			}
+		}
+
 		const buttonRow = this.contentEl.createDiv({ cls: "modal-button-container" });
 
 		buttonRow.createEl("button", { text: "Cancel" }).addEventListener("click", () => {
 			this.resolved = true;
-			this.resolve(false);
+			this.resolve({ confirmed: false, checked: false });
 			this.close();
 		});
 
@@ -40,21 +76,36 @@ export class ConfirmModal extends Modal {
 		});
 		confirmBtn.addEventListener("click", () => {
 			this.resolved = true;
-			this.resolve(true);
+			this.resolve({ confirmed: true, checked: this.checked });
 			this.close();
 		});
 	}
 
 	onClose(): void {
 		if (!this.resolved) {
-			this.resolve(false);
+			this.resolve({ confirmed: false, checked: false });
 		}
 	}
 }
 
 /** Show an Obsidian-native confirmation dialog. Resolves `true` if confirmed. */
-export function confirmDelete(app: App, entityName: string): Promise<boolean> {
+export async function confirmDelete(app: App, entityName: string): Promise<boolean> {
 	const modal = new ConfirmModal(app, "Confirm deletion", `Delete "${entityName}"?`);
+	modal.open();
+	return (await modal.promise).confirmed;
+}
+
+/**
+ * Confirmation dialog with an extra opt-in checkbox, for a secondary destructive
+ * action the user may or may not want bundled with the deletion.
+ */
+export function confirmDeleteWithOption(
+	app: App,
+	entityName: string,
+	checkbox: ConfirmCheckbox,
+	message = `Delete "${entityName}"?`,
+): Promise<ConfirmResult> {
+	const modal = new ConfirmModal(app, "Confirm deletion", message, "Delete", checkbox);
 	modal.open();
 	return modal.promise;
 }

--- a/src/components/settings/EmbeddingIndexSection.svelte
+++ b/src/components/settings/EmbeddingIndexSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { onDestroy, untrack } from "svelte";
-import { Platform } from "obsidian";
+import { Notice, Platform } from "obsidian";
 import { EmbeddingIndexSetupModal } from "../modal/EmbeddingIndexSetupModal";
 import { IndexingReportModal } from "../modal/IndexingReportModal";
 import ManagedEntityItem from "./ManagedEntityItem.svelte";
@@ -9,6 +9,7 @@ import Button from "../ui/Button.svelte";
 import ProgressBar from "../ui/ProgressBar.svelte";
 import GenericAIIcon from "../ui/logos/GenericAIIcon.svelte";
 import { confirmDelete } from "../modal/ConfirmModal";
+import { Logger } from "../../utils/logging";
 import { getProviderDefinition } from "../../providers/index";
 import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
@@ -129,7 +130,16 @@ async function deleteIndex(targetIndexId: string) {
 	if (!isVectorStoreInitialized()) return;
 	const entry = indexes.find((e) => e.id === targetIndexId);
 	if (!(await confirmDelete(plugin.app, entry?.model ?? targetIndexId))) return;
-	await getVectorStoreService().deleteIndex(targetIndexId);
+	try {
+		await getVectorStoreService().deleteIndex(targetIndexId);
+	} catch (error) {
+		// `deleteIndex` rejects when the stored vectors can't actually be dropped. Report it
+		// rather than letting it surface as an unhandled rejection: the index is still there,
+		// so the row below must not be reset as though it had been removed.
+		Logger.error(`[EmbeddingIndexSection] Failed to delete index ${targetIndexId}:`, error);
+		new Notice(`Could not delete this index: ${error instanceof Error ? error.message : String(error)}`);
+		return;
+	}
 	if (targetIndexId === indexId) {
 		indexProgress = {
 			isIndexing: false,

--- a/src/components/settings/ProviderItem.svelte
+++ b/src/components/settings/ProviderItem.svelte
@@ -10,6 +10,7 @@ import GenericAIIcon from "../ui/logos/GenericAIIcon.svelte";
 import CircularLoader from "../ui/CircularLoader.svelte";
 import Button from "../ui/Button.svelte";
 import { icon } from "../../utils/utils";
+import { Logger } from "../../utils/logging";
 import { ProviderSetupModal } from "../../views/provider-setup/ProviderSetup";
 import { confirmDelete, confirmDeleteWithOption } from "../modal/ConfirmModal";
 
@@ -84,8 +85,7 @@ async function removeProvider(purgeEmbeddings = false) {
 	if (!purgeEmbeddings) return;
 
 	// Separate error scope: the provider IS removed by now, so a purge failure must not
-	// report "Failed to remove provider". The vectors stay addressable by "provider:model"
-	// id, so a failed purge is recoverable by re-adding the provider and deleting again.
+	// report "Failed to remove provider" — that would misstate what happened.
 	//
 	// The vector store is only assigned at onLayoutReady, so it can genuinely be absent
 	// (its type asserts non-null, but `onunload` guards it for the same reason). Deleting
@@ -98,13 +98,26 @@ async function removeProvider(purgeEmbeddings = false) {
 		return;
 	}
 
-	try {
-		for (const indexId of orphanedIndexIds) {
+	// Each index is attempted independently: `deleteIndex` awaits `store.clear()` and
+	// `store.close()` before it reaches the IndexedDB drop, so one rejection would
+	// otherwise abandon every index after it — and their config records are already gone,
+	// which makes the survivors much harder to reach again. Failures are collected and
+	// reported together instead.
+	const failed: string[] = [];
+	for (const indexId of orphanedIndexIds) {
+		try {
 			await vectorStore.deleteIndex(indexId);
+		} catch (error) {
+			failed.push(indexId);
+			Logger.error(`[ProviderItem] Failed to delete embedding index ${indexId}:`, error);
 		}
-	} catch (error) {
+	}
+
+	if (failed.length > 0) {
 		new Notice(
-			`Provider removed, but deleting its embeddings failed: ${error instanceof Error ? error.message : String(error)}`,
+			`Provider removed, but deleting ${failed.length} of ${orphanedIndexIds.length} embedding ${
+				orphanedIndexIds.length === 1 ? "index" : "indexes"
+			} failed: ${failed.join(", ")}. See the console for details.`,
 		);
 	}
 }

--- a/src/components/settings/ProviderItem.svelte
+++ b/src/components/settings/ProviderItem.svelte
@@ -82,13 +82,25 @@ async function removeProvider(purgeEmbeddings = false) {
 	}
 
 	if (!purgeEmbeddings) return;
+
 	// Separate error scope: the provider IS removed by now, so a purge failure must not
 	// report "Failed to remove provider". The vectors stay addressable by "provider:model"
 	// id, so a failed purge is recoverable by re-adding the provider and deleting again.
+	//
+	// The vector store is only assigned at onLayoutReady, so it can genuinely be absent
+	// (its type asserts non-null, but `onunload` guards it for the same reason). Deleting
+	// embeddings is an explicit destructive choice the user opted into, so a missing
+	// service must be reported rather than optional-chained away — silently completing
+	// the dialog would leave every vector on disk with no sign anything was skipped.
+	const vectorStore = plugin.vectorStoreService;
+	if (!vectorStore) {
+		new Notice("Provider removed. Its embeddings were kept — the index service is still starting up.");
+		return;
+	}
+
 	try {
-		// Guarded: the vector store is initialized on layout-ready, so it can be absent.
 		for (const indexId of orphanedIndexIds) {
-			await plugin.vectorStoreService?.deleteIndex(indexId);
+			await vectorStore.deleteIndex(indexId);
 		}
 	} catch (error) {
 		new Notice(

--- a/src/components/settings/ProviderItem.svelte
+++ b/src/components/settings/ProviderItem.svelte
@@ -11,7 +11,7 @@ import CircularLoader from "../ui/CircularLoader.svelte";
 import Button from "../ui/Button.svelte";
 import { icon } from "../../utils/utils";
 import { ProviderSetupModal } from "../../views/provider-setup/ProviderSetup";
-import { confirmDelete } from "../modal/ConfirmModal";
+import { confirmDelete, confirmDeleteWithOption } from "../modal/ConfirmModal";
 
 interface Props {
 	provider: string;
@@ -46,14 +46,54 @@ function handleOpenSettings() {
 }
 
 async function handleRemoveProvider() {
-	if (!(await confirmDelete(plugin.app, displayName))) return;
+	// Embeddings this provider built are expensive to recompute, so deleting them is a
+	// separate, opt-in decision rather than a side effect of removing the provider —
+	// re-adding the same provider and model later reuses the vectors as they are.
+	// The checkbox only appears when there is actually something to delete.
+	const ownedIndexes = data.embeddingIndexes.filter((index) => index.provider === provider);
+	const indexedNotes = ownedIndexes.reduce((sum, index) => sum + (index.documentCount ?? 0), 0);
+
+	if (ownedIndexes.length === 0) {
+		if (!(await confirmDelete(plugin.app, displayName))) return;
+		await removeProvider();
+		return;
+	}
+
+	const { confirmed, checked } = await confirmDeleteWithOption(plugin.app, displayName, {
+		label: "Also delete the embeddings built with this provider",
+		description: `Frees the storage used by ${indexedNotes.toLocaleString()} indexed ${
+			indexedNotes === 1 ? "note" : "notes"
+		}. Leave this off to keep them — re-adding this provider reuses them instead of re-embedding, which can be slow and costly.`,
+	});
+	if (!confirmed) return;
+	await removeProvider(checked);
+}
+
+async function removeProvider(purgeEmbeddings = false) {
+	let orphanedIndexIds: string[];
 	try {
-		await data.deleteProvider(provider);
+		orphanedIndexIds = await data.deleteProvider(provider);
 		// Drop cached auth/state entirely (not just invalidate) so re-adding a provider with
 		// the same slug ID doesn't inherit this one's stale "connected" verdict from cache.
 		removeProviderQueries(provider);
 	} catch (error) {
 		new Notice(error instanceof Error ? error.message : "Failed to remove provider");
+		return;
+	}
+
+	if (!purgeEmbeddings) return;
+	// Separate error scope: the provider IS removed by now, so a purge failure must not
+	// report "Failed to remove provider". The vectors stay addressable by "provider:model"
+	// id, so a failed purge is recoverable by re-adding the provider and deleting again.
+	try {
+		// Guarded: the vector store is initialized on layout-ready, so it can be absent.
+		for (const indexId of orphanedIndexIds) {
+			await plugin.vectorStoreService?.deleteIndex(indexId);
+		}
+	} catch (error) {
+		new Notice(
+			`Provider removed, but deleting its embeddings failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
 	}
 }
 </script>

--- a/src/hooks/useAvailableModels.svelte.ts
+++ b/src/hooks/useAvailableModels.svelte.ts
@@ -1,10 +1,11 @@
 import { Notice } from "obsidian";
-import { createProviderStateQuery, invalidateAllProviders } from "../lib/query";
+import { invalidateAllProviders, type ProviderState, subscribeProviderState } from "../lib/query";
 import { hydrateChatModel, hydrateEmbeddingModel } from "../lib/modelMetadataNormalizer";
 import { fetchModelsDevData, type ModelsDevApiResponse } from "../providers/modelsDevApi";
 import { getOllamaModelsCache, type OllamaModelInfo } from "../providers/ollamaModels";
 import { fetchOpenRouterModels, type OpenRouterModelInfo } from "../providers/openrouterModels";
 import { getProviderDefinition, isEmbeddingProvider } from "../providers/index";
+import { onProvidersChanged } from "../providers/registrySync";
 import type { EmbedModelConfig } from "../providers/index";
 import type { ChatModel } from "../stores/chatStore.svelte";
 import { getData } from "../stores/dataStore.svelte";
@@ -65,9 +66,87 @@ export class AvailableModels {
 	#modelsDevData = $state<ModelsDevApiResponse | null>(null);
 	#openRouterData = $state<Map<string, OpenRouterModelInfo> | null>(null);
 	#metadataLoadStarted = false;
+	/**
+	 * Bumped whenever a subscribed provider query emits. The derived model lists read it
+	 * so they recompute as results arrive — the `QueryObserver` subscriptions live outside
+	 * Svelte's reactive graph, so without this nothing would re-run on new data.
+	 */
+	#queryEpoch = $state(0);
+	/** Live `QueryObserver` subscriptions, keyed by provider id. See the constructor. */
+	#subscriptions = new Map<string, () => void>();
+	/** Removes this instance's `onProvidersChanged` registration. Set in the constructor. */
+	#unsubscribeProvidersChanged: () => void;
 
 	constructor() {
 		void this.#loadMetadataSources();
+
+		// Keeps every configured provider's state query active for the whole session.
+		//
+		// This deliberately does NOT use `createQuery`. A `createQuery` result only
+		// subscribes from an `$effect` inside `createBaseQuery` while something actively
+		// *reads* it — so a provider configured at runtime got a query object that was
+		// never subscribed (`isActive() === false`, `fetchStatus: "idle"`) and therefore
+		// never fetched. `isLoadingModels` then stayed true forever and the UI sat on
+		// "Loading models…" until a reload. Reading `isPending` does not help either: it
+		// goes through `trackResult` and still doesn't subscribe.
+		//
+		// `subscribeProviderState` uses a bare `QueryObserver`, whose `subscribe()` activates
+		// the query and kicks off the fetch immediately, with no dependency on reactive
+		// ownership or reads.
+		//
+		// Reconciliation is driven by `onProvidersChanged` — which fires from the same
+		// registry-sync helpers the data store already calls on every provider add, remove,
+		// enable/disable and rename — NOT by an `$effect` here. This singleton lives in a
+		// bare `$effect.root` with no component driving the scheduler, and an `$effect` in
+		// that position was verified not to re-run when the provider set changed: a provider
+		// added at runtime kept getting no observer and no fetch, which is what left the UI
+		// on "Loading models…" until an Obsidian reload. A direct callback has no such
+		// dependency on reactive scheduling.
+		this.syncProviderSubscriptions();
+		this.#unsubscribeProvidersChanged = onProvidersChanged(() => this.syncProviderSubscriptions());
+	}
+
+	/**
+	 * Tear down everything this instance holds outside the reactive graph: the
+	 * provider-change registration and every live `QueryObserver` (each of whose queryFns
+	 * resolves provider credentials on fetch). Called via {@link resetAvailableModels} on
+	 * plugin unload — module state survives a disable/enable cycle, so without this the
+	 * observers would keep fetching with the unloaded plugin's auth, and the next enable
+	 * would reuse a singleton bound to the previous plugin's data store.
+	 */
+	dispose(): void {
+		this.#unsubscribeProvidersChanged();
+		for (const unsubscribe of this.#subscriptions.values()) unsubscribe();
+		this.#subscriptions.clear();
+	}
+
+	/**
+	 * Bring the live provider subscriptions in line with the configured providers:
+	 * subscribe anything new, drop anything removed, leave the rest untouched (so adding
+	 * one provider doesn't disturb the others' observers or cached data).
+	 *
+	 * Safe to call repeatedly — it's a no-op when nothing changed.
+	 */
+	syncProviderSubscriptions(): void {
+		const providerIds = this.#data.getConfiguredProviders();
+
+		for (const [providerId, unsubscribe] of this.#subscriptions) {
+			if (!providerIds.includes(providerId)) {
+				unsubscribe();
+				this.#subscriptions.delete(providerId);
+			}
+		}
+		for (const providerId of providerIds) {
+			if (this.#subscriptions.has(providerId)) continue;
+			this.#subscriptions.set(
+				providerId,
+				subscribeProviderState(providerId, () => {
+					// Nudge the reactive graph so `#availableModels` and friends recompute
+					// as each provider's models arrive.
+					this.#queryEpoch++;
+				}),
+			);
+		}
 	}
 
 	async #loadMetadataSources(): Promise<void> {
@@ -91,14 +170,45 @@ export class AvailableModels {
 	// Reactive providers list - reads from reactive $state in dataStore
 	#providers = $derived(this.#data.getConfiguredProviders());
 
-	// Combined query for each provider (auth + models together)
-	#providerQueries = $derived(this.#providers.map((provider) => createProviderStateQuery(() => provider)));
+	/**
+	 * Current state for each configured provider, aligned with `#providers` by index.
+	 *
+	 * Read straight from the query cache rather than from `createQuery` results.
+	 * `syncProviderSubscriptions` keeps a `QueryObserver` subscribed per provider, so the
+	 * cache is the authoritative, always-current copy; `#queryEpoch` (bumped by those
+	 * observers) is what makes this recompute when new data lands. Going through
+	 * `createQuery` here is what caused the "Loading models…" hang — see the constructor.
+	 */
+	#providerStates = $derived.by<(ProviderState | undefined)[]>(() => {
+		void this.#queryEpoch;
+		return this.#providers.map((provider) =>
+			this.#plugin.queryClient.getQueryData<ProviderState>(["provider", provider]),
+		);
+	});
+
+	/**
+	 * True while at least one configured provider's first fetch is still in flight.
+	 *
+	 * Checked via query *status*, not data presence: the queryFn is written to return
+	 * failure objects rather than throw, but its outer strips (secret resolution, auth
+	 * plumbing) can still reject, landing the query in `error` status with no data.
+	 * Treating "no data" as "loading" would then pin the UI on "Loading models…"
+	 * permanently — the exact hang this store exists to avoid. An errored query is
+	 * settled, not loading; the provider simply contributes no models.
+	 */
+	#isLoading = $derived.by(() => {
+		void this.#queryEpoch;
+		return this.#providers.some((provider) => {
+			const state = this.#plugin.queryClient.getQueryState(["provider", provider]);
+			return state === undefined || state.status === "pending";
+		});
+	});
 
 	// Compute available models from all providers - excludes embedding models
 	#availableModels = $derived.by(() => {
 		const out: ChatModel[] = [];
 		this.#providers.forEach((provider, idx) => {
-			const state = this.#providerQueries[idx]?.data;
+			const state = this.#providerStates[idx];
 			// Get all discovered models from the provider
 			const discoveredModels = state?.models ?? [];
 
@@ -136,7 +246,7 @@ export class AvailableModels {
 				return;
 			}
 
-			const state = this.#providerQueries[idx]?.data;
+			const state = this.#providerStates[idx];
 
 			// Use dedicated embedding models if provider supports discoverEmbeddingModels
 			// Otherwise, fall back to heuristic filtering on all models
@@ -174,7 +284,7 @@ export class AvailableModels {
 	#unavailableProviders = $derived.by(() => {
 		const unavailable: string[] = [];
 		this.#providers.forEach((provider, idx) => {
-			const state = this.#providerQueries[idx]?.data;
+			const state = this.#providerStates[idx];
 			if (state && !state.auth.success) {
 				unavailable.push(provider);
 			}
@@ -257,7 +367,7 @@ export class AvailableModels {
 	}
 
 	get isLoadingModels(): boolean {
-		return this.#providerQueries.some((q) => q.isPending);
+		return this.#isLoading;
 	}
 
 	get modelOptions(): ModelOption[] {
@@ -385,25 +495,45 @@ export class AvailableModels {
 
 // Module-level singleton instance (lazy initialized)
 let instance: AvailableModels | null = null;
+let disposeRoot: (() => void) | null = null;
 
 /**
  * Returns the singleton AvailableModels instance.
  * All components share the same reactive state.
  *
- * The instance is created inside an `$effect.root` so the TanStack queries it
- * spins up (each `createQuery` registers an internal `$effect`) always have a
- * stable, app-lifetime owner. Without this, the first `useAvailableModels()`
- * call from inside a consumer's `$derived` (e.g. the model-selection modal
- * reading `hydratedChatModels` during onboarding) constructs the singleton in
- * an unowned reactive context and Svelte throws `effect_in_unowned_derived`.
- * The root is never disposed — the singleton lives for the whole session.
+ * The instance is created inside an `$effect.root` so construction always happens in a
+ * stable reactive owner. Without this, the first `useAvailableModels()` call from inside
+ * a consumer's `$derived` (e.g. the model-selection modal reading `hydratedChatModels`
+ * during onboarding) constructs the singleton in an unowned reactive context and Svelte
+ * throws `effect_in_unowned_derived`. Note the fetching itself deliberately does NOT rely
+ * on this root: `$effect`s inside a bare root without a component driving the scheduler
+ * were verified never to re-run, so the per-provider fetch lifecycle is handled by plain
+ * `QueryObserver` subscriptions instead (see the constructor).
+ *
+ * The singleton lives until {@link resetAvailableModels} (plugin unload); `main.ts` also
+ * calls this eagerly at layout-ready so provider fetching is independent of which views
+ * happen to mount.
  */
 export function useAvailableModels(): AvailableModels {
 	if (!instance) {
-		$effect.root(() => {
+		disposeRoot = $effect.root(() => {
 			instance = new AvailableModels();
 		});
 	}
 	// biome-ignore lint/style/noNonNullAssertion: the $effect.root callback runs synchronously, so `instance` is set here.
 	return instance!;
+}
+
+/**
+ * Dispose the singleton (observers, listener registration, reactive root) and clear it so
+ * the next `useAvailableModels()` builds a fresh instance against the *current* plugin and
+ * data store. Must be called from the plugin's `onunload`: the module (and therefore
+ * `instance`) survives a disable/enable cycle, and a stale instance keeps dead references
+ * and live credential-fetching observers.
+ */
+export function resetAvailableModels(): void {
+	instance?.dispose();
+	disposeRoot?.();
+	instance = null;
+	disposeRoot = null;
 }

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,4 +1,4 @@
-import { createQuery } from "@tanstack/svelte-query";
+import { createQuery, QueryObserver } from "@tanstack/svelte-query";
 import { QueryClient } from "@tanstack/svelte-query";
 import type { AuthValidationResult } from "../agent/AgentManager";
 import { getProviderDefinition, isEmbeddingProvider } from "../providers";
@@ -104,9 +104,45 @@ export function getProviderStateQueryOptions(providerId: string) {
  * @param provider - Function returning the provider ID string
  */
 export function createProviderStateQuery(provider: () => string) {
-	return createQuery<ProviderState>(() => ({
-		...getProviderStateQueryOptions(provider()),
-	}));
+	// The client is passed explicitly rather than resolved from Svelte context: this query
+	// is also created outside any component (by the `AvailableModels` singleton, which lives
+	// in a bare `$effect.root`), and `getQueryClientContext()` *throws* when no
+	// `QueryClientProvider` is above it. It's the same module-level client the provider
+	// supplies, so component and non-component callers share one cache either way.
+	return createQuery<ProviderState>(
+		() => ({
+			...getProviderStateQueryOptions(provider()),
+		}),
+		() => queryClient,
+	);
+}
+
+/**
+ * Subscribe to a provider's state query imperatively, keeping it active (and therefore
+ * fetched and up to date) until the returned unsubscribe function is called.
+ *
+ * `createQuery` is not usable for this. Its observer only subscribes from an `$effect`
+ * inside `createBaseQuery`, which requires an active reactive owner *and* a live read of
+ * the result; merely constructing it — or touching `isPending`, which goes through
+ * `trackResult` — leaves the query `isActive() === false`, `fetchStatus: "idle"`, so it
+ * never fetches. That was the "Loading models…" hang: a provider added at runtime got a
+ * query object but no subscriber.
+ *
+ * A bare `QueryObserver` has no such dependency: `subscribe()` activates the query and
+ * triggers the initial fetch immediately.
+ *
+ * @param provider - The provider ID string
+ * @returns Unsubscribe function.
+ */
+export function subscribeProviderState(provider: string, onChange?: () => void): () => void {
+	const observer = new QueryObserver<ProviderState>(queryClient, {
+		...getProviderStateQueryOptions(provider),
+	});
+	const unsubscribe = observer.subscribe(() => onChange?.());
+	return () => {
+		unsubscribe();
+		observer.destroy();
+	};
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import "./lib/i18n";
 import "./lib/langgraphContext";
 import { Logger as Log, applyVerboseLogging } from "./utils/logging";
 import { isAgentFilePath } from "./utils/fileFiltering";
+import { resetAvailableModels, useAvailableModels } from "./hooks/useAvailableModels.svelte";
 import { isMobileUI } from "./utils/platform";
 import { StartupProfiler } from "./utils/startupProfiler";
 import { persistStartupRecord, recordStartupEnvironment } from "./utils/startupTimingsStore";
@@ -641,6 +642,15 @@ export default class SecondBrainPlugin extends Plugin {
 			// (ChatRecommendations.svelte reads pluginData.staleGuidance), so no startup
 			// Notice here — that would double-notify.
 
+			// Bring up the shared model store now rather than on first UI read. It keeps a
+			// QueryObserver subscribed per configured provider, which is what actually
+			// fetches each provider's auth + model list. Constructing it lazily tied that
+			// to whichever view happened to mount first: with, say, only the graph view
+			// open, nothing read it, so a provider added afterwards was never subscribed
+			// and its models never loaded ("Loading models…" until an Obsidian reload).
+			// Initializing here makes the subscriptions view-independent.
+			useAvailableModels();
+
 			// Start search/vector store initialization (non-blocking, fire-and-forget)
 			this.lexicalSearchService = StartupProfiler.measureSync("lexical:startInit", () =>
 				LexicalSearchService.startInitialize(this),
@@ -817,6 +827,10 @@ export default class SecondBrainPlugin extends Plugin {
 
 	onunload() {
 		Log.info("Unloading plugin");
+		// The model store's module state survives a disable/enable cycle. Without this
+		// reset, its QueryObservers keep fetching with the unloaded plugin's credentials
+		// and the next enable reuses a singleton bound to this (now dead) data store.
+		resetAvailableModels();
 		if (this.runningIndicator) {
 			void unmount(this.runningIndicator);
 			this.runningIndicator = null;

--- a/src/providers/registrySync.ts
+++ b/src/providers/registrySync.ts
@@ -28,6 +28,29 @@ export interface ProviderConfigSource {
 }
 
 /**
+ * Listeners notified whenever the set of usable providers changes.
+ *
+ * The model store (`AvailableModels`) uses this to keep a `QueryObserver` subscribed per
+ * configured provider. It can't do that from an `$effect`: it lives in a bare
+ * `$effect.root` with no component driving the scheduler, so its effects were verified not
+ * to re-run on provider changes — a provider added at runtime never got subscribed and its
+ * models never loaded. These hooks fire from the same places the registry is reconciled,
+ * which is exactly when the configured set can change.
+ */
+type ProvidersChangedListener = () => void;
+const providersChangedListeners = new Set<ProvidersChangedListener>();
+
+/** Subscribe to provider-set changes. Returns an unsubscribe function. */
+export function onProvidersChanged(listener: ProvidersChangedListener): () => void {
+	providersChangedListeners.add(listener);
+	return () => providersChangedListeners.delete(listener);
+}
+
+function notifyProvidersChanged(): void {
+	for (const listener of providersChangedListeners) listener();
+}
+
+/**
  * Registers a single provider, or refreshes its auth if already registered.
  *
  * @returns true if the provider is registered and usable afterwards.
@@ -39,12 +62,14 @@ export function syncProvider(data: ProviderConfigSource, providerId: string): bo
 		// Configured but unresolvable (e.g. its secret was cleared) — drop any stale entry
 		// rather than leaving the previous credentials live.
 		registry.unregister(providerId);
+		notifyProvidersChanged();
 		return false;
 	}
 
 	const definition = getProviderDefinition(providerId, data.getAllProviderMeta());
 	if (!definition) {
 		registry.unregister(providerId);
+		notifyProvidersChanged();
 		return false;
 	}
 
@@ -52,6 +77,7 @@ export function syncProvider(data: ProviderConfigSource, providerId: string): bo
 	// Going through it (rather than `updateAuth`) also refreshes the definition, which
 	// matters for template providers whose meta feeds `createTemplateDefinition`.
 	registry.register(providerId, definition, auth);
+	notifyProvidersChanged();
 	return true;
 }
 
@@ -60,6 +86,7 @@ export function syncProvider(data: ProviderConfigSource, providerId: string): bo
  */
 export function unsyncProvider(providerId: string): void {
 	getRegistry().unregister(providerId);
+	notifyProvidersChanged();
 }
 
 /**

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -2073,12 +2073,17 @@ export class PluginDataStore {
 		const wasConfigured = config.isConfigured;
 		config.isConfigured = isConfigured;
 
-		// If disabling, clear any agent chat model using that provider
+		// If disabling, clear every agent model slot pointing at this provider — not just
+		// the chat model. A dangling summarization/title reference would still be handed to
+		// the LLM path at runtime, and a dangling chatModel makes the chat view read as
+		// "model selected" and hide the provider CTA. Same cleanup as deleteProvider.
+		// (Favorites are deliberately kept: disabling is reversible, and an inert favorite
+		// is harmless while the provider is off.)
 		if (wasConfigured && !isConfigured) {
 			for (const agent of Object.values(this.#data.agents)) {
-				if (agent.chatModel?.provider === providerId) {
-					agent.chatModel = null;
-				}
+				if (agent.chatModel?.provider === providerId) agent.chatModel = null;
+				if (agent.summarizationModel?.provider === providerId) agent.summarizationModel = null;
+				if (agent.titleModel?.provider === providerId) agent.titleModel = null;
 			}
 		}
 
@@ -2320,7 +2325,16 @@ export class PluginDataStore {
 		await this.saveSettings();
 	}
 
-	async deleteProvider(providerId: string): Promise<void> {
+	/**
+	 * Delete a provider and every reference to it across plugin data.
+	 *
+	 * Returns the IDs of embedding indexes that belonged to this provider. Their config
+	 * records are gone, but their vectors are intentionally left on disk (see below) so
+	 * they can be reused. Pass these IDs to `VectorStoreService.deleteIndex` only when
+	 * the user has explicitly opted into discarding the embeddings; ignoring the return
+	 * value is the correct default, and drafts never own indexes anyway.
+	 */
+	async deleteProvider(providerId: string): Promise<string[]> {
 		if (!(providerId in this.#data.providerMeta)) {
 			throw new Error(`Provider with ID "${providerId}" not found`);
 		}
@@ -2333,6 +2347,46 @@ export class PluginDataStore {
 
 		delete this.#data.providerMeta[providerId];
 		delete this.#data.providerConfig[providerId];
+
+		// Drop every reference to the provider that just went away. Without this the
+		// selections survive as dangling pointers to a provider that no longer exists:
+		// an agent keeps a `chatModel` whose provider is gone, so the chat view still
+		// reads as "a model is selected" and shows suggestions instead of the "Add an
+		// AI provider" CTA, and the composer offers a model it can never run.
+		// `renameProvider` re-points these same fields; deletion clears them.
+		for (const agent of Object.values(this.#data.agents)) {
+			if (agent.chatModel?.provider === providerId) agent.chatModel = null;
+			if (agent.summarizationModel?.provider === providerId) agent.summarizationModel = null;
+			if (agent.titleModel?.provider === providerId) agent.titleModel = null;
+		}
+
+		if (this.#data.favoriteModels) {
+			this.#data.favoriteModels = this.#data.favoriteModels.filter((fav) => fav.provider !== providerId);
+		}
+
+		// Embedding indexes are keyed "provider:model", so the provider's indexes go
+		// too — along with the search/graph assignments pointing at them, which would
+		// otherwise keep naming an index whose provider can no longer embed anything.
+		//
+		// Only the config *records* are dropped; the vectors themselves are deliberately
+		// left in IndexedDB, because they are expensive to recompute. This does not
+		// strand them: the IndexedDB name is derived from the same "provider:model" id,
+		// and `setEmbedIndex` recreates the config record from that id — so re-adding
+		// this provider and selecting the same model reopens the existing database
+		// instead of re-embedding the vault. Purging is a separate, opt-in action, and
+		// the orphaned IDs are returned so a caller holding the vector store can do it.
+		const orphanedIndexIds = this.#data.embeddingIndexes
+			.filter((index) => index.provider === providerId)
+			.map((index) => index.id);
+		if (orphanedIndexIds.length > 0) {
+			this.#data.embeddingIndexes = this.#data.embeddingIndexes.filter((index) => index.provider !== providerId);
+			if (this.#data.searchEmbedIndex && orphanedIndexIds.includes(this.#data.searchEmbedIndex)) {
+				this.#data.searchEmbedIndex = null;
+			}
+			if (this.#data.graphEmbedIndex && orphanedIndexIds.includes(this.#data.graphEmbedIndex)) {
+				this.#data.graphEmbedIndex = null;
+			}
+		}
 
 		// A secret ID can be shared (assignSecretIdToProviderField lets one field
 		// point at an existing secret). Only remove secrets no remaining provider
@@ -2353,6 +2407,8 @@ export class PluginDataStore {
 		unsyncProvider(providerId);
 
 		await this.saveSettings();
+
+		return orphanedIndexIds;
 	}
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1043,6 +1043,35 @@
 	display: none;
 }
 
+/* Opt-in checkbox inside ConfirmModal, for a secondary destructive action the
+   user can bundle with the deletion (e.g. also discarding a provider's
+   embeddings). Sits between the message and the button row. */
+.s2b-confirm-checkbox {
+	margin: 0.75em 0;
+}
+
+.s2b-confirm-checkbox label {
+	display: flex;
+	align-items: center;
+	gap: 0.5em;
+	cursor: pointer;
+}
+
+.s2b-confirm-checkbox input {
+	flex-shrink: 0;
+	margin: 0;
+}
+
+/* Indented to the label's text edge (checkbox width + gap) so the description
+   reads as belonging to the option rather than to the dialog. */
+.s2b-confirm-checkbox-desc {
+	margin-top: 0.25em;
+	padding-inline-start: calc(var(--checkbox-size, 16px) + 0.5em);
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+	line-height: 1.4;
+}
+
 .s2b-model-filter-bar .s2b-pill {
 	min-height: 36px;
 	padding: 6px 14px;

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -2287,38 +2287,44 @@ export class VectorStoreService {
 		// call observes nothing and this method would resolve as if the databases were gone
 		// whatever happened.
 		//
-		// What is being dropped here is empty shells, not data: when an instance existed,
-		// `store.clear()` above already emptied every object store and dropped the persisted
-		// HNSW graph. So a database that survives is wasted space, not a stale index that
-		// could be reopened with old vectors.
+		// Note the vectors are already gone by this point: when an instance existed,
+		// `store.clear()` above emptied every object store and dropped the persisted HNSW
+		// graph. What survives an incomplete deletion is an empty shell, so the risk here is
+		// not stale data being read back — it is the queued-deletion hazard described below.
 		//
-		// That is why only a genuine `"error"` is fatal. `"blocked"` means another
-		// connection still holds the database (reachable for `-hnsw-index`, whose connection
-		// is owned by the `HNSWWithDB` wrapper and is not closed by
-		// `HNSWVectorStore.close()`); the request stays queued and the browser completes it
-		// once that connection closes. It cannot be cancelled, so failing the deletion would
-		// both misreport a delete that is still very likely to happen and strand a config
-		// record for an index whose data is already gone.
+		// A `"blocked"` result is treated as a failure, even though the deletion itself will
+		// eventually go through. Another connection holds the database (reachable for
+		// `-hnsw-index`, whose connection is owned by the `HNSWWithDB` wrapper and is not
+		// closed by `HNSWVectorStore.close()`, and for a second Obsidian window on the same
+		// vault). The request cannot be cancelled, so it stays queued and fires whenever that
+		// connection closes — and if the config record were removed now, the user could
+		// recreate the same "provider:model" index in the meantime and the queued request
+		// would delete the *replacement* database, destroying a freshly built HNSW graph.
+		//
+		// Keeping the config record is what prevents that: the index stays addressable, the
+		// caller reports the failure, and a retry once the other connection is gone deletes
+		// it cleanly.
 		const hnswDbName = getDbName("s2b-hnsw", this.vaultId, indexId);
 		const dbNames = [hnswDbName, `${hnswDbName}-hnsw-index`];
 		const results = await Promise.all(dbNames.map((dbName) => deleteDatabase(dbName)));
 
-		const errors: Error[] = [];
+		const failures: string[] = [];
 		results.forEach((result, idx) => {
 			if (result.status === "error") {
-				errors.push(result.error);
 				Logger.error(`[VectorStore] Failed to delete IndexedDB database ${dbNames[idx]}:`, result.error);
+				failures.push(`${dbNames[idx]}: ${result.error.message}`);
 			} else if (result.status === "blocked") {
 				Logger.warn(
-					`[VectorStore] Deletion of IndexedDB database ${dbNames[idx]} is blocked by an open connection; it will complete once that connection closes.`,
+					`[VectorStore] Deletion of IndexedDB database ${dbNames[idx]} is blocked by an open connection.`,
+				);
+				failures.push(
+					`${dbNames[idx]}: blocked by another open connection (close other Obsidian windows for this vault and try again)`,
 				);
 			}
 		});
 
-		if (errors.length > 0) {
-			throw new Error(
-				`Could not delete stored vectors for ${indexId}: ${errors.map((error) => error.message).join("; ")}`,
-			);
+		if (failures.length > 0) {
+			throw new Error(`Could not delete stored vectors for ${indexId}: ${failures.join("; ")}`);
 		}
 
 		// Remove from plugin data

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -2283,30 +2283,41 @@ export class VectorStoreService {
 
 		// Delete IndexedDB databases (HNSW + HNSW internal index).
 		//
-		// Awaited: `deleteDatabase` is asynchronous and returns a request, so a bare call
-		// reports nothing — `onerror`/`onblocked` would go unobserved and this method would
-		// resolve as if the vectors were gone while they were still on disk. `onblocked` is
-		// reachable in particular for the `-hnsw-index` database, whose connection is owned
-		// by the `HNSWWithDB` wrapper and is not closed by `HNSWVectorStore.close()`.
+		// Awaited: `deleteDatabase` is asynchronous and reports through events, so a bare
+		// call observes nothing and this method would resolve as if the databases were gone
+		// whatever happened.
+		//
+		// What is being dropped here is empty shells, not data: when an instance existed,
+		// `store.clear()` above already emptied every object store and dropped the persisted
+		// HNSW graph. So a database that survives is wasted space, not a stale index that
+		// could be reopened with old vectors.
+		//
+		// That is why only a genuine `"error"` is fatal. `"blocked"` means another
+		// connection still holds the database (reachable for `-hnsw-index`, whose connection
+		// is owned by the `HNSWWithDB` wrapper and is not closed by
+		// `HNSWVectorStore.close()`); the request stays queued and the browser completes it
+		// once that connection closes. It cannot be cancelled, so failing the deletion would
+		// both misreport a delete that is still very likely to happen and strand a config
+		// record for an index whose data is already gone.
 		const hnswDbName = getDbName("s2b-hnsw", this.vaultId, indexId);
-		const failures = (
-			await Promise.all([
-				deleteDatabase(hnswDbName).catch((error: unknown) => error),
-				deleteDatabase(`${hnswDbName}-hnsw-index`).catch((error: unknown) => error),
-			])
-		).filter((result): result is unknown => result !== undefined);
+		const dbNames = [hnswDbName, `${hnswDbName}-hnsw-index`];
+		const results = await Promise.all(dbNames.map((dbName) => deleteDatabase(dbName)));
 
-		// Config records are dropped only when the data is actually gone. Keeping them on
-		// failure leaves the index addressable (and re-deletable) instead of stranding
-		// orphaned databases that nothing references any more.
-		if (failures.length > 0) {
-			for (const failure of failures) {
-				Logger.error(`[VectorStore] Failed to delete IndexedDB database for ${indexId}:`, failure);
+		const errors: Error[] = [];
+		results.forEach((result, idx) => {
+			if (result.status === "error") {
+				errors.push(result.error);
+				Logger.error(`[VectorStore] Failed to delete IndexedDB database ${dbNames[idx]}:`, result.error);
+			} else if (result.status === "blocked") {
+				Logger.warn(
+					`[VectorStore] Deletion of IndexedDB database ${dbNames[idx]} is blocked by an open connection; it will complete once that connection closes.`,
+				);
 			}
+		});
+
+		if (errors.length > 0) {
 			throw new Error(
-				`Could not delete stored vectors for ${indexId}: ${failures
-					.map((failure) => (failure instanceof Error ? failure.message : String(failure)))
-					.join("; ")}`,
+				`Could not delete stored vectors for ${indexId}: ${errors.map((error) => error.message).join("; ")}`,
 			);
 		}
 

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -41,6 +41,7 @@ import {
 	type SkippedFile,
 	type VectorSearchResult,
 	type VectorStore,
+	deleteDatabase,
 	getDbName,
 	makeChunkId,
 	sanitizeIndexId,
@@ -2280,13 +2281,33 @@ export class VectorStoreService {
 			this.instances.delete(indexId);
 		}
 
-		// Delete IndexedDB databases (HNSW + HNSW internal index)
+		// Delete IndexedDB databases (HNSW + HNSW internal index).
+		//
+		// Awaited: `deleteDatabase` is asynchronous and returns a request, so a bare call
+		// reports nothing — `onerror`/`onblocked` would go unobserved and this method would
+		// resolve as if the vectors were gone while they were still on disk. `onblocked` is
+		// reachable in particular for the `-hnsw-index` database, whose connection is owned
+		// by the `HNSWWithDB` wrapper and is not closed by `HNSWVectorStore.close()`.
 		const hnswDbName = getDbName("s2b-hnsw", this.vaultId, indexId);
-		try {
-			indexedDB.deleteDatabase(hnswDbName);
-			indexedDB.deleteDatabase(`${hnswDbName}-hnsw-index`);
-		} catch (error) {
-			Logger.error(`[VectorStore] Failed to delete IndexedDB databases for ${indexId}:`, error);
+		const failures = (
+			await Promise.all([
+				deleteDatabase(hnswDbName).catch((error: unknown) => error),
+				deleteDatabase(`${hnswDbName}-hnsw-index`).catch((error: unknown) => error),
+			])
+		).filter((result): result is unknown => result !== undefined);
+
+		// Config records are dropped only when the data is actually gone. Keeping them on
+		// failure leaves the index addressable (and re-deletable) instead of stranding
+		// orphaned databases that nothing references any more.
+		if (failures.length > 0) {
+			for (const failure of failures) {
+				Logger.error(`[VectorStore] Failed to delete IndexedDB database for ${indexId}:`, failure);
+			}
+			throw new Error(
+				`Could not delete stored vectors for ${indexId}: ${failures
+					.map((failure) => (failure instanceof Error ? failure.message : String(failure)))
+					.join("; ")}`,
+			);
 		}
 
 		// Remove from plugin data

--- a/src/vectorstore/types.ts
+++ b/src/vectorstore/types.ts
@@ -283,10 +283,12 @@ export type DeleteDatabaseResult =
  *
  * Blocked deletions resolve as `"blocked"` rather than waiting on a timeout. An
  * IndexedDB delete request cannot be cancelled: it stays queued and the browser runs it
- * as soon as the blocking connection closes. Rejecting after a timeout would therefore
- * be a lie in both directions — the caller is told the delete failed, and it then
- * usually happens anyway, moments later. Reporting "blocked" states exactly what is
- * known: the request is in flight and out of our hands.
+ * as soon as the blocking connection closes. Waiting on a timeout would report a failure
+ * for something that usually completes moments later, and there is nothing to undo.
+ *
+ * `"blocked"` is deliberately distinct from `"deleted"`: the request is still pending
+ * against that database name, so callers must not treat the name as free to reuse — a
+ * recreated database can be destroyed by the queued request when it eventually fires.
  *
  * Never rejects; every outcome is described by the resolved value.
  */

--- a/src/vectorstore/types.ts
+++ b/src/vectorstore/types.ts
@@ -259,8 +259,18 @@ export function getDbName(prefix: string, vaultId: string, indexId?: string): st
 	return `${prefix}-${vaultId}-${sanitized}`;
 }
 
-/** How long to wait on a blocked `deleteDatabase` before giving up. */
-const DELETE_DB_BLOCKED_TIMEOUT_MS = 5000;
+/** Outcome of a {@link deleteDatabase} call. */
+export type DeleteDatabaseResult =
+	/** The database was deleted (or did not exist). */
+	| { status: "deleted" }
+	/**
+	 * Another open connection is holding the database. The request stays queued and the
+	 * browser completes it once that connection closes — this is a "not yet", not a
+	 * failure, and the request cannot be cancelled.
+	 */
+	| { status: "blocked" }
+	/** The deletion genuinely failed. */
+	| { status: "error"; error: Error };
 
 /**
  * Promisified `indexedDB.deleteDatabase`.
@@ -268,41 +278,37 @@ const DELETE_DB_BLOCKED_TIMEOUT_MS = 5000;
  * The raw API returns a request and reports outcomes through events, so a bare call
  * tells the caller nothing: `onerror` and `onblocked` are invisible to a surrounding
  * try/catch (which only sees synchronous throws), and the deletion silently doesn't
- * happen while the code proceeds as though it had.
+ * happen while the code proceeds as though it had. Deleting a database that does not
+ * exist succeeds, which is what we want for idempotent cleanup.
  *
- * `onblocked` fires when another connection still holds the database, and unlike
- * `onerror` it is not terminal — the delete completes if that connection closes, so
- * this waits rather than failing immediately. Deleting a database that does not exist
- * succeeds, which is what we want for idempotent cleanup.
+ * Blocked deletions resolve as `"blocked"` rather than waiting on a timeout. An
+ * IndexedDB delete request cannot be cancelled: it stays queued and the browser runs it
+ * as soon as the blocking connection closes. Rejecting after a timeout would therefore
+ * be a lie in both directions — the caller is told the delete failed, and it then
+ * usually happens anyway, moments later. Reporting "blocked" states exactly what is
+ * known: the request is in flight and out of our hands.
  *
- * @throws if the deletion errors, is aborted, or stays blocked past the timeout.
+ * Never rejects; every outcome is described by the resolved value.
  */
-export function deleteDatabase(name: string): Promise<void> {
-	return new Promise<void>((resolve, reject) => {
+export function deleteDatabase(name: string): Promise<DeleteDatabaseResult> {
+	return new Promise<DeleteDatabaseResult>((resolve) => {
 		let request: IDBOpenDBRequest;
 		try {
 			request = indexedDB.deleteDatabase(name);
 		} catch (error) {
-			reject(error instanceof Error ? error : new Error(String(error)));
+			resolve({ status: "error", error: error instanceof Error ? error : new Error(String(error)) });
 			return;
 		}
 
-		let blockedTimer: ReturnType<typeof setTimeout> | null = null;
-		const settle = (finish: () => void) => {
-			if (blockedTimer !== null) clearTimeout(blockedTimer);
-			finish();
-		};
-
-		request.onsuccess = () => settle(resolve);
+		request.onsuccess = () => resolve({ status: "deleted" });
 		request.onerror = () =>
-			settle(() => reject(request.error ?? new Error(`Failed to delete IndexedDB database "${name}"`)));
-		request.onblocked = () => {
-			// Still deletable if the blocking connection closes; only give up if it doesn't.
-			if (blockedTimer !== null) return;
-			blockedTimer = setTimeout(() => {
-				reject(new Error(`Deleting IndexedDB database "${name}" is blocked by an open connection`));
-			}, DELETE_DB_BLOCKED_TIMEOUT_MS);
-		};
+			resolve({
+				status: "error",
+				error: request.error ?? new Error(`Failed to delete IndexedDB database "${name}"`),
+			});
+		// Resolve immediately: the request stays live and will complete on its own once the
+		// blocking connection closes, so there is nothing to wait for or to undo.
+		request.onblocked = () => resolve({ status: "blocked" });
 	});
 }
 

--- a/src/vectorstore/types.ts
+++ b/src/vectorstore/types.ts
@@ -259,6 +259,53 @@ export function getDbName(prefix: string, vaultId: string, indexId?: string): st
 	return `${prefix}-${vaultId}-${sanitized}`;
 }
 
+/** How long to wait on a blocked `deleteDatabase` before giving up. */
+const DELETE_DB_BLOCKED_TIMEOUT_MS = 5000;
+
+/**
+ * Promisified `indexedDB.deleteDatabase`.
+ *
+ * The raw API returns a request and reports outcomes through events, so a bare call
+ * tells the caller nothing: `onerror` and `onblocked` are invisible to a surrounding
+ * try/catch (which only sees synchronous throws), and the deletion silently doesn't
+ * happen while the code proceeds as though it had.
+ *
+ * `onblocked` fires when another connection still holds the database, and unlike
+ * `onerror` it is not terminal — the delete completes if that connection closes, so
+ * this waits rather than failing immediately. Deleting a database that does not exist
+ * succeeds, which is what we want for idempotent cleanup.
+ *
+ * @throws if the deletion errors, is aborted, or stays blocked past the timeout.
+ */
+export function deleteDatabase(name: string): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		let request: IDBOpenDBRequest;
+		try {
+			request = indexedDB.deleteDatabase(name);
+		} catch (error) {
+			reject(error instanceof Error ? error : new Error(String(error)));
+			return;
+		}
+
+		let blockedTimer: ReturnType<typeof setTimeout> | null = null;
+		const settle = (finish: () => void) => {
+			if (blockedTimer !== null) clearTimeout(blockedTimer);
+			finish();
+		};
+
+		request.onsuccess = () => settle(resolve);
+		request.onerror = () =>
+			settle(() => reject(request.error ?? new Error(`Failed to delete IndexedDB database "${name}"`)));
+		request.onblocked = () => {
+			// Still deletable if the blocking connection closes; only give up if it doesn't.
+			if (blockedTimer !== null) return;
+			blockedTimer = setTimeout(() => {
+				reject(new Error(`Deleting IndexedDB database "${name}" is blocked by an open connection`));
+			}, DELETE_DB_BLOCKED_TIMEOUT_MS);
+		};
+	});
+}
+
 /**
  * Result from a vector similarity search (internal use).
  * Contains the document and its similarity score.

--- a/src/views/settings/TroubleshootingSettings.svelte
+++ b/src/views/settings/TroubleshootingSettings.svelte
@@ -9,6 +9,7 @@ import Toggle from "../../components/ui/Toggle.svelte";
 import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
 import { ConfirmModal } from "../../components/modal/ConfirmModal";
+import { Logger } from "../../utils/logging";
 
 const pluginData = getData();
 const plugin = getPlugin();
@@ -35,12 +36,28 @@ async function handleCleanupPluginData() {
 	if (!(await modal.promise).confirmed) return;
 
 	try {
+		// Each index is deleted independently, and a failure does not abort the cleanup:
+		// `deleteIndex` rejects when its IndexedDB databases can't be dropped (e.g. a
+		// connection still holds one), and letting that propagate would skip `deleteData()`
+		// entirely — so "clear plugin data" would leave the plugin data behind too.
+		const failed: string[] = [];
 		for (const index of [...pluginData.embeddingIndexes]) {
-			await plugin.vectorStoreService.deleteIndex(index.id);
+			try {
+				await plugin.vectorStoreService.deleteIndex(index.id);
+			} catch (error) {
+				failed.push(index.id);
+				Logger.error(`[Troubleshooting] Failed to delete embedding index ${index.id}:`, error);
+			}
 		}
 
 		await pluginData.deleteData();
-		new Notice(get(t)("plugin_data_cleared"));
+		if (failed.length > 0) {
+			new Notice(
+				`Plugin data cleared, but the stored vectors for ${failed.join(", ")} could not be deleted. See the console for details.`,
+			);
+		} else {
+			new Notice(get(t)("plugin_data_cleared"));
+		}
 	} catch (error) {
 		new Notice(error instanceof Error ? error.message : "Failed to clean plugin data");
 	}

--- a/src/views/settings/TroubleshootingSettings.svelte
+++ b/src/views/settings/TroubleshootingSettings.svelte
@@ -32,7 +32,7 @@ async function handleCleanupPluginData() {
 		"Delete",
 	);
 	modal.open();
-	if (!(await modal.promise)) return;
+	if (!(await modal.promise).confirmed) return;
 
 	try {
 		for (const index of [...pluginData.embeddingIndexes]) {

--- a/test/vectorstore/deleteDatabase.test.ts
+++ b/test/vectorstore/deleteDatabase.test.ts
@@ -24,21 +24,20 @@ function stubIndexedDB(request: ReturnType<typeof createRequestStub>) {
 
 afterEach(() => {
 	vi.unstubAllGlobals();
-	vi.useRealTimers();
 });
 
 describe("deleteDatabase", () => {
-	it("resolves when the request succeeds", async () => {
+	it("reports a successful deletion", async () => {
 		const request = createRequestStub();
 		stubIndexedDB(request);
 
 		const promise = deleteDatabase("db");
 		request.onsuccess?.();
 
-		await expect(promise).resolves.toBeUndefined();
+		await expect(promise).resolves.toEqual({ status: "deleted" });
 	});
 
-	it("rejects with the request error when deletion fails", async () => {
+	it("reports the request error when deletion fails", async () => {
 		const request = createRequestStub();
 		stubIndexedDB(request);
 
@@ -46,53 +45,45 @@ describe("deleteDatabase", () => {
 		request.error = new Error("quota exceeded");
 		request.onerror?.();
 
-		await expect(promise).rejects.toThrow("quota exceeded");
+		const result = await promise;
+		expect(result.status).toBe("error");
+		expect(result).toMatchObject({ error: { message: "quota exceeded" } });
 	});
 
-	it("rejects with a named fallback when the request exposes no error", async () => {
+	it("falls back to a named error when the request exposes none", async () => {
 		const request = createRequestStub();
 		stubIndexedDB(request);
 
 		const promise = deleteDatabase("my-db");
 		request.onerror?.();
 
-		await expect(promise).rejects.toThrow('Failed to delete IndexedDB database "my-db"');
+		const result = await promise;
+		expect(result.status).toBe("error");
+		expect(result).toMatchObject({ error: { message: 'Failed to delete IndexedDB database "my-db"' } });
 	});
 
-	it("still resolves when a blocked deletion later completes", async () => {
-		vi.useFakeTimers();
+	it("reports blocked immediately instead of waiting", async () => {
 		const request = createRequestStub();
 		stubIndexedDB(request);
 
 		const promise = deleteDatabase("db");
-		// Blocked is not terminal: the delete goes through once the other connection closes.
 		request.onblocked?.();
-		vi.advanceTimersByTime(1000);
-		request.onsuccess?.();
 
-		await expect(promise).resolves.toBeUndefined();
+		// Resolves without any timer advancing: an IndexedDB delete request cannot be
+		// cancelled, so there is nothing to wait for — the browser completes it once the
+		// blocking connection closes.
+		await expect(promise).resolves.toEqual({ status: "blocked" });
 	});
 
-	it("rejects when a deletion stays blocked past the timeout", async () => {
-		vi.useFakeTimers();
-		const request = createRequestStub();
-		stubIndexedDB(request);
-
-		const promise = deleteDatabase("stuck-db");
-		const assertion = expect(promise).rejects.toThrow(/blocked by an open connection/);
-		request.onblocked?.();
-		await vi.advanceTimersByTimeAsync(5000);
-
-		await assertion;
-	});
-
-	it("rejects when deleteDatabase throws synchronously", async () => {
+	it("never rejects when deleteDatabase throws synchronously", async () => {
 		vi.stubGlobal("indexedDB", {
 			deleteDatabase: vi.fn(() => {
 				throw new Error("indexedDB unavailable");
 			}),
 		});
 
-		await expect(deleteDatabase("db")).rejects.toThrow("indexedDB unavailable");
+		const result = await deleteDatabase("db");
+		expect(result.status).toBe("error");
+		expect(result).toMatchObject({ error: { message: "indexedDB unavailable" } });
 	});
 });

--- a/test/vectorstore/deleteDatabase.test.ts
+++ b/test/vectorstore/deleteDatabase.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { deleteDatabase } from "../../src/vectorstore/types";
+
+/**
+ * Minimal stand-in for the slice of `IDBOpenDBRequest` the helper touches. The real
+ * request reports outcomes through events, which is the whole reason the helper exists —
+ * a bare `indexedDB.deleteDatabase()` call resolves nothing and swallows failures.
+ */
+function createRequestStub() {
+	return {
+		onsuccess: null as (() => void) | null,
+		onerror: null as (() => void) | null,
+		onblocked: null as (() => void) | null,
+		error: null as Error | null,
+	};
+}
+
+function stubIndexedDB(request: ReturnType<typeof createRequestStub>) {
+	vi.stubGlobal("indexedDB", {
+		deleteDatabase: vi.fn(() => request),
+	});
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+describe("deleteDatabase", () => {
+	it("resolves when the request succeeds", async () => {
+		const request = createRequestStub();
+		stubIndexedDB(request);
+
+		const promise = deleteDatabase("db");
+		request.onsuccess?.();
+
+		await expect(promise).resolves.toBeUndefined();
+	});
+
+	it("rejects with the request error when deletion fails", async () => {
+		const request = createRequestStub();
+		stubIndexedDB(request);
+
+		const promise = deleteDatabase("db");
+		request.error = new Error("quota exceeded");
+		request.onerror?.();
+
+		await expect(promise).rejects.toThrow("quota exceeded");
+	});
+
+	it("rejects with a named fallback when the request exposes no error", async () => {
+		const request = createRequestStub();
+		stubIndexedDB(request);
+
+		const promise = deleteDatabase("my-db");
+		request.onerror?.();
+
+		await expect(promise).rejects.toThrow('Failed to delete IndexedDB database "my-db"');
+	});
+
+	it("still resolves when a blocked deletion later completes", async () => {
+		vi.useFakeTimers();
+		const request = createRequestStub();
+		stubIndexedDB(request);
+
+		const promise = deleteDatabase("db");
+		// Blocked is not terminal: the delete goes through once the other connection closes.
+		request.onblocked?.();
+		vi.advanceTimersByTime(1000);
+		request.onsuccess?.();
+
+		await expect(promise).resolves.toBeUndefined();
+	});
+
+	it("rejects when a deletion stays blocked past the timeout", async () => {
+		vi.useFakeTimers();
+		const request = createRequestStub();
+		stubIndexedDB(request);
+
+		const promise = deleteDatabase("stuck-db");
+		const assertion = expect(promise).rejects.toThrow(/blocked by an open connection/);
+		request.onblocked?.();
+		await vi.advanceTimersByTimeAsync(5000);
+
+		await assertion;
+	});
+
+	it("rejects when deleteDatabase throws synchronously", async () => {
+		vi.stubGlobal("indexedDB", {
+			deleteDatabase: vi.fn(() => {
+				throw new Error("indexedDB unavailable");
+			}),
+		});
+
+		await expect(deleteDatabase("db")).rejects.toThrow("indexedDB unavailable");
+	});
+});


### PR DESCRIPTION
Two related provider bugs, plus fixes found while reviewing them.

## Deleting a provider left dangling references

`deleteProvider` removed `providerMeta`, `providerConfig`, secrets and the registry entry — but unlike `renameProvider`, which re-points every reference, it cleared none of them.

The visible symptom: after deleting all providers the chat view still showed suggested queries instead of the "Add an AI provider" CTA. `ChatRecommendations` gates on `noModelSelected = !selectedAgent?.chatModel`, and the agent kept a `chatModel` naming a provider that no longer existed, so the CTA branch never ran. (`noProviderConfigured` was correct all along — it just sits inside the branch that never executed.)

`deleteProvider` now also clears agent `chatModel` / `summarizationModel` / `titleModel`, filters `favoriteModels`, and drops the provider's embedding index configs plus any `searchEmbedIndex` / `graphEmbedIndex` pointing at them.

### Embedding vectors are kept, and purging is opt-in

Vectors are expensive to recompute, and they survive config deletion intact: the IndexedDB name derives from the same `provider:model` id that `setEmbedIndex` rebuilds the config record from, so re-adding the provider and picking the same model reopens the existing database instead of re-embedding the vault. Only `VectorStoreService.deleteIndex` actually destroys them.

So purging is a separate, opt-in checkbox in the delete confirmation, shown only when the provider actually owns an index, with the indexed-note count in the description.

## Models never loaded for a provider added at runtime

"Loading models…" until an Obsidian reload. Two independent causes:

**1. A `createQuery` result only subscribes while something actively reads it.** Its observer subscribes from an `$effect` inside `createBaseQuery`. `AvailableModels` built its queries in a `$derived`, so a provider configured at runtime got a query object that was never subscribed (`isActive() === false`, `fetchStatus: "idle"`) and never fetched. Touching `isPending` does not help — it goes through `trackResult`. Replaced with `subscribeProviderState`, a bare `QueryObserver` whose `subscribe()` activates the query and fetches immediately.

**2. `$effect` inside a bare `$effect.root` does not re-run.** The singleton has no component driving the scheduler, so an effect there fires once and never again — verified live by polling for six seconds after adding a provider, with no re-run and no query created. Notably this is **not reproducible under Vitest**, where isolated probes pass with `await tick()`; it only shows up in the real Obsidian runtime.

Reconciliation is therefore callback-driven: `registrySync` exports `onProvidersChanged`, fired from `syncProvider` / `unsyncProvider` — the same helpers the store already calls on every add, remove, enable/disable and rename.

`useAvailableModels()` is also called eagerly at `onLayoutReady`. Lazy construction tied provider fetching to whichever view mounted first: with only the graph view open, nothing read it, so nothing subscribed.

## Found while reviewing the above

- **`#isLoading` could hang forever on an errored query.** It treated absent cache data as "loading". `validateProviderAuth` never throws, but the queryFn's outer strips (secret resolution) can, landing the query in `error` status with no data — recreating the same infinite spinner through a rarer door. Now status-based: an errored query is settled, not loading.
- **Nothing tore the singleton down on unload.** Module state survives a disable/enable cycle, so its `QueryObserver`s (whose queryFns resolve API keys) kept fetching with the unloaded plugin's credentials, and the next enable reused an instance bound to the dead data store. Added `dispose()` / `resetAvailableModels()`, called from `onunload`. This one is partly self-inflicted — active observers made a pre-existing latent issue real.
- **`setProviderConfigured`'s disable branch had the same bug in miniature:** it cleared only `chatModel`, leaving `summarizationModel` and `titleModel` pointing at a disabled provider. Favorites are deliberately kept on disable (reversible) and removed only on delete.
- **A failed embeddings purge reported "Failed to remove provider"** when the provider had in fact been removed. Split into its own error scope with an accurate message.

## Incidental: two pre-existing confirmation bugs

`ConfirmModal` gained an optional opt-in checkbox, which changed its promise from `boolean` to `ConfirmResult`. That surfaced two existing callers awaiting it as a bare boolean — SmartGraphView's "open all notes" and Troubleshooting's "clear plugin data". Left alone, both guards would have become permanently truthy: opening every note without confirmation, and wiping plugin data on a cancel. Both now check `.confirmed`.

## Verification

`bun run check` clean · Biome lint/format clean on changed files · 1564/1564 unit tests pass.

Verified live in the test vault (settings tab closed, only the graph view open):

- **Reload:** all 3 providers `obs: 1`, `success` — OpenRouter returning 422 models.
- **Runtime add** via the real commit path (`addProviderInstance` → `renameProvider` → `setProviderConfigured`): the new provider got `obs: 1` and `success` immediately, **no reload**.
- **Delete:** dropped to `obs: 0` — unsubscribed, no leak.

All test providers were removed afterwards; the vault is back to 3 providers, 3 queries, agent model intact.

### Not verified

The end-to-end click-through of the provider setup modal — I drove the underlying store methods rather than the UI. The delete confirmation's new checkbox was also verified by reading state rather than clicking. Both are worth a manual pass.

### Accepted trade-off

Eager init now fires all provider auth+model fetches (plus the models.dev / OpenRouter metadata fetches) at every layout-ready, even if no model UI is opened. Deliberate — chat needs them — but the metadata fetch could be deferred to first read if startup cost matters.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._