### PR TITLE
Review note changes without leaving the chat

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,10 @@
       "Bash(obsidian vault=\"S2B Test Vault\" dev:dom *)",
       "Bash(obsidian vault=\"S2B Test Vault\" dev:screenshot *)",
       "Bash(obsidian vault=\"S2B Test Vault\" dev:errors)",
-      "Bash(gh api graphql *)"
+      "Bash(gh api graphql *)",
+      "Bash(grep *)",
+      "Bash(egrep *)",
+      "Bash(rg *)"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ August 2026; recover it from git history if useful, but do not trust it.)
 
 ### Cross-cutting
 
-- **Staged writes:** Tools that mutate notes go through `pendingChangesStore` for user review rather than applying immediately.
+- **Staged writes:** Tools that mutate notes go through `pendingChangesStore` for user review rather than applying immediately. The review loop is closed in both directions: the outcomes (accepted / rejected / partially applied, plus still-pending paths) are injected into the model's next user turn as a context block via the same augment/strip mechanism as visible notes, and a same-thread re-stage of an already-pending update is rebased onto the pending proposal's `newContent` so the superseding proposal carries both rounds of edits. Entries are keyed by the model's tool-call id (`config.toolCall.id`), which lets the chat's `manage_notes` card show live review-status chips. A proposal whose note changed after staging can never be accepted (unconditional conflict check at apply time, including deletes); every review surface — chat bar, in-chat hunks, edit-mode and reading-view action bars — detects this and disables Accept with an explanation instead of letting it error.
 - **Worker offload:** Graph projection/clustering and HNSW operations run in workers (`hnswWorker.ts`, `computeWorker.ts`) to keep the UI fluid.
 - **Capability-driven multimodal:** Vision/PDF support is resolved per model at runtime — do not hard-code provider assumptions.
 - **Secrets:** `dataStore` holds secret IDs, not raw values; raw values resolve through `secretStorage.ts`.

--- a/integration/chat-ui.test.ts
+++ b/integration/chat-ui.test.ts
@@ -40,7 +40,7 @@ describe("chat view UI", () => {
 	});
 
 	it("should render the message input area with placeholder", () => {
-		expect(domCount('[aria-placeholder="Type a message..."]')).toBeGreaterThanOrEqual(1);
+		expect(domCount('[aria-placeholder="Ask about your notes..."]')).toBeGreaterThanOrEqual(1);
 	});
 
 	it("should show the agent selector button", () => {

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -16,7 +16,7 @@ import { getPlugin } from "../stores/state.svelte";
 import type { VisibleNoteRef } from "../hooks/useVisibleNotes.svelte";
 import type { SelectionRef } from "../hooks/useSelection.svelte";
 import type { GraphNoteRef } from "../stores/chatStore.svelte";
-import type { ChatAttachment, ThreadError } from "../types/shared";
+import type { ChatAttachment, ReviewStatusRef, ThreadError } from "../types/shared";
 import {
 	AiTransportDowngradeRequiredError,
 	bindAsyncIterableToTransportContext,
@@ -92,6 +92,9 @@ export interface AgentRunOptions {
 	selection?: SelectionRef;
 	/** Notes selected from the Smart Graph */
 	graphNotes?: GraphNoteRef[];
+	/** Review status of earlier staged note changes, appended as a context block
+	 * to the query by chatStore; persisted here so the UI can strip it again. */
+	reviewStatus?: ReviewStatusRef;
 }
 
 /** Options for editing a message (forks from checkpoint with new user message) */
@@ -739,6 +742,7 @@ export class Agent {
 		selection?: SelectionRef,
 		graphNotes?: GraphNoteRef[],
 		lcSource?: string,
+		reviewStatus?: ReviewStatusRef,
 	): HumanMessage {
 		const additional_kwargs: Record<string, unknown> = {};
 		if (attachments?.length) additional_kwargs.attachments = attachments;
@@ -746,6 +750,7 @@ export class Agent {
 		if (selection) additional_kwargs.selection = selection;
 		if (graphNotes?.length) additional_kwargs.graphNotes = graphNotes;
 		if (lcSource) additional_kwargs.lc_source = lcSource;
+		if (reviewStatus) additional_kwargs.reviewStatus = reviewStatus;
 		const hasKwargs = Object.keys(additional_kwargs).length > 0;
 		// Cast content — the HumanMessage constructor handles both string and
 		// MessageContentComplex[] at runtime, but the TS types are overly strict.
@@ -815,6 +820,7 @@ export class Agent {
 			options.selection,
 			options.graphNotes,
 			options.lcSource,
+			options.reviewStatus,
 		);
 
 		const transportContext = createAiTransportContext("default", `agent.run:${runId}`);
@@ -1169,6 +1175,7 @@ export class Agent {
 			options.selection,
 			options.graphNotes,
 			options.lcSource,
+			options.reviewStatus,
 		);
 
 		yield* this.runStream({

--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -29,7 +29,7 @@ import {
 	type AuthObject,
 	getProviderDefinition,
 } from "../providers/index";
-import type { ChatAttachment } from "../types/shared";
+import type { ChatAttachment, ReviewStatusRef } from "../types/shared";
 import { gzipString, toArrayBuffer } from "../utils/gzip";
 import { Logger } from "../utils/logging";
 import { basePromptPath, memoriesDir, memoryPromptPath } from "../utils/agentPaths";
@@ -1527,6 +1527,7 @@ export class AgentManager {
 		selection?: SelectionRef,
 		graphNotes?: GraphNoteRef[],
 		lcSource?: string,
+		reviewStatus?: ReviewStatusRef,
 	): AsyncGenerator<AgentManagerStreamChunk, void, unknown> {
 		const resolvedThreadId = this.normalizeThreadId(threadId);
 		const { agent, resolved, chatModel, runMetadata, resolvedAgentId } = await this.prepareAgentForStream(agentId);
@@ -1544,6 +1545,7 @@ export class AgentManager {
 				selection,
 				graphNotes,
 				lcSource,
+				reviewStatus,
 			}),
 			signal,
 			chatModel,

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -266,36 +266,70 @@ function applySequentialEdits(
 }
 
 /**
- * The text a new update's edits should be applied against.
+ * The candidate texts a new update's edits may be applied against, best first.
  *
- * When THIS thread already has a pending update to the file, the model's
- * follow-up edits are written against what it remembers proposing — its earlier
- * `newText`s — not against disk (staged edits are invisible to reads, and the
- * store's dedup will auto-reject the older proposal the moment the new one is
- * staged, silently dropping those edits). Basing the new edits on the pending
- * proposal's `newContent` makes the superseding proposal contain BOTH rounds of
- * changes, and makes the model's `oldText`s actually match.
+ * When THIS thread already has a pending update to the file, the model may be
+ * writing its follow-up edits against EITHER of two texts, and the tool cannot
+ * tell which:
  *
- * Guarded on the pending proposal still being current against disk: if the note
- * was hand-edited after staging, its `newContent` no longer accounts for those
- * edits, and rebasing onto it would stage a proposal that silently reverts the
- * user's own work on accept. In that case fall back to disk (the old proposal
- * was un-appliable anyway — accept would fail its conflict check).
+ *   - the pending proposal's `newContent` — what it remembers proposing, when it
+ *     is continuing from its own earlier edit; or
+ *   - the on-disk content — what `read_content`/`grep_notes` actually return,
+ *     since those are unaware of staged changes.
+ *
+ * So both are offered and the caller takes the first one the edits apply to
+ * cleanly (see the `applySequentialEdits` loop). Pending content is tried first:
+ * when the edits match there, rebasing makes the superseding proposal carry BOTH
+ * rounds of changes, rather than the store's dedup silently dropping the earlier
+ * one. When they only match disk, staging against disk is correct and the
+ * earlier proposal is superseded as before.
+ *
+ * The pending candidate is offered only while the proposal is still current
+ * against disk: if the note was hand-edited after staging, its `newContent` no
+ * longer accounts for those edits, and rebasing onto it would stage a proposal
+ * that silently reverts the user's own work on accept. (Such a proposal is
+ * un-appliable anyway — accept would fail its conflict check.)
  */
-function resolveUpdateBase(
-	threadId: string,
-	filePath: string,
-	diskContent: string,
-): { base: string; rebasedOnPending: boolean } {
+function resolveUpdateBases(threadId: string, filePath: string, diskContent: string): string[] {
 	const store = getPendingChangesStore();
 	const prior = store
 		.getPendingUpdatesForPath(filePath)
 		.filter((e) => e.threadId === threadId)
 		.at(-1);
-	if (prior?.change.type === "update" && prior.change.originalContent === diskContent) {
-		return { base: prior.change.newContent, rebasedOnPending: prior.change.newContent !== diskContent };
+	if (
+		prior?.change.type === "update" &&
+		prior.change.originalContent === diskContent &&
+		prior.change.newContent !== diskContent
+	) {
+		return [prior.change.newContent, diskContent];
 	}
-	return { base: diskContent, rebasedOnPending: false };
+	return [diskContent];
+}
+
+/**
+ * Apply `edits` to the first candidate base they succeed against.
+ *
+ * Returns the resulting content plus whether the winning base was a pending
+ * proposal (i.e. anything other than the last candidate, which is always disk).
+ * On total failure the LAST candidate's error is returned: that base is disk,
+ * whose content is what the model can actually see, so its "could not find the
+ * specified text" message is the one that will make sense to the model.
+ */
+function applyEditsToFirstMatchingBase(
+	bases: string[],
+	edits: { oldText: string; newText: string; is_regex?: boolean; replace_all?: boolean }[],
+	path: string,
+	operationNumber: number,
+): { content: string; rebasedOnPending: boolean } | { error: string } {
+	let lastError = "";
+	for (let i = 0; i < bases.length; i++) {
+		const result = applySequentialEdits(bases[i], edits, path, operationNumber);
+		if (!("error" in result)) {
+			return { content: result.content, rebasedOnPending: i < bases.length - 1 };
+		}
+		lastError = result.error;
+	}
+	return { error: lastError };
 }
 
 function summarizeOperations(changes: PendingChange[]): string {
@@ -461,10 +495,14 @@ export async function stageNoteOperations(
 			}
 
 			const originalContent = await app.vault.read(result.file);
-			const { base, rebasedOnPending } = resolveUpdateBase(threadId, result.file.path, originalContent);
-			if (rebasedOnPending) rebasedPaths.add(result.file.path);
-			const editResult = applySequentialEdits(base, operation.edits, result.file.path, operationNumber);
+			const editResult = applyEditsToFirstMatchingBase(
+				resolveUpdateBases(threadId, result.file.path, originalContent),
+				operation.edits,
+				result.file.path,
+				operationNumber,
+			);
 			if ("error" in editResult) return editResult.error;
+			if (editResult.rebasedOnPending) rebasedPaths.add(result.file.path);
 
 			stagedChanges.push({
 				type: "update",
@@ -598,10 +636,15 @@ export async function stageNoteOperations(
 
 			notesSearched++;
 			const originalContent = await app.vault.read(file);
-			// Same rebase as the update branch: replace against this thread's pending
-			// proposed content where one exists, so a replace doesn't silently drop a
-			// pending edit when the store's dedup supersedes it.
-			const { base, rebasedOnPending } = resolveUpdateBase(threadId, file.path, originalContent);
+			// Same rebase as the update branch, and the same ambiguity: a `find` may
+			// occur in this thread's pending proposed content, in the on-disk content
+			// the read tools actually returned, or both. Prefer the pending base when
+			// the pattern is present there (so the replace doesn't silently drop a
+			// pending edit the store's dedup then supersedes); otherwise fall back to
+			// disk, which is what a replace targeting text the model just read means.
+			const bases = resolveUpdateBases(threadId, file.path, originalContent);
+			const base = bases.find((candidate) => matcher.test(candidate)) ?? bases[bases.length - 1];
+			const rebasedOnPending = base !== originalContent;
 			// Skip notes too large to regex safely (unbounded backtracking would
 			// freeze the UI). Only regex ops are affected — a literal find is a
 			// plain string scan with no backtracking. Counted and surfaced below

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -265,6 +265,39 @@ function applySequentialEdits(
 	return { content };
 }
 
+/**
+ * The text a new update's edits should be applied against.
+ *
+ * When THIS thread already has a pending update to the file, the model's
+ * follow-up edits are written against what it remembers proposing — its earlier
+ * `newText`s — not against disk (staged edits are invisible to reads, and the
+ * store's dedup will auto-reject the older proposal the moment the new one is
+ * staged, silently dropping those edits). Basing the new edits on the pending
+ * proposal's `newContent` makes the superseding proposal contain BOTH rounds of
+ * changes, and makes the model's `oldText`s actually match.
+ *
+ * Guarded on the pending proposal still being current against disk: if the note
+ * was hand-edited after staging, its `newContent` no longer accounts for those
+ * edits, and rebasing onto it would stage a proposal that silently reverts the
+ * user's own work on accept. In that case fall back to disk (the old proposal
+ * was un-appliable anyway — accept would fail its conflict check).
+ */
+function resolveUpdateBase(
+	threadId: string,
+	filePath: string,
+	diskContent: string,
+): { base: string; rebasedOnPending: boolean } {
+	const store = getPendingChangesStore();
+	const prior = store
+		.getPendingUpdatesForPath(filePath)
+		.filter((e) => e.threadId === threadId)
+		.at(-1);
+	if (prior?.change.type === "update" && prior.change.originalContent === diskContent) {
+		return { base: prior.change.newContent, rebasedOnPending: prior.change.newContent !== diskContent };
+	}
+	return { base: diskContent, rebasedOnPending: false };
+}
+
 function summarizeOperations(changes: PendingChange[]): string {
 	const counts = {
 		create: 0,
@@ -360,6 +393,10 @@ export async function stageNoteOperations(
 	// conflicting diffs for one file (the second would be un-appliable), but the
 	// skip must be surfaced — otherwise a multi-op batch silently under-applies.
 	const conflictSkippedPaths = new Set<string>();
+	// Files whose new proposal was based on this thread's earlier pending update
+	// (see resolveUpdateBase) — surfaced so the model knows the superseding
+	// proposal carries both rounds of edits.
+	const rebasedPaths = new Set<string>();
 
 	for (let i = 0; i < operations.length; i++) {
 		const operation = operations[i];
@@ -424,17 +461,16 @@ export async function stageNoteOperations(
 			}
 
 			const originalContent = await app.vault.read(result.file);
-			const editResult = applySequentialEdits(
-				originalContent,
-				operation.edits,
-				result.file.path,
-				operationNumber,
-			);
+			const { base, rebasedOnPending } = resolveUpdateBase(threadId, result.file.path, originalContent);
+			if (rebasedOnPending) rebasedPaths.add(result.file.path);
+			const editResult = applySequentialEdits(base, operation.edits, result.file.path, operationNumber);
 			if ("error" in editResult) return editResult.error;
 
 			stagedChanges.push({
 				type: "update",
 				path: result.file.path,
+				// Disk content, NOT the edit base: accept-time conflict detection
+				// compares against what is actually in the vault.
 				originalContent,
 				newContent: editResult.content,
 			});
@@ -562,11 +598,15 @@ export async function stageNoteOperations(
 
 			notesSearched++;
 			const originalContent = await app.vault.read(file);
+			// Same rebase as the update branch: replace against this thread's pending
+			// proposed content where one exists, so a replace doesn't silently drop a
+			// pending edit when the store's dedup supersedes it.
+			const { base, rebasedOnPending } = resolveUpdateBase(threadId, file.path, originalContent);
 			// Skip notes too large to regex safely (unbounded backtracking would
 			// freeze the UI). Only regex ops are affected — a literal find is a
 			// plain string scan with no backtracking. Counted and surfaced below
 			// so the skip is visible, not a silent wrong answer.
-			if (operation.is_regex && originalContent.length > matcher.maxInputLength) {
+			if (operation.is_regex && base.length > matcher.maxInputLength) {
 				notesTooLarge++;
 				tooLargeSkippedTotal++;
 				continue;
@@ -576,16 +616,17 @@ export async function stageNoteOperations(
 			// every boundary. This is a property of the pattern, not the file — the
 			// first note that exhibits it proves the pattern is wrong for a replace —
 			// so abort the whole operation rather than silently skipping notes.
-			if (operation.is_regex && matcher.hasZeroWidthMatch(originalContent)) {
+			if (operation.is_regex && matcher.hasZeroWidthMatch(base)) {
 				return `Error in operation ${operationNumber}: The regex "${operation.find}" matches an empty (zero-width) position in "${file.path}", so replacing it would insert text at every boundary rather than substitute. Use a pattern that matches concrete text.`;
 			}
-			if (!matcher.test(originalContent)) continue;
+			if (!matcher.test(base)) continue;
 
 			const newContent = operation.is_regex
-				? originalContent.replace(matcher.globalRegex(), operation.replace)
-				: originalContent.split(operation.find).join(operation.replace);
+				? base.replace(matcher.globalRegex(), operation.replace)
+				: base.split(operation.find).join(operation.replace);
 
-			if (newContent === originalContent) continue;
+			if (newContent === base) continue;
+			if (rebasedOnPending) rebasedPaths.add(file.path);
 
 			seenPaths.add(file.path);
 			if (store.countOtherThreadsPendingUpdate(file.path, threadId) > 0) {
@@ -634,6 +675,9 @@ export async function stageNoteOperations(
 			try {
 				// Sequential await respects the store's per-file lock ordering.
 				await store.acceptChange(entryIds[i]);
+				// This result already tells the model the write was applied — keep
+				// the next turn's review-outcome block from repeating it.
+				store.markReportedToModel([entryIds[i]]);
 				autoAppliedCount++;
 			} catch (e) {
 				const path = change.type === "move" ? change.newPath : change.path;
@@ -657,6 +701,10 @@ export async function stageNoteOperations(
 	}
 	if (autoApplyFailures.length > 0) {
 		summary += ` ${autoApplyFailures.length} memory write(s) could not be applied: ${autoApplyFailures.join("; ")}.`;
+	}
+	if (rebasedPaths.size > 0) {
+		const paths = [...rebasedPaths].map((p) => `"${p}"`).join(", ");
+		summary += ` Note: this thread already had a pending (not yet reviewed) update to ${paths}; the new proposal was built on top of it and contains both rounds of edits — the older proposal was superseded.`;
 	}
 	if (crossThreadPaths.size > 0) {
 		const paths = [...crossThreadPaths].map((p) => `"${p}"`).join(", ");
@@ -693,9 +741,19 @@ export function createManageNotesTool(app: App, agentId = "") {
 	const toolConfig = getManageNotesToolConfig(agentId);
 
 	return tool(
-		async ({ operations }: ManageNotesInput, config: RunnableConfig & { runId?: string }) => {
+		async (
+			{ operations }: ManageNotesInput,
+			config: RunnableConfig & { runId?: string; toolCall?: { id?: string } },
+		) => {
 			const threadId = resolveThreadIdFromConfig(config);
-			return stageNoteOperations(app, operations, threadId, config?.runId, agentId);
+			// `config.toolCall.id` is the MODEL's tool-call id — the same id the chat
+			// timeline shows for this call — set by LangChain when ToolNode invokes
+			// the tool with a ToolCall object. Keying the staged entries by it lets
+			// the chat's tool card look its entries up and show live review status.
+			// (`config.runId` is deleted by StructuredTool.call before the func runs,
+			// so the old `config?.runId` here was always undefined and every batch
+			// fell through to a fresh UUID.)
+			return stageNoteOperations(app, operations, threadId, config?.toolCall?.id ?? config?.runId, agentId);
 		},
 		{
 			name: toolConfig.name,

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -314,6 +314,20 @@ function resolveUpdateBases(threadId: string, filePath: string, diskContent: str
  * On total failure the LAST candidate's error is returned: that base is disk,
  * whose content is what the model can actually see, so its "could not find the
  * specified text" message is the one that will make sense to the model.
+ *
+ * Why pending is tried FIRST, given the model may have read disk (asked twice in
+ * review) — the two cases are disjoint, and neither is served by disk-first:
+ *
+ *   - The edits CONFLICT with the pending one (both rewrite the same text). Then
+ *     the model's `oldText` no longer exists in the pending base, that base fails
+ *     to match, and the loop falls through to disk on its own. The disk-derived
+ *     intent wins without any precedence rule.
+ *   - BOTH bases match. Then the target text survived the pending edit, so the
+ *     two edits are necessarily orthogonal — and only the pending base carries
+ *     both rounds. Disk-first would silently drop the earlier unreviewed edit,
+ *     which is exactly the data loss this rebase exists to prevent.
+ *
+ * Both are pinned by tests in test/agent/manageNotes.test.ts.
  */
 function applyEditsToFirstMatchingBase(
 	bases: string[],

--- a/src/components/chat/AttachPopover.svelte
+++ b/src/components/chat/AttachPopover.svelte
@@ -62,15 +62,29 @@ function pick(action: () => void) {
     width: max-content;
   }
 
-  /* Prominent accent-tinted circle, not a muted glyph. */
+  /* Prominent accent-tinted circle, not a muted glyph. Explicit square
+     dimensions (matching the send button at the row's other end) instead of
+     `.clickable-icon`'s default padding, which is wider than tall — that
+     rendered this as an oval next to send's true circle. The tint mixes with
+     `--background-primary`, the fill the composer actually has. */
   :global(.attach-context-button.clickable-icon) {
-    background: color-mix(in srgb, var(--interactive-accent) 14%, var(--background-secondary));
+    background: color-mix(in srgb, var(--interactive-accent) 14%, var(--background-primary));
     color: var(--interactive-accent);
     border-radius: 999px;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    flex: 0 0 auto;
+  }
+
+  /* Same touch-size bump the send button gets on mobile. */
+  :global(.is-mobile .attach-context-button.clickable-icon) {
+    width: 2.75rem;
+    height: 2.75rem;
   }
 
   :global(.attach-context-button.clickable-icon:hover) {
-    background: color-mix(in srgb, var(--interactive-accent) 24%, var(--background-secondary));
+    background: color-mix(in srgb, var(--interactive-accent) 24%, var(--background-primary));
     color: var(--interactive-accent);
   }
 

--- a/src/components/chat/ChatEmbedPreview.svelte
+++ b/src/components/chat/ChatEmbedPreview.svelte
@@ -60,7 +60,7 @@ const formattedDate = $derived(
 							<CollapsibleUserBubble
 								content={pair.userMessage.content}
 								attachments={pair.userMessage.attachments}
-								class="max-w-[85%] rounded-t-lg rounded-bl-lg bg-[color-mix(in_srgb,var(--color-accent)_20%,transparent)] px-3 py-2"
+								class="max-w-[85%] rounded-[16px] bg-[color-mix(in_srgb,var(--color-accent)_20%,transparent)] px-3 py-2"
 							/>
 						</div>
 					{/if}

--- a/src/components/chat/CollapsibleUserBubble.svelte
+++ b/src/components/chat/CollapsibleUserBubble.svelte
@@ -56,7 +56,7 @@ function handleClick(evt: MouseEvent) {
   {#if isTruncated && !isExpanded}
     <!-- Fade gradient overlay -->
     <div
-      class="absolute bottom-0 left-0 right-0 h-8 pointer-events-none rounded-bl-lg"
+      class="absolute bottom-0 left-0 right-0 h-8 pointer-events-none rounded-b-[16px]"
       style="background: linear-gradient(to top, color-mix(in srgb, var(--color-accent) 20%, var(--background-primary)), transparent);"
     ></div>
   {/if}

--- a/src/components/chat/ContextTray.svelte
+++ b/src/components/chat/ContextTray.svelte
@@ -240,7 +240,7 @@ onDestroy(() => {
 </script>
 
 {#if hasAny}
-  <div class="context-tray inline-flex flex-row flex-wrap items-start gap-1.5">
+  <div class="context-tray flex flex-row flex-wrap items-start gap-1.5 min-w-0 max-w-full">
     <!-- Visible notes (auto references) -->
     {#each visibleNotes as note (note.file.path)}
       {@const deactivated = deactivatedPaths.has(note.file.path)}
@@ -351,7 +351,7 @@ onDestroy(() => {
         onfocus={(evt) => previewLink(evt, attachment.vaultPath)}
       >
         <div class="chip-icon" use:icon={attachmentIcon(attachment)} style="--icon-size: 12px"></div>
-        <span>{attachment.name}</span>
+        <span class="chip-label">{attachment.name}</span>
       </button>
     {/each}
   </div>
@@ -361,6 +361,15 @@ onDestroy(() => {
   .s2b-chip {
     display: inline-flex;
     align-items: center;
+    /* Every chip caps its own width and can be squeezed below its intrinsic
+       text size. `.s2b-pill` sets `white-space: nowrap`, so without this a
+       long filename grows the pill until it pushes past the composer's edge —
+       `.chip-label`'s `text-overflow` can only engage once the chip itself is
+       allowed to be narrower than its content. `min(100%, 18rem)` keeps a
+       single chip inside the tray on a narrow composer while still letting
+       short names size naturally. */
+    max-width: min(100%, 18rem);
+    min-width: 0;
   }
 
   /* One accent-tinted HUE for every chip, mixed against `--background-primary`
@@ -493,10 +502,16 @@ onDestroy(() => {
      without this the body renders `--interactive-normal` grey next to a
      tinted action and the chip reads as two unrelated buttons. The scoped
      selector is what wins that fight. */
+  /* The chip's cap has to reach the label, and the label lives inside this
+     inner button on `.visible` / `.graph-group` chips. Without `min-width: 0`
+     the button floors at its content width and the ellipsis never engages. */
   .chip-body {
     background: var(--s2b-pill-bg);
     color: inherit;
+    min-width: 0;
+    flex-shrink: 1;
   }
+
 
   .chip-body:hover {
     background: var(--s2b-pill-bg-hover);
@@ -505,6 +520,9 @@ onDestroy(() => {
   .chip-action {
     display: inline-flex;
     align-items: center;
+    /* Fixed-size target: it must not absorb the squeeze that belongs to the
+       label when the chip hits its width cap. */
+    flex-shrink: 0;
     /* Vertical padding tracks the compact tray pill above. */
     padding: 2px 7px 2px 5px;
     border: 1px solid var(--s2b-pill-border);

--- a/src/components/chat/ContextTray.svelte
+++ b/src/components/chat/ContextTray.svelte
@@ -261,7 +261,7 @@ onDestroy(() => {
             use:icon={deactivated ? "eye-off" : "eye"}
             style="--icon-size: 12px"
           ></div>
-          <span
+          <span class="chip-label"
             >{note.file.basename}{#if !deactivated && note.context}<span
                 class="chip-meta"> · {note.context}</span
               >{/if}</span
@@ -363,15 +363,27 @@ onDestroy(() => {
     align-items: center;
   }
 
-  /* One accent-tinted palette for every chip, attachments included, mixed
-     against `--background-primary` — the fill the composer actually has now
-     (mixing into `--background-secondary` produced a grey-shifted tint over
-     the page-coloured card). Attachments used to be green, which read muddy
-     and collided with what green means one surface up: in the pending-changes
-     bar and tool cards green is DIFF-ADD semantics, so a green chip implied a
+  /* One accent-tinted HUE for every chip, mixed against `--background-primary`
+     — the fill the composer actually has now (mixing into
+     `--background-secondary` produced a grey-shifted tint over the
+     page-coloured card). Attachments used to be green, which read muddy and
+     collided with what green means one surface up: in the pending-changes bar
+     and tool cards green is DIFF-ADD semantics, so a green chip implied a
      pending mutation rather than "this file rides along with the message".
-     What distinguishes an attachment is its file-type icon and remove action;
-     what distinguishes a reference is the eye icon and its promote action. */
+
+     The two chip families are separated by WEIGHT within that one hue, not by
+     colour (see the `.attachment` override below). A hollow chip reads as a
+     pointer to something; a filled chip reads as containing something — which
+     is exactly the difference: a reference sends a path the model may choose
+     to read, an attachment inlines the file's bytes into the message. It also
+     tracks how each is created: references appear on their own as you move
+     around the vault (ambient, so quiet), attachments are a deliberate act
+     (louder). And promoting one to the other visibly fills the chip, so the
+     paperclip action shows its own result.
+
+     This carries real weight: the reference/attachment distinction drives
+     token cost and what reaches an untrusted provider, and it was previously
+     encoded only in a 12px icon plus a hover tooltip that mobile never shows. */
   /* Compact variant of the shared pill: inside the composer card the default
      4px vertical padding reads oversized next to the single text line below.
      Scoped to the tray so search-modal / history pills keep their size. */
@@ -379,14 +391,36 @@ onDestroy(() => {
     padding: 2px 8px;
   }
 
+  /* Ghost: the default for reference chips (visible note, selection, graph).
+     Fill is the page colour, so the chip is defined by its border alone —
+     the same "outline, not slab" logic the composer itself now follows. The
+     accent-tinted border and `--text-normal` label are what keep it clearly
+     active rather than disabled; hover brings in a faint tint so it still
+     answers the pointer. */
   .context-tray :global(.s2b-chip) {
-    --s2b-pill-bg: color-mix(in srgb, var(--interactive-accent) 6%, var(--background-primary));
-    --s2b-pill-border: color-mix(in srgb, var(--interactive-accent) 16%, var(--background-modifier-border));
+    --s2b-pill-bg: var(--background-primary);
+    --s2b-pill-border: color-mix(in srgb, var(--interactive-accent) 20%, var(--background-modifier-border));
     --s2b-pill-color: var(--text-normal);
-    --s2b-pill-bg-hover: color-mix(in srgb, var(--interactive-accent) 10%, var(--background-primary));
-    --s2b-pill-border-hover: color-mix(in srgb, var(--interactive-accent) 22%, var(--background-modifier-border));
+    --s2b-pill-bg-hover: color-mix(in srgb, var(--interactive-accent) 7%, var(--background-primary));
+    --s2b-pill-border-hover: color-mix(in srgb, var(--interactive-accent) 30%, var(--background-modifier-border));
   }
 
+  /* Filled: attachments carry content, so they carry pigment. 12% is enough
+     to read as solid next to a hollow chip at 11px without competing with the
+     accent border of the focused composer around it. */
+  .context-tray :global(.s2b-chip.attachment) {
+    --s2b-pill-bg: color-mix(in srgb, var(--interactive-accent) 12%, var(--background-primary));
+    --s2b-pill-border: color-mix(in srgb, var(--interactive-accent) 24%, var(--background-modifier-border));
+    --s2b-pill-bg-hover: color-mix(in srgb, var(--interactive-accent) 17%, var(--background-primary));
+    --s2b-pill-border-hover: color-mix(in srgb, var(--interactive-accent) 32%, var(--background-modifier-border));
+  }
+
+  /* Now that an ACTIVE reference chip is also page-filled (ghost), fill no
+     longer separates deactivated from active — so the remaining cues have to
+     carry it: no accent in the border at all, muted label, reduced opacity,
+     and a struck-through name. The strikethrough is the unambiguous one; it
+     says "excluded from the message" without relying on a tint difference
+     that some themes render nearly invisible. */
   .s2b-chip.deactivated {
     --s2b-pill-bg: var(--background-primary);
     --s2b-pill-border: color-mix(in srgb, var(--background-modifier-border) 90%, transparent);
@@ -395,6 +429,11 @@ onDestroy(() => {
     --s2b-pill-border-hover: color-mix(in srgb, var(--background-modifier-border) 90%, transparent);
     --s2b-pill-color-hover: var(--text-muted);
     opacity: 0.6;
+  }
+
+  .s2b-chip.deactivated .chip-label {
+    text-decoration: line-through;
+    text-decoration-color: color-mix(in srgb, currentColor 55%, transparent);
   }
 
   .s2b-chip.deactivated:hover {

--- a/src/components/chat/ContextTray.svelte
+++ b/src/components/chat/ContextTray.svelte
@@ -363,24 +363,28 @@ onDestroy(() => {
     align-items: center;
   }
 
-  /* Active-note / graph: accent-tinted reference chips */
-  .s2b-chip.visible,
-  .s2b-chip.selection,
-  .context-tray :global(.s2b-chip):not(.attachment) {
-    --s2b-pill-bg: color-mix(in srgb, var(--interactive-accent) 6%, var(--background-secondary));
-    --s2b-pill-border: color-mix(in srgb, var(--interactive-accent) 16%, var(--background-modifier-border));
-    --s2b-pill-color: var(--text-normal);
-    --s2b-pill-bg-hover: color-mix(in srgb, var(--interactive-accent) 9%, var(--background-secondary));
-    --s2b-pill-border-hover: color-mix(in srgb, var(--interactive-accent) 22%, var(--background-modifier-border));
+  /* One accent-tinted palette for every chip, attachments included, mixed
+     against `--background-primary` — the fill the composer actually has now
+     (mixing into `--background-secondary` produced a grey-shifted tint over
+     the page-coloured card). Attachments used to be green, which read muddy
+     and collided with what green means one surface up: in the pending-changes
+     bar and tool cards green is DIFF-ADD semantics, so a green chip implied a
+     pending mutation rather than "this file rides along with the message".
+     What distinguishes an attachment is its file-type icon and remove action;
+     what distinguishes a reference is the eye icon and its promote action. */
+  /* Compact variant of the shared pill: inside the composer card the default
+     4px vertical padding reads oversized next to the single text line below.
+     Scoped to the tray so search-modal / history pills keep their size. */
+  .context-tray :global(.s2b-pill) {
+    padding: 2px 8px;
   }
 
-  /* Content attachments: green */
-  .s2b-chip.attachment {
-    --s2b-pill-bg: color-mix(in srgb, var(--color-green) 12%, var(--background-secondary));
-    --s2b-pill-border: color-mix(in srgb, var(--color-green) 22%, var(--background-modifier-border));
+  .context-tray :global(.s2b-chip) {
+    --s2b-pill-bg: color-mix(in srgb, var(--interactive-accent) 6%, var(--background-primary));
+    --s2b-pill-border: color-mix(in srgb, var(--interactive-accent) 16%, var(--background-modifier-border));
     --s2b-pill-color: var(--text-normal);
-    --s2b-pill-bg-hover: color-mix(in srgb, var(--color-green) 16%, var(--background-secondary));
-    --s2b-pill-border-hover: color-mix(in srgb, var(--color-green) 28%, var(--background-modifier-border));
+    --s2b-pill-bg-hover: color-mix(in srgb, var(--interactive-accent) 10%, var(--background-primary));
+    --s2b-pill-border-hover: color-mix(in srgb, var(--interactive-accent) 22%, var(--background-modifier-border));
   }
 
   .s2b-chip.deactivated {
@@ -421,11 +425,6 @@ onDestroy(() => {
     border-bottom-right-radius: 0;
   }
 
-  .s2b-chip.graph-group .chip-action:hover {
-    background: var(--s2b-pill-bg-hover);
-    color: var(--text-normal);
-  }
-
   .chip-chevron {
     opacity: 0.55;
     margin-left: 2px;
@@ -449,15 +448,26 @@ onDestroy(() => {
     min-width: 0;
   }
 
+  /* Restates the pill fill (same `--s2b-pill-bg` the adjacent `.chip-action`
+     paints) because it can't be left to `.s2b-pill`: the body is a <button>,
+     and Obsidian's app.css button rule outspecifies the unscoped pill class —
+     without this the body renders `--interactive-normal` grey next to a
+     tinted action and the chip reads as two unrelated buttons. The scoped
+     selector is what wins that fight. */
   .chip-body {
-    background: none;
+    background: var(--s2b-pill-bg);
     color: inherit;
+  }
+
+  .chip-body:hover {
+    background: var(--s2b-pill-bg-hover);
   }
 
   .chip-action {
     display: inline-flex;
     align-items: center;
-    padding: 4px 8px 4px 6px;
+    /* Vertical padding tracks the compact tray pill above. */
+    padding: 2px 7px 2px 5px;
     border: 1px solid var(--s2b-pill-border);
     border-left: none;
     border-top-right-radius: 999px;
@@ -468,8 +478,11 @@ onDestroy(() => {
     transition: background 0.15s ease, color 0.15s ease;
   }
 
+  /* Hover uses the chip's own tint family via the var, not a hardcoded green:
+     this action sits on the accent-tinted visible-note chip, and green is the
+     attachment palette — flashing it here implied a different chip type. */
   .chip-action:hover {
-    background: color-mix(in srgb, var(--color-green) 16%, var(--background-secondary));
+    background: var(--s2b-pill-bg-hover);
     color: var(--text-normal);
   }
 

--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -32,7 +32,6 @@ interface Props {
 	onMessageSent?: () => void;
 	onDragStateChange?: (state: DragOverlayState) => void;
 	dropTargetMode?: "input" | "view";
-	externalDragActive?: boolean;
 }
 
 type DragOverlayState = {
@@ -57,7 +56,6 @@ const {
 	onMessageSent,
 	onDragStateChange,
 	dropTargetMode = "input",
-	externalDragActive = false,
 }: Props = $props();
 
 // Pinned to this tab's own thread — never follows a global pointer.
@@ -204,7 +202,13 @@ const canSendMessage = $derived(inputValue.trim().length > 0 || attachments.leng
 const canSummarizeNow = $derived.by(() => {
 	return Boolean(session && session.messageState === MessageState.idle && session.messages.length > 0);
 });
-const showDragActive = $derived(dropTargetMode === "view" ? externalDragActive : isDragging);
+// Only the composer's OWN drag state tints the composer. In `view` mode the
+// whole pane is the drop target and Chat.svelte draws one dashed frame around
+// it — the composer sits inside that frame, so tinting it too painted a second,
+// competing target for a drop that behaves identically either way. (It also put
+// a solid accent slab where the composer is deliberately a flat, bordered
+// surface.) The frame communicates the target; the composer stays itself.
+const showDragActive = $derived(dropTargetMode === "input" && isDragging);
 
 $effect(() => {
 	onDragStateChange?.({

--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -47,6 +47,8 @@ const acceptedFileTypes =
 const MAX_FILE_SIZE_BYTES = 15 * 1024 * 1024; // 15 MB per file
 const MAX_TOTAL_ATTACHMENTS_BYTES = 25 * 1024 * 1024; // 25 MB per message
 const FULLSCREEN_TRANSITION_MS = 220;
+/** Usage % below which the context circle stays hidden (see the action row). */
+const CONTEXT_USAGE_VISIBLE_THRESHOLD = 50;
 
 const {
 	registry,
@@ -380,6 +382,17 @@ function handleMobileTapFocus(event: TouchEvent) {
 	markdownEditor.focus();
 }
 
+/** A click on the composer card's empty padding focuses the editor, so the
+ * whole card acts as the text target — the editor box hugs its content
+ * (`min-h-[24px]`) instead of padding the card out with clickable dead space.
+ * Controls and the editor itself are excluded: buttons/chips keep their own
+ * behavior, and clicks inside CM must keep placing the caret. */
+function handleWrapperClick(event: MouseEvent) {
+	const target = event.target as HTMLElement;
+	if (target.closest("button, a, .s2b-chip, .markdown-editor-container")) return;
+	markdownEditor?.focus();
+}
+
 function initializeEditor() {
 	if (!editorContainer) return;
 
@@ -387,7 +400,9 @@ function initializeEditor() {
 
 	markdownEditor = new EmbeddableMarkdownEditor(plugin.app, editorContainer, {
 		value: inputValue,
-		placeholder: "Type a message...",
+		// Orients first-time users toward the product's actual job — chatting
+		// with the vault — instead of the generic "Type a message...".
+		placeholder: "Ask about your notes...",
 		cls: "chat-markdown-editor",
 		enterVimInsertMode: true,
 		onPaste: (event) => {
@@ -1095,12 +1110,11 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
 >
   {#if selectedChatModel && models.unavailableProviders.includes(selectedChatModel.provider)}
     <button
-      class="flex flex-row items-center gap-1 text-xs cursor-pointer border-none bg-transparent p-0"
-      style="color: var(--text-error);"
+      class="provider-unreachable-banner flex flex-row items-center gap-1.5 text-xs cursor-pointer"
       onclick={models.refetchProviders}
       title="Click to retry connection"
     >
-      <div class="h-icon-xs" use:icon={"alert-triangle"} style="--icon-size: var(--icon-xs)"></div>
+      <div class="h-icon-xs shrink-0" use:icon={"alert-triangle"} style="--icon-size: var(--icon-xs)"></div>
       <span>Cannot connect to {selectedChatModel.provider} — click to retry</span>
     </button>
   {/if}
@@ -1113,8 +1127,11 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
        reflow when the mobile keyboard opens. The fullscreen expand/collapse
        animation is unaffected: it lives on `.chat-input-container`, which has
        its own explicit transition list. -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -- the click is a
+       pointer-only convenience (focus the editor from the card's padding);
+       keyboard users reach the editor by Tab, so no key handler is needed. -->
   <div
-    class="chat-input-wrapper flex flex-col gap-3 border border-solid border-bg-modifier-border rounded-[14px] pb-2 px-3 transition-[background-color,border-color] duration-200 ease-in-out relative isolate {isFullscreen
+    class="chat-input-wrapper flex flex-col gap-3 border border-solid pb-2 px-3 transition-[background-color,border-color] duration-200 ease-in-out relative isolate {isFullscreen
       ? 'flex-1 min-h-0'
       : ''} {showDragActive
       ? 'border-[--interactive-accent] chat-input-wrapper-drag-active'
@@ -1123,6 +1140,7 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
     ondragover={dropTargetMode === "input" ? handleDragOver : undefined}
     ondragleave={dropTargetMode === "input" ? handleDragLeave : undefined}
     ondrop={dropTargetMode === "input" ? handleDrop : undefined}
+    onclick={handleWrapperClick}
     role="region"
   >
     {#if !isMobileUI()}
@@ -1140,7 +1158,12 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
         tooltip={isFullscreen ? "Exit fullscreen (Esc)" : "Fullscreen editor"}
       />
     {/if}
-    <div class="flex flex-row flex-wrap items-start gap-1.5 pt-2">
+    <!-- `pt-0.5` (2px) on top of the wrapper's 4px `padding-top` puts the tray
+         6px below the border, matching the fullscreen toggle's `top-1.5` so
+         the two top-anchored elements sit on one line. The old `pt-2` put it
+         at 12px — a visibly large gap that also read as misaligned against
+         the button. -->
+    <div class="composer-tray-row flex flex-row flex-wrap items-start gap-1.5 pt-0.5">
       <ContextTray
         bind:this={contextTrayRef}
         graphPaths={registry.graphSelection}
@@ -1157,15 +1180,15 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
     <!-- Markdown Editor Container -->
     <div
       bind:this={editorContainer}
-      class="markdown-editor-container w-full overflow-y-auto {isFullscreen
+      class="markdown-editor-container w-full overflow-y-auto py-1 {isFullscreen
         ? 'flex-1'
-        : 'min-h-[40px] max-h-[200px]'}"
+        : 'min-h-[24px] max-h-[200px]'}"
       id="chat-view-user-input-element"
       data-testid="message-input"
     ></div>
 
     <!-- Actions row: attachment, agent+model, send -->
-    <div class="flex items-center gap-2 flex-wrap">
+    <div class="chat-actions-row flex items-center gap-2">
       <input
         bind:this={attachmentInputEl}
         type="file"
@@ -1182,7 +1205,12 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
       <AgentPopover {threadPath} />
       <ModelSelectButton {threadPath} />
       <div class="ml-auto flex items-center gap-2">
-        {#if !isMobileUI()}
+        <!-- Threshold-gated: at low usage the ring is an empty grey track that
+             reads as a loading spinner next to the send button, and the number
+             it encodes isn't actionable. Appearing at 50% is itself the signal
+             ("context is filling up"), and puts the popover's Summarize action
+             in reach exactly when a user starts wanting it. -->
+        {#if !isMobileUI() && contextUsage.usagePercent >= CONTEXT_USAGE_VISIBLE_THRESHOLD}
           <ContextUsageCircle
             usagePercent={contextUsage.usagePercent}
             used={contextUsage.estimatedUsedTokens}
@@ -1214,19 +1242,18 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
                 : "Send message"}
             onClick={attemptSend}
             dataTestId="send-message-button"
-            styles="send-message-button p-0 rounded-md border-none cursor-pointer flex items-center justify-center shrink-0 transition-all duration-200 disabled:cursor-not-allowed"
+            styles="send-message-button p-0 border-none cursor-pointer flex items-center justify-center shrink-0 transition-all duration-200 disabled:cursor-not-allowed"
             style={sendButtonStyle}
-            iconId={isEditing ? "check" : "send-horizontal"}
+            iconId={isEditing ? "check" : "arrow-up"}
           />
         {:else if session.messageState === MessageState.answering}
           <Button
             ariaLabel="stop streaming"
             tooltip="Stop streaming"
             onClick={() => session?.stopStreaming()}
-            styles="send-message-button p-0 rounded-md border-none cursor-pointer flex items-center justify-center shrink-0 transition-all duration-200"
+            styles="send-message-button p-0 border-none cursor-pointer flex items-center justify-center shrink-0 transition-all duration-200"
             style={sendButtonStyle}
             iconId="square"
-            iconSize="xs"
           />
         {/if}
       </div>
@@ -1234,7 +1261,7 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
 
     {#if dropTargetMode === "input" && isDragging}
       <div
-        class="absolute inset-0 z-20 rounded-[14px] pointer-events-none flex items-center justify-center gap-2 text-sm font-medium {dragHasIssue
+        class="absolute inset-0 z-20 rounded-[22px] pointer-events-none flex items-center justify-center gap-2 text-sm font-medium {dragHasIssue
           ? 'text-[--text-error]'
           : 'text-[--text-accent]'}"
       >
@@ -1255,12 +1282,27 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
 <style>
   .chat-input-container {
     background: transparent !important;
-    --input-bg: var(--background-secondary);
+    /* Same fill as the page, everywhere. The composer is defined by its
+       border, not by a contrasting slab — see `.chat-input-wrapper`. */
+    --input-bg: var(--background-primary);
   }
 
-  :global(.mod-left-split .chat-input-container),
-  :global(.mod-right-split .chat-input-container) {
-    --input-bg: var(--background-primary);
+  /* Same card language as the other pre-composer bars (PendingChangesBar,
+     EditingMessageBar): page fill, real border, the composer stack's 22px
+     pill. An error state shouldn't be the one surface in the stack rendered
+     as bare floating text — it deserves more structure than routine bars,
+     not less. Red is kept to the text/icon and a tinted border rather than a
+     filled red slab: this is a retryable connectivity hiccup, not data loss. */
+  .provider-unreachable-banner {
+    padding: 6px 12px;
+    border: 1px solid color-mix(in srgb, var(--text-error) 35%, var(--background-modifier-border));
+    border-radius: 22px;
+    background: var(--input-bg);
+    color: var(--text-error);
+  }
+
+  .provider-unreachable-banner:hover {
+    background: color-mix(in srgb, var(--text-error) 6%, var(--input-bg));
   }
 
   /* The scroller runs 24px past this container's top edge (see
@@ -1279,18 +1321,15 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
     background: linear-gradient(to bottom, transparent 0%, var(--background-primary) 24px) !important;
   }
 
-  /* Overrides for the utility classes on the element itself
-     (`rounded-[14px] gap-3 border-bg-modifier-border`). All platform-neutral:
-     the shape and internal rhythm aren't platform-specific, so keeping
-     desktop squarer or looser would just be an inconsistency.
+  /* The wrapper's shape and internal rhythm live here, not in utility classes
+     on the element (the markup carries only layout/transition utilities, so
+     this block and the markup can't disagree about the design). All
+     platform-neutral: keeping desktop squarer or looser than mobile would
+     just be an inconsistency.
 
-     `border-color: transparent` drops the resting border and lets the fill
-     define the card. Only safe where the fill actually contrasts with the
-     page: in the main view `--input-bg` is `--background-secondary` (#282828)
-     against a `--background-primary` (#1C1C1C) page. In a sidebar
-     `--input-bg` IS `--background-primary`, identical to the page behind it,
-     so there the border is the only thing separating the composer from the
-     background and has to stay — see the split rule below.
+     The fill matches the page (`--input-bg` is `--background-primary`), so
+     the border is the only thing separating the composer from the background
+     and always has to be drawn — in the main view as well as in a sidebar.
 
      Plain selector, NOT `:not(:focus-within)` — that has the same specificity
      as the `:focus-within` rule further down and, coming earlier in the file,
@@ -1299,17 +1338,71 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
   .chat-input-wrapper {
     background: var(--input-bg);
     border-radius: 22px;
-    border-color: transparent;
+    border-color: var(--background-modifier-border);
     gap: 8px;
+    /* Query container for the action row's progressive collapse (see the
+       `@container` rules below). The real constraint on that row is how wide
+       the COMPOSER is, which is not the viewport and not `.mod-*-split`: a
+       sidebar can be dragged wide, and a narrow window's main view is just as
+       cramped as a sidebar. Querying the wrapper itself is the only measure
+       that tracks the actual available space in every one of those cases. */
+    container-type: inline-size;
+    container-name: chat-composer;
     /* The `pb-2 px-3` utilities on the element leave `padding-top` at 0, which
        started the text inside the 22px corner's curve — it read as if the
        first line was crowding the border. Clear the curve. */
     padding-top: 4px;
   }
 
-  :global(.mod-left-split) .chat-input-wrapper,
-  :global(.mod-right-split) .chat-input-wrapper {
-    border-color: var(--background-modifier-border);
+  /* The row is `nowrap`: wrapping dropped the send button onto a second line
+     and grew the composer taller, which is worse than any amount of label
+     truncation. With nowrap, overflow has to be absorbed by something, so
+     pin every fixed-size control and let ONLY the model name shrink (it sets
+     `flex-shrink: 1` + `min-width: 0` in ModelSelectButton). Without these
+     `flex-shrink: 0` guards the browser is free to squeeze the icon buttons
+     and the agent pill instead, which would deform the touch targets. */
+  .chat-actions-row > :global(*) {
+    flex-shrink: 0;
+  }
+
+  .chat-actions-row :global(.model-select-btn) {
+    flex-shrink: 1;
+    min-width: 0;
+  }
+
+  /* Progressive collapse of the action row as the composer narrows.
+     These breakpoints shed elements entirely, in priority order (least useful
+     first), before/alongside the truncation above:
+
+       1. <340px — drop the context-usage circle. It's the only thing in the
+          row that isn't a control; you never need it to send a message. Also
+          already hidden on mobile for exactly this reason.
+       2. <260px — collapse the agent to its icon. The agent's icon is
+          user-chosen and genuinely identifying, and the agent changes far
+          less often than the model, so icon-only stays legible. This mirrors
+          the existing `.is-mobile` rule in AgentPopover.
+
+     The model name is deliberately NOT collapsed at either step: unlike the
+     agent, its icon is generic, so an icon-only model button would tell you
+     nothing about which model you're about to spend tokens on. It truncates
+     with an ellipsis instead (`max-width` in ModelSelectButton) and is the
+     last label standing. */
+  @container chat-composer (max-width: 340px) {
+    .chat-actions-row :global(.context-usage-trigger) {
+      display: none;
+    }
+  }
+
+  @container chat-composer (max-width: 260px) {
+    .chat-actions-row :global(.agent-pill-label) {
+      display: none;
+    }
+
+    /* The 190px trigger cap exists to bound the LABEL; with the label gone it
+       would just leave dead space around the icon. */
+    .chat-actions-row :global(.agent-popover-trigger) {
+      max-width: none;
+    }
   }
 
   /* Circular, matching the attach button (already `999px`) and the reference
@@ -1430,6 +1523,16 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
     aspect-ratio: 1;
   }
 
+  /* Lucide ships at `stroke-width: 2`, which reads thin for a glyph reversed
+     out of a filled accent circle at 28px — light-on-dark makes strokes
+     optically thinner than the same weight dark-on-light. 2.5 matches the
+     attach button, the other icon in this row that needed the same
+     correction. Applies to all three states (arrow-up / check / square), so
+     the button's weight doesn't shift as it changes state. */
+  :global(.send-message-button .svg-icon) {
+    stroke-width: 2.5;
+  }
+
   /* Bump the send target to a comfortable touch size on mobile. */
   :global(.is-mobile .send-message-button) {
     width: 2.75rem !important;
@@ -1470,8 +1573,32 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
     opacity: 1;
   }
 
+  /* The toggle is absolutely positioned over the wrapper's top-right corner,
+     outside the flow — reserve that corner in the tray row so a wrapping chip
+     can't land underneath it, where the toggle would swallow the chip's
+     clicks (its paperclip/close actions live exactly at a chip's right edge).
+     2.5rem = the 6px right offset + 1.75rem button + a 6px gap. Only the
+     row's FIRST line can collide (the toggle band ends where a second chip
+     line begins), so the over-reservation on later lines is the price of
+     doing this in CSS. Mobile never renders the toggle — no reservation. */
+  .composer-tray-row {
+    padding-right: 2.5rem;
+  }
+
+  :global(.is-mobile) .composer-tray-row {
+    padding-right: 0;
+  }
+
   /* Markdown editor styling */
   .markdown-editor-container {
+    /* The text column starts 6px right of the wrapper's 12px rail (CM6's
+       `.cm-line` keeps `padding: 0 2px 0 6px`; its horizontal padding is
+       load-bearing for list hanging-indents — see the `.cm-content` note
+       below). That offset is kept deliberately: bordered controls (chips, the
+       attach button) can sit on the 12px rail because their border is their
+       visual edge, but bare text at the same x hugs the card border. Strict
+       geometric alignment here reads WORSE than the 6px optical inset. */
+
     /* Reset some CM6 styles for chat input look */
     :global(.cm-editor) {
       background: transparent !important;

--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -1167,7 +1167,7 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
          the two top-anchored elements sit on one line. The old `pt-2` put it
          at 12px — a visibly large gap that also read as misaligned against
          the button. -->
-    <div class="composer-tray-row flex flex-row flex-wrap items-start gap-1.5 pt-0.5">
+    <div class="composer-tray-row flex flex-row flex-wrap items-start gap-1.5 pt-0.5 min-w-0">
       <ContextTray
         bind:this={contextTrayRef}
         graphPaths={registry.graphSelection}

--- a/src/components/chat/MessageContainer.svelte
+++ b/src/components/chat/MessageContainer.svelte
@@ -795,7 +795,7 @@ $effect(() => {
                   <CollapsibleUserBubble
                     content={messagePair.userMessage.content}
                     attachments={messagePair.userMessage.attachments}
-                    class="max-w-[80%] rounded-t-lg rounded-bl-lg px-4 py-2 {isBeingEdited
+                    class="max-w-[80%] rounded-[16px] px-4 py-2 {isBeingEdited
                       ? 's2b-user-bubble-editing'
                       : 'bg-[color-mix(in_srgb,var(--color-accent)_20%,transparent)]'}"
                   />

--- a/src/components/chat/ModelSelectButton.svelte
+++ b/src/components/chat/ModelSelectButton.svelte
@@ -67,35 +67,37 @@ function openModelSelectionModal() {
 </Button>
 
 <style>
+  /* `flex-shrink` (not just `min-width: 0`) makes this the one control in the
+     action row that gives up width under pressure. The row is `nowrap`, so
+     something has to absorb a narrow composer; the alternatives are all worse
+     — the attach/send buttons are fixed-size touch targets, and the agent
+     collapses to an icon at its own breakpoint. An over-long model name
+     ellipsises instead of pushing the send button onto a second line. */
   :global(.model-select-btn) {
     display: flex;
     align-items: center;
     gap: 0.25rem;
     min-width: 0;
+    flex-shrink: 1;
   }
 
+  /* No max-width: the name shows in full whenever the row has room, and is
+     capped only by actual width pressure — the action row is `nowrap` with
+     this button as its only shrinkable item (see Input.svelte), so when the
+     composer narrows, flex squeezes the button and `min-width: 0` +
+     `text-overflow` turn the surplus into an ellipsis. A fixed cap here
+     truncated long names even when the row had plenty of free space. */
   .model-name {
-    max-width: 120px;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     font-size: 0.8rem;
-    color: var(--text-muted);
-  }
-
-  /* On mobile the row is just attach + (icon-only) agent pill + this + send, all
-     at the 44px touch floor, so there's far more free width than the old fixed
-     84px cap used. Measured on-device at a 402px viewport: row 23..379, label
-     ending at 228 while the send button only starts at 330 — ~100px sitting
-     unused while names like "Free Models Router" truncated.
-
-     `45vw` tracks the viewport (≈181px there, landing just short of the send
-     button with a small gutter) and the 190px ceiling stops it crowding the row
-     on wider tablets. The button is `min-width: 0` inside a `flex-wrap` row, so
-     it still shrinks rather than pushing send off-screen if a future control
-     joins the row. */
-  :global(.is-mobile) .model-name {
-    max-width: min(45vw, 190px);
+    /* `--text-normal`, matching the agent pill beside it: the two text
+       triggers in the row are the same kind of control and should read as
+       one family. Muted is this app's label colour, and a muted model name
+       read as a caption rather than something clickable. */
+    color: var(--text-normal);
   }
 
   .model-name.no-model {

--- a/src/components/chat/PendingChangesBar.svelte
+++ b/src/components/chat/PendingChangesBar.svelte
@@ -71,30 +71,66 @@ let batchRunning = $state(false);
  * staleness up front instead of letting Accept error as the first signal.
  * Async (`hasConflict` reads the vault), hence state + explicit recompute
  * rather than a `$derived`.
+ *
+ * Staleness only changes when DISK changes, so vault reads happen in exactly
+ * two places: a full pass when the thread changes (or on mount), and a
+ * targeted pass for the one path a vault event named. Store mutations can't
+ * change disk — a fresh stage reads disk as its original, and a group accept
+ * advances originalContent to exactly what it wrote — so the revision effect
+ * below only PRUNES resolved ids, without a single read. (The previous
+ * version re-read every staged file on every store revision: a 100-entry
+ * vault-wide replace did 100 reads per accept click.)
  */
 let staleEntryIds = $state(new Set<string>());
+/** Invalidates in-flight recomputes: reads are async, so a slow older pass
+ * must not overwrite the result of a newer one. Last started wins. */
+let staleToken = 0;
 
-async function recomputeStale() {
-	const ids = new Set<string>();
+/** Re-evaluate staleness against disk. `paths` limits the pass to entries
+ * targeting those vault paths (others keep their current verdict); omitted =
+ * full pass over the thread's pending entries. */
+async function recomputeStale(paths?: ReadonlySet<string>) {
+	const token = ++staleToken;
+	const ids = paths ? new Set(staleEntryIds) : new Set<string>();
 	for (const entry of threadId ? getPendingChangesStore().getPendingForThread(threadId) : []) {
 		if (entry.change.type === "create") continue;
+		if (paths && !paths.has(entry.change.path)) continue;
 		try {
 			if (await store.hasConflict(entry.id)) ids.add(entry.id);
+			else ids.delete(entry.id);
 		} catch {
 			// vault read failed — leave the entry unmarked rather than crying wolf
 		}
 	}
-	staleEntryIds = ids;
+	if (token === staleToken) staleEntryIds = ids;
 }
 
+// Full pass only when the surveyed thread changes (covers mount, where
+// entries may have gone stale while the plugin was unloaded).
 $effect(() => {
-	void store.revision;
 	void threadId;
 	void recomputeStale();
 });
 
-// Store revision only tracks store mutations; external edits to a staged note
-// arrive as vault events. Recompute on modify/delete of any staged path.
+// Store mutations: prune ids whose entry is no longer pending — synchronous,
+// no vault reads (see the state doc above for why none are needed).
+$effect(() => {
+	void store.revision;
+	if (!threadId) return;
+	const pendingIds = new Set(
+		getPendingChangesStore()
+			.getPendingForThread(threadId)
+			.map((e) => e.id),
+	);
+	// Only assign on an actual removal: this effect reads staleEntryIds, so an
+	// unconditional write would re-trigger it (harmlessly, but noisily).
+	if ([...staleEntryIds].some((id) => !pendingIds.has(id))) {
+		staleEntryIds = new Set([...staleEntryIds].filter((id) => pendingIds.has(id)));
+	}
+});
+
+// External edits to a staged note arrive as vault events, scoped to the one
+// path the event names.
 $effect(() => {
 	const app = getPlugin().app;
 	const touchesStagedPath = (path: string) =>
@@ -103,10 +139,10 @@ $effect(() => {
 			.getPendingForThread(threadId)
 			.some((e) => e.change.path === path);
 	const modifyRef = app.vault.on("modify", (file) => {
-		if (touchesStagedPath(file.path)) void recomputeStale();
+		if (touchesStagedPath(file.path)) void recomputeStale(new Set([file.path]));
 	});
 	const deleteRef = app.vault.on("delete", (file) => {
-		if (touchesStagedPath(file.path)) void recomputeStale();
+		if (touchesStagedPath(file.path)) void recomputeStale(new Set([file.path]));
 	});
 	return () => {
 		app.vault.offref(modifyRef);
@@ -249,13 +285,23 @@ function describeSkip(skip: RevertSkip): string {
 
 async function handleAcceptAll() {
 	if (!threadId || batchRunning) return;
-	const count = pendingCount;
+	// Stale entries can never apply (their conflict check fails unconditionally),
+	// so exclude them up front — the result then reads "skipped", not "failed".
+	const acceptable = pendingEntries.filter((e) => !staleEntryIds.has(e.id));
+	const staleCount = pendingCount - acceptable.length;
+	const count = acceptable.length;
+	if (count === 0) {
+		new Notice(
+			"All pending changes are stale — the notes changed after they were proposed. Reject them and ask the agent to re-stage.",
+		);
+		return;
+	}
 
 	// One click on a collapsed bar can apply deletions and privacy-affecting
 	// moves the user never looked at. Those two get a confirm; ordinary
 	// creates/updates keep the frictionless path.
-	const deletes = pendingEntries.filter((e) => e.change.type === "delete").length;
-	const deprivatizing = pendingEntries.filter((e) => store.isDeprivatizingMove(e.change)).length;
+	const deletes = acceptable.filter((e) => e.change.type === "delete").length;
+	const deprivatizing = acceptable.filter((e) => store.isDeprivatizingMove(e.change)).length;
 	if (deletes > 0 || deprivatizing > 0) {
 		const risks: string[] = [];
 		if (deletes > 0) risks.push(`${deletes} note deletion${deletes !== 1 ? "s" : ""}`);
@@ -273,11 +319,14 @@ async function handleAcceptAll() {
 
 	batchRunning = true;
 	try {
-		const failures = await store.acceptAll(threadId);
+		const failures = await store.acceptAll(threadId, staleEntryIds);
+		const skippedNote = staleCount > 0 ? `, skipped ${staleCount} stale` : "";
 		if (failures.length === 0) {
-			new Notice(`Applied all ${count} changes`);
+			new Notice(`Applied ${count === 1 ? "the change" : `all ${count} changes`}${skippedNote}`);
 		} else {
-			new Notice(`Applied ${count - failures.length} changes, ${failures.length} failed: ${failures.join(", ")}`);
+			new Notice(
+				`Applied ${count - failures.length} changes${skippedNote}, ${failures.length} failed: ${failures.join(", ")}`,
+			);
 		}
 	} catch (e) {
 		new Notice(`Error applying changes: ${e instanceof Error ? e.message : String(e)}`);
@@ -592,34 +641,23 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
   .pcb-container {
     display: flex;
     flex-direction: column;
-    /* Matches `.chat-input-wrapper`, which this bar sits directly above: a
-       transparent 1px border (so the box still reserves the same layout space
-       as a bordered one) and the wrapper's literal 22px pill. 22px is hardcoded
-       rather than a --radius-* token because Obsidian's largest, --radius-l, is
-       only 12px — still visibly squarer than the composer next to it. */
-    border: 1px solid transparent;
+    /* Matches `.chat-input-wrapper`, which this bar sits directly above: the
+       page-coloured fill defined by a real border, and the wrapper's literal
+       22px pill. 22px is hardcoded rather than a --radius-* token because
+       Obsidian's largest, --radius-l, is only 12px — still visibly squarer
+       than the composer next to it. */
+    border: 1px solid var(--background-modifier-border);
     border-radius: 22px;
     overflow: hidden;
     background: var(--pcb-bg);
-    /* Tracks `--input-bg` in Input.svelte — same value, same per-split flip, so
-       the bar and the composer always read as one stacked surface. */
-    --pcb-bg: var(--background-secondary);
+    /* Tracks `--input-bg` in Input.svelte — same value, so the bar and the
+       composer always read as one stacked surface. */
+    --pcb-bg: var(--background-primary);
     /* Cap the whole bar, not just the list, so a long run of changes can't grow
        past the composer. The summary row is a flex sibling that never shrinks,
        so it stays pinned and Accept/Reject All remain reachable at any length. */
     min-height: 0;
     max-height: 45vh;
-  }
-
-  /* In a sidebar the page itself is `--background-primary`, and in many themes
-     that is indistinguishable from `--background-secondary` — so the fill alone
-     stopped separating the bar from the chat view behind it. Flip the fill to
-     the page colour and let a real border define the card, exactly as
-     `.chat-input-wrapper` does for the composer directly below. */
-  :global(.mod-left-split) .pcb-container,
-  :global(.mod-right-split) .pcb-container {
-    --pcb-bg: var(--background-primary);
-    border-color: var(--background-modifier-border);
   }
 
   .pcb-summary {
@@ -630,8 +668,8 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
        controls have to stay reachable however many changes are pending. */
     flex-shrink: 0;
     padding: 6px 10px;
-    /* Inherits the container's per-split fill rather than re-stating
-       `--background-secondary`, which would paint over it in a sidebar. */
+    /* Inherits the container's fill rather than re-stating a colour that
+       would paint over it. */
     background: var(--pcb-bg);
     border: none;
     cursor: pointer;
@@ -714,6 +752,13 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
     cursor: pointer;
     background: transparent;
     transition: background 100ms ease;
+  }
+
+  /* 12px icons + 2px padding are pointer-sized; on touch, bump the hit areas
+     to guideline size. Obsidian marks mobile with body.is-mobile. */
+  :global(.is-mobile) .pcb-action-icon,
+  :global(.is-mobile) .pcb-preview-toggle {
+    padding: 8px;
   }
 
   /* Disabled accept on a stale row: keep it visible (its absence would read as

--- a/src/components/chat/PendingChangesBar.svelte
+++ b/src/components/chat/PendingChangesBar.svelte
@@ -7,6 +7,7 @@ import type { PendingChangeEntry } from "../../types/shared";
 import type { RevertSkip } from "../../stores/pendingChangesStore.svelte";
 import { icon } from "../../utils/utils";
 import { VIEW_TYPE_CHAT } from "../../views/chat/Chat";
+import { ConfirmModal } from "../modal/ConfirmModal";
 import MarkdownRenderer from "../ui/MarkdownRenderer.svelte";
 import PendingDiffHunks from "./PendingDiffHunks.svelte";
 
@@ -38,15 +39,87 @@ const pendingCount = $derived(pendingEntries.length);
 const appliedEntries = $derived(actionableEntries.filter((e) => e.status !== "pending"));
 const appliedCount = $derived(appliedEntries.length);
 
-/** Headline for the summary row, which now covers two distinct kinds of entry. */
+/** Headline for the summary row, which now covers two distinct kinds of entry.
+ * Spells out the pending batch's composition — "2 updates, 1 delete pending"
+ * reads very differently from "3 pending changes" when Accept All sits one
+ * click away and the destructive rows are hidden behind the collapse. */
 const summaryLabel = $derived.by(() => {
 	const parts: string[] = [];
-	if (pendingCount > 0) parts.push(`${pendingCount} pending change${pendingCount !== 1 ? "s" : ""}`);
+	if (pendingCount > 0) {
+		const counts = { create: 0, update: 0, delete: 0, move: 0 };
+		for (const e of pendingEntries) counts[e.change.type]++;
+		const composition = (Object.keys(counts) as Array<keyof typeof counts>)
+			.filter((type) => counts[type] > 0)
+			.map((type) => `${counts[type]} ${type}${counts[type] !== 1 ? "s" : ""}`)
+			.join(", ");
+		parts.push(`${composition} pending`);
+	}
 	if (appliedCount > 0) parts.push(`${appliedCount} partially applied`);
 	return parts.join(", ");
 });
 
 let isExpanded = $state(false);
+
+/** True while an Accept All / Reject All batch is running — disables both
+ * buttons so a double-click can't queue a second batch (the store's guard
+ * makes re-entry a silent no-op, but the button shouldn't invite it). */
+let batchRunning = $state(false);
+
+/**
+ * Entries whose target no longer matches what was staged (edited externally,
+ * or deleted). Accepting one will fail its conflict check, so surface the
+ * staleness up front instead of letting Accept error as the first signal.
+ * Async (`hasConflict` reads the vault), hence state + explicit recompute
+ * rather than a `$derived`.
+ */
+let staleEntryIds = $state(new Set<string>());
+
+async function recomputeStale() {
+	const ids = new Set<string>();
+	for (const entry of threadId ? getPendingChangesStore().getPendingForThread(threadId) : []) {
+		if (entry.change.type === "create") continue;
+		try {
+			if (await store.hasConflict(entry.id)) ids.add(entry.id);
+		} catch {
+			// vault read failed — leave the entry unmarked rather than crying wolf
+		}
+	}
+	staleEntryIds = ids;
+}
+
+$effect(() => {
+	void store.revision;
+	void threadId;
+	void recomputeStale();
+});
+
+// Store revision only tracks store mutations; external edits to a staged note
+// arrive as vault events. Recompute on modify/delete of any staged path.
+$effect(() => {
+	const app = getPlugin().app;
+	const touchesStagedPath = (path: string) =>
+		threadId &&
+		getPendingChangesStore()
+			.getPendingForThread(threadId)
+			.some((e) => e.change.path === path);
+	const modifyRef = app.vault.on("modify", (file) => {
+		if (touchesStagedPath(file.path)) void recomputeStale();
+	});
+	const deleteRef = app.vault.on("delete", (file) => {
+		if (touchesStagedPath(file.path)) void recomputeStale();
+	});
+	return () => {
+		app.vault.offref(modifyRef);
+		app.vault.offref(deleteRef);
+	};
+});
+
+/** Explains a badge on click/keypress — `title` tooltips don't exist on touch,
+ * so every badge needs a tap path to its explanation. */
+function explainBadge(evt: Event, text: string) {
+	evt.stopPropagation();
+	new Notice(text, 8000);
+}
 
 /**
  * Ids of entries whose preview is open.
@@ -108,8 +181,17 @@ function changeTypeBadgeClass(type: string): string {
 	}
 }
 
+/** Vault path as Obsidian shows notes natively: no `.md` extension. The folder
+ * prefix stays — it disambiguates same-named notes, and staged changes can
+ * target any folder. */
+function displayPath(path: string): string {
+	return path.replace(/\.md$/, "");
+}
+
 function changePathLabel(entry: PendingChangeEntry): string {
-	return entry.change.type === "move" ? `${entry.change.path} -> ${entry.change.newPath}` : entry.change.path;
+	return entry.change.type === "move"
+		? `${displayPath(entry.change.path)} → ${displayPath(entry.change.newPath)}`
+		: displayPath(entry.change.path);
 }
 
 /** Whether this move takes a note out of a private location into a public one.
@@ -166,8 +248,30 @@ function describeSkip(skip: RevertSkip): string {
 }
 
 async function handleAcceptAll() {
-	if (!threadId) return;
+	if (!threadId || batchRunning) return;
 	const count = pendingCount;
+
+	// One click on a collapsed bar can apply deletions and privacy-affecting
+	// moves the user never looked at. Those two get a confirm; ordinary
+	// creates/updates keep the frictionless path.
+	const deletes = pendingEntries.filter((e) => e.change.type === "delete").length;
+	const deprivatizing = pendingEntries.filter((e) => store.isDeprivatizingMove(e.change)).length;
+	if (deletes > 0 || deprivatizing > 0) {
+		const risks: string[] = [];
+		if (deletes > 0) risks.push(`${deletes} note deletion${deletes !== 1 ? "s" : ""}`);
+		if (deprivatizing > 0)
+			risks.push(`${deprivatizing} move${deprivatizing !== 1 ? "s" : ""} out of a private location`);
+		const modal = new ConfirmModal(
+			getPlugin().app,
+			"Accept all changes?",
+			`This batch includes ${risks.join(" and ")}. Apply all ${count} change${count !== 1 ? "s" : ""}?`,
+			"Accept All",
+		);
+		modal.open();
+		if (!(await modal.promise).confirmed) return;
+	}
+
+	batchRunning = true;
 	try {
 		const failures = await store.acceptAll(threadId);
 		if (failures.length === 0) {
@@ -177,22 +281,29 @@ async function handleAcceptAll() {
 		}
 	} catch (e) {
 		new Notice(`Error applying changes: ${e instanceof Error ? e.message : String(e)}`);
+	} finally {
+		batchRunning = false;
 	}
 }
 
 async function handleRejectAll() {
-	if (!threadId) return;
+	if (!threadId || batchRunning) return;
 	// Capture before the call — both counts are zero afterwards.
 	const hadPending = pendingCount > 0;
-	const skipped = await store.rejectAll(threadId);
-	if (skipped.length === 0) {
-		new Notice(hadPending ? "Rejected all pending changes" : "Restored the partially applied notes");
-	} else {
-		// A partially-accepted note that couldn't be restored is left as it is. Say
-		// so per reason — otherwise "Rejected all" reads as "everything was undone"
-		// while those files still hold the accepted groups.
-		const head = hadPending ? "Rejected all pending changes." : "Finished undoing applied changes.";
-		new Notice(`${head} ${skipped.map(describeSkip).join(" ")}`);
+	batchRunning = true;
+	try {
+		const skipped = await store.rejectAll(threadId);
+		if (skipped.length === 0) {
+			new Notice(hadPending ? "Rejected all pending changes" : "Restored the partially applied notes");
+		} else {
+			// A partially-accepted note that couldn't be restored is left as it is. Say
+			// so per reason — otherwise "Rejected all" reads as "everything was undone"
+			// while those files still hold the accepted groups.
+			const head = hadPending ? "Rejected all pending changes." : "Finished undoing applied changes.";
+			new Notice(`${head} ${skipped.map(describeSkip).join(" ")}`);
+		}
+	} finally {
+		batchRunning = false;
 	}
 }
 
@@ -224,10 +335,23 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
 
 {#if actionableEntries.length > 0}
   <div class="pcb-container">
-    <!-- Summary bar -->
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- Summary bar. A div with button semantics, not a <button>: it CONTAINS
+         the Accept/Reject All buttons, and interactive elements can't nest. -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="pcb-summary" onclick={() => (isExpanded = !isExpanded)}>
+    <div
+      class="pcb-summary"
+      role="button"
+      tabindex="0"
+      aria-expanded={isExpanded}
+      aria-label={isExpanded ? "Collapse pending changes" : "Expand pending changes"}
+      onclick={() => (isExpanded = !isExpanded)}
+      onkeydown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          isExpanded = !isExpanded;
+        }
+      }}
+    >
       <div class="pcb-summary-left">
         <div class="pcb-icon" use:icon={"file-diff"} style="--icon-size: var(--icon-xs)"></div>
         <span class="pcb-count">
@@ -244,6 +368,7 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
             }}
             title="Accept all changes"
             type="button"
+            disabled={batchRunning}
           >
             <div use:icon={"check"} style="--icon-size: 12px"></div>
             <span>Accept All</span>
@@ -259,6 +384,7 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
             ? "Reject all changes, restoring any partially applied notes"
             : "Restore the partially applied notes to their original content"}
           type="button"
+          disabled={batchRunning}
         >
           <div use:icon={"x"} style="--icon-size: 12px"></div>
           <span>{pendingCount > 0 ? "Reject All" : "Undo Applied"}</span>
@@ -306,17 +432,44 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
                   {changeTypeLabel(entry)}
                 </span>
                 {#if entry.status !== "pending"}
+                  {@const appliedText =
+                    "Some of this change was applied to the note. Undo it to restore the note's original content."}
                   <!-- Not a proposal awaiting review: its groups were all resolved
                        individually and some accepted text is still in the note. -->
                   <span
                     class="pcb-applied"
-                    title="Some of this change was applied to the note. Undo it to restore the note's original content."
+                    title={appliedText}
+                    role="button"
+                    tabindex="0"
+                    onclick={(e) => explainBadge(e, appliedText)}
+                    onkeydown={(e) => e.key === "Enter" && explainBadge(e, appliedText)}
                   >
                     <span use:icon={"circle-alert"} style="--icon-size: 11px"></span>
                     Partly applied
                   </span>
                 {/if}
-                {#if entry.change.type === "update"}
+                {#if staleEntryIds.has(entry.id)}
+                  {@const staleText =
+                    entry.change.type === "delete"
+                      ? "This note changed after the delete was proposed — the preview no longer matches what would be deleted. Accepting will fail; reject and ask the agent to re-stage it."
+                      : "This note changed after the change was proposed, so accepting it will fail. Reject it and ask the agent to re-apply its edit on the current content."}
+                  <span
+                    class="pcb-stale"
+                    title={staleText}
+                    role="button"
+                    tabindex="0"
+                    onclick={(e) => explainBadge(e, staleText)}
+                    onkeydown={(e) => e.key === "Enter" && explainBadge(e, staleText)}
+                  >
+                    <span use:icon={"triangle-alert"} style="--icon-size: 11px"></span>
+                    Stale
+                  </span>
+                {/if}
+                {#if entry.change.type !== "create"}
+                  <!-- Everything except a create targets a note that exists on disk
+                       right now — link it. For a delete, the live note is a better
+                       review surface than the staged snapshot; for a move, it shows
+                       what would be relocated. -->
                   <!-- svelte-ignore a11y_mouse_events_have_key_events -->
                   <a
                     class="internal-link pcb-path"
@@ -333,18 +486,29 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
                   <span class="pcb-path">{changePathLabel(entry)}</span>
                 {/if}
                 {#if isDeprivatizing(entry)}
-                <span
-                  class="pcb-deprivatizing"
-                  title="This note is currently private. Moving it to this location takes it out of the privacy filter, so it will be indexed, searchable, and available to untrusted providers from then on."
-                >
-                  <span use:icon={"shield-off"} style="--icon-size: 11px"></span>
-                  Leaves private
-                </span>
-              {/if}
-              {#if otherThreadCount(entry) > 0}
+                  {@const deprivatizingText =
+                    "This note is currently private. Moving it to this location takes it out of the privacy filter, so it will be indexed, searchable, and available to untrusted providers from then on."}
+                  <span
+                    class="pcb-deprivatizing"
+                    title={deprivatizingText}
+                    role="button"
+                    tabindex="0"
+                    onclick={(e) => explainBadge(e, deprivatizingText)}
+                    onkeydown={(e) => e.key === "Enter" && explainBadge(e, deprivatizingText)}
+                  >
+                    <span use:icon={"shield-off"} style="--icon-size: 11px"></span>
+                    Leaves private
+                  </span>
+                {/if}
+                {#if otherThreadCount(entry) > 0}
+                  {@const crossThreadText = `${otherThreadCount(entry)} other chat${otherThreadCount(entry) !== 1 ? "s" : ""} also ${otherThreadCount(entry) !== 1 ? "have" : "has"} a pending edit to this file. Whichever is accepted first wins; the others may then fail to apply.`}
                   <span
                     class="pcb-cross-thread"
-                    title={`${otherThreadCount(entry)} other chat${otherThreadCount(entry) !== 1 ? "s" : ""} also ${otherThreadCount(entry) !== 1 ? "have" : "has"} a pending edit to this file. Whichever is accepted first wins; the others may then fail to apply.`}
+                    title={crossThreadText}
+                    role="button"
+                    tabindex="0"
+                    onclick={(e) => explainBadge(e, crossThreadText)}
+                    onkeydown={(e) => e.key === "Enter" && explainBadge(e, crossThreadText)}
                   >
                     <span use:icon={"users"} style="--icon-size: 11px"></span>
                     {otherThreadCount(entry)}
@@ -353,15 +517,22 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
               </div>
               <div class="pcb-entry-actions">
                 {#if entry.status === "pending"}
+                  <!-- Accept is disabled while stale: the store's conflict check
+                       makes it fail unconditionally, so an enabled button is just
+                       an error with extra steps. If the note reverts to the staged
+                       content, the vault-event recompute re-enables it. -->
                   <button
                     class="pcb-action-icon pcb-action-accept"
                     onclick={(e) => {
                       e.stopPropagation();
                       handleAccept(entry);
                     }}
-                    title="Accept change"
+                    title={staleEntryIds.has(entry.id)
+                      ? "Cannot accept — the note changed after this was proposed. Reject it and ask the agent to re-stage."
+                      : "Accept change"}
                     aria-label="Accept change to {entry.change.path}"
                     type="button"
+                    disabled={staleEntryIds.has(entry.id)}
                   >
                     <div use:icon={"check"} style="--icon-size: 12px"></div>
                   </button>
@@ -399,7 +570,7 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
 
             {#if isPreviewOpen && showsDiff}
               <div class="pcb-preview">
-                <PendingDiffHunks {entry} />
+                <PendingDiffHunks {entry} stale={staleEntryIds.has(entry.id)} />
               </div>
             {:else if isPreviewOpen && previewContent !== null}
               <div class="pcb-preview">
@@ -511,6 +682,12 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
     transition: background 100ms ease;
   }
 
+  .pcb-action[disabled] {
+    opacity: 0.5;
+    cursor: default;
+    pointer-events: none;
+  }
+
   .pcb-action-accept {
     color: var(--color-green);
   }
@@ -537,6 +714,18 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
     cursor: pointer;
     background: transparent;
     transition: background 100ms ease;
+  }
+
+  /* Disabled accept on a stale row: keep it visible (its absence would read as
+     "this row can't be accepted ever") but clearly inert. pointer-events stays
+     on so the explanatory title tooltip still shows on hover. */
+  .pcb-action-icon[disabled] {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  .pcb-action-icon[disabled]:hover {
+    background: transparent;
   }
 
   .pcb-chevron {
@@ -592,9 +781,11 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
     min-width: 0;
   }
 
+  /* Reads as a note title, not code: the row's UI font, no monospace, and the
+     label itself already drops the `.md` extension (see displayPath) — matching
+     how Obsidian names notes everywhere else. */
   .pcb-path {
-    font-family: var(--font-monospace);
-    font-size: var(--font-smallest);
+    font-size: var(--font-ui-smaller);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -623,6 +814,22 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
      themes (Cupertino among them), which silently renders the badge
      transparent. */
   .pcb-deprivatizing {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    flex-shrink: 0;
+    padding: 1px 5px;
+    border-radius: var(--radius-s);
+    font-size: 10px;
+    font-weight: var(--font-semibold);
+    background: color-mix(in srgb, var(--color-red) 20%, transparent);
+    color: var(--color-red);
+    cursor: help;
+  }
+
+  /* Same shape family; red — accepting a stale entry is guaranteed to fail its
+     conflict check, and for a delete the preview misrepresents what would go. */
+  .pcb-stale {
     display: inline-flex;
     align-items: center;
     gap: 3px;

--- a/src/components/chat/PendingChangesBar.svelte
+++ b/src/components/chat/PendingChangesBar.svelte
@@ -8,6 +8,7 @@ import type { RevertSkip } from "../../stores/pendingChangesStore.svelte";
 import { icon } from "../../utils/utils";
 import { VIEW_TYPE_CHAT } from "../../views/chat/Chat";
 import MarkdownRenderer from "../ui/MarkdownRenderer.svelte";
+import PendingDiffHunks from "./PendingDiffHunks.svelte";
 
 interface Props {
 	threadPath: string | null;
@@ -48,13 +49,14 @@ const summaryLabel = $derived.by(() => {
 let isExpanded = $state(false);
 
 /**
- * Ids of entries whose content preview is open.
+ * Ids of entries whose preview is open.
  *
- * An `update` can be reviewed in the note itself — the inline-diff decorations
- * render there, which is what the path link jumps to. A `create` has no note to
- * jump to yet and a `delete` is about to lose one, so their content was
- * reviewable nowhere: the row showed only a path. These two render their body
- * inline here instead.
+ * A `create` has no note to jump to yet and a `delete` is about to lose one,
+ * so those render their full content inline. An `update` can also be reviewed
+ * in the note itself (the inline-diff decorations, which the path link jumps
+ * to), but that means leaving the chat — and on mobile the hover page-preview
+ * doesn't exist at all — so it additionally gets an in-chat per-hunk diff
+ * (PendingDiffHunks) behind the same toggle.
  */
 let previewedEntryIds = $state(new Set<string>());
 
@@ -64,11 +66,18 @@ function togglePreview(entryId: string) {
 	previewedEntryIds = next;
 }
 
-/** The content a row can preview inline, or null when the note itself is the review surface. */
+/** The content a row can preview inline, or null when the row previews a diff (update) or nothing (move). */
 function previewContentOf(entry: PendingChangeEntry): string | null {
 	if (entry.change.type === "create") return entry.change.content;
 	if (entry.change.type === "delete") return entry.change.originalContent;
 	return null;
+}
+
+/** Whether a row previews an in-chat diff instead of full content. Only pending
+ * updates: a resolved-but-partly-applied entry has originalContent == newContent
+ * (no groups left to show), and its remaining action is Undo, not review. */
+function hasDiffPreview(entry: PendingChangeEntry): boolean {
+	return entry.change.type === "update" && entry.status === "pending";
 }
 
 function changeTypeLabel(entry: PendingChangeEntry): string {
@@ -263,19 +272,30 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
       <div class="pcb-list">
         {#each actionableEntries as entry (entry.id)}
           {@const previewContent = previewContentOf(entry)}
+          {@const showsDiff = hasDiffPreview(entry)}
           {@const isPreviewOpen = previewedEntryIds.has(entry.id)}
           <div class="pcb-entry">
             <div class="pcb-entry-header">
               <div class="pcb-entry-left">
-                {#if previewContent !== null}
+                {#if previewContent !== null || showsDiff}
                   <button
                     class="pcb-preview-toggle"
                     class:pcb-preview-toggle-open={isPreviewOpen}
                     onclick={() => togglePreview(entry.id)}
-                    title={isPreviewOpen ? "Hide content" : "Show content"}
-                    aria-label={isPreviewOpen
-                      ? `Hide content of ${entry.change.path}`
-                      : `Show content of ${entry.change.path}`}
+                    title={showsDiff
+                      ? isPreviewOpen
+                        ? "Hide changes"
+                        : "Show changes"
+                      : isPreviewOpen
+                        ? "Hide content"
+                        : "Show content"}
+                    aria-label={showsDiff
+                      ? isPreviewOpen
+                        ? `Hide changes to ${entry.change.path}`
+                        : `Show changes to ${entry.change.path}`
+                      : isPreviewOpen
+                        ? `Hide content of ${entry.change.path}`
+                        : `Show content of ${entry.change.path}`}
                     aria-expanded={isPreviewOpen}
                     type="button"
                   >
@@ -377,7 +397,11 @@ function previewChange(evt: Event, entry: PendingChangeEntry) {
               </div>
             </div>
 
-            {#if previewContent !== null && isPreviewOpen}
+            {#if isPreviewOpen && showsDiff}
+              <div class="pcb-preview">
+                <PendingDiffHunks {entry} />
+              </div>
+            {:else if isPreviewOpen && previewContent !== null}
               <div class="pcb-preview">
                 {#if previewContent.trim() === ""}
                   <div class="pcb-preview-empty">This note is empty.</div>

--- a/src/components/chat/PendingDiffHunks.svelte
+++ b/src/components/chat/PendingDiffHunks.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+import { diffWords } from "diff";
+import { Notice } from "obsidian";
+import { identifyGroups } from "../../lib/diffGroups";
+import { getPendingChangesStore } from "../../stores/pendingChangesStore.svelte";
+import type { PendingChangeEntry } from "../../types/shared";
+import { icon } from "../../utils/utils";
+
+/**
+ * In-chat diff for a pending `update`: one hunk per contiguous change group,
+ * rendered as a word-level diff, with per-hunk Accept/Reject wired to the
+ * store's group operations. This is the same grouping the inline editor
+ * decorations and the store's partial accept/reject use (see diffGroups.ts),
+ * so hunk N here is exactly the group N those act on.
+ */
+interface Props {
+	entry: PendingChangeEntry;
+}
+
+const { entry }: Props = $props();
+const store = getPendingChangesStore();
+
+/**
+ * Recomputed on every store mutation: a group accept/reject rewrites
+ * originalContent/newContent, which renumbers the remaining groups — stale
+ * indices would target the wrong group, so the hunks must track the store.
+ */
+const groups = $derived.by(() => {
+	void store.revision;
+	if (entry.change.type !== "update") return [];
+	return identifyGroups(entry.change.originalContent, entry.change.newContent);
+});
+
+const isPending = $derived(entry.status === "pending");
+
+/**
+ * Strip the group's trailing newline before diffing for display. Line-diff
+ * parts carry it, and in a pre-wrap container a highlighted trailing "\n"
+ * renders as a stray empty green/red line under the hunk.
+ */
+function trimTrailingNewline(text: string): string {
+	return text.replace(/\n$/, "");
+}
+
+async function acceptGroup(groupIndex: number) {
+	try {
+		await store.acceptChangeGroup(entry.id, groupIndex);
+	} catch (e) {
+		new Notice(`Failed to apply change: ${e instanceof Error ? e.message : String(e)}`);
+	}
+}
+
+function rejectGroup(groupIndex: number) {
+	store.rejectChangeGroup(entry.id, groupIndex);
+}
+</script>
+
+{#if groups.length === 0}
+  <div class="pdh-empty">No remaining differences.</div>
+{:else}
+  <div class="pdh-hunks">
+    {#each groups as group, groupIndex (groupIndex)}
+      <div class="pdh-hunk">
+        <!-- Single-hunk entries skip the header: the position is meaningless
+             ("1/1") and per-hunk accept/reject would exactly duplicate the
+             row-level buttons (accepting the only group accepts the entry). -->
+        {#if groups.length > 1}
+          <div class="pdh-hunk-header">
+            <span class="pdh-hunk-position">{groupIndex + 1}/{groups.length}</span>
+            {#if isPending}
+              <div class="pdh-hunk-actions">
+                <button
+                  class="pdh-action-icon pdh-action-accept"
+                  onclick={() => acceptGroup(groupIndex)}
+                  title="Accept this change"
+                  aria-label="Accept change {groupIndex + 1} of {groups.length}"
+                  type="button"
+                >
+                  <div use:icon={"check"} style="--icon-size: 12px"></div>
+                </button>
+                <button
+                  class="pdh-action-icon pdh-action-reject"
+                  onclick={() => rejectGroup(groupIndex)}
+                  title="Reject this change"
+                  aria-label="Reject change {groupIndex + 1} of {groups.length}"
+                  type="button"
+                >
+                  <div use:icon={"x"} style="--icon-size: 12px"></div>
+                </button>
+              </div>
+            {/if}
+          </div>
+        {/if}
+        <!-- Word-level old->new diff, same idiom as the in-note card. The each
+             body stays on one line: the container is pre-wrap, so template
+             whitespace between spans would render as stray spaces. -->
+        <div class="pdh-hunk-body">{#each diffWords(trimTrailingNewline(group.removedText), trimTrailingNewline(group.addedText)) as part, partIndex (partIndex)}<span
+              class={part.removed ? "s2b-diff-word-removed" : part.added ? "s2b-diff-word-added" : ""}
+              >{part.value}</span
+            >{/each}</div>
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .pdh-empty {
+    color: var(--text-faint);
+    font-size: var(--font-ui-smaller);
+    font-style: italic;
+  }
+
+  .pdh-hunks {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Flat hunks separated by hairline dividers — the surrounding .pcb-preview
+     already draws the frame, so boxed cards here read as chrome-in-chrome. */
+  .pdh-hunk + .pdh-hunk {
+    border-top: 1px solid var(--background-modifier-border);
+    margin-top: 6px;
+    padding-top: 4px;
+  }
+
+  .pdh-hunk-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .pdh-hunk-position {
+    font-size: 10px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .pdh-hunk-actions {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    /* Right-align even when no position indicator precedes them. */
+    margin-left: auto;
+  }
+
+  .pdh-action-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px;
+    border: none;
+    border-radius: var(--radius-s);
+    cursor: pointer;
+    background: transparent;
+    transition: background 100ms ease;
+  }
+
+  .pdh-action-accept {
+    color: var(--color-green);
+  }
+
+  .pdh-action-accept:hover {
+    background: color-mix(in srgb, var(--color-green) 15%, transparent);
+  }
+
+  .pdh-action-reject {
+    color: var(--color-red);
+  }
+
+  .pdh-action-reject:hover {
+    background: color-mix(in srgb, var(--color-red) 15%, transparent);
+  }
+
+  .pdh-hunk-body {
+    font-size: var(--font-ui-smaller);
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+</style>

--- a/src/components/chat/PendingDiffHunks.svelte
+++ b/src/components/chat/PendingDiffHunks.svelte
@@ -15,9 +15,14 @@ import { icon } from "../../utils/utils";
  */
 interface Props {
 	entry: PendingChangeEntry;
+	/** The entry no longer matches the note on disk (see the bar's stale badge).
+	 * Group accepts hit the same conflict check as whole-entry accepts, so they
+	 * are disabled too; rejecting a group only rewrites the proposal and stays
+	 * available. */
+	stale?: boolean;
 }
 
-const { entry }: Props = $props();
+const { entry, stale = false }: Props = $props();
 const store = getPendingChangesStore();
 
 /**
@@ -72,9 +77,12 @@ function rejectGroup(groupIndex: number) {
                 <button
                   class="pdh-action-icon pdh-action-accept"
                   onclick={() => acceptGroup(groupIndex)}
-                  title="Accept this change"
+                  title={stale
+                    ? "Cannot accept — the note changed after this was proposed. Reject it and ask the agent to re-stage."
+                    : "Accept this change"}
                   aria-label="Accept change {groupIndex + 1} of {groups.length}"
                   type="button"
+                  disabled={stale}
                 >
                   <div use:icon={"check"} style="--icon-size: 12px"></div>
                 </button>
@@ -153,6 +161,15 @@ function rejectGroup(groupIndex: number) {
     cursor: pointer;
     background: transparent;
     transition: background 100ms ease;
+  }
+
+  .pdh-action-icon[disabled] {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  .pdh-action-icon[disabled]:hover {
+    background: transparent;
   }
 
   .pdh-action-accept {

--- a/src/components/chat/PendingDiffHunks.svelte
+++ b/src/components/chat/PendingDiffHunks.svelte
@@ -26,6 +26,15 @@ const { entry, stale = false }: Props = $props();
 const store = getPendingChangesStore();
 
 /**
+ * Combined removed+added size above which a hunk is not word-diffed inline.
+ * A whole-file rewrite is one giant group; `diffWords` over it plus thousands
+ * of highlight spans would stall the chat view for a preview nobody can read
+ * at that size anyway — the note (which virtualizes) is the review surface.
+ * Accept/Reject on the hunk keep working either way.
+ */
+const MAX_HUNK_PREVIEW_CHARS = 20000;
+
+/**
  * Recomputed on every store mutation: a group accept/reject rewrites
  * originalContent/newContent, which renumbers the remaining groups — stale
  * indices would target the wrong group, so the hunks must track the store.
@@ -99,20 +108,27 @@ function rejectGroup(groupIndex: number) {
             {/if}
           </div>
         {/if}
-        <!-- Word-level old->new diff, same idiom as the in-note card. The each
-             body stays on one line: the container is pre-wrap, so template
-             whitespace between spans would render as stray spaces. -->
-        <div class="pdh-hunk-body">{#each diffWords(trimTrailingNewline(group.removedText), trimTrailingNewline(group.addedText)) as part, partIndex (partIndex)}<span
-              class={part.removed ? "s2b-diff-word-removed" : part.added ? "s2b-diff-word-added" : ""}
-              >{part.value}</span
-            >{/each}</div>
+        {#if group.removedText.length + group.addedText.length > MAX_HUNK_PREVIEW_CHARS}
+          <div class="pdh-too-large">
+            This change is too large to preview here — open the note to review it.
+          </div>
+        {:else}
+          <!-- Word-level old->new diff, same idiom as the in-note card. The each
+               body stays on one line: the container is pre-wrap, so template
+               whitespace between spans would render as stray spaces. -->
+          <div class="pdh-hunk-body">{#each diffWords(trimTrailingNewline(group.removedText), trimTrailingNewline(group.addedText)) as part, partIndex (partIndex)}<span
+                class={part.removed ? "s2b-diff-word-removed" : part.added ? "s2b-diff-word-added" : ""}
+                >{part.value}</span
+              >{/each}</div>
+        {/if}
       </div>
     {/each}
   </div>
 {/if}
 
 <style>
-  .pdh-empty {
+  .pdh-empty,
+  .pdh-too-large {
     color: var(--text-faint);
     font-size: var(--font-ui-smaller);
     font-style: italic;
@@ -161,6 +177,12 @@ function rejectGroup(groupIndex: number) {
     cursor: pointer;
     background: transparent;
     transition: background 100ms ease;
+  }
+
+  /* 12px icon + 2px padding is a 16px target — fine for a pointer, far below
+     touch guidelines. Obsidian marks mobile with body.is-mobile. */
+  :global(.is-mobile) .pdh-action-icon {
+    padding: 8px;
   }
 
   .pdh-action-icon[disabled] {

--- a/src/components/chat/ToolCallsSection.svelte
+++ b/src/components/chat/ToolCallsSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { AssistantTimelineEvent } from "../../stores/chatStore.svelte";
 import { getData } from "../../stores/dataStore.svelte";
+import { getPendingChangesStore } from "../../stores/pendingChangesStore.svelte";
 import { buildToolOutputRenderModel, type ToolOutputRenderModel } from "./toolOutputRenderModel";
 import {
 	buildStepsFromEvents,
@@ -73,6 +74,43 @@ function getTaskSummary(input: Record<string, unknown> | null | undefined): stri
 /** Output render model for a tool call, or undefined if it hasn't produced output. */
 function toOutputModel(tool: UnifiedToolCall): ToolOutputRenderModel | undefined {
 	return tool.output !== undefined ? buildToolOutputRenderModel(tool.name, tool.output, tool.input) : undefined;
+}
+
+/**
+ * Live review status of the entries a `manage_notes` call staged, as chips.
+ * Without this the card's "will be reviewed by the user" stays frozen forever;
+ * with it the transcript shows what actually happened to each proposal.
+ * Reads `store.revision`, so the chips update as the user accepts/rejects.
+ * Empty for calls with no matching entries (e.g. staged before this linkage
+ * existed, or a thread whose entries were pruned) — the card just shows its
+ * static summary then.
+ */
+function reviewStatusChips(toolCallId: string): Array<{ label: string; cls: string }> {
+	try {
+		const store = getPendingChangesStore();
+		void store.revision;
+		const entries = store.getEntriesByToolCallId(toolCallId);
+		if (entries.length === 0) return [];
+		let accepted = 0;
+		let rejected = 0;
+		let partial = 0;
+		let pending = 0;
+		for (const e of entries) {
+			if (e.status === "pending") pending++;
+			else if (e.status === "accepted") accepted++;
+			else if (store.hasUnrevertedApplication(e)) partial++;
+			else rejected++;
+		}
+		const chips: Array<{ label: string; cls: string }> = [];
+		if (accepted > 0) chips.push({ label: `${accepted} accepted`, cls: "tool-output-metric-chip-success" });
+		if (partial > 0) chips.push({ label: `${partial} partly applied`, cls: "tool-output-metric-chip-warning" });
+		if (rejected > 0) chips.push({ label: `${rejected} rejected`, cls: "tool-output-metric-chip-danger" });
+		if (pending > 0) chips.push({ label: `${pending} awaiting review`, cls: "tool-output-metric-chip-accent" });
+		return chips;
+	} catch {
+		// store not initialized (e.g. tests rendering the section standalone)
+		return [];
+	}
 }
 
 /**
@@ -444,7 +482,7 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
   {#if hasFriendlyResult(outputModel)}
     <div class="tool-io-section">
       <div class="tool-io-output">
-        {@render outputBody(outputModel!)}
+        {@render outputBody(outputModel!, tool.id)}
       </div>
     </div>
   {:else if showRawIO && tool.status !== "running"}
@@ -494,7 +532,7 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
         <div class="tool-subagent-output">
           <div class="tool-subagent-output-label">Result</div>
           <div class="tool-io-output">
-            {@render outputBody(outputModel!)}
+            {@render outputBody(outputModel!, tool.id)}
           </div>
         </div>
       {/if}
@@ -610,7 +648,7 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
   {/each}
 {/snippet}
 
-{#snippet outputBody(model: ToolOutputRenderModel)}
+{#snippet outputBody(model: ToolOutputRenderModel, toolCallId: string = "")}
   {#if model.kind === "markdown"}
     <MarkdownRenderer
       content={model.markdown}
@@ -782,6 +820,9 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
       <span class="tool-output-metric-chip">paths: {model.summary.paths}</span>
       {#each model.summary.breakdown as part (part)}
         <span class="tool-output-metric-chip tool-output-metric-chip-accent">{part}</span>
+      {/each}
+      {#each reviewStatusChips(toolCallId) as chip (chip.label)}
+        <span class="tool-output-metric-chip {chip.cls}">{chip.label}</span>
       {/each}
     </div>
     <div class="tool-output-message">{model.summary.message}</div>
@@ -1690,6 +1731,18 @@ const showThinkingHeader = $derived(steps.length > 0 || !!isStreaming);
   .tool-output-metric-chip-warning {
     color: var(--color-orange);
     background: color-mix(in srgb, var(--color-orange) 12%, transparent);
+  }
+
+  /* Live review-status chips on the manage_notes card (green/red mirror the
+     pending-changes bar's accept/reject colours). */
+  .tool-output-metric-chip-success {
+    color: var(--color-green);
+    background: color-mix(in srgb, var(--color-green) 12%, transparent);
+  }
+
+  .tool-output-metric-chip-danger {
+    color: var(--color-red);
+    background: color-mix(in srgb, var(--color-red) 12%, transparent);
   }
 
   .tool-output-group {

--- a/src/components/modal/PrivacyListModal.svelte
+++ b/src/components/modal/PrivacyListModal.svelte
@@ -307,14 +307,33 @@ const introBody = $derived.by(() =>
 		? "Untrusted providers can only access the files listed below. Everything else stays private unless the provider is marked as trusted."
 		: "Untrusted providers can access vault files by default, except for the files listed below as private. Trusted providers always bypass this restriction.",
 );
-// This protects file *content*. File and folder names/paths in the vault are not
-// hidden from untrusted providers — they can appear in search results, directory
-// listings, and elsewhere regardless of a file's privacy status. Renaming/moving
-// files and folders is safe: rules that reference a path (folder, or a wikilink
-// inside a property value) follow the rename automatically, so this list won't
-// drift out of date.
+// A private file is withheld *entirely* from an untrusted provider — path included.
+// Every vault-facing read tool filters on `shouldBlockFile` before the path reaches a
+// result: `list_directory` reports only a count, `search_notes` drops the hit,
+// `grep_notes` never opens the file, `read_content`/`get_properties` refuse, and
+// `get_all_tags` omits tags that occur only in private notes (a tag name is itself
+// content). Indexing skips them (`VectorStoreService`) and the graph withholds their
+// titles from topic labelling.
+//
+// Three routes still expose a private path, so the note narrows to those rather than
+// making the old blanket "names are always visible" claim:
+//   1. Workspace context blocks — `[Currently visible notes]`, `[Selected text from
+//      <path>]`, `[Graph-selected notes]` are appended to the outgoing message in
+//      `chatStore.augmentWithVisibleNotes` with no privacy check. This is the one worth
+//      warning about: it is silent, and the selection block carries the selected *text*,
+//      not just the path.
+//   2. Verbatim content of a *non-private* file — a public note (or `.chat` transcript,
+//      which is gated by its own path, not by what it quotes) that contains
+//      `[[Private Note]]` passes that name through as ordinary body text.
+//   3. `exec_<plugin>` integrations, which bypass the filter wholesale — already covered
+//      by `IntegrationPrivacyWarningModal` at enable time, so it is not repeated here.
+// Attachments also bypass the filter, but attaching is an explicit user act on a named
+// file, so it is not a surprise the way (1) is.
 const pathVisibilityNote =
-	"This controls file content, not file or folder names — those can still appear to any provider. " +
+	"Private files are withheld from untrusted providers entirely — content, names and paths alike. " +
+	"Two exceptions: a private note that is open, selected, or graph-selected still has its path (and any " +
+	"selected text) sent with your message, and a private note's name can appear inside another note that " +
+	"links to it and isn't itself private. " +
 	"Rules here follow renames automatically, so you can freely rename or move files without breaking this list.";
 const managedTitle = $derived.by(() =>
 	privacyMode === "private-by-default" ? "Files exposed to untrusted providers" : "Private files",

--- a/src/editor/inlineDiffExtension.ts
+++ b/src/editor/inlineDiffExtension.ts
@@ -39,9 +39,9 @@ function createEditActionBar(entryId: string, groupIndex: number, groupTotal: nu
 	}
 
 	// Prev/next chevrons: step through this chat thread's pending changes across
-	// files, reusing the SAME shared cursor as the chat-bar arrows and palette
-	// commands so all three entry points stay in sync. The entry's threadId is
-	// resolved lazily on click (the bar only knows the entryId).
+	// files, reusing the SAME shared cursor as the palette commands and the
+	// reading-view bars so all entry points stay in sync. The entry's threadId
+	// is resolved lazily on click (the bar only knows the entryId).
 	const makeNavBtn = (iconName: string, ariaLabel: string, direction: "next" | "prev"): HTMLButtonElement => {
 		const btn = document.createElement("button");
 		btn.className = "s2b-diff-nav-btn";

--- a/src/editor/inlineDiffExtension.ts
+++ b/src/editor/inlineDiffExtension.ts
@@ -18,7 +18,7 @@ const refreshPendingChanges = StateEffect.define();
  * the "Pending change" label, a view-mode toggle, and Accept / Reject buttons.
  * The diff detail below is always shown (no collapse).
  */
-function createEditActionBar(entryId: string, groupIndex: number, groupTotal: number): HTMLElement {
+function createEditActionBar(entryId: string, groupIndex: number, groupTotal: number, stale: boolean): HTMLElement {
 	const bar = document.createElement("div");
 	bar.className = "s2b-diff-action-bar-widget";
 
@@ -98,6 +98,16 @@ function createEditActionBar(entryId: string, groupIndex: number, groupTotal: nu
 	const acceptBtn = document.createElement("button");
 	acceptBtn.className = "s2b-diff-accept-btn";
 	acceptBtn.textContent = "Accept";
+	// Stale parity with the chat bar: once the document no longer matches the
+	// staged original, the store's conflict check makes every group accept fail
+	// unconditionally, so offer the explanation instead of the error.
+	if (stale) {
+		acceptBtn.disabled = true;
+		acceptBtn.setAttribute(
+			"title",
+			"Cannot accept — the note changed after this was proposed. Reject it and ask the agent to re-stage.",
+		);
+	}
 	acceptBtn.addEventListener("click", (e) => {
 		e.preventDefault();
 		e.stopPropagation();
@@ -228,6 +238,7 @@ interface WidgetClasses {
 		mode: DiffViewMode,
 		app: App | null,
 		sourcePath: string,
+		stale: boolean,
 	) => WidgetType;
 	CrossThreadBannerWidget: new (otherCount: number) => WidgetType;
 }
@@ -258,6 +269,7 @@ function getWidgetClasses(): WidgetClasses {
 			readonly mode: DiffViewMode,
 			readonly app: App | null,
 			readonly sourcePath: string,
+			readonly stale: boolean,
 		) {
 			super();
 		}
@@ -278,7 +290,7 @@ function getWidgetClasses(): WidgetClasses {
 			const container = document.createElement("div");
 			container.className = "s2b-diff-edit-group";
 
-			container.appendChild(createEditActionBar(this.entryId, this.groupIndex, this.groupTotal));
+			container.appendChild(createEditActionBar(this.entryId, this.groupIndex, this.groupTotal, this.stale));
 			container.appendChild(this.buildDetail());
 
 			return container;
@@ -296,7 +308,10 @@ function getWidgetClasses(): WidgetClasses {
 				this.removedText === other.removedText &&
 				this.addedText === other.addedText &&
 				this.mode === other.mode &&
-				this.sourcePath === other.sourcePath
+				this.sourcePath === other.sourcePath &&
+				// Part of identity so a staleness flip re-renders the bar (CM6 reuses
+				// the DOM of eq widgets, so toDOM would otherwise never re-run).
+				this.stale === other.stale
 			);
 		}
 
@@ -348,6 +363,7 @@ function createGroupDecoration(
 	mode: DiffViewMode,
 	app: App | null,
 	sourcePath: string,
+	stale: boolean,
 ): Decoration {
 	const widget = new (getWidgetClasses().PendingGroupWidget)(
 		entryId,
@@ -358,6 +374,7 @@ function createGroupDecoration(
 		mode,
 		app,
 		sourcePath,
+		stale,
 	);
 	return Decoration.widget({ widget, side: -1, block: true });
 }
@@ -474,6 +491,13 @@ function buildDecorations(state: EditorState, entryOverride?: PendingChangeEntry
 		const groups = identifyGroups(change.originalContent, change.newContent);
 		if (groups.length === 0) return Decoration.none;
 
+		// The document no longer matches the staged original (user edits, or an
+		// external change loaded into the editor). Every group accept would fail
+		// the store's disk conflict check, so the action bars disable Accept.
+		// Doc-based rather than a disk read: it's synchronous, and the editor's
+		// content is what the user is looking at while reviewing here.
+		const stale = docText !== change.originalContent;
+
 		const mapPos = buildPositionMapper(change.originalContent, docText);
 		const decorations = [];
 
@@ -514,7 +538,7 @@ function buildDecorations(state: EditorState, entryOverride?: PendingChangeEntry
 			// Compact collapsible action bar for the group, anchored above its
 			// first line (side: -1 so it sorts before the line decoration).
 			decorations.push(
-				createGroupDecoration(group, entry.id, gi, groups.length, mode, app, filePath).range(lineStart),
+				createGroupDecoration(group, entry.id, gi, groups.length, mode, app, filePath, stale).range(lineStart),
 			);
 
 			// Line-background tints — additive, no document reflow. Only lines that
@@ -576,9 +600,14 @@ const pendingDiffField = StateField.define<DecorationSet>({
 	},
 	update(deco, tr) {
 		const refreshRequested = tr.effects.some((e) => e.is(refreshPendingChanges));
-		if (refreshRequested || tr.docChanged) {
+		if (refreshRequested) {
 			return buildDecorations(tr.state);
 		}
+		// Doc changes only MAP the existing set (O(changes), keeps positions
+		// valid) — rebuilding here ran two full-document diffLines passes on
+		// every keystroke while a pending change was open. The companion plugin
+		// debounces a refresh effect after typing pauses, which also flips the
+		// bars' stale state (the mapped set still carries pre-edit staleness).
 		return deco.map(tr.changes);
 	},
 	provide: (f) => EditorView.decorations.from(f),
@@ -599,6 +628,7 @@ const inlineDiffSideEffects = ViewPlugin.fromClass(
 		private initialized = false;
 		private refreshAttempts = 0;
 		private lastFilePath: string | null = null;
+		private docRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
 		constructor(view: EditorView) {
 			this.view = view;
@@ -634,6 +664,9 @@ const inlineDiffSideEffects = ViewPlugin.fromClass(
 		update(update: ViewUpdate) {
 			if (!this.initialized) return;
 
+			// Viewport and geometry changes deliberately do NOT refresh: the
+			// decoration set is document-anchored, so scrolling can't change it —
+			// refreshing there ran two full diffLines passes per scroll frame.
 			const filePath = getEditorFilePath(this.view.state);
 			if (filePath !== this.lastFilePath) {
 				this.lastFilePath = filePath;
@@ -641,14 +674,21 @@ const inlineDiffSideEffects = ViewPlugin.fromClass(
 				return;
 			}
 
-			// docChanged is handled directly by the field; only viewport/geometry
-			// changes (which the field can't observe) need a nudge.
-			if (update.viewportChanged || update.geometryChanged) {
-				this.refreshHandler();
+			// The field only MAPS the set through doc changes; schedule the real
+			// rebuild for after typing pauses so the diffs run once per pause, not
+			// once per keystroke. The mapped set stays visually correct meanwhile;
+			// the rebuild re-verifies group text and updates the bars' stale state.
+			if (update.docChanged) {
+				if (this.docRefreshTimer) clearTimeout(this.docRefreshTimer);
+				this.docRefreshTimer = setTimeout(() => {
+					this.docRefreshTimer = null;
+					this.refreshHandler();
+				}, 250);
 			}
 		}
 
 		destroy() {
+			if (this.docRefreshTimer) clearTimeout(this.docRefreshTimer);
 			document.removeEventListener("s2b-pending-changes-updated", this.refreshHandler);
 			document.removeEventListener("s2b-diff-mode-changed", this.refreshHandler);
 		}

--- a/src/editor/inlineDiffExtension.ts
+++ b/src/editor/inlineDiffExtension.ts
@@ -2,6 +2,7 @@ import { type DecorationSet, Decoration, EditorView, ViewPlugin, type ViewUpdate
 import { type EditorState, type Extension, StateEffect, StateField } from "@codemirror/state";
 import { diffLines, diffWords } from "diff";
 import { type App, Component, MarkdownRenderer, editorInfoField, setIcon } from "obsidian";
+import { type ChangeGroup, identifyGroups } from "../lib/diffGroups";
 import { navigateToPendingChange } from "../lib/pendingChangeNavigation";
 import { getData } from "../stores/dataStore.svelte";
 import { getPendingChangesStore } from "../stores/pendingChangesStore.svelte";
@@ -339,14 +340,6 @@ function getWidgetClasses(): WidgetClasses {
 	return widgetClasses;
 }
 
-/** A contiguous group of line-level changes in the diff. */
-interface ChangeGroup {
-	removedText: string;
-	addedText: string;
-	docOffset: number;
-	docLength: number;
-}
-
 function createGroupDecoration(
 	group: ChangeGroup,
 	entryId: string,
@@ -376,42 +369,6 @@ const removedLineDecoration = Decoration.line({ class: "s2b-diff-line-removed" }
 /** Neutral tint for removed lines in word-diff mode — marks the source lines
  * the card's diff refers to without the "deleted" connotation of red. */
 const mutedLineDecoration = Decoration.line({ class: "s2b-diff-line-muted" });
-
-/**
- * Identify contiguous change groups from a line-level diff.
- * Each group tracks its removed/added text and position relative to the first text.
- */
-function identifyGroups(fromText: string, toText: string): ChangeGroup[] {
-	const lineChanges = diffLines(fromText, toText);
-	const groups: ChangeGroup[] = [];
-	let docPos = 0;
-	let current: ChangeGroup | null = null;
-
-	for (const part of lineChanges) {
-		if (part.removed) {
-			if (!current) {
-				current = { removedText: "", addedText: "", docOffset: docPos, docLength: 0 };
-			}
-			current.removedText += part.value;
-			current.docLength += part.value.length;
-			docPos += part.value.length;
-		} else if (part.added) {
-			if (!current) {
-				current = { removedText: "", addedText: "", docOffset: docPos, docLength: 0 };
-			}
-			current.addedText += part.value;
-		} else {
-			if (current) {
-				groups.push(current);
-				current = null;
-			}
-			docPos += part.value.length;
-		}
-	}
-	if (current) groups.push(current);
-
-	return groups;
-}
 
 /**
  * Build a function that maps positions from originalContent-space to docText-space,

--- a/src/editor/readingViewDiffProcessor.ts
+++ b/src/editor/readingViewDiffProcessor.ts
@@ -52,6 +52,7 @@ export function computeOriginalAffectedLines(originalContent: string, newContent
 	const changes = diffLines(originalContent, newContent);
 	const totalOriginalLines = countOriginalLines(changes);
 	let oldLine = 0; // 0-based
+	let prevRemoved = false;
 
 	for (const part of changes) {
 		if (part.value === "") continue;
@@ -62,13 +63,21 @@ export function computeOriginalAffectedLines(originalContent: string, newContent
 				affected.add(oldLine + i);
 			}
 			oldLine += lines;
+			prevRemoved = true;
 		} else if (part.added) {
-			// A pure insertion removes no original line. Anchor it to exactly ONE
-			// line (the following line, or the line before at EOF) so a single
-			// rendered section owns it — see insertionAnchorLine.
-			affected.add(insertionAnchorLine(oldLine, totalOriginalLines));
+			// Only a PURE insertion needs an anchor line. An added part preceded by
+			// a removed part is a REPLACEMENT: its home is the removed lines, which
+			// are already in the set — and `oldLine` has already advanced past them,
+			// so anchoring here would falsely mark the line AFTER the replaced run
+			// (the next rendered section, when the run ends its section — e.g. any
+			// single-line heading edit).
+			if (!prevRemoved) {
+				affected.add(insertionAnchorLine(oldLine, totalOriginalLines));
+			}
+			prevRemoved = false;
 		} else {
 			oldLine += lines;
+			prevRemoved = false;
 		}
 	}
 
@@ -166,10 +175,16 @@ interface ExtractionState {
 	suffixText: string;
 	oldLine: number;
 	seenChange: boolean;
+	/** First original line of the immediately-preceding removed part, or null
+	 * when the previous part wasn't a removal. An added part that follows a
+	 * removed one is a REPLACEMENT and belongs to the section owning this line
+	 * (see extractSectionTexts). */
+	lastRemovedStart: number | null;
 }
 
 /** Process a removed diff part, collecting lines within the section range. */
 function processRemovedPart(lines: string[], lineStart: number, lineEnd: number, state: ExtractionState): void {
+	state.lastRemovedStart = state.oldLine;
 	for (const line of lines) {
 		if (state.oldLine >= lineStart && state.oldLine <= lineEnd) {
 			state.seenChange = true;
@@ -205,6 +220,7 @@ function extractSectionTexts(changes: Change[], lineStart: number, lineEnd: numb
 		suffixText: "",
 		oldLine: 0,
 		seenChange: false,
+		lastRemovedStart: null,
 	};
 	const totalOriginalLines = countOriginalLines(changes);
 
@@ -215,17 +231,32 @@ function extractSectionTexts(changes: Change[], lineStart: number, lineEnd: numb
 		if (part.removed) {
 			processRemovedPart(partLines, lineStart, lineEnd, state);
 		} else if (part.added) {
-			// Match the insertion to the section that owns its single anchor line
-			// (the following line, or the line before at EOF) — see
-			// insertionAnchorLine. Mirrors computeOriginalAffectedLines /
-			// checkPartForSection so all three agree on which section owns it.
-			const anchor = insertionAnchorLine(state.oldLine, totalOriginalLines);
-			if (anchor >= lineStart && anchor <= lineEnd) {
-				state.seenChange = true;
-				state.sectionNew += part.value;
+			// A REPLACEMENT (added part right after a removed one) belongs with the
+			// removed run — attributed to the section owning the run's FIRST line,
+			// so exactly one section claims it even when the run spans sections.
+			// The anchor heuristic is for PURE insertions only: by the time we get
+			// here oldLine has advanced past any removed lines, so anchoring a
+			// replacement would land on the line AFTER the run — outside the section
+			// whenever the run ends it (every single-line heading edit), silently
+			// dropping the new text from the card and handing it to the next
+			// section. Mirrors computeOriginalAffectedLines / checkPartForSection so
+			// all three agree on which section owns which change.
+			if (state.lastRemovedStart !== null) {
+				if (state.lastRemovedStart >= lineStart && state.lastRemovedStart <= lineEnd) {
+					state.seenChange = true;
+					state.sectionNew += part.value;
+				}
+			} else {
+				const anchor = insertionAnchorLine(state.oldLine, totalOriginalLines);
+				if (anchor >= lineStart && anchor <= lineEnd) {
+					state.seenChange = true;
+					state.sectionNew += part.value;
+				}
 			}
+			state.lastRemovedStart = null;
 		} else {
 			processUnchangedPart(partLines, lineStart, lineEnd, state);
+			state.lastRemovedStart = null;
 		}
 	}
 
@@ -382,9 +413,9 @@ function createReadingDiffActionBar(
 	}
 
 	// Prev/next chevrons: step through this chat thread's pending changes across
-	// files, reusing the SAME shared cursor as the edit-mode bar, the chat-bar
-	// arrows, and the palette commands. Mirrors createEditActionBar in
-	// inlineDiffExtension.ts (reading + edit views have parallel action bars).
+	// files, reusing the SAME shared cursor as the edit-mode bar and the palette
+	// commands. Mirrors createEditActionBar in inlineDiffExtension.ts (reading +
+	// edit views have parallel action bars).
 	const makeNavBtn = (iconName: string, ariaLabel: string, direction: "next" | "prev"): HTMLButtonElement => {
 		const btn = document.createElement("button");
 		btn.className = "s2b-diff-nav-btn";
@@ -515,18 +546,27 @@ function checkPartForSection(
 	sectionStart: number,
 	sectionEnd: number,
 	totalOriginalLines: number,
+	lastRemovedStart: number | null,
 ): number {
 	if (part.removed) {
 		if (rangeOverlapsSection(oldLine, lineCount, sectionStart, sectionEnd)) {
 			return groupIndex;
 		}
 	} else if (part.added) {
-		// Mirror computeOriginalAffectedLines: match the insertion's single anchor
-		// line (following line, or line before at EOF) so group-index detection
-		// stays consistent with the affected set and only one section claims it.
-		const anchor = insertionAnchorLine(oldLine, totalOriginalLines);
-		if (anchor >= sectionStart && anchor <= sectionEnd) {
-			return groupIndex;
+		// Mirror computeOriginalAffectedLines / extractSectionTexts: a REPLACEMENT
+		// (added right after removed) is owned by the section holding the removed
+		// run's first line; only a PURE insertion uses the single anchor line
+		// (following line, or line before at EOF), so exactly one section claims
+		// each change either way.
+		if (lastRemovedStart !== null) {
+			if (lastRemovedStart >= sectionStart && lastRemovedStart <= sectionEnd) {
+				return groupIndex;
+			}
+		} else {
+			const anchor = insertionAnchorLine(oldLine, totalOriginalLines);
+			if (anchor >= sectionStart && anchor <= sectionEnd) {
+				return groupIndex;
+			}
 		}
 	}
 	return -1;
@@ -540,6 +580,7 @@ function computeGroupIndexForSection(changes: Change[], sectionLineStart: number
 	let oldLine = 0;
 	let groupIndex = -1;
 	let inGroup = false;
+	let lastRemovedStart: number | null = null;
 	const totalOriginalLines = countOriginalLines(changes);
 
 	for (const part of changes) {
@@ -559,11 +600,18 @@ function computeGroupIndexForSection(changes: Change[], sectionLineStart: number
 				sectionLineStart,
 				sectionLineEnd,
 				totalOriginalLines,
+				lastRemovedStart,
 			);
 			if (result >= 0) return result;
-			if (part.removed) oldLine += partLineCount;
+			if (part.removed) {
+				lastRemovedStart = oldLine;
+				oldLine += partLineCount;
+			} else {
+				lastRemovedStart = null;
+			}
 		} else {
 			inGroup = false;
+			lastRemovedStart = null;
 			oldLine += partLineCount;
 		}
 	}

--- a/src/editor/readingViewDiffProcessor.ts
+++ b/src/editor/readingViewDiffProcessor.ts
@@ -450,6 +450,29 @@ function createReadingDiffActionBar(
 	});
 	bar.appendChild(acceptBtn);
 
+	// Stale parity with the chat bar and the edit-mode bar: accepting a group
+	// whose note changed after staging always fails the store's conflict check.
+	// Async (disk read) — the reading view isn't an editing surface, so disk is
+	// the right source here; the bar is recreated on every section re-render
+	// (file modify, store change), which keeps the answer current.
+	try {
+		void getPendingChangesStore()
+			.hasConflict(entryId)
+			.then((conflict) => {
+				if (!conflict) return;
+				acceptBtn.disabled = true;
+				acceptBtn.setAttribute(
+					"title",
+					"Cannot accept — the note changed after this was proposed. Reject it and ask the agent to re-stage.",
+				);
+			})
+			.catch(() => {
+				/* vault read failed — leave the button as-is */
+			});
+	} catch {
+		/* store not initialized */
+	}
+
 	const rejectBtn = document.createElement("button");
 	rejectBtn.className = "s2b-diff-reject-btn";
 	rejectBtn.textContent = "Reject";

--- a/src/lib/diffGroups.ts
+++ b/src/lib/diffGroups.ts
@@ -1,0 +1,57 @@
+import { diffLines } from "diff";
+
+/**
+ * A contiguous group of line-level changes in a pending update's diff.
+ *
+ * Group identity (its index in the returned array) is load-bearing: it is the
+ * `groupIndex` the store's `acceptChangeGroup` / `rejectChangeGroup` operate
+ * on, so every surface that renders or acts on groups — the inline editor
+ * decorations, the reading-view cards, and the chat bar's diff hunks — must
+ * derive them from this one function to stay in agreement with the store
+ * (which re-derives the same grouping from `diffLines` internally, see
+ * `buildPartialContent`).
+ */
+export interface ChangeGroup {
+	removedText: string;
+	addedText: string;
+	/** Offset of the group's first removed char in originalContent-space. */
+	docOffset: number;
+	/** Total length of the group's removed text (0 for a pure insertion). */
+	docLength: number;
+}
+
+/**
+ * Identify contiguous change groups from a line-level diff.
+ * Each group tracks its removed/added text and position relative to the first text.
+ */
+export function identifyGroups(fromText: string, toText: string): ChangeGroup[] {
+	const lineChanges = diffLines(fromText, toText);
+	const groups: ChangeGroup[] = [];
+	let docPos = 0;
+	let current: ChangeGroup | null = null;
+
+	for (const part of lineChanges) {
+		if (part.removed) {
+			if (!current) {
+				current = { removedText: "", addedText: "", docOffset: docPos, docLength: 0 };
+			}
+			current.removedText += part.value;
+			current.docLength += part.value.length;
+			docPos += part.value.length;
+		} else if (part.added) {
+			if (!current) {
+				current = { removedText: "", addedText: "", docOffset: docPos, docLength: 0 };
+			}
+			current.addedText += part.value;
+		} else {
+			if (current) {
+				groups.push(current);
+				current = null;
+			}
+			docPos += part.value.length;
+		}
+	}
+	if (current) groups.push(current);
+
+	return groups;
+}

--- a/src/lib/pendingChangeNavigation.ts
+++ b/src/lib/pendingChangeNavigation.ts
@@ -261,17 +261,17 @@ export async function revealAndScroll(plugin: SecondBrainPlugin, path: string, l
 
 /**
  * Advance the thread's navigation cursor in `direction` (wrapping around) and
- * reveal+scroll to that change group. Shared by the in-note diff bars, the
- * PendingChangesBar arrows, and the command-palette commands so all stay in
- * sync. Steps through each changed spot (group) within a file before moving to
- * the next file.
+ * reveal+scroll to that change group. Shared by the in-note diff bars (edit +
+ * reading view) and the command-palette commands so all stay in sync. Steps
+ * through each changed spot (group) within a file before moving to the next
+ * file.
  *
  * `origin`, when given, is the stop the step is taken RELATIVE TO — the in-note
  * action bars pass their own `(entryId, groupIndex)` so their chevrons move
  * relative to the change they're attached to, not the thread's shared cursor.
- * Without it (palette commands, chat-bar arrows) the shared per-thread cursor is
- * used. Either way the resulting stop becomes the new shared cursor, keeping all
- * entry points in sync. If the origin isn't found among the current stops (e.g.
+ * Without it (palette commands) the shared per-thread cursor is used. Either
+ * way the resulting stop becomes the new shared cursor, keeping all entry
+ * points in sync. If the origin isn't found among the current stops (e.g.
  * it was just accepted/rejected) we fall back to the shared cursor.
  *
  * Returns the stop navigated to, or null when the thread has no pending changes

--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -13,7 +13,7 @@ import type { AgentStreamChunk, CheckpointHistoryItem, ThreadHistory } from "../
 import type { AgentManager } from "../agent/AgentManager";
 import { BASE_SYSTEM_PROMPT } from "../agent/prompts";
 import type { ChatModelConfig } from "../providers/index";
-import type { ChatAttachment, ThreadError } from "../types/shared";
+import type { ChatAttachment, ReviewStatusRef, ThreadError } from "../types/shared";
 import type { AgentConfig } from "../types/plugin";
 import { getPendingChangesStore } from "./pendingChangesStore.svelte";
 import { formatVisibleNotesContext, type VisibleNoteRef } from "../hooks/useVisibleNotes.svelte";
@@ -764,6 +764,34 @@ export function formatGraphNotesContext(notes: GraphNoteRef[]): string {
 	return `[Graph-selected notes]\n${links.join("\n")}`;
 }
 
+/**
+ * Formats staged-change review outcomes into a context block for the agent.
+ * Without this the model never learns what the user decided: its tool result
+ * said "will be reviewed", and every later turn it would keep assuming its
+ * edits were (or will be) applied — including ones the user rejected.
+ */
+export function formatReviewOutcomesContext(status: ReviewStatusRef): string {
+	if (status.outcomes.length === 0 && status.pendingPaths.length === 0) return "";
+	const lines = ["[Status of your proposed note changes]"];
+	for (const o of status.outcomes) {
+		if (o.outcome === "accepted") {
+			lines.push(`- "${o.path}": accepted by the user and applied.`);
+		} else if (o.outcome === "rejected") {
+			lines.push(`- "${o.path}": rejected by the user — NOT applied. Do not assume this edit exists.`);
+		} else {
+			lines.push(
+				`- "${o.path}": partially applied — the user accepted some of the proposed changes and rejected the rest. Read the note if you need its exact current content.`,
+			);
+		}
+	}
+	if (status.pendingPaths.length > 0) {
+		lines.push(
+			`- Still awaiting the user's review (NOT applied yet): ${status.pendingPaths.map((p) => `"${p}"`).join(", ")}`,
+		);
+	}
+	return lines.join("\n");
+}
+
 /** Strips the augmented context suffix (visible notes + selection + graph notes) from a message.
  * Reconstructs the exact suffix that was appended by augmentWithVisibleNotes()
  * and removes it by exact string match from the end. This is safe even when user
@@ -774,6 +802,7 @@ function stripAugmentedSuffix(
 	visibleNotes?: VisibleNoteRef[],
 	selection?: SelectionRef,
 	graphNotes?: GraphNoteRef[],
+	reviewStatus?: ReviewStatusRef,
 ): string {
 	// Reconstruct the exact suffix in the same order it was appended
 	let suffix = "";
@@ -786,6 +815,10 @@ function stripAugmentedSuffix(
 	}
 	if (graphNotes?.length) {
 		const ctx = formatGraphNotesContext(graphNotes);
+		if (ctx) suffix += `\n\n${ctx}`;
+	}
+	if (reviewStatus) {
+		const ctx = formatReviewOutcomesContext(reviewStatus);
 		if (ctx) suffix += `\n\n${ctx}`;
 	}
 	if (suffix && content.endsWith(suffix)) {
@@ -1268,11 +1301,12 @@ export function baseMessagesToMessagePairs(
 			const visibleNotes = (msg.additional_kwargs?.visibleNotes as VisibleNoteRef[] | undefined) ?? undefined;
 			const selection = (msg.additional_kwargs?.selection as SelectionRef | undefined) ?? undefined;
 			const graphNotes = (msg.additional_kwargs?.graphNotes as GraphNoteRef[] | undefined) ?? undefined;
+			const reviewStatus = (msg.additional_kwargs?.reviewStatus as ReviewStatusRef | undefined) ?? undefined;
 
 			// Strip the augmented context blocks by reconstructing the exact suffix
 			// that was appended, then removing it from the end. This is safe even when
 			// user content or selected text contains bracket patterns like "[Selected text from".
-			userContent = stripAugmentedSuffix(userContent, visibleNotes, selection, graphNotes);
+			userContent = stripAugmentedSuffix(userContent, visibleNotes, selection, graphNotes, reviewStatus);
 
 			const pairId = genUUIDv7();
 
@@ -2027,12 +2061,15 @@ export class ChatSession {
 		return shouldSummarizeForEstimatedTokens(estimatedTokens, contextWindow);
 	}
 
-	/** Augments the user query with visible notes context from the provided refs. */
+	/** Augments the user query with visible notes context from the provided refs.
+	 * Order must match stripAugmentedSuffix exactly — the UI strips by exact
+	 * suffix reconstruction. */
 	private augmentWithVisibleNotes(
 		userContent: string,
 		visibleNotes?: VisibleNoteRef[],
 		selection?: SelectionRef,
 		graphNotes?: GraphNoteRef[],
+		reviewStatus?: ReviewStatusRef,
 	): string {
 		let result = userContent;
 		if (visibleNotes?.length) {
@@ -2044,6 +2081,10 @@ export class ChatSession {
 		}
 		if (graphNotes?.length) {
 			const ctx = formatGraphNotesContext(graphNotes);
+			if (ctx) result = `${result}\n\n${ctx}`;
+		}
+		if (reviewStatus) {
+			const ctx = formatReviewOutcomesContext(reviewStatus);
 			if (ctx) result = `${result}\n\n${ctx}`;
 		}
 		return result;
@@ -2061,7 +2102,19 @@ export class ChatSession {
 		const plugin = getPlugin();
 		const beforeCheckpointIds = new Set(this.graphState.nodes.keys());
 		const parentCheckpointId = this.graphState.activeCheckpointId ?? this.graphState.rootCheckpointId;
-		const augmented = this.augmentWithVisibleNotes(userContent, visibleNotes, selection, graphNotes);
+		// Review outcomes for changes the model staged earlier in this thread —
+		// collected at send time so the model stops assuming rejected edits exist.
+		// `take` marks resolved entries reported; if this send then fails before
+		// the checkpoint persists, those outcomes are lost to the model (it can
+		// still read the notes) — accepted over re-reporting them forever.
+		let reviewStatus: ReviewStatusRef | undefined;
+		try {
+			const { outcomes, pendingPaths } = getPendingChangesStore().takeReviewOutcomesForThread(String(this.id));
+			if (outcomes.length > 0 || pendingPaths.length > 0) reviewStatus = { outcomes, pendingPaths };
+		} catch {
+			// store not initialized — send without the block
+		}
+		const augmented = this.augmentWithVisibleNotes(userContent, visibleNotes, selection, graphNotes, reviewStatus);
 
 		checkpointDebug("send.parent", {
 			threadId: this.id,
@@ -2083,6 +2136,7 @@ export class ChatSession {
 					selection,
 					graphNotes,
 					undefined,
+					reviewStatus,
 				) as AsyncIterable<AgentStreamChunk>,
 			{
 				generateTitle: userContent,

--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -49,7 +49,6 @@ export enum AssistantState {
 export enum MessageState {
 	idle = 0,
 	answering = 1,
-	editing = 2,
 }
 
 const HIDDEN_HUMAN_MESSAGE_SOURCES = new Set(["summarization", "manual_summarization"]);

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -511,16 +511,15 @@ export class PendingChangesStore {
 		this.notifyChange();
 	}
 
-	/** Whether a batch accept/reject is currently running for this thread. The UI
-	 * reads this (via `revision`-tracked derivations after `notifyChange`, or its
-	 * own in-flight state) to disable the batch buttons rather than depending on
-	 * the re-entrancy guard below, which is a silent no-op. */
-	isBatchProcessing(threadId: string): boolean {
-		return this.#batchProcessing.has(threadId);
-	}
-
-	/** Accept all pending changes for a thread. Returns paths that failed. */
-	async acceptAll(threadId: string): Promise<string[]> {
+	/** Accept all pending changes for a thread. Returns paths that failed.
+	 *
+	 * `excludeEntryIds` lets the caller skip entries it already knows can't be
+	 * applied (the bar passes its stale set, so a batch reads "applied N,
+	 * skipped M stale" instead of stale entries erroring into the failure
+	 * list). Purely an optimization of the message — an outdated exclusion is
+	 * harmless either way: a wrongly-included stale entry still fails its own
+	 * conflict check, and a wrongly-excluded fresh one just stays pending. */
+	async acceptAll(threadId: string, excludeEntryIds?: ReadonlySet<string>): Promise<string[]> {
 		// Keyed by thread so concurrent chats accepting their own (disjoint) changes
 		// don't spuriously block each other. Re-entry is a silent no-op — the first
 		// run is still doing exactly what was asked; callers disable the button
@@ -529,7 +528,9 @@ export class PendingChangesStore {
 		this.#batchProcessing.add(threadId);
 		try {
 			// Snapshot the list before iterating to avoid picking up entries added mid-loop
-			const pending = [...this.#entries.filter((e) => e.threadId === threadId && e.status === "pending")];
+			const pending = this.#entries.filter(
+				(e) => e.threadId === threadId && e.status === "pending" && !excludeEntryIds?.has(e.id),
+			);
 			const failures: string[] = [];
 			for (const entry of pending) {
 				try {
@@ -770,11 +771,6 @@ export class PendingChangesStore {
 	/** Get a single entry by ID. */
 	getEntry(entryId: string): PendingChangeEntry | undefined {
 		return this.#entries.find((e) => e.id === entryId);
-	}
-
-	/** Get entry by tool call ID. */
-	getEntryByToolCallId(toolCallId: string): PendingChangeEntry | undefined {
-		return this.#entries.find((e) => e.toolCallId === toolCallId);
 	}
 
 	/** All entries one tool call staged — the chat's `manage_notes` card uses

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -2,7 +2,7 @@ import { type EventRef, normalizePath, TFile } from "obsidian";
 import { type Change, diffLines } from "diff";
 import { z } from "zod";
 import type SecondBrainPlugin from "../main";
-import type { PendingChange, PendingChangeEntry } from "../types/shared";
+import type { PendingChange, PendingChangeEntry, ReviewOutcomeRef } from "../types/shared";
 import { shouldProcessVaultPath } from "../utils/fileFiltering";
 import { genUUIDv7 } from "../utils/uuid7Validator";
 import { Logger } from "../utils/logging";
@@ -31,6 +31,7 @@ const pendingChangeEntrySchema = z.object({
 	toolCallId: z.string(),
 	threadId: z.string(),
 	createdAt: z.number(),
+	reportedToModel: z.boolean().optional(),
 });
 
 const pendingChangesArraySchema = z.array(pendingChangeEntrySchema);
@@ -140,6 +141,7 @@ export class PendingChangesStore {
 				this.#entries = [];
 			}
 		}
+		await this.#pruneOrphanedThreads();
 		this.#renameHandler = this.#plugin.app.vault.on("rename", (file, oldPath) => {
 			this.#handleFileRename(oldPath, file.path);
 		});
@@ -155,12 +157,61 @@ export class PendingChangesStore {
 		return normalizePath(`${this.#plugin.manifest.dir}/${STORAGE_FILE}`);
 	}
 
+	/**
+	 * Drop entries whose chat no longer exists. `removeThread` only runs through
+	 * the in-app delete path, so a `.chat` file deleted externally (or while the
+	 * plugin was unloaded) leaves orphans behind: invisible in every per-thread
+	 * bar, yet still counted by `countOtherThreadsPendingUpdate` — a note banner
+	 * claiming "another chat is editing this file" with no chat to resolve it
+	 * from, forever.
+	 *
+	 * Scoped to threadIds that look like chat files. The api staging path can
+	 * pass arbitrary thread keys that were never vault paths; existence checks
+	 * against those would always "fail" and wrongly sweep live entries.
+	 */
+	async #pruneOrphanedThreads(): Promise<void> {
+		const chatThreadIds = new Set(
+			this.#entries.map((e) => e.threadId).filter((threadId) => threadId.endsWith(".chat")),
+		);
+		if (chatThreadIds.size === 0) return;
+
+		const orphaned: string[] = [];
+		for (const threadId of chatThreadIds) {
+			if (!(await this.#plugin.app.vault.adapter.exists(normalizePath(threadId)))) {
+				orphaned.push(threadId);
+			}
+		}
+		if (orphaned.length === 0) return;
+
+		Logger.warn(`[PendingChanges] Pruning entries for ${orphaned.length} deleted chat(s): ${orphaned.join(", ")}`);
+		// removeThread carries the stranded-content warning and the save/notify.
+		for (const threadId of orphaned) {
+			this.removeThread(threadId);
+		}
+	}
+
 	private scheduleSave(): void {
 		if (this.#saveTimer) clearTimeout(this.#saveTimer);
 		this.#saveTimer = setTimeout(
 			() => void this.saveToDisk().catch((e) => Logger.error("[PendingChanges] Failed to save:", e)),
 			SAVE_DEBOUNCE_MS,
 		);
+	}
+
+	/**
+	 * Persist immediately, cancelling any debounced save. Used after transitions
+	 * that already wrote to the vault (accept, group accept, revert): the vault
+	 * write is durable the moment it happens, so a crash inside the debounce
+	 * window would resurrect the entry as `pending` on reload — and its next
+	 * accept would then fail the conflict check against content we ourselves
+	 * wrote. Staging bursts keep the debounce; they have no vault side effect.
+	 */
+	private flushSave(): void {
+		if (this.#saveTimer) {
+			clearTimeout(this.#saveTimer);
+			this.#saveTimer = null;
+		}
+		void this.saveToDisk().catch((e) => Logger.error("[PendingChanges] Failed to save:", e));
 	}
 
 	private async saveToDisk(): Promise<void> {
@@ -300,6 +351,16 @@ export class PendingChangesStore {
 				if (!(file instanceof TFile)) {
 					throw new TypeError(`Cannot apply delete — file not found: ${change.path}`);
 				}
+				// Conflict detection, matching update: the review surfaces (bar preview,
+				// hover) show the STAGED snapshot, so trashing whatever is there now
+				// would delete content the user never reviewed. Trash is recoverable,
+				// but the review step should not misrepresent what it destroys.
+				const currentContent = await app.vault.read(file);
+				if (currentContent !== change.originalContent) {
+					throw new Error(
+						`File "${change.path}" was modified after the delete was proposed. Review the note and re-stage the delete.`,
+					);
+				}
 				await app.vault.trash(file, true);
 			} else if (change.type === "move") {
 				const file = app.vault.getAbstractFileByPath(normalizedPath);
@@ -323,7 +384,7 @@ export class PendingChangesStore {
 		// snapshot from earlier group accepts is settled — see `hasUnrevertedApplication`.
 		// Leaving it set would let `rejectAll` revert a change they just accepted.
 		if (change.type === "update") change.initialOriginalContent = undefined;
-		this.scheduleSave();
+		this.flushSave();
 		this.notifyChange();
 	}
 
@@ -422,7 +483,7 @@ export class PendingChangesStore {
 				}
 			});
 
-			this.scheduleSave();
+			this.flushSave();
 			this.notifyChange();
 		} finally {
 			this.#processingGroups.delete(entryId);
@@ -450,11 +511,21 @@ export class PendingChangesStore {
 		this.notifyChange();
 	}
 
+	/** Whether a batch accept/reject is currently running for this thread. The UI
+	 * reads this (via `revision`-tracked derivations after `notifyChange`, or its
+	 * own in-flight state) to disable the batch buttons rather than depending on
+	 * the re-entrancy guard below, which is a silent no-op. */
+	isBatchProcessing(threadId: string): boolean {
+		return this.#batchProcessing.has(threadId);
+	}
+
 	/** Accept all pending changes for a thread. Returns paths that failed. */
 	async acceptAll(threadId: string): Promise<string[]> {
 		// Keyed by thread so concurrent chats accepting their own (disjoint) changes
-		// don't spuriously block each other.
-		if (this.#batchProcessing.has(threadId)) return ["Batch operation already in progress"];
+		// don't spuriously block each other. Re-entry is a silent no-op — the first
+		// run is still doing exactly what was asked; callers disable the button
+		// while awaiting rather than reporting a phantom failure.
+		if (this.#batchProcessing.has(threadId)) return [];
 		this.#batchProcessing.add(threadId);
 		try {
 			// Snapshot the list before iterating to avoid picking up entries added mid-loop
@@ -556,7 +627,7 @@ export class PendingChangesStore {
 
 		const skipped = await this.revertAppliedGroups(entry);
 		entry.status = "rejected";
-		this.scheduleSave();
+		this.flushSave();
 		this.notifyChange();
 		return skipped;
 	}
@@ -568,28 +639,37 @@ export class PendingChangesStore {
 	 *  file keeps its current content. Callers should surface these: a silent skip reads as
 	 *  "everything was undone" when it wasn't. */
 	async rejectAll(threadId: string): Promise<RevertSkip[]> {
-		// Two distinct sets, deliberately:
-		//
-		//  - anything still `pending`, which must be marked rejected; and
-		//  - anything with `initialOriginalContent` set, which has partially-applied
-		//    content ON DISK that must be undone regardless of its status.
-		//
-		// The second set is not a subset of the first. Accepting one diff group and
-		// then rejecting the remaining ones drives `newContent` back to
-		// `originalContent`, so `rejectChangeGroup` already flipped the entry to
-		// `rejected` — while the accepted group is still written to the note. Filtering
-		// on `pending` alone skipped exactly those entries, leaving the applied text in
-		// the vault while the UI reported that everything had been rejected.
-		const targets = this.getActionableForThread(threadId);
-		const skippedReverts: RevertSkip[] = [];
-		for (const entry of targets) {
-			const skipped = await this.revertAppliedGroups(entry);
-			if (skipped) skippedReverts.push(skipped);
-			entry.status = "rejected";
+		// Same per-thread guard as acceptAll — and the same Set, so an accept-all
+		// and a reject-all for one thread can't interleave their vault writes.
+		if (this.#batchProcessing.has(threadId)) return [];
+		this.#batchProcessing.add(threadId);
+		try {
+			// Two distinct sets, deliberately:
+			//
+			//  - anything still `pending`, which must be marked rejected; and
+			//  - anything with `initialOriginalContent` set, which has partially-applied
+			//    content ON DISK that must be undone regardless of its status.
+			//
+			// The second set is not a subset of the first. Accepting one diff group and
+			// then rejecting the remaining ones drives `newContent` back to
+			// `originalContent`, so `rejectChangeGroup` already flipped the entry to
+			// `rejected` — while the accepted group is still written to the note. Filtering
+			// on `pending` alone skipped exactly those entries, leaving the applied text in
+			// the vault while the UI reported that everything had been rejected.
+			const targets = this.getActionableForThread(threadId);
+			const skippedReverts: RevertSkip[] = [];
+			for (const entry of targets) {
+				const skipped = await this.revertAppliedGroups(entry);
+				if (skipped) skippedReverts.push(skipped);
+				entry.status = "rejected";
+			}
+			// Reverts are vault writes — flush like the other write paths.
+			this.flushSave();
+			this.notifyChange();
+			return skippedReverts;
+		} finally {
+			this.#batchProcessing.delete(threadId);
 		}
-		this.scheduleSave();
-		this.notifyChange();
-		return skippedReverts;
 	}
 
 	/** Get all entries for a thread. */
@@ -634,6 +714,59 @@ export class PendingChangesStore {
 		);
 	}
 
+	/**
+	 * The review outcomes to surface to the model in the next user turn, plus the
+	 * paths still awaiting review. Resolved entries are marked reported so each
+	 * outcome reaches the model exactly once; pending paths are returned every
+	 * call until they resolve (the model must keep treating them as not applied).
+	 *
+	 * Only consults entries the model itself staged in this thread — outcomes for
+	 * other chats' proposals would be noise it has no proposal to correlate with.
+	 */
+	takeReviewOutcomesForThread(threadId: string): { outcomes: ReviewOutcomeRef[]; pendingPaths: string[] } {
+		const outcomes: ReviewOutcomeRef[] = [];
+		const pendingPaths: string[] = [];
+		let changed = false;
+		for (const entry of this.#entries) {
+			if (entry.threadId !== threadId) continue;
+			if (entry.status === "pending") {
+				pendingPaths.push(entry.change.path);
+				continue;
+			}
+			if (entry.reportedToModel) continue;
+			outcomes.push({
+				path: entry.change.path,
+				// Rejected with applied text still on disk = some groups were
+				// accepted first — the note DOES contain part of the proposal.
+				outcome:
+					entry.status === "accepted"
+						? "accepted"
+						: this.hasUnrevertedApplication(entry)
+							? "partially"
+							: "rejected",
+			});
+			entry.reportedToModel = true;
+			changed = true;
+		}
+		if (changed) this.scheduleSave();
+		return { outcomes, pendingPaths };
+	}
+
+	/** Mark entries as already surfaced to the model, so the next turn's outcome
+	 * block skips them. Used for memory auto-applies, whose outcome the tool
+	 * result itself already reported ("applied automatically"). */
+	markReportedToModel(entryIds: string[]): void {
+		let changed = false;
+		for (const id of entryIds) {
+			const entry = this.#entries.find((e) => e.id === id);
+			if (entry && !entry.reportedToModel) {
+				entry.reportedToModel = true;
+				changed = true;
+			}
+		}
+		if (changed) this.scheduleSave();
+	}
+
 	/** Get a single entry by ID. */
 	getEntry(entryId: string): PendingChangeEntry | undefined {
 		return this.#entries.find((e) => e.id === entryId);
@@ -642,6 +775,12 @@ export class PendingChangesStore {
 	/** Get entry by tool call ID. */
 	getEntryByToolCallId(toolCallId: string): PendingChangeEntry | undefined {
 		return this.#entries.find((e) => e.toolCallId === toolCallId);
+	}
+
+	/** All entries one tool call staged — the chat's `manage_notes` card uses
+	 * this to show live review status for its own proposals. */
+	getEntriesByToolCallId(toolCallId: string): PendingChangeEntry[] {
+		return this.#entries.filter((e) => e.toolCallId === toolCallId);
 	}
 
 	/** Get count of pending changes for a thread. */

--- a/src/styles.css
+++ b/src/styles.css
@@ -841,6 +841,17 @@
 	background-color: rgba(0, 180, 0, 0.35);
 }
 
+/* Stale entry: the accept is guaranteed to fail its conflict check, so the
+   in-note bars disable it with an explanatory title (parity with the chat bar). */
+.s2b-diff-accept-btn[disabled] {
+	opacity: 0.45;
+	cursor: not-allowed;
+}
+
+.s2b-diff-accept-btn[disabled]:hover {
+	background-color: rgba(0, 180, 0, 0.2);
+}
+
 .s2b-diff-reject-btn {
 	background-color: rgba(220, 50, 47, 0.2);
 	color: var(--text-normal);

--- a/src/styles.css
+++ b/src/styles.css
@@ -95,6 +95,19 @@
 	text-align: left;
 }
 
+/* Many pills are <button>s (context-tray chips, graph members), and Obsidian's
+   app.css button background outspecifies the bare `.s2b-pill` class — those
+   pills rendered `--interactive-normal` grey while span pills showed the
+   intended fill. Re-state fill and hover at button specificity; this file
+   loads after app.css, so the equal-specificity tie breaks our way. */
+button.s2b-pill {
+	background: var(--s2b-pill-bg, color-mix(in srgb, var(--background-secondary) 92%, var(--background-primary)));
+}
+
+button.s2b-pill--interactive:hover {
+	background: var(--s2b-pill-bg-hover, var(--background-modifier-hover));
+}
+
 .s2b-pill--interactive {
 	cursor: pointer;
 	transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, opacity 0.15s ease;

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -110,4 +110,31 @@ export interface PendingChangeEntry {
 	threadId: string;
 	/** Timestamp when the change was proposed */
 	createdAt: number;
+	/** Whether this entry's accept/reject outcome has been surfaced to the model
+	 * (in a later user turn's context block). Resolved-but-unreported entries are
+	 * reported exactly once; pending ones are re-reported until resolved. */
+	reportedToModel?: boolean;
+}
+
+/**
+ * The review outcome of one staged note change, as reported to the model in a
+ * user turn's context suffix. Stored in the message's `additional_kwargs` so the
+ * exact suffix can be reconstructed and stripped for display (the same pattern
+ * as visible notes / selection).
+ *
+ * `partially` = an update whose diff groups were resolved individually with at
+ * least one accepted and the rest rejected — some proposed text IS in the note.
+ */
+export interface ReviewOutcomeRef {
+	path: string;
+	outcome: "accepted" | "rejected" | "partially";
+}
+
+/** The review status of a thread's staged note changes at the moment a user
+ * turn was sent: freshly resolved outcomes plus paths still awaiting review.
+ * Persisted in the message's `additional_kwargs` (like visible notes) so the
+ * appended context block can be exactly reconstructed and stripped for display. */
+export interface ReviewStatusRef {
+	outcomes: ReviewOutcomeRef[];
+	pendingPaths: string[];
 }

--- a/src/views/chat/Chat.svelte
+++ b/src/views/chat/Chat.svelte
@@ -269,7 +269,6 @@ function portalComposer(node: HTMLElement) {
         {registry}
         {threadPath}
         dropTargetMode="view"
-        externalDragActive={isDragging}
         onDragStateChange={(state) => {
           isDragging = state.isDragging;
           dragMessage = state.dragMessage;
@@ -286,21 +285,29 @@ function portalComposer(node: HTMLElement) {
     {/if}
 
     {#if isDragging}
+      <!-- One dashed frame around the whole pane, because the whole pane is the
+           drop target. The dashed border is the conventional "this region
+           accepts drops" signal, so it belongs on the region — previously it
+           was wrapped around a small floating pill, which read as "drop onto
+           this chicklet" and left the actual target unmarked. The label sits
+           inside the frame and no longer carries a border of its own. -->
       <div
-        class="chat-drop-overlay absolute inset-0 z-30 pointer-events-none flex items-center justify-center p-6"
+        class="chat-drop-overlay absolute inset-0 z-30 pointer-events-none flex items-center justify-center p-2 {dragHasIssue
+          ? 'chat-drop-overlay-issue'
+          : 'chat-drop-overlay-active'}"
       >
-        <div
-          class="chat-drop-overlay-panel flex items-center gap-3 rounded-2xl px-5 py-4 text-sm font-medium shadow-lg {dragHasIssue
-            ? 'chat-drop-overlay-panel-issue'
-            : 'chat-drop-overlay-panel-active'}"
-        >
+        <div class="chat-drop-frame flex items-center justify-center rounded-[16px]">
           <div
-            class="h-icon-s w-icon-s"
-            style="--icon-size: var(--icon-s)"
-            data-testid="chat-drop-overlay-icon"
-            use:icon={dragHasIssue ? "alert-triangle" : "upload"}
-          ></div>
-          <span data-testid="chat-drop-overlay-message">{dragMessage}</span>
+            class="chat-drop-overlay-panel flex items-center gap-3 rounded-2xl px-5 py-4 text-sm font-medium"
+          >
+            <div
+              class="h-icon-s w-icon-s"
+              style="--icon-size: var(--icon-s)"
+              data-testid="chat-drop-overlay-icon"
+              use:icon={dragHasIssue ? "alert-triangle" : "upload"}
+            ></div>
+            <span data-testid="chat-drop-overlay-message">{dragMessage}</span>
+          </div>
         </div>
       </div>
     {/if}
@@ -344,21 +351,6 @@ function portalComposer(node: HTMLElement) {
     margin-top: -12px;
     padding-top: 12px;
     z-index: 10;
-  }
-
-  .chat-root::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 140ms ease;
-    background: radial-gradient(
-        circle at top,
-        color-mix(in srgb, var(--interactive-accent) 16%, transparent),
-        transparent 58%
-      ),
-      color-mix(in srgb, var(--chat-bg) 72%, transparent);
   }
 
   .chat-root {
@@ -497,25 +489,41 @@ function portalComposer(node: HTMLElement) {
       );
   }
 
-  .chat-root:has(.chat-drop-overlay)::before {
-    opacity: 1;
+  /* The frame IS the drop affordance: dashed border marking the boundary, plus
+     a uniform wash across the interior so the whole enclosed area reads as one
+     active region. This replaces the radial glow that used to sit at the top of
+     the view (`.chat-root::before`, no longer triggered) — a gradient anchored
+     to one edge suggested the target was up there rather than everywhere.
+     16px radius matches the composer and message bubbles. */
+  .chat-drop-frame {
+    position: absolute;
+    inset: 0;
+    border: 2px dashed var(--s2b-drop-border);
+    background: var(--s2b-drop-wash);
+    backdrop-filter: blur(2px);
   }
 
+  .chat-drop-overlay-active {
+    --s2b-drop-border: color-mix(in srgb, var(--interactive-accent) 55%, transparent);
+    --s2b-drop-wash: color-mix(in srgb, var(--interactive-accent) 5%, transparent);
+    --s2b-drop-label-color: var(--text-accent);
+    --s2b-drop-label-bg: color-mix(in srgb, var(--interactive-accent) 14%, var(--background-primary));
+  }
+
+  /* Same geometry as the active state, error palette — so nothing shifts or
+     jumps if validity changes mid-drag; only the colours cross-fade. */
+  .chat-drop-overlay-issue {
+    --s2b-drop-border: color-mix(in srgb, var(--text-error) 45%, transparent);
+    --s2b-drop-wash: color-mix(in srgb, var(--text-error) 5%, transparent);
+    --s2b-drop-label-color: var(--text-error);
+    --s2b-drop-label-bg: color-mix(in srgb, var(--background-modifier-error) 70%, var(--background-primary));
+  }
+
+  /* Label: no border of its own — the frame owns that. Keeps a solid fill so
+     it stays legible over whatever conversation content is behind it. */
   .chat-drop-overlay-panel {
-    border: 1px dashed transparent;
-    backdrop-filter: blur(6px);
-  }
-
-  .chat-drop-overlay-panel-active {
-    color: var(--text-accent);
-    background: color-mix(in srgb, var(--interactive-accent) 14%, var(--background-primary));
-    border-color: color-mix(in srgb, var(--interactive-accent) 55%, transparent);
-  }
-
-  .chat-drop-overlay-panel-issue {
-    color: var(--text-error);
-    background: color-mix(in srgb, var(--background-modifier-error) 70%, var(--background-primary));
-    border-color: color-mix(in srgb, var(--text-error) 45%, transparent);
+    color: var(--s2b-drop-label-color);
+    background: var(--s2b-drop-label-bg);
   }
 
 </style>

--- a/test/agent/agentConcurrency.test.ts
+++ b/test/agent/agentConcurrency.test.ts
@@ -225,7 +225,7 @@ describe("PendingChangesStore.acceptAll — per-thread concurrency", () => {
 		expect(failuresB).toHaveLength(0);
 	});
 
-	it("second acceptAll on the SAME thread while first is in flight returns the in-progress error", async () => {
+	it("second acceptAll on the SAME thread while first is in flight is a silent no-op", async () => {
 		const plugin = createMockPlugin();
 		// Slow down vault.modify so the first acceptAll is still running when the second starts.
 		// We use a deferred promise so we can resolve it after modify has been called.
@@ -248,14 +248,18 @@ describe("PendingChangesStore.acceptAll — per-thread concurrency", () => {
 		const first = store.acceptAll("thread-C");
 		const second = store.acceptAll("thread-C");
 
-		// Second should return the in-progress rejection immediately
+		// Second returns immediately with no failures — the first run is already
+		// doing exactly what was asked; the UI disables the button while awaiting,
+		// so re-entry must not report a phantom failure.
 		const secondResult = await second;
-		expect(secondResult).toContain("Batch operation already in progress");
+		expect(secondResult).toHaveLength(0);
 
 		// Now unblock modify so `first` can finish
 		modifyResolve();
 		const firstResult = await first;
 		expect(firstResult).toHaveLength(0);
+		// The no-op second run must not have applied the staged change again.
+		expect(plugin.app.vault.modify).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/test/agent/editNote.test.ts
+++ b/test/agent/editNote.test.ts
@@ -7,12 +7,14 @@ const mockAddChanges = vi.fn();
 const mockIsPathAllowed = vi.fn().mockReturnValue(true);
 const mockShouldBlockFile = vi.fn().mockReturnValue(false);
 const mockCountOtherThreads = vi.fn().mockReturnValue(0);
+const mockGetPendingUpdatesForPath = vi.fn().mockReturnValue([]);
 vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({
 	getPendingChangesStore: () => ({
 		addChanges: mockAddChanges,
 		isPathAllowed: mockIsPathAllowed,
 		shouldBlockFile: mockShouldBlockFile,
 		countOtherThreadsPendingUpdate: mockCountOtherThreads,
+		getPendingUpdatesForPath: (...args: unknown[]) => mockGetPendingUpdatesForPath(...args),
 	}),
 }));
 
@@ -83,6 +85,7 @@ describe("manageNotes tool (update operations)", () => {
 		vi.clearAllMocks();
 		mockIsPathAllowed.mockReturnValue(true);
 		mockShouldBlockFile.mockReturnValue(false);
+		mockGetPendingUpdatesForPath.mockReturnValue([]);
 		mockCountOtherThreads.mockReturnValue(0);
 		app = createMockApp();
 		tool = createManageNotesTool(app);

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -6,6 +6,7 @@ const mockAddChanges = vi.fn().mockReturnValue(["mock-id"]);
 const mockIsPathAllowed = vi.fn().mockReturnValue(true);
 const mockCountOtherThreads = vi.fn().mockReturnValue(0);
 const mockShouldBlockFile = vi.fn().mockReturnValue(false);
+const mockGetPendingUpdatesForPath = vi.fn().mockReturnValue([]);
 
 vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({
 	getPendingChangesStore: () => ({
@@ -13,6 +14,7 @@ vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({
 		isPathAllowed: mockIsPathAllowed,
 		countOtherThreadsPendingUpdate: mockCountOtherThreads,
 		shouldBlockFile: (...args: unknown[]) => mockShouldBlockFile(...args),
+		getPendingUpdatesForPath: (...args: unknown[]) => mockGetPendingUpdatesForPath(...args),
 	}),
 }));
 
@@ -97,6 +99,7 @@ describe("manageNotes tool", () => {
 		mockIsPathAllowed.mockReturnValue(true);
 		mockCountOtherThreads.mockReturnValue(0);
 		mockShouldBlockFile.mockReturnValue(false);
+		mockGetPendingUpdatesForPath.mockReturnValue([]);
 		mockGetIndexableVaultFiles.mockReturnValue([]);
 		setManageNotesPermissions();
 		app = createMockApp();
@@ -629,6 +632,114 @@ describe("manageNotes tool", () => {
 
 			expect(result).toContain("zero-width");
 			expect(mockAddChanges).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("same-thread re-staging rebases onto pending content", () => {
+		const DISK = "line one\nline two\nline three\n";
+		const PROPOSED = "line one\nline two edited\nline three\n";
+
+		function pendingEntry(threadId: string, originalContent = DISK) {
+			return {
+				id: "prior-id",
+				status: "pending",
+				toolCallId: "tc-prior",
+				threadId,
+				createdAt: 1,
+				change: { type: "update", path: "Notes/doc.md", originalContent, newContent: PROPOSED },
+			};
+		}
+
+		beforeEach(() => {
+			const file = makeFile("Notes/doc.md");
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file });
+			vi.mocked(app.vault.read).mockResolvedValue(DISK);
+		});
+
+		it("applies edits against this thread's pending newContent and says so", async () => {
+			mockGetPendingUpdatesForPath.mockReturnValue([pendingEntry("test-thread-id")]);
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							// Matches only the PENDING proposal's text, not disk.
+							edits: [{ oldText: "line two edited", newText: "line two edited twice" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("superseded");
+			const staged = mockAddChanges.mock.calls[0][0][0];
+			// Conflict baseline stays disk; the proposal carries both rounds of edits.
+			expect(staged.originalContent).toBe(DISK);
+			expect(staged.newContent).toBe("line one\nline two edited twice\nline three\n");
+		});
+
+		it("falls back to disk when the pending proposal is stale against disk", async () => {
+			mockGetPendingUpdatesForPath.mockReturnValue([
+				pendingEntry("test-thread-id", "some older disk content\n"),
+			]);
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							edits: [{ oldText: "line two edited", newText: "x" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			// The edit targeted the pending proposal's text, which is not the base here.
+			expect(result).toContain("Could not find the specified text");
+			expect(mockAddChanges).not.toHaveBeenCalled();
+		});
+
+		it("ignores pending updates from other threads", async () => {
+			mockGetPendingUpdatesForPath.mockReturnValue([pendingEntry("some-other-thread")]);
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							edits: [{ oldText: "line two", newText: "line 2" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).not.toContain("superseded");
+			const staged = mockAddChanges.mock.calls[0][0][0];
+			expect(staged.newContent).toBe("line one\nline 2\nline three\n");
+		});
+
+		it("rebases a vault-wide replace the same way", async () => {
+			const file = makeFile("Notes/doc.md");
+			mockGetIndexableVaultFiles.mockReturnValue([file]);
+			mockGetPendingUpdatesForPath.mockReturnValue([pendingEntry("test-thread-id")]);
+
+			const result = await tool.invoke(
+				{
+					operations: [{ type: "replace", find: "edited", replace: "changed" }],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("superseded");
+			const staged = mockAddChanges.mock.calls[0][0][0];
+			expect(staged.originalContent).toBe(DISK);
+			expect(staged.newContent).toBe("line one\nline two changed\nline three\n");
 		});
 	});
 

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -680,6 +680,68 @@ describe("manageNotes tool", () => {
 			expect(staged.newContent).toBe("line one\nline two edited twice\nline three\n");
 		});
 
+		/**
+		 * Regression (PR #426 review): the read tools are unaware of staged
+		 * changes, so a model that re-reads the note holds DISK text. Rebasing
+		 * unconditionally onto the pending proposal made those edits miss and
+		 * aborted the whole batch instead of staging a reviewable proposal.
+		 */
+		it("falls back to disk when the edits match disk, not the pending proposal", async () => {
+			// The pending proposal REPLACED "line two" with "changed line", so the
+			// disk text no longer exists in it — the two bases are unambiguous.
+			mockGetPendingUpdatesForPath.mockReturnValue([
+				{
+					...pendingEntry("test-thread-id"),
+					change: {
+						type: "update",
+						path: "Notes/doc.md",
+						originalContent: DISK,
+						newContent: "line one\nchanged line\nline three\n",
+					},
+				},
+			]);
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							// Matches DISK content — what read_content would have returned.
+							edits: [{ oldText: "line two", newText: "line two rewritten" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("Proposed");
+			expect(result).not.toContain("superseded");
+			const staged = mockAddChanges.mock.calls[0][0][0];
+			expect(staged.originalContent).toBe(DISK);
+			expect(staged.newContent).toBe("line one\nline two rewritten\nline three\n");
+		});
+
+		it("reports the disk-base error when the edits match neither base", async () => {
+			mockGetPendingUpdatesForPath.mockReturnValue([pendingEntry("test-thread-id")]);
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							edits: [{ oldText: "nowhere at all", newText: "x" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("Could not find the specified text");
+			expect(mockAddChanges).not.toHaveBeenCalled();
+		});
+
 		it("falls back to disk when the pending proposal is stale against disk", async () => {
 			mockGetPendingUpdatesForPath.mockReturnValue([
 				pendingEntry("test-thread-id", "some older disk content\n"),
@@ -740,6 +802,35 @@ describe("manageNotes tool", () => {
 			const staged = mockAddChanges.mock.calls[0][0][0];
 			expect(staged.originalContent).toBe(DISK);
 			expect(staged.newContent).toBe("line one\nline two changed\nline three\n");
+		});
+
+		it("replaces against disk when the pattern only occurs there", async () => {
+			const file = makeFile("Notes/doc.md");
+			mockGetIndexableVaultFiles.mockReturnValue([file]);
+			// Pending proposal replaced "three" with "3", so "three" now exists
+			// only on disk — the replace must target the text the model can see.
+			mockGetPendingUpdatesForPath.mockReturnValue([
+				{
+					...pendingEntry("test-thread-id"),
+					change: {
+						type: "update",
+						path: "Notes/doc.md",
+						originalContent: DISK,
+						newContent: "line one\nline two\nline 3\n",
+					},
+				},
+			]);
+
+			const result = await tool.invoke(
+				{
+					operations: [{ type: "replace", find: "three", replace: "THREE" }],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("Proposed");
+			const staged = mockAddChanges.mock.calls[0][0][0];
+			expect(staged.newContent).toBe("line one\nline two\nline THREE\n");
 		});
 	});
 

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -722,6 +722,85 @@ describe("manageNotes tool", () => {
 			expect(staged.newContent).toBe("line one\nline two rewritten\nline three\n");
 		});
 
+		/**
+		 * Pending-first precedence, pinned (PR #426 review, second pass).
+		 *
+		 * When the model's edit CONFLICTS with the pending one (both touch the same
+		 * text), the pending base simply fails to match and the loop falls through
+		 * to disk — so the model's disk-derived intent wins on its own.
+		 *
+		 * When both bases match, the edits are necessarily orthogonal (the target
+		 * text survived the pending edit), and pending-first is what preserves BOTH
+		 * rounds. Disk-first would silently drop the earlier unreviewed edit, which
+		 * is the data loss this whole rebase exists to prevent.
+		 */
+		it("keeps both rounds when the follow-up edit is orthogonal to the pending one", async () => {
+			mockGetPendingUpdatesForPath.mockReturnValue([
+				{
+					...pendingEntry("test-thread-id"),
+					change: {
+						type: "update",
+						path: "Notes/doc.md",
+						originalContent: DISK,
+						// Pending touched line ONE; the follow-up below touches line three.
+						newContent: "line one edited\nline two\nline three\n",
+					},
+				},
+			]);
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							edits: [{ oldText: "line three", newText: "line three edited" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("superseded");
+			const staged = mockAddChanges.mock.calls[0][0][0];
+			// Both edits present — disk-first would have lost "line one edited".
+			expect(staged.newContent).toBe("line one edited\nline two\nline three edited\n");
+		});
+
+		it("lets a conflicting disk-derived edit win over the pending base", async () => {
+			mockGetPendingUpdatesForPath.mockReturnValue([
+				{
+					...pendingEntry("test-thread-id"),
+					change: {
+						type: "update",
+						path: "Notes/doc.md",
+						originalContent: DISK,
+						// Pending rewrote the very line the follow-up targets.
+						newContent: "line one\nPENDING VERSION\nline three\n",
+					},
+				},
+			]);
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							// Written against disk; no longer present in the pending base.
+							edits: [{ oldText: "line two", newText: "MODEL VERSION" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			// Pending base can't match, so disk wins and the model's intent stands.
+			expect(result).not.toContain("superseded");
+			const staged = mockAddChanges.mock.calls[0][0][0];
+			expect(staged.newContent).toBe("line one\nMODEL VERSION\nline three\n");
+		});
+
 		it("reports the disk-base error when the edits match neither base", async () => {
 			mockGetPendingUpdatesForPath.mockReturnValue([pendingEntry("test-thread-id")]);
 

--- a/test/editor/readingViewDiffProcessor.test.ts
+++ b/test/editor/readingViewDiffProcessor.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("obsidian", () => import("../__mocks__/obsidian"));
+// Only the pure diff-attribution helpers are under test; stub the module's
+// UI-side imports so the test doesn't drag in the whole view layer.
+vi.mock("../../src/lib/pendingChangeNavigation", () => ({ navigateToPendingChange: vi.fn() }));
+vi.mock("../../src/stores/state.svelte", () => ({ getPlugin: vi.fn() }));
+vi.mock("../../src/stores/dataStore.svelte", () => ({ getData: vi.fn() }));
+vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({ getPendingChangesStore: vi.fn() }));
+
+import { computeOriginalAffectedLines, insertionAnchorLine } from "../../src/editor/readingViewDiffProcessor";
+
+describe("insertionAnchorLine", () => {
+	it("anchors to the following line, and to the previous line at EOF", () => {
+		expect(insertionAnchorLine(2, 5)).toBe(2);
+		expect(insertionAnchorLine(5, 5)).toBe(4);
+		expect(insertionAnchorLine(0, 0)).toBe(0);
+	});
+});
+
+describe("computeOriginalAffectedLines", () => {
+	it("marks removed lines as affected", () => {
+		const affected = computeOriginalAffectedLines("a\nb\nc\n", "a\nc\n");
+		expect(affected).toEqual(new Set([1]));
+	});
+
+	it("anchors a pure insertion to the following original line", () => {
+		const affected = computeOriginalAffectedLines("a\nb\n", "a\nNEW\nb\n");
+		expect(affected).toEqual(new Set([1]));
+	});
+
+	it("anchors a pure insertion at EOF to the last original line", () => {
+		const affected = computeOriginalAffectedLines("a\nb\n", "a\nb\nNEW\n");
+		expect(affected).toEqual(new Set([1]));
+	});
+
+	/**
+	 * Regression: a REPLACEMENT (removed + added in one group) must affect only
+	 * the replaced lines. The added part used to be anchored like a pure
+	 * insertion — but by then the line counter had advanced past the removed
+	 * run, so the line AFTER the replacement was falsely marked. In the reading
+	 * view that handed the change's new text to the NEXT rendered section: any
+	 * single-line heading edit showed the old heading as fully removed with the
+	 * new text missing from its card, while the following section got a phantom
+	 * card.
+	 */
+	it("does not mark the line after a replacement as affected", () => {
+		const affected = computeOriginalAffectedLines(
+			"# Title\n\nintro paragraph\n",
+			"# Title (edited)\n\nintro paragraph\n",
+		);
+		expect(affected).toEqual(new Set([0]));
+	});
+
+	it("keeps replacement and pure-insertion attribution independent in one diff", () => {
+		// Line 0 replaced; a new line inserted before line 2 ("c").
+		const affected = computeOriginalAffectedLines("a\nb\nc\n", "A\nb\nNEW\nc\n");
+		expect(affected).toEqual(new Set([0, 2]));
+	});
+});

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -150,11 +150,19 @@ describe("PendingChangesStore", () => {
 		});
 
 		it("should retrieve entries by tool call ID", () => {
-			store.addChanges([{ type: "create", path: "a.md", content: "A" }], "tc-unique", "thread-1");
+			store.addChanges(
+				[
+					{ type: "create", path: "a.md", content: "A" },
+					{ type: "create", path: "b.md", content: "B" },
+				],
+				"tc-unique",
+				"thread-1",
+			);
+			store.addChanges([{ type: "create", path: "c.md", content: "C" }], "tc-other", "thread-1");
 
-			const entry = store.getEntryByToolCallId("tc-unique");
-			expect(entry).toBeDefined();
-			expect(entry?.toolCallId).toBe("tc-unique");
+			const entries = store.getEntriesByToolCallId("tc-unique");
+			expect(entries).toHaveLength(2);
+			expect(entries.map((e) => e.change.path)).toEqual(["a.md", "b.md"]);
 		});
 
 		it("should return pending updates for a specific path", () => {

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -263,6 +263,7 @@ describe("PendingChangesStore", () => {
 		it("should accept and apply a delete change", async () => {
 			const file = makeTFile("delete-me.md");
 			(plugin.app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(file);
+			(plugin.app.vault.read as ReturnType<typeof vi.fn>).mockResolvedValue("content");
 
 			const [id] = store.addChanges(
 				[{ type: "delete", path: "delete-me.md", originalContent: "content" }],
@@ -274,6 +275,23 @@ describe("PendingChangesStore", () => {
 
 			expect(store.getEntry(id)?.status).toBe("accepted");
 			expect(plugin.app.vault.trash).toHaveBeenCalledWith(file, true);
+		});
+
+		it("should refuse a delete when the file was modified after staging", async () => {
+			const file = makeTFile("delete-me.md");
+			(plugin.app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(file);
+			// The preview shows the staged snapshot; the note has since changed.
+			(plugin.app.vault.read as ReturnType<typeof vi.fn>).mockResolvedValue("edited since staging");
+
+			const [id] = store.addChanges(
+				[{ type: "delete", path: "delete-me.md", originalContent: "content" }],
+				"tc-1",
+				"thread-1",
+			);
+
+			await expect(store.acceptChange(id)).rejects.toThrow("was modified after the delete was proposed");
+			expect(store.getEntry(id)?.status).toBe("pending");
+			expect(plugin.app.vault.trash).not.toHaveBeenCalled();
 		});
 
 		it("should accept and apply a move change", async () => {
@@ -846,6 +864,118 @@ describe("PendingChangesStore", () => {
 			expect(store.getEntry(pendingId)).toBeUndefined();
 			expect(store.getEntry(resolvedId)).toBeUndefined();
 			expect(store.getPendingCount("Chats/gone.chat")).toBe(0);
+		});
+	});
+
+	/* --------------------------------------------------------------------------
+	 * takeReviewOutcomesForThread — model feedback
+	 * ------------------------------------------------------------------------*/
+
+	describe("takeReviewOutcomesForThread", () => {
+		it("reports resolved entries once and pending paths every time", async () => {
+			const file = makeTFile("a.md");
+			(plugin.app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(file);
+			(plugin.app.vault.read as ReturnType<typeof vi.fn>).mockResolvedValue("x");
+
+			const [acceptedId] = store.addChanges(
+				[{ type: "update", path: "a.md", originalContent: "x", newContent: "y" }],
+				"tc-1",
+				"thread-1",
+			);
+			const [rejectedId] = store.addChanges([{ type: "create", path: "b.md", content: "B" }], "tc-2", "thread-1");
+			store.addChanges([{ type: "create", path: "c.md", content: "C" }], "tc-3", "thread-1");
+			// Another thread's entry must not leak into this thread's report.
+			store.addChanges([{ type: "create", path: "d.md", content: "D" }], "tc-4", "thread-2");
+
+			await store.acceptChange(acceptedId);
+			store.rejectChange(rejectedId);
+
+			const first = store.takeReviewOutcomesForThread("thread-1");
+			expect(first.outcomes).toEqual([
+				{ path: "a.md", outcome: "accepted" },
+				{ path: "b.md", outcome: "rejected" },
+			]);
+			expect(first.pendingPaths).toEqual(["c.md"]);
+
+			// Resolved outcomes are delivered exactly once; pending repeats.
+			const second = store.takeReviewOutcomesForThread("thread-1");
+			expect(second.outcomes).toEqual([]);
+			expect(second.pendingPaths).toEqual(["c.md"]);
+		});
+
+		it("reports a group-resolved entry with applied text as partially applied", async () => {
+			const original = "line1\nline2\nline3\n";
+			const updated = "line1\nCHANGED\nline3\nADDED\n";
+			const file = makeTFile("note.md");
+			(plugin.app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(file);
+			(plugin.app.vault.read as ReturnType<typeof vi.fn>).mockResolvedValue(original);
+
+			const [id] = store.addChanges(
+				[{ type: "update", path: "note.md", originalContent: original, newContent: updated }],
+				"tc-1",
+				"thread-1",
+			);
+			await store.acceptChangeGroup(id, 0);
+			store.rejectChangeGroup(id, 0);
+			expect(store.getEntry(id)?.status).toBe("rejected");
+			expect(store.hasUnrevertedApplication(store.getEntry(id)!)).toBe(true);
+
+			const { outcomes } = store.takeReviewOutcomesForThread("thread-1");
+			expect(outcomes).toEqual([{ path: "note.md", outcome: "partially" }]);
+		});
+	});
+
+	/* --------------------------------------------------------------------------
+	 * load — orphaned-thread pruning
+	 * ------------------------------------------------------------------------*/
+
+	describe("load orphan pruning", () => {
+		/**
+		 * A `.chat` deleted outside the app (or while the plugin was unloaded) never
+		 * reaches `removeThread`. Its entries were invisible in every per-thread bar
+		 * yet still counted by `countOtherThreadsPendingUpdate` — a permanent
+		 * "another chat is editing this file" banner with no chat to resolve it from.
+		 */
+		it("drops entries whose chat file no longer exists", async () => {
+			const persisted = JSON.stringify([
+				{
+					id: "01a00000-0000-7000-8000-000000000001",
+					change: { type: "update", path: "note.md", originalContent: "a", newContent: "b" },
+					status: "pending",
+					toolCallId: "tc-1",
+					threadId: "Chats/alive.chat",
+					createdAt: 1,
+				},
+				{
+					id: "01a00000-0000-7000-8000-000000000002",
+					change: { type: "update", path: "note.md", originalContent: "a", newContent: "c" },
+					status: "pending",
+					toolCallId: "tc-2",
+					threadId: "Chats/gone.chat",
+					createdAt: 2,
+				},
+				{
+					// Non-.chat thread key (api staging path) — never existence-checked.
+					id: "01a00000-0000-7000-8000-000000000003",
+					change: { type: "create", path: "api.md", content: "X" },
+					status: "pending",
+					toolCallId: "tc-3",
+					threadId: "api-thread",
+					createdAt: 3,
+				},
+			]);
+			(plugin.app.vault.adapter.read as ReturnType<typeof vi.fn>).mockResolvedValue(persisted);
+			(plugin.app.vault.adapter.exists as ReturnType<typeof vi.fn>).mockImplementation(
+				async (path: string) => path !== "Chats/gone.chat",
+			);
+
+			await store.load();
+
+			expect(store.getPendingCount("Chats/alive.chat")).toBe(1);
+			expect(store.getPendingCount("Chats/gone.chat")).toBe(0);
+			expect(store.getPendingCount("api-thread")).toBe(1);
+			// The orphan no longer inflates cross-thread collision counts.
+			expect(store.countOtherThreadsPendingUpdate("note.md", "Chats/alive.chat")).toBe(0);
 		});
 	});
 


### PR DESCRIPTION
Makes staged note changes reviewable **without leaving the chat**, then closes the
loop around that review: the model learns what you decided, stale proposals are
surfaced instead of erroring, and destructive batches ask first.

## In-chat diff view

An `update` was the one pending change with no in-chat review surface — the bar
showed a path, and seeing what changed meant opening the note. On mobile that was
the only option at all (the hover page-preview is desktop-only). Pending update
rows now expand into a per-hunk word diff with per-hunk accept/reject, wired to
the store's existing group operations.

`identifyGroups` moved to `lib/diffGroups.ts`, shared with the inline editor
decorations — the grouping is load-bearing, since the hunk index shown in chat is
the `groupIndex` the store acts on.

## Closing the review loop

- **The model now learns outcomes.** Previously the tool result said "will be
  reviewed" and nothing ever followed up: reject everything, say "continue", and
  the model still believed its edits were live. Outcomes (accepted / rejected /
  partially applied, plus still-pending paths) are appended to the next user turn
  via the same augment/strip mechanism as visible notes, each reported once.
- **Re-staging rebases.** A follow-up edit in the same thread applies against the
  pending proposal's `newContent` — what the model remembers writing — so the
  superseding proposal carries both rounds instead of failing `oldText` matches.
- **Stale proposals are surfaced, not thrown.** A proposal whose note changed
  after staging can never be accepted, so every review surface (chat bar, in-chat
  hunks, edit-mode and reading-view bars) shows a badge and disables Accept with
  an explanation.
- **Tool-call linkage fixed.** Entries were keyed by `config.runId`, which
  LangChain deletes before the tool func runs — so it was always `undefined` and
  every batch fell through to a fresh UUID. Now keyed by the model's
  `config.toolCall.id`, which lets the chat card show live review-status chips.

## Store hardening

Delete accepts are conflict-checked against the staged snapshot (the preview
could show one version while trash took another); saves flush immediately after
vault writes (a crash mid-debounce resurrected applied entries as pending);
`rejectAll` gained `acceptAll`'s re-entrancy guard; orphaned entries whose `.chat`
file is gone are pruned on load (they were invisible but still drove the
cross-thread banner).

## Bug fix: reading view dropped a replacement's new text

All three section-attribution points applied the pure-insertion anchor heuristic
to every added diff part. For a replacement the line counter had already advanced
past the removed run, so the anchor landed on the line *after* it — meaning any
single-line heading edit showed the old text fully removed with the new text
missing, while the next section claimed a phantom card. Added regression tests.

## Perf

- Inline diff decorations no longer rebuild per keystroke (map + debounce to
  typing pauses) or per scroll frame (viewport refreshes dropped entirely) —
  previously two full-document `diffLines` passes each time.
- Stale checks are event-scoped: reads happen on thread change and for the one
  path a vault event names, not for every staged file on every store mutation.
- Chat hunks over 20k chars show a "review in the note" notice instead of
  word-diffing a whole-file rewrite into thousands of spans.

## UX

Composition summary ("2 updates, 1 delete pending"); Accept All confirms when the
batch contains deletes or deprivatizing moves, and skips stale entries; paths
render in the UI font without `.md`; delete/move rows link to the live note;
badges are tappable and keyboard-focusable (tooltips don't exist on touch);
mobile hit areas bumped to 28px.

Also included: a composer rework (flat surface, responsive action row) and a
correction to the privacy modal's path-visibility note, which claimed file names
are always visible to untrusted providers — they aren't, except via workspace
context blocks and links from non-private notes.

## Testing

- 1583/1583 unit tests pass; `bun run check` clean.
- Verified live in the S2B Test Vault: hunk rendering, stale badge appearing and
  clearing on external edit/revert, disabled accepts, decorations surviving
  scroll, and the reading-view attribution fix against the exact failing case.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._