### PR TITLE
fix(mobile): make settings render natively on phones

### DIFF
--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -2473,17 +2473,20 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
     align-items: center;
     gap: 10px;
     padding: 6px 8px 6px 14px;
-    /* Secondary background + native shadow token, so the bar reads as a floating
-       surface the way Obsidian's own popovers do rather than as a flat card that
-       tracks the canvas colour. */
-    background: var(--background-secondary);
+    /* Page fill + border, no shadow — the plugin's surface language after the
+       composer went flat: a surface is defined by its outline, not by
+       elevation. This bar previously used `--background-secondary` +
+       `--shadow-l` to read as a floating popover, which made it the one
+       shadowed slab left in the plugin. The bar is opaque, so separation from
+       the canvas behind it comes from the border alone, exactly like the
+       composer against the page. */
+    background: var(--background-primary);
     border: 1px solid var(--background-modifier-border);
     /* `--radius-l` (12px) rather than the composer's literal 22px: that 22px is
        half the composer's height — a pill — not a house rounding, and it only
        reads as one at that height. 12px is Obsidian's own value for floating
        panels, and being a token it tracks whatever the user's theme defines. */
     border-radius: var(--radius-l);
-    box-shadow: var(--shadow-l);
     z-index: 12;
     white-space: nowrap;
     animation: s2b-selection-bar-in 120ms ease-out;
@@ -2519,6 +2522,28 @@ function handleHoverPreview(event: MouseEvent, path: string, targetEl: HTMLEleme
     display: flex;
     align-items: center;
     gap: 4px;
+  }
+
+  /* Quiet toolbar buttons. Obsidian's stock `button` styling
+     (`--interactive-normal` fill + `--input-shadow`) is its FORM treatment —
+     Settings pages, dialogs — where each button is a standalone control on a
+     page. In a toolbar Obsidian's own convention is transparent-at-rest
+     controls that highlight on hover (view-header actions, search-view
+     toggles), and the composer's action row already treats its labelled
+     triggers the same way. With the bar itself flat, the stock fill also
+     re-imported the raised-slab look at button scale: several small
+     `--input-shadow`s inside a deliberately shadowless bar. The bar's border
+     and divider do the grouping; buttons need no individual fill to read as
+     actionable in a bar that only appears once something is selected.
+     (Scoped to the floating bar — the mobile selection sheet styles its own
+     rows.) */
+  .graph-selection-bar :global(button) {
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .graph-selection-bar :global(button:hover) {
+    background: var(--background-modifier-hover);
   }
 
   /* Separates the count and its view control from the verbs acting on the notes. */

--- a/src/components/modal/AgentEditorModal.svelte
+++ b/src/components/modal/AgentEditorModal.svelte
@@ -1300,6 +1300,22 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
     flex-shrink: 0;
   }
 
+  /* Phone: core stretches both `.setting-item-control` buttons and inputs toward
+     100%, which lets the icon trigger eat the row and crush the name input to its
+     min-content. Pin the trigger to its square and give the freed space back to
+     the input. `!important` because core's `.is-phone .modal .setting-item-control`
+     rules out-specify these single-class selectors. */
+  :global(.is-phone .modal .setting-item-control button.agent-icon-trigger) {
+    width: var(--input-height) !important;
+    flex: 0 0 auto !important;
+  }
+
+  :global(.is-phone .modal .setting-item-control input.agent-overview-name-input) {
+    flex: 1 1 auto !important;
+    width: auto !important;
+    min-width: 0;
+  }
+
   .agent-icon-trigger-preview {
     display: flex;
     align-items: center;
@@ -1409,6 +1425,13 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
   .mcp-empty-state {
     margin: 0;
     padding: 8px 0;
+  }
+
+  /* Phone: core insets `.setting-item` rows (incl. the section heading) by 16px
+     inside the group card, so the flush empty state reads outdented there. */
+  :global(.is-phone) .skill-empty-state,
+  :global(.is-phone) .mcp-empty-state {
+    padding: 8px 16px;
   }
   :global(.skill-entity),
   :global(.mcp-entity) {

--- a/src/components/modal/EmbeddingIndexSetupModal.svelte
+++ b/src/components/modal/EmbeddingIndexSetupModal.svelte
@@ -21,11 +21,15 @@ interface Props {
 	plugin: SecondBrainPlugin;
 	currentSelection: SelectedModel | null;
 	onSave: (selectedModel: SelectedModel, batchSize: number) => void;
+	/** Resolves true when an index was imported, false when cancelled or rejected.
+	 * Omitted when importing isn't available (desktop-only), which hides the row. */
+	onImport?: () => Promise<boolean>;
 }
 
-const { modal, plugin, currentSelection, onSave }: Props = $props();
+const { modal, plugin, currentSelection, onSave, onImport }: Props = $props();
 const availableModels = useAvailableModels();
 let selectedModel = $state<SelectedModel | null>(null);
+let isImporting = $state(false);
 
 $effect(() => {
 	if (!selectedModel && currentSelection) {
@@ -109,6 +113,27 @@ function handleSave() {
 	onSave(selectedModel, normalizeEmbeddingBatchSize(batchSize, selectedModel.provider));
 	modal.close();
 }
+
+// A successful import selects the imported index outright, so there is nothing
+// left to configure here and the modal closes. Cancelling the file dialog (or
+// picking a file that gets rejected — that reports itself through a notice) must
+// leave the modal open, so the user can still build an index instead.
+async function handleImport() {
+	if (!onImport || isImporting) {
+		return;
+	}
+
+	isImporting = true;
+	try {
+		if (await onImport()) {
+			modal.close();
+		}
+	} catch (importError) {
+		error = importError instanceof Error ? importError.message : String(importError);
+	} finally {
+		isImporting = false;
+	}
+}
 </script>
 
 <div class="embedding-index-setup-modal">
@@ -145,6 +170,20 @@ function handleSave() {
         }}
       />
     </SettingContainer>
+
+    {#if onImport}
+      <SettingContainer
+        name="Import Existing Index"
+        desc="Load an index exported from another vault instead of building one. Rebuilding is only needed if the export is outdated."
+      >
+        <Button
+          iconId="upload"
+          buttonText={isImporting ? "Importing…" : "Import"}
+          disabled={isImporting}
+          onClick={() => void handleImport()}
+        />
+      </SettingContainer>
+    {/if}
 
     {#if error}
       <div class="setting-item">

--- a/src/components/modal/EmbeddingIndexSetupModal.ts
+++ b/src/components/modal/EmbeddingIndexSetupModal.ts
@@ -10,6 +10,11 @@ export interface EmbeddingIndexSetupModalOptions {
 	purpose: "search" | "graph";
 	currentSelection: SelectedModel | null;
 	onSave: (selectedModel: SelectedModel, batchSize: number) => void;
+	/** Import an already-built index from a `.msgpack` export instead of building
+	 * one. Resolves true when an index was imported, false when the user cancelled
+	 * or the file was rejected. Omitted where importing isn't possible (it needs
+	 * Electron's file dialog and Node `fs`, so desktop only), which hides the row. */
+	onImport?: () => Promise<boolean>;
 }
 
 export class EmbeddingIndexSetupModal extends Modal {
@@ -47,6 +52,7 @@ export class EmbeddingIndexSetupModal extends Modal {
 				plugin: SecondBrainPlugin;
 				currentSelection: SelectedModel | null;
 				onSave: (selectedModel: SelectedModel, batchSize: number) => void;
+				onImport?: () => Promise<boolean>;
 			}>,
 			{
 				target: this.contentEl,
@@ -58,6 +64,7 @@ export class EmbeddingIndexSetupModal extends Modal {
 						plugin: this.plugin,
 						currentSelection: this.options.currentSelection,
 						onSave: this.options.onSave,
+						onImport: this.options.onImport,
 					},
 				},
 			},

--- a/src/components/modal/IndexingReportModal.ts
+++ b/src/components/modal/IndexingReportModal.ts
@@ -2,9 +2,11 @@ import { Modal } from "obsidian";
 import { mount, unmount } from "svelte";
 import type SecondBrainPlugin from "../../main";
 import IndexingReportModalComponent from "./IndexingReportModal.svelte";
+import { applyModalLayout } from "./modalLayout";
 
 export class IndexingReportModal extends Modal {
 	private component: ReturnType<typeof IndexingReportModalComponent> | null = null;
+	private restoreLayout: (() => void) | null = null;
 	private indexId: string;
 
 	constructor(plugin: SecondBrainPlugin, indexId: string) {
@@ -13,8 +15,11 @@ export class IndexingReportModal extends Modal {
 	}
 
 	onOpen() {
-		this.modalEl.style.width = "min(600px, 90vw)";
-		this.modalEl.style.maxWidth = "90vw";
+		this.restoreLayout = applyModalLayout(this, {
+			width: "min(600px, 90vw)",
+			maxWidth: "90vw",
+			contentFill: false,
+		});
 
 		this.setTitle("Indexing Report");
 
@@ -28,8 +33,8 @@ export class IndexingReportModal extends Modal {
 	}
 
 	onClose() {
-		this.modalEl.style.removeProperty("width");
-		this.modalEl.style.removeProperty("max-width");
+		this.restoreLayout?.();
+		this.restoreLayout = null;
 
 		if (this.component) {
 			unmount(this.component);

--- a/src/components/modal/MCPServerModal.svelte
+++ b/src/components/modal/MCPServerModal.svelte
@@ -521,6 +521,13 @@ async function handleTestConnection() {
     gap: 8px;
   }
 
+  /* Phone: core stacks `.modal-button-container` into a column; the row-oriented
+     `align-items: center` above would shrink each button to its label width.
+     Stretch restores the native full-width stacked footer buttons. */
+  :global(.is-phone) .mcp-actions {
+    align-items: stretch;
+  }
+
   /* Test Results Styles */
   .mcp-test-results {
     padding: 12px;

--- a/src/components/modal/MCPServerModal.ts
+++ b/src/components/modal/MCPServerModal.ts
@@ -3,6 +3,7 @@ import { mount, unmount } from "svelte";
 import type SecondBrainPlugin from "../../main";
 import type { MCPServerConfig } from "../../types/plugin";
 import MCPServerModalComponent from "./MCPServerModal.svelte";
+import { applyModalLayout } from "./modalLayout";
 
 /**
  * Callback signature for MCPServerModal
@@ -17,6 +18,7 @@ export interface MCPServerAccessors {
 
 export class MCPServerModal extends Modal {
 	private component: ReturnType<typeof MCPServerModalComponent> | null = null;
+	private restoreLayout: (() => void) | null = null;
 	private plugin: SecondBrainPlugin;
 	private serverId: string | null;
 	private existingConfig: MCPServerConfig | null;
@@ -46,20 +48,13 @@ export class MCPServerModal extends Modal {
 	}
 
 	onOpen() {
-		// Set modal dimensions
-		this.modalEl.style.width = "min(550px, 90vw)";
-		this.modalEl.style.maxWidth = "90vw";
-		this.modalEl.style.height = "auto";
-		this.modalEl.style.maxHeight = "85vh";
-		this.modalEl.style.display = "flex";
-		this.modalEl.style.flexDirection = "column";
-
-		// Make contentEl fill available space
-		this.contentEl.style.display = "flex";
-		this.contentEl.style.flexDirection = "column";
-		this.contentEl.style.flex = "1";
-		this.contentEl.style.minHeight = "0";
-		this.contentEl.style.overflow = "auto";
+		this.restoreLayout = applyModalLayout(this, {
+			width: "min(550px, 90vw)",
+			maxWidth: "90vw",
+			height: "auto",
+			maxHeight: "85vh",
+			contentOverflow: "auto",
+		});
 
 		this.component = mount(MCPServerModalComponent, {
 			target: this.contentEl,
@@ -75,18 +70,8 @@ export class MCPServerModal extends Modal {
 	}
 
 	onClose() {
-		this.modalEl.style.removeProperty("width");
-		this.modalEl.style.removeProperty("max-width");
-		this.modalEl.style.removeProperty("height");
-		this.modalEl.style.removeProperty("max-height");
-		this.modalEl.style.removeProperty("display");
-		this.modalEl.style.removeProperty("flex-direction");
-
-		this.contentEl.style.removeProperty("display");
-		this.contentEl.style.removeProperty("flex-direction");
-		this.contentEl.style.removeProperty("flex");
-		this.contentEl.style.removeProperty("min-height");
-		this.contentEl.style.removeProperty("overflow");
+		this.restoreLayout?.();
+		this.restoreLayout = null;
 
 		if (this.component) {
 			unmount(this.component);

--- a/src/components/modal/PrivacyListModal.ts
+++ b/src/components/modal/PrivacyListModal.ts
@@ -1,23 +1,20 @@
 import { Modal } from "obsidian";
 import { mount, unmount } from "svelte";
+import { applyModalLayout } from "./modalLayout";
 import PrivacyListComponent from "./PrivacyListModal.svelte";
 
 export class PrivacyListModal extends Modal {
 	private component: Record<string, never> | null = null;
+	private restoreLayout: (() => void) | null = null;
 
 	onOpen() {
 		this.setTitle("Manage Note Access Policy");
-		this.modalEl.style.width = "min(960px, 96vw)";
-		this.modalEl.style.maxWidth = "96vw";
-		this.modalEl.style.height = "min(840px, 92vh)";
-		this.modalEl.style.display = "flex";
-		this.modalEl.style.flexDirection = "column";
-
-		this.contentEl.style.display = "flex";
-		this.contentEl.style.flexDirection = "column";
-		this.contentEl.style.flex = "1";
-		this.contentEl.style.minHeight = "0";
-		this.contentEl.style.overflow = "hidden";
+		this.restoreLayout = applyModalLayout(this, {
+			width: "min(960px, 96vw)",
+			maxWidth: "96vw",
+			height: "min(840px, 92vh)",
+			contentOverflow: "hidden",
+		});
 
 		this.component = mount(PrivacyListComponent, {
 			target: this.contentEl,
@@ -28,17 +25,8 @@ export class PrivacyListModal extends Modal {
 	}
 
 	onClose() {
-		this.modalEl.style.removeProperty("width");
-		this.modalEl.style.removeProperty("max-width");
-		this.modalEl.style.removeProperty("height");
-		this.modalEl.style.removeProperty("display");
-		this.modalEl.style.removeProperty("flex-direction");
-
-		this.contentEl.style.removeProperty("display");
-		this.contentEl.style.removeProperty("flex-direction");
-		this.contentEl.style.removeProperty("flex");
-		this.contentEl.style.removeProperty("min-height");
-		this.contentEl.style.removeProperty("overflow");
+		this.restoreLayout?.();
+		this.restoreLayout = null;
 
 		if (this.component) {
 			unmount(this.component);

--- a/src/components/modal/ToolConfigModal.ts
+++ b/src/components/modal/ToolConfigModal.ts
@@ -2,6 +2,7 @@ import { Modal } from "obsidian";
 import { mount, unmount } from "svelte";
 import type SecondBrainPlugin from "../../main";
 import type { BuiltInToolId, ToolConfig } from "../../types/plugin";
+import { applyModalLayout } from "./modalLayout";
 import ToolConfigModalComponent from "./ToolConfigModal.svelte";
 
 /**
@@ -15,6 +16,7 @@ export interface ToolConfigAccessors {
 
 export class ToolConfigModal extends Modal {
 	private component: ReturnType<typeof ToolConfigModalComponent> | null = null;
+	private restoreLayout: (() => void) | null = null;
 	private plugin: SecondBrainPlugin;
 	private toolId: BuiltInToolId;
 	private onSave: () => void;
@@ -29,20 +31,13 @@ export class ToolConfigModal extends Modal {
 	}
 
 	onOpen() {
-		// Set modal dimensions
-		this.modalEl.style.width = "min(600px, 90vw)";
-		this.modalEl.style.maxWidth = "90vw";
-		this.modalEl.style.height = "auto";
-		this.modalEl.style.maxHeight = "80vh";
-		this.modalEl.style.display = "flex";
-		this.modalEl.style.flexDirection = "column";
-
-		// Make contentEl fill available space
-		this.contentEl.style.display = "flex";
-		this.contentEl.style.flexDirection = "column";
-		this.contentEl.style.flex = "1";
-		this.contentEl.style.minHeight = "0";
-		this.contentEl.style.overflow = "auto";
+		this.restoreLayout = applyModalLayout(this, {
+			width: "min(600px, 90vw)",
+			maxWidth: "90vw",
+			height: "auto",
+			maxHeight: "80vh",
+			contentOverflow: "auto",
+		});
 
 		this.component = mount(ToolConfigModalComponent, {
 			target: this.contentEl,
@@ -57,18 +52,8 @@ export class ToolConfigModal extends Modal {
 	}
 
 	onClose() {
-		this.modalEl.style.removeProperty("width");
-		this.modalEl.style.removeProperty("max-width");
-		this.modalEl.style.removeProperty("height");
-		this.modalEl.style.removeProperty("max-height");
-		this.modalEl.style.removeProperty("display");
-		this.modalEl.style.removeProperty("flex-direction");
-
-		this.contentEl.style.removeProperty("display");
-		this.contentEl.style.removeProperty("flex-direction");
-		this.contentEl.style.removeProperty("flex");
-		this.contentEl.style.removeProperty("min-height");
-		this.contentEl.style.removeProperty("overflow");
+		this.restoreLayout?.();
+		this.restoreLayout = null;
 
 		if (this.component) {
 			unmount(this.component);

--- a/src/components/modal/modalLayout.ts
+++ b/src/components/modal/modalLayout.ts
@@ -1,4 +1,4 @@
-import type { Modal } from "obsidian";
+import { type Modal, Platform } from "obsidian";
 
 interface ModalLayoutOptions {
 	width?: string;
@@ -13,12 +13,20 @@ interface ModalLayoutOptions {
 export function applyModalLayout(modal: Modal, options: ModalLayoutOptions): () => void {
 	const { width, maxWidth, height, maxHeight, contentPadding, contentOverflow, contentFill = true } = options;
 
-	const modalStyleMap = new Map<string, string | undefined>([
-		["width", width],
-		["max-width", maxWidth],
-		["height", height],
-		["max-height", maxHeight],
-	]);
+	// Phones get Obsidian's native full-screen modal sheet; forcing a desktop-ish
+	// width/height (e.g. `min(720px, 94vw)` × `90vh`) turns it into a floating box
+	// that neither fills the screen nor respects the keyboard inset. Only the
+	// content-level tweaks (fill/overflow/padding) apply there.
+	const sizeOverrides = Platform.isPhone
+		? []
+		: ([
+				["width", width],
+				["max-width", maxWidth],
+				["height", height],
+				["max-height", maxHeight],
+			] as const);
+
+	const modalStyleMap = new Map<string, string | undefined>(sizeOverrides);
 
 	for (const [property, value] of modalStyleMap) {
 		if (value === undefined) {

--- a/src/components/settings/EmbeddingIndexSection.svelte
+++ b/src/components/settings/EmbeddingIndexSection.svelte
@@ -96,6 +96,9 @@ function openAddIndexModal() {
 				getVectorStoreService().ensureIndex(`${selectedModel.provider}:${selectedModel.model}`);
 			}
 		},
+		// Import needs a native file dialog + node fs, so it's offered on desktop
+		// only; leaving it undefined hides the row rather than showing a dead control.
+		onImport: Platform.isDesktopApp ? importFromFile : undefined,
 	}).open();
 }
 
@@ -169,14 +172,20 @@ async function exportIndex(targetIndexId: string) {
 	await getVectorStoreService().exportIndex(targetIndexId);
 }
 
-async function importFromFile() {
-	if (!isVectorStoreInitialized()) return;
+/** Returns whether an index was actually imported: `importIndex` yields null both
+ * when the user cancels the file dialog and when the file is rejected (it reports
+ * why through its own notice), and callers need to distinguish "nothing happened"
+ * from "done" to decide whether to stay open. */
+async function importFromFile(): Promise<boolean> {
+	if (!isVectorStoreInitialized()) return false;
 	const service = getVectorStoreService();
 	const indexId = await service.importIndex(purpose);
 	if (indexId) {
 		const sep = indexId.indexOf(":");
 		pluginData.setEmbedIndex(purpose, indexId.slice(0, sep), indexId.slice(sep + 1));
+		return true;
 	}
+	return false;
 }
 
 function formatDate(timestamp: number | null): string {
@@ -203,34 +212,26 @@ function getSelectionGroupLabel(): string {
   hasItems={indexes.length > 0}
 >
   {#snippet actions()}
-    <div class="flex items-center gap-2 justify-end">
-      {#if indexProgress.isIndexing}
-        <div class="index-progress-summary">
-          <ProgressBar progress={indexProgress.percentage} />
-          <span>
-            {indexProgress.indexed}/{indexProgress.total}
-            {#if indexProgress.skipped > 0}
-              ({indexProgress.skipped} skipped)
-            {/if}
-            {#if indexProgress.etaMs !== null}
-              (~{formatEta(indexProgress.etaMs)} left)
-            {/if}
-          </span>
-        </div>
-        <Button buttonText="Cancel" onClick={cancelIndexing} />
-      {:else}
-        <!-- Index import uses a native file dialog + node fs; desktop only. -->
-        {#if Platform.isDesktopApp}
-        <Button
-          iconId="upload"
-          ariaLabel="Import index from file"
-          tooltip="Import index from file"
-          onClick={() => void importFromFile()}
-        />
-        {/if}
-        <Button buttonText="Add index" cta={true} onClick={openAddIndexModal} />
-      {/if}
-    </div>
+    {#if indexProgress.isIndexing}
+      <div class="index-progress-summary">
+        <ProgressBar progress={indexProgress.percentage} />
+        <span>
+          {indexProgress.indexed}/{indexProgress.total}
+          {#if indexProgress.skipped > 0}
+            ({indexProgress.skipped} skipped)
+          {/if}
+          {#if indexProgress.etaMs !== null}
+            (~{formatEta(indexProgress.etaMs)} left)
+          {/if}
+        </span>
+      </div>
+      <Button buttonText="Cancel" onClick={cancelIndexing} />
+    {:else}
+      <!-- Importing an existing index lives inside the setup modal, as the
+           alternative to building one — not as a bare icon competing with the
+           primary action here. -->
+      <Button buttonText="Add index" cta={true} onClick={openAddIndexModal} />
+    {/if}
   {/snippet}
 
   {#if indexes.length > 0}

--- a/src/components/settings/ManagedEntityItem.svelte
+++ b/src/components/settings/ManagedEntityItem.svelte
@@ -149,6 +149,42 @@ function handleRadioClick(event: MouseEvent) {
     border-radius: 14px;
   }
 
+  /* Mobile: Obsidian's core `.is-mobile .setting-item` stacks the control under
+     the info column — right for form rows with wide controls, wrong for these
+     list rows, whose actions are a compact icon cluster. Stacking them burns a
+     full row per item (name, then a lonely strip of icons). Keep the native
+     mobile list pattern instead: content left, accessories right. `!important`
+     mirrors -main's own flex-direction override below — core's `.is-mobile
+     .setting-item` rule outranks a single scoped class. */
+  :global(.is-mobile) .managed-entity-item {
+    flex-direction: row !important;
+    align-items: center;
+  }
+
+  /* Restored to a row, the info column must also get its grow back — core's
+     mobile stacking sizes `.setting-item-info` for a full-width layout, which
+     in a row collapses it to min-content (names wrap per word, badges drop to
+     their own line). */
+  :global(.is-mobile) .managed-entity-item .managed-entity-item-main {
+    flex: 1 1 auto !important;
+    min-width: 0;
+    width: auto;
+  }
+
+  /* Core's mobile stacking also stretches `.setting-item-control` full-width
+     with a top inset AND gives it `flex: 1 0 auto` — the grow is what actually
+     breaks the row layout (the icon cluster expands and squeezes the info column
+     to zero width, so names wrap per word). Undo all of it so the actions hug
+     the right edge at their natural size. */
+  :global(.is-mobile) .managed-entity-item .managed-entity-item-actions,
+  :global(.is-mobile) .managed-entity-item .managed-entity-item-trailing {
+    width: auto !important;
+    margin-top: 0;
+    padding-top: 0;
+    justify-content: flex-end;
+    flex: 0 0 auto !important;
+  }
+
   .managed-entity-item::before {
     content: "";
     position: absolute;

--- a/src/components/settings/ManagedEntitySection.svelte
+++ b/src/components/settings/ManagedEntitySection.svelte
@@ -88,6 +88,21 @@ const shouldRenderChildren = $derived(hasItems ?? !!children);
     display: flex;
     align-items: center;
     justify-content: flex-end;
+    gap: 8px;
+  }
+
+  /* Phone: core stretches a `.setting-item-control` button to `width: 100%`, but
+     that resolves against this wrapper — which, as a `justify-end` flex row, is
+     only as wide as its content. The button then "fills" ~92px and reads as a
+     stray pill rather than the native full-width action. Give the wrapper the
+     row's full width and let the button (the only flexible child; icon buttons
+     are `.clickable-icon` and stay fixed) take what's left. */
+  :global(.is-phone) .managed-entity-section-actions {
+    width: 100%;
+  }
+
+  :global(.is-phone) .managed-entity-section-actions :global(button:not(.clickable-icon)) {
+    flex: 1 1 auto;
   }
 
   .managed-entity-section-header {

--- a/src/components/settings/ModalField.svelte
+++ b/src/components/settings/ModalField.svelte
@@ -48,6 +48,14 @@ let { label, desc, for: forId, inline = false, class: className = "", children, 
     gap: 6px;
   }
 
+  /* Phone: `.setting-item` rows inside a setting-group card get `0 16px`
+     horizontal padding from core; a plain modal field has none, so its text
+     sits flush against the card edge when the two are mixed in one group.
+     Match the rows. */
+  :global(.is-phone .modal .setting-items) .modal-field {
+    padding: 0 16px;
+  }
+
   .modal-field--inline {
     flex-direction: row;
     align-items: center;

--- a/src/components/settings/SettingContainer.svelte
+++ b/src/components/settings/SettingContainer.svelte
@@ -30,7 +30,7 @@ const isRowDisabled = $derived(disabled || isDisabled);
 </script>
 
 <div
-  class="setting-item {isHeading ? 'setting-item-heading' : ''} {isRowDisabled
+  class="setting-item s2b-setting-item {isHeading ? 'setting-item-heading' : ''} {isRowDisabled
     ? 'opacity-50 pointer-events-none'
     : ''} {compact ? 'setting-item--compact' : ''} {className}"
 >
@@ -87,5 +87,33 @@ const isRowDisabled = $derived(disabled || isDisabled);
      the name always hints that there is something to reveal. */
   .setting-item--compact .setting-item-name {
     cursor: help;
+  }
+
+  /* Phone: core stacks a setting's control full-width under its info column
+     (`.is-phone .modal .setting-item:not(:is(.mod-toggle, …))`), which is right
+     for wide controls — inputs, selects, text buttons — but wrong for compact
+     ones: native rows built via Obsidian's Setting API keep toggles and small
+     actions inline on the right (the .mod-toggle/.mod-action exemptions).
+     Our rows take arbitrary snippets, so detect the compact case structurally
+     instead: every direct child of the control is a toggle or an icon button.
+     Global because the snippet-rendered children carry other components' scopes. */
+  :global(
+    .is-phone .modal .s2b-setting-item:has(.setting-item-control :is(.checkbox-container, .clickable-icon)):not(
+      :has(.setting-item-control :is(input:not([type="checkbox"]), select, textarea, .dropdown, button:not(.clickable-icon)))
+    )
+  ) {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  :global(
+    .is-phone .modal .s2b-setting-item:has(.setting-item-control :is(.checkbox-container, .clickable-icon)):not(
+      :has(.setting-item-control :is(input:not([type="checkbox"]), select, textarea, .dropdown, button:not(.clickable-icon)))
+    ) > .setting-item-control
+  ) {
+    width: auto;
+    flex: 0 0 auto;
+    margin-top: 0;
+    padding-top: 0;
   }
 </style>

--- a/src/components/ui/SlidingTabs.svelte
+++ b/src/components/ui/SlidingTabs.svelte
@@ -92,6 +92,10 @@ $effect(() => {
 		raf = requestAnimationFrame(tick);
 	};
 	raf = requestAnimationFrame(tick);
+	// When the strip scrolls horizontally (single-row mobile layout), keep the
+	// active tab fully visible. `nearest` makes this a no-op when it already is,
+	// so the wrapped desktop layout is unaffected.
+	triggerEls.get(value)?.scrollIntoView({ behavior: "smooth", inline: "nearest", block: "nearest" });
 	return () => cancelAnimationFrame(raf);
 });
 
@@ -177,6 +181,27 @@ function registerTrigger(node: HTMLElement, id: T) {
 	   it statically — must be :global. */
 	:global(.s2b-sliding-tabs) {
 		position: relative;
+	}
+
+	/* Phone: the strip wraps into 2–3 rows at ~390px and pushes the actual settings
+	   most of a screen down. Swap wrapping for a single scrollable row — the native
+	   mobile pattern for tab bars. The indicator already accounts for scrollLeft in
+	   measure(), so the pill tracks the active tab while the strip scrolls. */
+	:global(.is-mobile .s2b-sliding-tabs) {
+		flex-wrap: nowrap;
+		justify-content: flex-start;
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+		scrollbar-width: none;
+	}
+
+	:global(.is-mobile .s2b-sliding-tabs)::-webkit-scrollbar {
+		display: none;
+	}
+
+	:global(.is-mobile .s2b-sliding-tabs [data-tabs-trigger]) {
+		flex-shrink: 0;
+		white-space: nowrap;
 	}
 
 	/* Strip Obsidian's default <button> chrome so only the sliding accent pill shows

--- a/src/views/chat/Chat.svelte
+++ b/src/views/chat/Chat.svelte
@@ -99,17 +99,25 @@ function portalComposer(node: HTMLElement) {
 	// goes stale with the keyboard exactly like `.view-content`, but that no
 	// longer matters because the composer is positioned off `100vh`.
 	//
-	// Exception: with "Open new chat in" set to a sidebar, the phone chat leaf
-	// lives in a `.workspace-drawer` — a SIBLING of mod-root, painted over it.
-	// A composer portaled to mod-root then sits behind the open drawer (only its
-	// overflowing buttons peek out). Host it in the drawer instead: the drawer is
-	// `position: fixed` at the full viewport height, so the same 100vh-anchored
-	// positioning holds, and being a descendant inherits the drawer's own slide
-	// transform exactly like mod-root's.
-	const host =
+	// Exception: with "Open new chat in" set to a sidebar, the chat leaf lives in
+	// a `.workspace-drawer` — a SIBLING of mod-root, painted over it. (Both phones
+	// and tablets use drawers; `.mod-left-split`/`.mod-right-split` are the
+	// desktop-only shape.) A composer portaled to mod-root then sits behind the
+	// open drawer, or lands off-viewport entirely at the drawer's x-offset. Host
+	// it in the drawer instead: the drawer is `position: fixed` at the full
+	// viewport height, so the same 100vh-anchored positioning holds, and being a
+	// descendant inherits the drawer's own slide transform exactly like mod-root's.
+	//
+	// Resolved lazily, not once at mount: this action runs as soon as `.chat-root`
+	// exists, which can be BEFORE Obsidian has moved the leaf into the drawer (the
+	// composer itself is awaited via MutationObserver below, so `portal()` often
+	// runs a good deal later). Capturing the host up front therefore pinned
+	// drawer-docked chats to mod-root — the tablet symptom was a composer sitting
+	// at x=1366 on a 1366px-wide viewport, i.e. just off-screen.
+	const resolveHost = () =>
 		node.closest<HTMLElement>(".workspace-drawer") ??
 		document.querySelector<HTMLElement>(".workspace-split.mod-root");
-	if (!host) return {};
+	if (!resolveHost()) return {};
 
 	let composer: HTMLElement | null = null;
 	let home: HTMLElement | null = null;
@@ -117,6 +125,7 @@ function portalComposer(node: HTMLElement) {
 	let ro: ResizeObserver | null = null;
 	let leafObserver: MutationObserver | null = null;
 	let classObserver: MutationObserver | null = null;
+	let treeObserver: MutationObserver | null = null;
 
 	// Horizontal placement and height come from wherever the leaf actually is
 	// (main view, sidebar split, …), so measure rather than assume full width.
@@ -136,7 +145,10 @@ function portalComposer(node: HTMLElement) {
 	const publishGeometry = () => {
 		if (!composer) return;
 		const leaf = node.getBoundingClientRect();
-		const hostRect = host.getBoundingClientRect();
+		// The composer's ACTUAL parent, not a freshly resolved host: these two can
+		// disagree while a re-host is pending, and `left` is only transform-neutral
+		// when measured against the element the composer actually inherits from.
+		const hostRect = (composer.parentElement ?? node).getBoundingClientRect();
 		const height = composer.getBoundingClientRect().height;
 		composer.style.setProperty("--s2b-composer-left", `${Math.round(leaf.left - hostRect.left)}px`);
 		composer.style.setProperty("--s2b-composer-width", `${Math.round(leaf.width)}px`);
@@ -198,12 +210,26 @@ function portalComposer(node: HTMLElement) {
 		}
 	};
 
+	// Move the composer under whichever host currently owns the leaf. Called on
+	// first portal and again whenever the leaf is relocated (docking a chat into
+	// a drawer, or dragging it back out) — otherwise a chat that moves after mount
+	// keeps a host it no longer belongs to and the composer strands off-screen.
+	const rehost = () => {
+		if (!composer) return;
+		const currentHost = resolveHost();
+		if (!currentHost || composer.parentElement === currentHost) return;
+		currentHost.appendChild(composer);
+		publishGeometry();
+	};
+
 	const portal = (found: HTMLElement) => {
 		composer = found;
 		home = found.parentElement;
 		nextSibling = found.nextSibling;
+		(resolveHost() ?? node).appendChild(found);
+		// After the append, so the host-relative `left` is measured against the
+		// element the composer now actually inherits its transform from.
 		publishGeometry();
-		host.appendChild(found);
 		found.classList.add("s2b-composer-portaled");
 		// The composer grows and shrinks with its content (attachments,
 		// multi-line drafts), and the leaf moves when splits resize — both
@@ -213,10 +239,24 @@ function portalComposer(node: HTMLElement) {
 		ro.observe(node);
 		if (leafEl) {
 			syncActiveState();
-			leafObserver = new MutationObserver(syncActiveState);
+			leafObserver = new MutationObserver(() => {
+				syncActiveState();
+				// The leaf may have been moved into (or out of) a drawer, which
+				// changes which element should host the composer.
+				rehost();
+			});
 			// `style` as well as `class`: `syncActiveState` reads the leaf's
 			// computed `display`, which Obsidian can change either way.
 			leafObserver.observe(leafEl, { attributes: true, attributeFilter: ["class", "style"] });
+		}
+
+		// Relocating a leaf is a DOM move, not an attribute change, so the observer
+		// above never sees it. Watch the workspace subtree for structural changes
+		// and re-evaluate the host; `rehost` is a no-op when nothing moved.
+		const workspaceEl = document.querySelector<HTMLElement>(".workspace");
+		if (workspaceEl) {
+			treeObserver = new MutationObserver(rehost);
+			treeObserver.observe(workspaceEl, { childList: true, subtree: true });
 		}
 		classObserver = new MutationObserver(ensurePortaledClass);
 		classObserver.observe(found, { attributes: true, attributeFilter: ["class"] });
@@ -245,6 +285,7 @@ function portalComposer(node: HTMLElement) {
 			ro?.disconnect();
 			leafObserver?.disconnect();
 			classObserver?.disconnect();
+			treeObserver?.disconnect();
 			if (!composer) return;
 			composer.style.display = "";
 			composer.classList.remove("s2b-composer-portaled");

--- a/src/views/chat/Chat.svelte
+++ b/src/views/chat/Chat.svelte
@@ -98,7 +98,17 @@ function portalComposer(node: HTMLElement) {
 	// `overflow: visible`, so it is a usable containing block; its own height
 	// goes stale with the keyboard exactly like `.view-content`, but that no
 	// longer matters because the composer is positioned off `100vh`.
-	const host = document.querySelector<HTMLElement>(".workspace-split.mod-root");
+	//
+	// Exception: with "Open new chat in" set to a sidebar, the phone chat leaf
+	// lives in a `.workspace-drawer` — a SIBLING of mod-root, painted over it.
+	// A composer portaled to mod-root then sits behind the open drawer (only its
+	// overflowing buttons peek out). Host it in the drawer instead: the drawer is
+	// `position: fixed` at the full viewport height, so the same 100vh-anchored
+	// positioning holds, and being a descendant inherits the drawer's own slide
+	// transform exactly like mod-root's.
+	const host =
+		node.closest<HTMLElement>(".workspace-drawer") ??
+		document.querySelector<HTMLElement>(".workspace-split.mod-root");
 	if (!host) return {};
 
 	let composer: HTMLElement | null = null;

--- a/src/views/settings/AgentsSettings.svelte
+++ b/src/views/settings/AgentsSettings.svelte
@@ -119,9 +119,7 @@ function getAgentSkillsSummary(agentId: string): { icons: string[]; overflow: nu
     hasItems={agentIds.length > 0}
   >
     {#snippet actions()}
-      <div class="flex items-center justify-end">
-        <Button buttonText="Add agent" cta={true} onClick={createNewAgent} />
-      </div>
+      <Button buttonText="Add agent" cta={true} onClick={createNewAgent} />
     {/snippet}
 
     {#each agentIds as agentId (agentId)}

--- a/src/views/settings/GeneralSettings.svelte
+++ b/src/views/settings/GeneralSettings.svelte
@@ -31,9 +31,7 @@ function handleOpenProviderSetup() {
   hasItems={configuredProviderIds.length > 0}
 >
   {#snippet actions()}
-    <div class="flex items-center justify-end w-full">
-      <Button buttonText="Add provider" cta={true} onClick={handleOpenProviderSetup} />
-    </div>
+    <Button buttonText="Add provider" cta={true} onClick={handleOpenProviderSetup} />
   {/snippet}
 
   {#if configuredProviderIds.length > 0}


### PR DESCRIPTION
Walks every settings surface on a phone-emulated vault and fixes what didn't render like native Obsidian. Most of these are the same root cause wearing different hats: core's phone CSS reshapes `.setting-item` layouts based on classes Obsidian's own `Setting` API adds, which our Svelte-rendered rows never get.

## What was broken

**Tab strip wrapped into 2–3 rows** at ~390px, pushing the actual settings most of a screen down. Now a single scrollable row, the native pattern, with the active tab scrolled into view.

**List rows collapsed to one word per line.** Provider/index/agent names wrapped as `SAP` / `HAI` because core gives `.setting-item-control` `flex: 1 0 auto` on phones — the *grow*, not the width, squeezed the info column to zero. An earlier pass had reset `width` but not the grow.

**Toggles and icon buttons stacked below their descriptions.** Core stacks controls full-width but exempts `.mod-toggle`/`.mod-action`; our rows don't carry those. Now detected structurally — a row stays horizontal when its control holds only toggles and `.clickable-icon` buttons, while text buttons, inputs and selects still stack as core intends.

**Modals rendered as floating desktop boxes** instead of native full-screen sheets, because we forced `min(720px, 94vw)` × `90vh`. Size overrides are now skipped on phones. Four modals hand-rolled the same sizing instead of using `applyModalLayout`, so they'd have missed the guard — migrated, dropping ~50 lines of duplicated teardown.

**Agent editor's Name field was invisible** — the icon-picker stretched to ~295px and crushed the input to its 32px min-content.

**"Add agent" and "Add index" rendered as stray half-width pills** while "Add provider" filled the row: core's `width: 100%` resolved against `justify-end` wrappers that had shrink-wrapped to 92px and 136px. Only "Add provider" happened to carry `w-full`. Fixed centrally in `ManagedEntitySection`, which already owns an actions wrapper — the three per-call-site wrappers were duplicating it and are gone.

## Chat in the mobile drawer

"Open new chat in: left/right sidebar" turned out to already work on phones — leaves land in the drawer with no extra API (same approach as [obsidian-mobile-sidebar-notes](https://github.com/ckep1/obsidian-mobile-sidebar-notes)). The one breakage was the composer: `portalComposer` re-parents it to `.workspace-split.mod-root` to escape the leaf's stale box, and phone drawers are *siblings* of that element, painted over it — so the composer sat behind the open drawer with only its buttons peeking out.

It now prefers the leaf's enclosing `.workspace-drawer`. Everything else transfers unchanged: the drawer is `position: fixed` at full viewport height so the 100vh keyboard formula holds, and being a descendant inherits the drawer's slide transform for free.

**Tablets use the same drawers** — `.mod-left-split`/`.mod-right-split` are the desktop shape, which this code never sees (it early-returns on `isMobileUI`). So the selector was already right, but the *timing* wasn't: the host was resolved once at action-mount, which can be before Obsidian has moved the leaf into the drawer (and `portal()` runs later still, waiting on a MutationObserver for the composer). Drawer-docked chats therefore captured mod-root and kept it — on tablet the composer landed at x=1366 on a 1366px viewport, exactly one viewport off-screen. The phone case was passing on timing luck.

The host is now resolved lazily at portal time and re-evaluated when the leaf moves between drawer and main area (relocation is a DOM move, not an attribute change, so the existing leaf observer never saw it). Geometry is measured against the composer's actual parent rather than a re-resolved host, since the two can disagree mid-rehost.

## Index import moved into the modal

The upload icon sat in the section header as a bare glyph next to the primary "Add index" action — a rare, recovery-shaped action given equal billing with the common one, with its meaning only in a tooltip that touch devices never surface. It's now a labelled row inside the setup modal, where it reads as what it is: the alternative to building an index. The modal stays presentational (import arrives as an optional `onImport`), so omitting it — desktop-only gate, and the "Re-index" notice path — simply hides the row.

`importFromFile` now reports whether an index actually landed, since `importIndex` returns null both on cancel and on a rejected file and the modal must stay open in either case.

## Testing

`bun run check` clean, 1588 unit tests pass. Every surface screenshotted before/after in a phone-emulated vault: all five settings tabs, the agent editor, tools, model picker, add-skill, MCP, privacy list + filter builder, provider setup, search display, indexing report, and the drawer chat (including collapse/expand and a main-area regression check).

Also verified in **tablet** emulation: composer docks in the drawer at x=916 (on-screen, was x=1366 off-screen), survives collapse/expand, and a chat moved out to the main area re-hosts to mod-root while a second drawer chat keeps its own host.

**Not verified, worth a manual pass:**
- Composer with a *real* keyboard in the drawer — the emulator can't raise one. The formula is viewport-anchored so it should hold, but this machinery has bitten us before.
- The actual import file-picker flow, which opens Electron's native dialog the CLI can't drive. Wiring and both close/stay-open branches are type-checked and the UI renders.

## Other mobile gaps noted, not addressed

- Pill buttons (`--interactive-normal`) are nearly invisible against grey group cards in Cupertino — affects desktop too.
- Long modal titles clip under the round close button ("Configure Search Embedding Inde…").
- Known core gap: base modals ignore `--keyboard-height`.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._