### PR TITLE
feat(notes): let the agent retract its own pending proposals

### DIFF
--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -392,6 +392,57 @@ function summarizeOperations(changes: PendingChange[]): string {
 }
 
 /**
+ * The entry paths a `discard` should target, given the reference the model wrote.
+ *
+ * A discard names a PROPOSAL, not a file, so it must resolve against the entries
+ * rather than the vault. Three cases the vault alone cannot serve:
+ *
+ *   - the note was renamed after staging (`#handleFileRename` re-keys the entry
+ *     to the new path, so the old path the model remembers no longer resolves);
+ *   - the proposal is a delete for a note that is already gone; and
+ *   - the model used a wiki-link, which normalizes to a bare basename that never
+ *     equals the canonical `Notes/todo.md` an entry is keyed by.
+ *
+ * Resolution order is strict-to-loose, and stops at the first tier that hits so
+ * a loose match can never override an exact one:
+ *
+ *   1. the vault-resolved canonical path, when the file still exists;
+ *   2. an entry whose path equals the normalized reference exactly;
+ *   3. entries whose basename matches, with or without the `.md` the model may
+ *      have omitted — the wiki-link and renamed-note cases.
+ *
+ * Tier 3 can legitimately return several paths (two pending proposals for
+ * same-named notes in different folders). Both are this thread's own proposals
+ * and the model asked to withdraw that name, so both are withdrawn and each is
+ * reported by full path — silently picking one would leave the other stuck.
+ * Returns the reference itself when nothing matches, so the caller still reports
+ * an honest "nothing to withdraw" against the name the model used.
+ */
+function resolveDiscardTargets(
+	pending: { change: { path: string } }[],
+	cleanPath: string,
+	vaultResolvedPath: string | undefined,
+): string[] {
+	if (vaultResolvedPath) return [vaultResolvedPath];
+
+	const normalized = normalizePath(cleanPath);
+	if (pending.some((entry) => entry.change.path === normalized)) return [normalized];
+
+	// Basename comparison, tolerating a missing `.md` on the model's reference.
+	const wanted = normalized.split("/").pop() ?? normalized;
+	const wantedWithExt = wanted.endsWith(".md") ? wanted : `${wanted}.md`;
+	const byBasename = [
+		...new Set(
+			pending
+				.map((entry) => entry.change.path)
+				.filter((path) => (path.split("/").pop() ?? path) === wantedWithExt),
+		),
+	];
+
+	return byBasename.length > 0 ? byBasename : [normalized];
+}
+
+/**
  * Phrase the outcome of this batch's `discard` operations for the model.
  *
  * A discard that matched nothing is reported plainly rather than as an error:
@@ -607,16 +658,27 @@ export async function stageNoteOperations(
 			// path in a single batch is the natural correction idiom, and the
 			// update branch still guards against a *second* update to that path.
 			//
-			// Resolved leniently: unlike update/delete/move this never touches the
-			// file, so a note that has since been renamed or deleted must still be
-			// discardable. Fall back to the literal normalized path when the
-			// vault can't resolve it, since that is what the entry is keyed by.
+			// Resolved against the THREAD'S OWN PENDING ENTRIES, not just the vault.
+			// Unlike update/delete/move this never touches the file, so the note may
+			// legitimately be gone: renamed after staging, or a proposal to delete a
+			// note that has since been removed. Vault resolution alone fails there,
+			// and falling back to the literal input is worse than useless — a
+			// wiki-link (`[[todo]]`) normalizes to a bare basename that can never
+			// equal the canonical `Notes/todo.md` an entry is keyed by, so the
+			// discard would silently match nothing and wrongly report that there was
+			// nothing to withdraw. Matching entry paths by basename closes both gaps.
 			const cleanPath = normalizeReferencePath(operation.path);
 			const resolved = resolveVaultFileDetailed(app, cleanPath);
-			const targetPath = resolved.status === "found" ? resolved.file.path : normalizePath(cleanPath);
+			const targetPaths = resolveDiscardTargets(
+				store.getPendingForThread(threadId),
+				cleanPath,
+				resolved.status === "found" ? resolved.file.path : undefined,
+			);
 
-			const { discarded, skippedApplied } = store.discardPendingForPath(targetPath, threadId);
-			discardResults.push({ path: targetPath, discarded, skippedApplied });
+			for (const targetPath of targetPaths) {
+				const { discarded, skippedApplied } = store.discardPendingForPath(targetPath, threadId);
+				discardResults.push({ path: targetPath, discarded, skippedApplied });
+			}
 			continue;
 		}
 

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -398,7 +398,8 @@ function summarizeOperations(changes: PendingChange[]): string {
  * rather than the vault. Three cases the vault alone cannot serve:
  *
  *   - the note was renamed after staging (`#handleFileRename` re-keys the entry
- *     to the new path, so the old path the model remembers no longer resolves);
+ *     to the new path, so the old path the model remembers no longer resolves —
+ *     which is why that handler records the path it leaves in `formerPaths`);
  *   - the proposal is a delete for a note that is already gone; and
  *   - the model used a wiki-link, which normalizes to a bare basename that never
  *     equals the canonical `Notes/todo.md` an entry is keyed by.
@@ -408,18 +409,24 @@ function summarizeOperations(changes: PendingChange[]): string {
  *
  *   1. the vault-resolved canonical path, when the file still exists;
  *   2. an entry whose path equals the normalized reference exactly;
- *   3. entries whose basename matches, with or without the `.md` the model may
- *      have omitted — the wiki-link and renamed-note cases.
+ *   3. an entry one of whose `formerPaths` equals it — the note was renamed
+ *      after staging, and the model still knows it by the name it was staged
+ *      under. This is an EXACT match on a path the entry genuinely had, so it
+ *      precedes the basename tier: a rename that also changes the basename
+ *      (`Notes/doc.md` -> `Notes/renamed.md`) is unreachable by name alone;
+ *   4. entries whose basename matches, with or without the `.md` the model may
+ *      have omitted — the wiki-link case, and renames that kept the basename
+ *      but predate `formerPaths` being recorded.
  *
- * Tier 3 can legitimately return several paths (two pending proposals for
- * same-named notes in different folders). Both are this thread's own proposals
- * and the model asked to withdraw that name, so both are withdrawn and each is
- * reported by full path — silently picking one would leave the other stuck.
+ * Tiers 3 and 4 can legitimately return several paths (two pending proposals for
+ * same-named notes in different folders). All are this thread's own proposals
+ * and the model asked to withdraw that name, so all are withdrawn and each is
+ * reported by full path — silently picking one would leave the others stuck.
  * Returns the reference itself when nothing matches, so the caller still reports
  * an honest "nothing to withdraw" against the name the model used.
  */
 function resolveDiscardTargets(
-	pending: { change: { path: string } }[],
+	pending: { change: { path: string }; formerPaths?: string[] }[],
 	cleanPath: string,
 	vaultResolvedPath: string | undefined,
 ): string[] {
@@ -428,18 +435,21 @@ function resolveDiscardTargets(
 	const normalized = normalizePath(cleanPath);
 	if (pending.some((entry) => entry.change.path === normalized)) return [normalized];
 
+	const dedupePaths = (entries: typeof pending) => [...new Set(entries.map((entry) => entry.change.path))];
+
+	// The note was renamed after staging; match the name it was staged under.
+	const byFormerPath = pending.filter((entry) => entry.formerPaths?.includes(normalized));
+	if (byFormerPath.length > 0) return dedupePaths(byFormerPath);
+
 	// Basename comparison, tolerating a missing `.md` on the model's reference.
 	const wanted = normalized.split("/").pop() ?? normalized;
 	const wantedWithExt = wanted.endsWith(".md") ? wanted : `${wanted}.md`;
-	const byBasename = [
-		...new Set(
-			pending
-				.map((entry) => entry.change.path)
-				.filter((path) => (path.split("/").pop() ?? path) === wantedWithExt),
-		),
-	];
+	const byBasename = pending.filter((entry) => {
+		const path = entry.change.path;
+		return (path.split("/").pop() ?? path) === wantedWithExt;
+	});
 
-	return byBasename.length > 0 ? byBasename : [normalized];
+	return byBasename.length > 0 ? dedupePaths(byBasename) : [normalized];
 }
 
 /**

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -49,10 +49,10 @@ const updateOperationSchema = z.object({
 
 const discardOperationSchema = z.object({
 	type: z.literal("discard"),
-	path: z
+	id: z
 		.string()
 		.describe(
-			"File path or wiki link reference whose pending (not yet reviewed) proposals from this chat should be withdrawn, e.g. 'Notes/todo.md' or '[[todo]]'",
+			"The id of the pending proposal to withdraw, exactly as given when it was staged (or in the status block listing changes awaiting review). Not a file path — one path can name more than one proposal. Never guess an id.",
 		),
 });
 
@@ -391,136 +391,49 @@ function summarizeOperations(changes: PendingChange[]): string {
 		.join(", ");
 }
 
-/**
- * The entry paths a `discard` should target, given the reference the model wrote.
- *
- * A discard names a PROPOSAL, not a file, so it must resolve against the entries
- * rather than the vault. Three cases the vault alone cannot serve:
- *
- *   - the note was renamed after staging (`#handleFileRename` re-keys the entry
- *     to the new path, so the old path the model remembers no longer resolves —
- *     which is why that handler records the path it leaves in `formerPaths`);
- *   - the proposal is a delete for a note that is already gone; and
- *   - the model used a wiki-link, which normalizes to a bare basename that never
- *     equals the canonical `Notes/todo.md` an entry is keyed by.
- *
- * Resolution is strict-to-loose, stopping at the first tier that hits so a loose
- * match can never override an exact one:
- *
- *   1. proposals living AT the name — an entry whose path equals the reference,
- *      or equals what the vault resolves the reference to. Both answer "which
- *      proposal is at this name now" and are merged;
- *   2. a proposal one of whose `formerPaths` equals it — the note was renamed
- *      after staging and the model still knows it by the name it was staged
- *      under. An exact match on a path the entry genuinely had, so it beats the
- *      basename tier: a rename that also changes the basename
- *      (`Notes/doc.md` -> `Notes/renamed.md`) is unreachable by name alone;
- *   3. proposals whose basename matches, with or without the `.md` the model may
- *      have omitted — the wiki-link case, and renames that kept the basename but
- *      predate `formerPaths` being recorded.
- *
- * A tier may legitimately return several paths (two pending proposals for
- * same-named notes in different folders). All are this thread's own proposals and
- * the model asked to withdraw that name, so all are withdrawn and each is
- * reported by full path — silently picking one would leave the others stuck.
- *
- * But when tiers 1 and 2 hit DIFFERENT proposals the name is genuinely ambiguous:
- * it belongs to one note now and belonged to another when that one was staged,
- * and both have live proposals. Nothing in the reference resolves that, and any
- * ranking silently withdraws a proposal the model did not ask about while leaving
- * the one it did. That case returns `ambiguous` so the caller can ask the model
- * to name a path, mirroring `validateExistingMarkdownFile`'s ambiguous branch.
- *
- * Returns the reference itself when nothing matches, so the caller still reports
- * an honest "nothing to withdraw" against the name the model used.
- */
-function resolveDiscardTargets(
-	pending: { change: { path: string }; formerPaths?: string[] }[],
-	cleanPath: string,
-	vaultResolvedPath: string | undefined,
-): { paths: string[] } | { ambiguous: string[] } {
-	const normalized = normalizePath(cleanPath);
-	const dedupePaths = (entries: typeof pending) => [...new Set(entries.map((entry) => entry.change.path))];
-
-	// Tier 1 and tier 2 both name a path a proposal LIVES at. Tier 1 is the
-	// vault's answer to "what file is at this name now"; tier 2 is an entry
-	// sitting at the reference as written. They can only disagree when the
-	// reference is a basename or wiki-link, and either way the union is what the
-	// model named.
-	const atPath = pending.filter(
-		(entry) => entry.change.path === normalized || (!!vaultResolvedPath && entry.change.path === vaultResolvedPath),
-	);
-
-	// A proposal staged under this name before its note was renamed away.
-	const byFormerPath = pending.filter((entry) => entry.formerPaths?.includes(normalized));
-
-	// Both tiers hit on DIFFERENT proposals: the name now belongs to one note and
-	// used to belong to another, and both have live proposals. Nothing in the
-	// reference says which the model meant, and picking either silently withdraws
-	// a proposal it did not ask about while leaving the one it did. Ask instead —
-	// same resolution as `validateExistingMarkdownFile`'s ambiguous branch.
-	if (atPath.length > 0 && byFormerPath.length > 0) {
-		const candidates = [...new Set([...dedupePaths(atPath), ...dedupePaths(byFormerPath)])];
-		if (candidates.length > 1) return { ambiguous: candidates };
-	}
-
-	if (atPath.length > 0) return { paths: dedupePaths(atPath) };
-	if (byFormerPath.length > 0) return { paths: dedupePaths(byFormerPath) };
-
-	// Basename comparison, tolerating a missing `.md` on the model's reference.
-	// Reached only when nothing matched by path, so there is no live proposal at
-	// this name to confuse it with — the wiki-link case, and renames that kept
-	// the basename but predate `formerPaths` being recorded.
-	const wanted = normalized.split("/").pop() ?? normalized;
-	const wantedWithExt = wanted.endsWith(".md") ? wanted : `${wanted}.md`;
-	const byBasename = pending.filter((entry) => {
-		const path = entry.change.path;
-		return (path.split("/").pop() ?? path) === wantedWithExt;
-	});
-
-	if (byBasename.length > 0) return { paths: dedupePaths(byBasename) };
-
-	// Nothing matched. Report against the canonical path when the vault knows
-	// one, so the "nothing to withdraw" names the real file rather than a bare
-	// wiki-link basename; otherwise echo the model's own reference.
-	return { paths: [vaultResolvedPath ?? normalized] };
+/** One `discard` operation's outcome, for `summarizeDiscards`. */
+interface DiscardResult {
+	id: string;
+	/** The proposal's path, when the id matched one. */
+	path?: string;
+	outcome: "discarded" | "not_found" | "partially_applied";
 }
 
 /**
  * Phrase the outcome of this batch's `discard` operations for the model.
  *
- * A discard that matched nothing is reported plainly rather than as an error:
- * the proposal may already have been reviewed, and treating "nothing to withdraw"
- * as a failure would punish the safe habit of discarding before re-staging. But
- * it must not read as a success either, or the model will tell the user it took
- * back something that is still pending — or already applied.
+ * An id that matched nothing is reported plainly rather than as an error: the
+ * proposal may already have been reviewed, and treating that as a failure would
+ * punish the safe habit of discarding before re-staging. But it must not read as
+ * a success either, or the model will tell the user it took back something that
+ * is still pending — or already applied.
  */
-function summarizeDiscards(results: { path: string; discarded: number; skippedApplied: number }[]): string {
+function summarizeDiscards(results: DiscardResult[]): string {
 	if (results.length === 0) return "";
 
 	const parts: string[] = [];
-	const withdrawn = results.filter((r) => r.discarded > 0);
+
+	const withdrawn = results.filter((r) => r.outcome === "discarded");
 	if (withdrawn.length > 0) {
-		const total = withdrawn.reduce((sum, r) => sum + r.discarded, 0);
 		const paths = withdrawn.map((r) => `"${r.path}"`).join(", ");
 		parts.push(
-			`Withdrew ${total} pending proposal(s) for ${paths} — they are no longer awaiting review and will not be applied.`,
+			`Withdrew ${withdrawn.length} pending proposal(s) — ${paths} are no longer awaiting review and will not be applied.`,
 		);
 	}
 
-	const empty = results.filter((r) => r.discarded === 0 && r.skippedApplied === 0);
-	if (empty.length > 0) {
-		const paths = empty.map((r) => `"${r.path}"`).join(", ");
+	const missing = results.filter((r) => r.outcome === "not_found");
+	if (missing.length > 0) {
+		const ids = missing.map((r) => `"${r.id}"`).join(", ");
 		parts.push(
-			`Nothing to withdraw for ${paths} — this chat had no pending proposals there (they may already have been accepted or rejected). Do not tell the user you took anything back.`,
+			`No pending proposal in this chat with id ${ids} — it may already have been accepted or rejected, or the id may be wrong. Nothing was withdrawn; do not tell the user you took anything back.`,
 		);
 	}
 
-	const skipped = results.filter((r) => r.skippedApplied > 0);
-	if (skipped.length > 0) {
-		const paths = skipped.map((r) => `"${r.path}"`).join(", ");
+	const applied = results.filter((r) => r.outcome === "partially_applied");
+	if (applied.length > 0) {
+		const paths = applied.map((r) => `"${r.path}"`).join(", ");
 		parts.push(
-			`Could not withdraw ${skipped.reduce((sum, r) => sum + r.skippedApplied, 0)} proposal(s) for ${paths}: the user already accepted part of those changes, so that content is in the note. Leave it to them to undo.`,
+			`Could not withdraw ${applied.length} proposal(s) for ${paths}: the user already accepted part of those changes, so that content is in the note. Leave it to them to undo.`,
 		);
 	}
 
@@ -607,7 +520,7 @@ export async function stageNoteOperations(
 	// Outcome of each `discard` operation. Tracked separately from `stagedChanges`
 	// because a discard stages nothing — it withdraws — so it must not be counted
 	// in the "Proposed N operation(s)" tally the user's review surfaces reflect.
-	const discardResults: { path: string; discarded: number; skippedApplied: number }[] = [];
+	const discardResults: DiscardResult[] = [];
 
 	for (let i = 0; i < operations.length; i++) {
 		const operation = operations[i];
@@ -698,36 +611,20 @@ export async function stageNoteOperations(
 			// one. Gating it on `allowUpdate` would let a permission change
 			// strand proposals the agent is otherwise able to clean up.
 			//
-			// Also exempt from `ensureUniqueTarget`: `discard` + `update` on one
-			// path in a single batch is the natural correction idiom, and the
-			// update branch still guards against a *second* update to that path.
+			// Also exempt from `ensureUniqueTarget`, which keys on paths: a discard
+			// names an id, and `discard` + `update` touching one note in a single
+			// batch is the natural correction idiom. The update branch still guards
+			// against a *second* update to that path.
 			//
-			// Resolved against the THREAD'S OWN PENDING ENTRIES, not just the vault.
-			// Unlike update/delete/move this never touches the file, so the note may
-			// legitimately be gone: renamed after staging, or a proposal to delete a
-			// note that has since been removed. Vault resolution alone fails there,
-			// and falling back to the literal input is worse than useless — a
-			// wiki-link (`[[todo]]`) normalizes to a bare basename that can never
-			// equal the canonical `Notes/todo.md` an entry is keyed by, so the
-			// discard would silently match nothing and wrongly report that there was
-			// nothing to withdraw. Matching entry paths by basename closes both gaps.
-			const cleanPath = normalizeReferencePath(operation.path);
-			const resolved = resolveVaultFileDetailed(app, cleanPath);
-			const discardTargets = resolveDiscardTargets(
-				store.getPendingForThread(threadId),
-				cleanPath,
-				resolved.status === "found" ? resolved.file.path : undefined,
-			);
-
-			if ("ambiguous" in discardTargets) {
-				const candidatesList = discardTargets.ambiguous.map((candidate) => `- ${candidate}`).join("\n");
-				return `Error in operation ${operationNumber}: "${operation.path}" matches more than one pending proposal — it names one note now and named another when that one was staged. Re-run the discard with the full path of the one you mean. Candidates:\n${candidatesList}`;
-			}
-
-			for (const targetPath of discardTargets.paths) {
-				const { discarded, skippedApplied } = store.discardPendingForPath(targetPath, threadId);
-				discardResults.push({ path: targetPath, discarded, skippedApplied });
-			}
+			// Identified by id, never by path. A path is a mutable label — it moves
+			// with a rename, can be reused by a different note, and can name two
+			// proposals at once (one staged before a rename, one after). Resolving
+			// a proposal from a name went through four rounds of tie-breaking rules
+			// and still had a case where any choice was wrong. An id has no such
+			// case, so the lookup is exact and there is nothing left to rank.
+			const path = store.getPendingByShortId(operation.id, threadId)?.change.path;
+			const outcome = store.discardPendingById(operation.id, threadId);
+			discardResults.push({ id: operation.id, path, outcome });
 			continue;
 		}
 
@@ -963,6 +860,17 @@ export async function stageNoteOperations(
 		}
 		if (stagedCount > 0) {
 			summary += ` ${stagedCount} will be reviewed by the user, who will approve or reject them.`;
+			// The ids are what makes a proposal retractable later: `discard` takes
+			// one, and the model cannot name a proposal any other way. Listed here
+			// and re-listed in every turn's review-status block, so an id stays
+			// recoverable even once this tool result falls out of context.
+			const staged = (entryIds ?? [])
+				.map((entryId) => store.getEntry(entryId))
+				.filter((entry) => entry?.status === "pending" && entry.shortId)
+				.map((entry) => `- "${entry?.change.path}" (id: ${entry?.shortId})`);
+			if (staged.length > 0) {
+				summary += ` Awaiting review — use these ids with a \`discard\` operation to withdraw one:\n${staged.join("\n")}`;
+			}
 		}
 		if (discardSummary) summary += ` ${discardSummary}`;
 	}

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -407,7 +407,10 @@ function summarizeOperations(changes: PendingChange[]): string {
  * Resolution order is strict-to-loose, and stops at the first tier that hits so
  * a loose match can never override an exact one:
  *
- *   1. the vault-resolved canonical path, when the file still exists;
+ *   1. the vault-resolved canonical path — but ONLY when a pending entry sits at
+ *      it. The vault answers "what file is at this name now", which diverges
+ *      from "which proposal did the model mean" as soon as a note is renamed
+ *      away and something else takes its old path;
  *   2. an entry whose path equals the normalized reference exactly;
  *   3. an entry one of whose `formerPaths` equals it — the note was renamed
  *      after staging, and the model still knows it by the name it was staged
@@ -430,12 +433,21 @@ function resolveDiscardTargets(
 	cleanPath: string,
 	vaultResolvedPath: string | undefined,
 ): string[] {
-	if (vaultResolvedPath) return [vaultResolvedPath];
-
 	const normalized = normalizePath(cleanPath);
-	if (pending.some((entry) => entry.change.path === normalized)) return [normalized];
-
 	const dedupePaths = (entries: typeof pending) => [...new Set(entries.map((entry) => entry.change.path))];
+
+	// Tier 1 only wins when it names a proposal this thread actually has.
+	// Resolving through the vault answers "what file is at this name NOW", which
+	// is not the same question: once a proposal's note is renamed away, a NEW
+	// file can occupy the path it was staged under. Returning that path
+	// unconditionally aimed the discard at a note with no pending entry and
+	// reported nothing to withdraw, while the re-keyed proposal stayed queued.
+	// Falling through instead lets the `formerPaths` tier below find it.
+	if (vaultResolvedPath && pending.some((entry) => entry.change.path === vaultResolvedPath)) {
+		return [vaultResolvedPath];
+	}
+
+	if (pending.some((entry) => entry.change.path === normalized)) return [normalized];
 
 	// The note was renamed after staging; match the name it was staged under.
 	const byFormerPath = pending.filter((entry) => entry.formerPaths?.includes(normalized));
@@ -449,7 +461,12 @@ function resolveDiscardTargets(
 		return (path.split("/").pop() ?? path) === wantedWithExt;
 	});
 
-	return byBasename.length > 0 ? dedupePaths(byBasename) : [normalized];
+	if (byBasename.length > 0) return dedupePaths(byBasename);
+
+	// Nothing matched. Report against the canonical path when the vault knows
+	// one, so the "nothing to withdraw" names the real file rather than a bare
+	// wiki-link basename; otherwise echo the model's own reference.
+	return [vaultResolvedPath ?? normalized];
 }
 
 /**

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -37,10 +37,23 @@ const createOperationSchema = z.object({
 	content: z.string().describe("Full markdown content for the new note"),
 });
 
+const REPLACE_PENDING_DESCRIPTION =
+	"Set true when this edit REPLACES an earlier, still-unreviewed proposal of yours for the same file rather than adding to it. By default a re-edit is applied on top of your pending proposal so both rounds survive; with this flag the edit is applied to the note as it is on disk and the earlier proposal is dropped. Use it whenever the user is correcting you.";
+
 const updateOperationSchema = z.object({
 	type: z.literal("update"),
 	path: z.string().describe("File path or wiki link reference, e.g. 'Notes/todo.md' or '[[todo]]'"),
 	edits: z.array(editSchema).min(1).describe("Sequential search-and-replace edits to apply"),
+	replace_pending: z.boolean().optional().describe(REPLACE_PENDING_DESCRIPTION),
+});
+
+const discardOperationSchema = z.object({
+	type: z.literal("discard"),
+	path: z
+		.string()
+		.describe(
+			"File path or wiki link reference whose pending (not yet reviewed) proposals from this chat should be withdrawn, e.g. 'Notes/todo.md' or '[[todo]]'",
+		),
 });
 
 const deleteOperationSchema = z.object({
@@ -64,6 +77,7 @@ const replaceOperationSchema = z.object({
 		.string()
 		.optional()
 		.describe("Optional folder to scope the replace (e.g. 'Projects'). Omit to replace across the whole vault."),
+	replace_pending: z.boolean().optional().describe(REPLACE_PENDING_DESCRIPTION),
 });
 
 const manageNotesSchema = z.object({
@@ -75,6 +89,7 @@ const manageNotesSchema = z.object({
 				deleteOperationSchema,
 				moveOperationSchema,
 				replaceOperationSchema,
+				discardOperationSchema,
 			]),
 		)
 		.min(1)
@@ -289,8 +304,16 @@ function applySequentialEdits(
  * longer accounts for those edits, and rebasing onto it would stage a proposal
  * that silently reverts the user's own work on accept. (Such a proposal is
  * un-appliable anyway — accept would fail its conflict check.)
+ *
+ * `replacePending` opts out of the rebase entirely. The heuristic above cannot
+ * distinguish "another edit" from "a correction of my last edit" — it only asks
+ * whether the anchor text still matches, so a correction whose anchor happens to
+ * survive gets merged with the very edit it was meant to replace. The model knows
+ * which it meant; this flag is how it says so, and the store's update-dedup then
+ * supersedes the earlier proposal as usual.
  */
-function resolveUpdateBases(threadId: string, filePath: string, diskContent: string): string[] {
+function resolveUpdateBases(threadId: string, filePath: string, diskContent: string, replacePending = false): string[] {
+	if (replacePending) return [diskContent];
 	const store = getPendingChangesStore();
 	const prior = store
 		.getPendingUpdatesForPath(filePath)
@@ -369,6 +392,47 @@ function summarizeOperations(changes: PendingChange[]): string {
 }
 
 /**
+ * Phrase the outcome of this batch's `discard` operations for the model.
+ *
+ * A discard that matched nothing is reported plainly rather than as an error:
+ * the proposal may already have been reviewed, and treating "nothing to withdraw"
+ * as a failure would punish the safe habit of discarding before re-staging. But
+ * it must not read as a success either, or the model will tell the user it took
+ * back something that is still pending — or already applied.
+ */
+function summarizeDiscards(results: { path: string; discarded: number; skippedApplied: number }[]): string {
+	if (results.length === 0) return "";
+
+	const parts: string[] = [];
+	const withdrawn = results.filter((r) => r.discarded > 0);
+	if (withdrawn.length > 0) {
+		const total = withdrawn.reduce((sum, r) => sum + r.discarded, 0);
+		const paths = withdrawn.map((r) => `"${r.path}"`).join(", ");
+		parts.push(
+			`Withdrew ${total} pending proposal(s) for ${paths} — they are no longer awaiting review and will not be applied.`,
+		);
+	}
+
+	const empty = results.filter((r) => r.discarded === 0 && r.skippedApplied === 0);
+	if (empty.length > 0) {
+		const paths = empty.map((r) => `"${r.path}"`).join(", ");
+		parts.push(
+			`Nothing to withdraw for ${paths} — this chat had no pending proposals there (they may already have been accepted or rejected). Do not tell the user you took anything back.`,
+		);
+	}
+
+	const skipped = results.filter((r) => r.skippedApplied > 0);
+	if (skipped.length > 0) {
+		const paths = skipped.map((r) => `"${r.path}"`).join(", ");
+		parts.push(
+			`Could not withdraw ${skipped.reduce((sum, r) => sum + r.skippedApplied, 0)} proposal(s) for ${paths}: the user already accepted part of those changes, so that content is in the note. Leave it to them to undo.`,
+		);
+	}
+
+	return parts.join(" ");
+}
+
+/**
  * True when `path` is the folder itself or nested inside it. Both are normalized
  * first so a trailing slash or `.`-segment doesn't cause a false negative. Used to
  * scope memory auto-approval strictly to the agent's memory folder — mirrors the
@@ -442,9 +506,13 @@ export async function stageNoteOperations(
 	// skip must be surfaced — otherwise a multi-op batch silently under-applies.
 	const conflictSkippedPaths = new Set<string>();
 	// Files whose new proposal was based on this thread's earlier pending update
-	// (see resolveUpdateBase) — surfaced so the model knows the superseding
-	// proposal carries both rounds of edits.
+	// (see resolveUpdateBases) — surfaced so the model knows the new proposal
+	// carries BOTH rounds of edits rather than replacing the earlier one.
 	const rebasedPaths = new Set<string>();
+	// Outcome of each `discard` operation. Tracked separately from `stagedChanges`
+	// because a discard stages nothing — it withdraws — so it must not be counted
+	// in the "Proposed N operation(s)" tally the user's review surfaces reflect.
+	const discardResults: { path: string; discarded: number; skippedApplied: number }[] = [];
 
 	for (let i = 0; i < operations.length; i++) {
 		const operation = operations[i];
@@ -510,7 +578,7 @@ export async function stageNoteOperations(
 
 			const originalContent = await app.vault.read(result.file);
 			const editResult = applyEditsToFirstMatchingBase(
-				resolveUpdateBases(threadId, result.file.path, originalContent),
+				resolveUpdateBases(threadId, result.file.path, originalContent, operation.replace_pending),
 				operation.edits,
 				result.file.path,
 				operationNumber,
@@ -526,6 +594,29 @@ export async function stageNoteOperations(
 				originalContent,
 				newContent: editResult.content,
 			});
+			continue;
+		}
+
+		if (operation.type === "discard") {
+			// No permission gate, deliberately. Discarding is strictly
+			// de-escalatory — it can only REMOVE a proposed write, never cause
+			// one. Gating it on `allowUpdate` would let a permission change
+			// strand proposals the agent is otherwise able to clean up.
+			//
+			// Also exempt from `ensureUniqueTarget`: `discard` + `update` on one
+			// path in a single batch is the natural correction idiom, and the
+			// update branch still guards against a *second* update to that path.
+			//
+			// Resolved leniently: unlike update/delete/move this never touches the
+			// file, so a note that has since been renamed or deleted must still be
+			// discardable. Fall back to the literal normalized path when the
+			// vault can't resolve it, since that is what the entry is keyed by.
+			const cleanPath = normalizeReferencePath(operation.path);
+			const resolved = resolveVaultFileDetailed(app, cleanPath);
+			const targetPath = resolved.status === "found" ? resolved.file.path : normalizePath(cleanPath);
+
+			const { discarded, skippedApplied } = store.discardPendingForPath(targetPath, threadId);
+			discardResults.push({ path: targetPath, discarded, skippedApplied });
 			continue;
 		}
 
@@ -656,7 +747,7 @@ export async function stageNoteOperations(
 			// the pattern is present there (so the replace doesn't silently drop a
 			// pending edit the store's dedup then supersedes); otherwise fall back to
 			// disk, which is what a replace targeting text the model just read means.
-			const bases = resolveUpdateBases(threadId, file.path, originalContent);
+			const bases = resolveUpdateBases(threadId, file.path, originalContent, operation.replace_pending);
 			const base = bases.find((candidate) => matcher.test(candidate)) ?? bases[bases.length - 1];
 			const rebasedOnPending = base !== originalContent;
 			// Skip notes too large to regex safely (unbounded backtracking would
@@ -743,10 +834,17 @@ export async function stageNoteOperations(
 		}
 	}
 
+	// Built first so a discard-only batch (which stages nothing) can stand on it
+	// as the whole summary rather than reporting "Proposed 0 note operation(s)".
+	const discardSummary = summarizeDiscards(discardResults);
+
 	const stagedCount = stagedChanges.length - autoAppliedCount - autoApplyFailures.length;
 	let summary: string;
-	if (autoAppliedCount > 0 && stagedCount === 0 && autoApplyFailures.length === 0) {
+	if (stagedChanges.length === 0 && discardResults.length > 0) {
+		summary = discardSummary;
+	} else if (autoAppliedCount > 0 && stagedCount === 0 && autoApplyFailures.length === 0) {
 		summary = `Saved ${autoAppliedCount} memory note operation(s) (${summarizeOperations(stagedChanges)}) to \`${memory.folder}/\` — applied automatically, no user review needed.`;
+		if (discardSummary) summary += ` ${discardSummary}`;
 	} else {
 		summary = `Proposed ${stagedChanges.length} note operation(s) across ${seenPaths.size} path(s) (${summarizeOperations(stagedChanges)}).`;
 		if (autoAppliedCount > 0) {
@@ -755,13 +853,19 @@ export async function stageNoteOperations(
 		if (stagedCount > 0) {
 			summary += ` ${stagedCount} will be reviewed by the user, who will approve or reject them.`;
 		}
+		if (discardSummary) summary += ` ${discardSummary}`;
+	}
+	// Deliberately FIRST among the trailing notes. This one changes what the model
+	// should say to the user, so it must not be buried behind up to four other
+	// clauses — and it avoids the word "superseded", which was read as "only my
+	// new edit remains" and led to the model telling the user the earlier edit was
+	// gone while BOTH sat in the review queue.
+	if (rebasedPaths.size > 0) {
+		const paths = [...rebasedPaths].map((p) => `"${p}"`).join(", ");
+		summary += ` IMPORTANT: ${paths} now contains BOTH your earlier pending edit AND this one — this proposal ADDS to the earlier one, it does not replace it. The user will see every edit together. If you meant to REPLACE your earlier edit (e.g. the user is correcting you), re-stage it with "replace_pending": true, or "discard" the file first. Do not tell the user this supersedes the earlier edit unless you did one of those.`;
 	}
 	if (autoApplyFailures.length > 0) {
 		summary += ` ${autoApplyFailures.length} memory write(s) could not be applied: ${autoApplyFailures.join("; ")}.`;
-	}
-	if (rebasedPaths.size > 0) {
-		const paths = [...rebasedPaths].map((p) => `"${p}"`).join(", ");
-		summary += ` Note: this thread already had a pending (not yet reviewed) update to ${paths}; the new proposal was built on top of it and contains both rounds of edits — the older proposal was superseded.`;
 	}
 	if (crossThreadPaths.size > 0) {
 		const paths = [...crossThreadPaths].map((p) => `"${p}"`).join(", ");

--- a/src/agent/tools/manageNotes.ts
+++ b/src/agent/tools/manageNotes.ts
@@ -404,27 +404,33 @@ function summarizeOperations(changes: PendingChange[]): string {
  *   - the model used a wiki-link, which normalizes to a bare basename that never
  *     equals the canonical `Notes/todo.md` an entry is keyed by.
  *
- * Resolution order is strict-to-loose, and stops at the first tier that hits so
- * a loose match can never override an exact one:
+ * Resolution is strict-to-loose, stopping at the first tier that hits so a loose
+ * match can never override an exact one:
  *
- *   1. the vault-resolved canonical path — but ONLY when a pending entry sits at
- *      it. The vault answers "what file is at this name now", which diverges
- *      from "which proposal did the model mean" as soon as a note is renamed
- *      away and something else takes its old path;
- *   2. an entry whose path equals the normalized reference exactly;
- *   3. an entry one of whose `formerPaths` equals it — the note was renamed
- *      after staging, and the model still knows it by the name it was staged
- *      under. This is an EXACT match on a path the entry genuinely had, so it
- *      precedes the basename tier: a rename that also changes the basename
+ *   1. proposals living AT the name — an entry whose path equals the reference,
+ *      or equals what the vault resolves the reference to. Both answer "which
+ *      proposal is at this name now" and are merged;
+ *   2. a proposal one of whose `formerPaths` equals it — the note was renamed
+ *      after staging and the model still knows it by the name it was staged
+ *      under. An exact match on a path the entry genuinely had, so it beats the
+ *      basename tier: a rename that also changes the basename
  *      (`Notes/doc.md` -> `Notes/renamed.md`) is unreachable by name alone;
- *   4. entries whose basename matches, with or without the `.md` the model may
- *      have omitted — the wiki-link case, and renames that kept the basename
- *      but predate `formerPaths` being recorded.
+ *   3. proposals whose basename matches, with or without the `.md` the model may
+ *      have omitted — the wiki-link case, and renames that kept the basename but
+ *      predate `formerPaths` being recorded.
  *
- * Tiers 3 and 4 can legitimately return several paths (two pending proposals for
- * same-named notes in different folders). All are this thread's own proposals
- * and the model asked to withdraw that name, so all are withdrawn and each is
+ * A tier may legitimately return several paths (two pending proposals for
+ * same-named notes in different folders). All are this thread's own proposals and
+ * the model asked to withdraw that name, so all are withdrawn and each is
  * reported by full path — silently picking one would leave the others stuck.
+ *
+ * But when tiers 1 and 2 hit DIFFERENT proposals the name is genuinely ambiguous:
+ * it belongs to one note now and belonged to another when that one was staged,
+ * and both have live proposals. Nothing in the reference resolves that, and any
+ * ranking silently withdraws a proposal the model did not ask about while leaving
+ * the one it did. That case returns `ambiguous` so the caller can ask the model
+ * to name a path, mirroring `validateExistingMarkdownFile`'s ambiguous branch.
+ *
  * Returns the reference itself when nothing matches, so the caller still reports
  * an honest "nothing to withdraw" against the name the model used.
  */
@@ -432,28 +438,39 @@ function resolveDiscardTargets(
 	pending: { change: { path: string }; formerPaths?: string[] }[],
 	cleanPath: string,
 	vaultResolvedPath: string | undefined,
-): string[] {
+): { paths: string[] } | { ambiguous: string[] } {
 	const normalized = normalizePath(cleanPath);
 	const dedupePaths = (entries: typeof pending) => [...new Set(entries.map((entry) => entry.change.path))];
 
-	// Tier 1 only wins when it names a proposal this thread actually has.
-	// Resolving through the vault answers "what file is at this name NOW", which
-	// is not the same question: once a proposal's note is renamed away, a NEW
-	// file can occupy the path it was staged under. Returning that path
-	// unconditionally aimed the discard at a note with no pending entry and
-	// reported nothing to withdraw, while the re-keyed proposal stayed queued.
-	// Falling through instead lets the `formerPaths` tier below find it.
-	if (vaultResolvedPath && pending.some((entry) => entry.change.path === vaultResolvedPath)) {
-		return [vaultResolvedPath];
+	// Tier 1 and tier 2 both name a path a proposal LIVES at. Tier 1 is the
+	// vault's answer to "what file is at this name now"; tier 2 is an entry
+	// sitting at the reference as written. They can only disagree when the
+	// reference is a basename or wiki-link, and either way the union is what the
+	// model named.
+	const atPath = pending.filter(
+		(entry) => entry.change.path === normalized || (!!vaultResolvedPath && entry.change.path === vaultResolvedPath),
+	);
+
+	// A proposal staged under this name before its note was renamed away.
+	const byFormerPath = pending.filter((entry) => entry.formerPaths?.includes(normalized));
+
+	// Both tiers hit on DIFFERENT proposals: the name now belongs to one note and
+	// used to belong to another, and both have live proposals. Nothing in the
+	// reference says which the model meant, and picking either silently withdraws
+	// a proposal it did not ask about while leaving the one it did. Ask instead —
+	// same resolution as `validateExistingMarkdownFile`'s ambiguous branch.
+	if (atPath.length > 0 && byFormerPath.length > 0) {
+		const candidates = [...new Set([...dedupePaths(atPath), ...dedupePaths(byFormerPath)])];
+		if (candidates.length > 1) return { ambiguous: candidates };
 	}
 
-	if (pending.some((entry) => entry.change.path === normalized)) return [normalized];
-
-	// The note was renamed after staging; match the name it was staged under.
-	const byFormerPath = pending.filter((entry) => entry.formerPaths?.includes(normalized));
-	if (byFormerPath.length > 0) return dedupePaths(byFormerPath);
+	if (atPath.length > 0) return { paths: dedupePaths(atPath) };
+	if (byFormerPath.length > 0) return { paths: dedupePaths(byFormerPath) };
 
 	// Basename comparison, tolerating a missing `.md` on the model's reference.
+	// Reached only when nothing matched by path, so there is no live proposal at
+	// this name to confuse it with — the wiki-link case, and renames that kept
+	// the basename but predate `formerPaths` being recorded.
 	const wanted = normalized.split("/").pop() ?? normalized;
 	const wantedWithExt = wanted.endsWith(".md") ? wanted : `${wanted}.md`;
 	const byBasename = pending.filter((entry) => {
@@ -461,12 +478,12 @@ function resolveDiscardTargets(
 		return (path.split("/").pop() ?? path) === wantedWithExt;
 	});
 
-	if (byBasename.length > 0) return dedupePaths(byBasename);
+	if (byBasename.length > 0) return { paths: dedupePaths(byBasename) };
 
 	// Nothing matched. Report against the canonical path when the vault knows
 	// one, so the "nothing to withdraw" names the real file rather than a bare
 	// wiki-link basename; otherwise echo the model's own reference.
-	return [vaultResolvedPath ?? normalized];
+	return { paths: [vaultResolvedPath ?? normalized] };
 }
 
 /**
@@ -696,13 +713,18 @@ export async function stageNoteOperations(
 			// nothing to withdraw. Matching entry paths by basename closes both gaps.
 			const cleanPath = normalizeReferencePath(operation.path);
 			const resolved = resolveVaultFileDetailed(app, cleanPath);
-			const targetPaths = resolveDiscardTargets(
+			const discardTargets = resolveDiscardTargets(
 				store.getPendingForThread(threadId),
 				cleanPath,
 				resolved.status === "found" ? resolved.file.path : undefined,
 			);
 
-			for (const targetPath of targetPaths) {
+			if ("ambiguous" in discardTargets) {
+				const candidatesList = discardTargets.ambiguous.map((candidate) => `- ${candidate}`).join("\n");
+				return `Error in operation ${operationNumber}: "${operation.path}" matches more than one pending proposal — it names one note now and named another when that one was staged. Re-run the discard with the full path of the one you mean. Candidates:\n${candidatesList}`;
+			}
+
+			for (const targetPath of discardTargets.paths) {
 				const { discarded, skippedApplied } = store.discardPendingForPath(targetPath, threadId);
 				discardResults.push({ path: targetPath, discarded, skippedApplied });
 			}

--- a/src/components/chat/MessageContainer.svelte
+++ b/src/components/chat/MessageContainer.svelte
@@ -918,7 +918,7 @@ $effect(() => {
                 {@const genLabel = shouldShowGenerationLabel(index) ? getGenerationLabel(messagePair) : null}
                 {@const timestamp = onMobile ? null : formatMessageTimestamp(messagePair)}
                 <div
-                  class="message-footer flex flex-row items-center gap-3 flex-wrap opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 pointer-events-none group-hover:pointer-events-auto transition-all duration-200 ease-out"
+                  class="message-footer message-footer-assistant flex flex-row items-center gap-3 flex-nowrap opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 pointer-events-none group-hover:pointer-events-auto transition-all duration-200 ease-out"
                 >
                   <div class="footer-actions flex flex-row items-center gap-1.5">
                     {#if messagePair.assistantBranchInfo}
@@ -1112,9 +1112,74 @@ $effect(() => {
     color: var(--text-faint);
   }
 
+  /* Everything below is scoped to `.message-footer-assistant`. The user
+     message reuses `.message-footer` but lays out in the OPPOSITE order
+     (timestamp then actions, right-aligned) and carries no metadata group,
+     so the sizing rules here actively break it: pinning its actions with
+     nothing else able to yield pushes the buttons off the right edge. */
+  .message-footer-assistant {
+    /* Query container for the metadata's progressive collapse (see the
+       `@container` rules below). As in the composer, the constraint is the
+       width of the CHAT PANE, not the viewport: a sidebar can be dragged
+       wide and a narrow window's main view is just as cramped as a sidebar,
+       so only querying an element in the actual column tracks it. */
+    container-type: inline-size;
+    container-name: chat-message-footer;
+  }
+
+  /* The assistant footer is `nowrap`: it must stay a single line at every
+     width. It previously wrapped, which dropped the agent/model group onto
+     its own row and made the footer grow taller than the message it
+     annotates. With nowrap the overflow has to go somewhere, so pin the
+     controls and let ONLY the metadata shrink — otherwise the browser is
+     free to squeeze the icon buttons and deform the touch targets. */
+  .message-footer-assistant .footer-actions {
+    flex-shrink: 0;
+  }
+
   .footer-meta {
     color: var(--text-faint);
     overflow: hidden;
+    flex-shrink: 1;
+    min-width: 0;
+  }
+
+  /* Progressive collapse of the footer metadata as the chat pane narrows.
+     Without this, everything stays on one line and merely truncates, which
+     produced unreadable stubs ("S2B Ag…", "openai/gemma-4-26b-a4b-i…") that
+     identify neither the agent nor the model. Shed whole items instead, in
+     priority order (least identifying first):
+
+       1. <400px — drop the timestamp. It's the only item that says nothing
+          about WHO answered, and it's already hidden on mobile for this
+          reason. Dropping it hands its width to the labels.
+       2. <300px — drop the model. The agent name + its user-chosen icon
+          still identify the responder; a truncated provider/model string
+          does not.
+       3. <220px — drop the metadata entirely, leaving the action buttons.
+          Below this the labels can't survive at any useful length, and the
+          controls are the part you actually click.
+
+     Every shed item remains in the group's `title` tooltip, so the full
+     agent · model text stays reachable on hover at any width. */
+  @container chat-message-footer (max-width: 400px) {
+    .message-footer-assistant .message-timestamp,
+    .message-footer-assistant .footer-dot {
+      display: none;
+    }
+  }
+
+  @container chat-message-footer (max-width: 300px) {
+    .message-footer-assistant .generation-model,
+    .message-footer-assistant .generation-sep {
+      display: none;
+    }
+  }
+
+  @container chat-message-footer (max-width: 220px) {
+    .message-footer-assistant .footer-meta {
+      display: none;
+    }
   }
 
   .generation-label {
@@ -1122,8 +1187,15 @@ $effect(() => {
     line-height: 1.15;
   }
 
+  /* The agent is the more identifying of the two labels and is far shorter,
+     so let the model absorb the truncation first: the agent only shrinks
+     once the model has already collapsed to nothing. Otherwise flexbox
+     splits the deficit between them and clips BOTH into stubs, which is
+     exactly the "S2B Ag… · openai/gemma-4-26b-a4b-i…" case. */
   .generation-agent {
     font-weight: 500;
+    flex-shrink: 0;
+    max-width: 100%;
   }
 
   .generation-agent-icon {
@@ -1141,6 +1213,8 @@ $effect(() => {
   .generation-model {
     color: var(--text-faint);
     font-variant-numeric: tabular-nums;
+    flex-shrink: 1;
+    min-width: 0;
   }
 
   /* Small dot separating the model label from the timestamp. */

--- a/src/skills/defaults/edit-notes/SKILL.md
+++ b/src/skills/defaults/edit-notes/SKILL.md
@@ -23,11 +23,16 @@ replacing it. The user then sees both edits. When the user is correcting you
 - **Replacing your own pending edit** — re-stage the update with
   `"replace_pending": true`. Your earlier proposal is dropped and only the new
   edit is reviewed.
-- **Withdrawing an edit entirely** — use a `discard` operation for that path. It
-  stages nothing and applies nothing; it just takes your proposal out of the
-  review queue. Safe to use when you are unsure whether anything is pending. If
-  it reports that the name matches more than one pending proposal, re-run it with
-  the full path of the one you meant — do not guess.
+- **Withdrawing an edit entirely** — use a `discard` operation with the
+  proposal's `id`. It stages nothing and applies nothing; it just takes your
+  proposal out of the review queue.
+
+Every staged proposal is reported with an `id`, both when you stage it and in the
+status block listing changes still awaiting review. `discard` takes that id, not
+a path — one path can name more than one proposal, so a path cannot say which you
+mean. Use an id you were actually given; never invent or guess one. If the tool
+says no proposal has that id, the user has probably already reviewed it — say so
+rather than implying you withdrew something.
 - **Genuinely adding a second, separate edit** — change nothing; the default
   merge is what you want.
 

--- a/src/skills/defaults/edit-notes/SKILL.md
+++ b/src/skills/defaults/edit-notes/SKILL.md
@@ -25,7 +25,9 @@ replacing it. The user then sees both edits. When the user is correcting you
   edit is reviewed.
 - **Withdrawing an edit entirely** — use a `discard` operation for that path. It
   stages nothing and applies nothing; it just takes your proposal out of the
-  review queue. Safe to use when you are unsure whether anything is pending.
+  review queue. Safe to use when you are unsure whether anything is pending. If
+  it reports that the name matches more than one pending proposal, re-run it with
+  the full path of the one you meant — do not guess.
 - **Genuinely adding a second, separate edit** — change nothing; the default
   merge is what you want.
 

--- a/src/skills/defaults/edit-notes/SKILL.md
+++ b/src/skills/defaults/edit-notes/SKILL.md
@@ -4,7 +4,7 @@ description: Create, update, delete, and move notes. All writes are staged for t
 allowed-tools: manage_notes
 metadata:
   author: "S2B"
-  version: "1.0"
+  version: "1.1"
   category: "core"
 ---
 
@@ -13,3 +13,23 @@ metadata:
 - Modify only what the user asked for and preserve surrounding content.
 - Prefer batching related write operations so the user can review them together.
 - Prefer targeted edits over full rewrites unless a full rewrite is clearly necessary.
+
+## Correcting an Edit You Already Staged
+Staged changes wait for the user's review, so you can still revise them — but by
+default a new edit to the same note **adds to** your pending proposal rather than
+replacing it. The user then sees both edits. When the user is correcting you
+("no, at the bottom", "actually make it X"), say which you mean:
+
+- **Replacing your own pending edit** — re-stage the update with
+  `"replace_pending": true`. Your earlier proposal is dropped and only the new
+  edit is reviewed.
+- **Withdrawing an edit entirely** — use a `discard` operation for that path. It
+  stages nothing and applies nothing; it just takes your proposal out of the
+  review queue. Safe to use when you are unsure whether anything is pending.
+- **Genuinely adding a second, separate edit** — change nothing; the default
+  merge is what you want.
+
+Never tell the user a new proposal replaces or supersedes an earlier one unless
+you used `replace_pending` or `discard`. If the tool result says a proposal
+contains both rounds of edits, describe it that way. Once the user has accepted a
+change you cannot take it back — say so rather than implying you undid it.

--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -776,7 +776,12 @@ export function formatGraphNotesContext(notes: GraphNoteRef[]): string {
  * edits were (or will be) applied — including ones the user rejected.
  */
 export function formatReviewOutcomesContext(status: ReviewStatusRef): string {
-	if (status.outcomes.length === 0 && status.pendingPaths.length === 0) return "";
+	const pendingProposals = status.pendingProposals ?? [];
+	// Messages persisted before proposals carried ids kept only paths. Their block
+	// is reconstructed here to be stripped by exact match, so it has to render the
+	// way it originally did — hence reading the legacy field rather than migrating.
+	const legacyPendingPaths = pendingProposals.length === 0 ? (status.pendingPaths ?? []) : [];
+	if (status.outcomes.length === 0 && pendingProposals.length === 0 && legacyPendingPaths.length === 0) return "";
 	const lines = ["[Status of your proposed note changes]"];
 	for (const o of status.outcomes) {
 		if (o.outcome === "accepted") {
@@ -789,9 +794,16 @@ export function formatReviewOutcomesContext(status: ReviewStatusRef): string {
 			);
 		}
 	}
-	if (status.pendingPaths.length > 0) {
+	if (pendingProposals.length > 0) {
 		lines.push(
-			`- Still awaiting the user's review (NOT applied yet): ${status.pendingPaths.map((p) => `"${p}"`).join(", ")}`,
+			"- Still awaiting the user's review (NOT applied yet). Use the id with a `discard` operation to withdraw one:",
+		);
+		for (const proposal of pendingProposals) {
+			lines.push(`  - "${proposal.path}" (id: ${proposal.shortId})`);
+		}
+	} else if (legacyPendingPaths.length > 0) {
+		lines.push(
+			`- Still awaiting the user's review (NOT applied yet): ${legacyPendingPaths.map((p) => `"${p}"`).join(", ")}`,
 		);
 	}
 	return lines.join("\n");
@@ -2149,8 +2161,10 @@ export class ChatSession {
 		// still read the notes) — accepted over re-reporting them forever.
 		let reviewStatus: ReviewStatusRef | undefined;
 		try {
-			const { outcomes, pendingPaths } = getPendingChangesStore().takeReviewOutcomesForThread(String(this.id));
-			if (outcomes.length > 0 || pendingPaths.length > 0) reviewStatus = { outcomes, pendingPaths };
+			const { outcomes, pendingProposals } = getPendingChangesStore().takeReviewOutcomesForThread(
+				String(this.id),
+			);
+			if (outcomes.length > 0 || pendingProposals.length > 0) reviewStatus = { outcomes, pendingProposals };
 		} catch {
 			// store not initialized — send without the block
 		}

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -336,7 +336,7 @@ export const DEFAULT_TOOLS_CONFIG: ToolsConfig = {
 		enabled: true,
 		name: "manage_notes",
 		description:
-			"Create, update, delete, move, or find-and-replace across markdown notes in one staged batch. For a single note, use 'update' with targeted search-and-replace edits (add is_regex/replace_all to match by regex or replace every occurrence). For vault-wide or folder-scoped find-and-replace, use the 'replace' operation (find/replace, optional is_regex/case_sensitive/path_prefix) — preview its blast radius first with grep_notes. Batch related note operations together.",
+			"Create, update, delete, move, or find-and-replace across markdown notes in one staged batch. For a single note, use 'update' with targeted search-and-replace edits (add is_regex/replace_all to match by regex or replace every occurrence). For vault-wide or folder-scoped find-and-replace, use the 'replace' operation (find/replace, optional is_regex/case_sensitive/path_prefix) — preview its blast radius first with grep_notes. Batch related note operations together. Staged changes can still be revised: editing a note you already have a pending proposal for ADDS to that proposal, so set replace_pending on the update to replace it instead, or use the 'discard' operation to withdraw it entirely.",
 		settings: {
 			allowCreate: true,
 			allowUpdate: true,

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -336,7 +336,7 @@ export const DEFAULT_TOOLS_CONFIG: ToolsConfig = {
 		enabled: true,
 		name: "manage_notes",
 		description:
-			"Create, update, delete, move, or find-and-replace across markdown notes in one staged batch. For a single note, use 'update' with targeted search-and-replace edits (add is_regex/replace_all to match by regex or replace every occurrence). For vault-wide or folder-scoped find-and-replace, use the 'replace' operation (find/replace, optional is_regex/case_sensitive/path_prefix) — preview its blast radius first with grep_notes. Batch related note operations together. Staged changes can still be revised: editing a note you already have a pending proposal for ADDS to that proposal, so set replace_pending on the update to replace it instead, or use the 'discard' operation to withdraw it entirely.",
+			"Create, update, delete, move, or find-and-replace across markdown notes in one staged batch. For a single note, use 'update' with targeted search-and-replace edits (add is_regex/replace_all to match by regex or replace every occurrence). For vault-wide or folder-scoped find-and-replace, use the 'replace' operation (find/replace, optional is_regex/case_sensitive/path_prefix) — preview its blast radius first with grep_notes. Batch related note operations together. Staged changes can still be revised: editing a note you already have a pending proposal for ADDS to that proposal, so set replace_pending on the update to replace it instead, or use the 'discard' operation with the proposal's id (reported when it was staged) to withdraw it entirely.",
 		settings: {
 			allowCreate: true,
 			allowUpdate: true,

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -32,7 +32,7 @@ const pendingChangeEntrySchema = z.object({
 	threadId: z.string(),
 	createdAt: z.number(),
 	reportedToModel: z.boolean().optional(),
-	formerPaths: z.array(z.string()).optional(),
+	shortId: z.string().optional(),
 });
 
 const pendingChangesArraySchema = z.array(pendingChangeEntrySchema);
@@ -91,6 +91,28 @@ function buildPartialContent(changes: Change[], groupIndex: number, targetUsesNe
 
 	return result;
 }
+/** Characters in a freshly minted short id, before collision lengthening. */
+const SHORT_ID_LENGTH = 6;
+
+/**
+ * A short handle for an entry, unique among `taken`.
+ *
+ * Derived from the END of the UUID, never the start: UUIDv7's leading bits are
+ * a millisecond timestamp, so entries staged in one batch share a long prefix —
+ * a leading 8-char slice collided on every member of a 12-entry burst in
+ * testing. The trailing bits are random, but not collision-proof at scale
+ * (~1 per 500 ids at 6 chars), so this lengthens on collision rather than
+ * truncating blindly. Falls back to the full id if even that collides.
+ */
+function mintShortId(fullId: string, taken: ReadonlySet<string>): string {
+	const compact = fullId.replace(/-/g, "");
+	for (let length = SHORT_ID_LENGTH; length <= compact.length; length++) {
+		const candidate = compact.slice(-length);
+		if (!taken.has(candidate)) return candidate;
+	}
+	return fullId;
+}
+
 export function getPendingChangesStore(): PendingChangesStore {
 	if (!_store) throw new Error("PendingChangesStore not initialized");
 	return _store;
@@ -142,6 +164,7 @@ export class PendingChangesStore {
 				this.#entries = [];
 			}
 		}
+		this.#backfillShortIds();
 		await this.#pruneOrphanedThreads();
 		this.#renameHandler = this.#plugin.app.vault.on("rename", (file, oldPath) => {
 			this.#handleFileRename(oldPath, file.path);
@@ -152,6 +175,25 @@ export class PendingChangesStore {
 		if (this.#entries.length > 0) {
 			this.notifyChange();
 		}
+	}
+
+	/**
+	 * Give every loaded entry a short id. Entries persisted before short ids
+	 * existed have none, and without one the model has no way to name them — they
+	 * would be permanently undiscardable while still sitting in the review queue.
+	 * Minted against the ids already present so a backfilled entry cannot collide
+	 * with one that was persisted.
+	 */
+	#backfillShortIds(): void {
+		const taken = new Set(this.#entries.map((entry) => entry.shortId).filter((id): id is string => !!id));
+		let changed = false;
+		for (const entry of this.#entries) {
+			if (entry.shortId) continue;
+			entry.shortId = mintShortId(entry.id, taken);
+			taken.add(entry.shortId);
+			changed = true;
+		}
+		if (changed) this.scheduleSave();
 	}
 
 	private get storagePath(): string {
@@ -299,14 +341,23 @@ export class PendingChangesStore {
 		}
 
 		const createdAt = Date.now();
-		const entries: PendingChangeEntry[] = changes.map((change) => ({
-			id: genUUIDv7(),
-			change,
-			status: "pending",
-			toolCallId,
-			threadId,
-			createdAt,
-		}));
+		// Seeded with every live short id and grown as we go, so a batch cannot
+		// collide with existing entries OR within itself.
+		const takenShortIds = new Set(this.#entries.map((entry) => entry.shortId).filter((id): id is string => !!id));
+		const entries: PendingChangeEntry[] = changes.map((change) => {
+			const id = genUUIDv7();
+			const shortId = mintShortId(id, takenShortIds);
+			takenShortIds.add(shortId);
+			return {
+				id,
+				shortId,
+				change,
+				status: "pending",
+				toolCallId,
+				threadId,
+				createdAt,
+			};
+		});
 
 		this.#entries.push(...entries);
 		this.scheduleSave();
@@ -732,14 +783,19 @@ export class PendingChangesStore {
 	 * Only consults entries the model itself staged in this thread — outcomes for
 	 * other chats' proposals would be noise it has no proposal to correlate with.
 	 */
-	takeReviewOutcomesForThread(threadId: string): { outcomes: ReviewOutcomeRef[]; pendingPaths: string[] } {
+	takeReviewOutcomesForThread(threadId: string): {
+		outcomes: ReviewOutcomeRef[];
+		pendingProposals: { path: string; shortId: string }[];
+	} {
 		const outcomes: ReviewOutcomeRef[] = [];
-		const pendingPaths: string[] = [];
+		const pendingProposals: { path: string; shortId: string }[] = [];
 		let changed = false;
 		for (const entry of this.#entries) {
 			if (entry.threadId !== threadId) continue;
 			if (entry.status === "pending") {
-				pendingPaths.push(entry.change.path);
+				// `shortId` is backfilled on load, so a pending entry without one
+				// cannot normally exist; skip rather than emit an unusable id.
+				if (entry.shortId) pendingProposals.push({ path: entry.change.path, shortId: entry.shortId });
 				continue;
 			}
 			if (entry.reportedToModel) continue;
@@ -758,7 +814,7 @@ export class PendingChangesStore {
 			changed = true;
 		}
 		if (changed) this.scheduleSave();
-		return { outcomes, pendingPaths };
+		return { outcomes, pendingProposals };
 	}
 
 	/** Mark entries as already surfaced to the model, so the next turn's outcome
@@ -800,41 +856,41 @@ export class PendingChangesStore {
 	}
 
 	/**
-	 * Reject this thread's pending entries for `filePath` — the agent's own
-	 * retraction path (`manage_notes` `discard`), so it can withdraw a proposal
-	 * it no longer stands behind instead of only ever stacking new ones on top.
+	 * Withdraw one pending proposal by its short id — the agent's own retraction
+	 * path (`manage_notes` `discard`), so it can take back a proposal it no
+	 * longer stands behind instead of only ever stacking new ones on top.
+	 *
+	 * Keyed by id rather than path because a path is not identity: it can move
+	 * with a rename, be reused by a different note, or name two proposals at once
+	 * (a since-renamed one and whatever took its place). Every attempt to rank
+	 * those cases picked wrong in some scenario; an id has none of that ambiguity.
 	 *
 	 * Scoped to `threadId` deliberately: another chat's proposal is not this
-	 * agent's to drop, matching how `resolveUpdateBases` and the update-dedup
-	 * both refuse to reach across threads.
+	 * agent's to drop, matching how the update-dedup refuses to reach across
+	 * threads.
 	 *
-	 * Entries holding unreverted partially-applied content are SKIPPED, not
+	 * An entry holding unreverted partially-applied content is REFUSED, not
 	 * rejected. That content is on disk because the user accepted a diff group;
-	 * silently reverting it (or marking it resolved while it sits there) would
-	 * undo their own decision. They are returned separately so the caller can
-	 * tell the model, which must then leave them to the user.
-	 *
-	 * @returns the number discarded, plus the paths' entry count that was skipped.
+	 * silently resolving the entry while it sits there would discard their only
+	 * undo record. The caller reports that so the model leaves it to the user.
 	 */
-	discardPendingForPath(filePath: string, threadId: string): { discarded: number; skippedApplied: number } {
-		let discarded = 0;
-		let skippedApplied = 0;
-		for (const entry of this.#entries) {
-			if (entry.threadId !== threadId) continue;
-			if (entry.status !== "pending") continue;
-			if (entry.change.path !== filePath) continue;
-			if (this.hasUnrevertedApplication(entry)) {
-				skippedApplied++;
-				continue;
-			}
-			entry.status = "rejected";
-			discarded++;
-		}
-		if (discarded > 0) {
-			this.scheduleSave();
-			this.notifyChange();
-		}
-		return { discarded, skippedApplied };
+	discardPendingById(shortId: string, threadId: string): "discarded" | "not_found" | "partially_applied" {
+		const entry = this.#entries.find(
+			(e) => e.shortId === shortId && e.threadId === threadId && e.status === "pending",
+		);
+		if (!entry) return "not_found";
+		if (this.hasUnrevertedApplication(entry)) return "partially_applied";
+
+		entry.status = "rejected";
+		this.scheduleSave();
+		this.notifyChange();
+		return "discarded";
+	}
+
+	/** Look up a pending entry by the short id the model was given. Thread-scoped
+	 * for the same reason as `discardPendingById`. */
+	getPendingByShortId(shortId: string, threadId: string): PendingChangeEntry | undefined {
+		return this.#entries.find((e) => e.shortId === shortId && e.threadId === threadId && e.status === "pending");
 	}
 
 	/** Count distinct OTHER threads that also have a pending update to `filePath`.
@@ -917,14 +973,6 @@ export class PendingChangesStore {
 			// reported success while the applied content sat at the new path.
 			if (entry.status !== "pending" && !this.hasUnrevertedApplication(entry)) continue;
 			if (entry.change.path === oldPath) {
-				// Keep the path we are leaving. `change.path` is overwritten in place,
-				// so otherwise the entry retains no trace of where it was staged —
-				// while the model still knows it only by that original path. An
-				// agent-side `discard` of a since-renamed note would then be
-				// unresolvable whenever the rename also changed the basename.
-				// Appended (not replaced) so a twice-renamed note stays reachable by
-				// the name the model actually saw.
-				entry.formerPaths = [...(entry.formerPaths ?? []), oldPath];
 				entry.change.path = newPath;
 				changed = true;
 			}

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -32,6 +32,7 @@ const pendingChangeEntrySchema = z.object({
 	threadId: z.string(),
 	createdAt: z.number(),
 	reportedToModel: z.boolean().optional(),
+	formerPaths: z.array(z.string()).optional(),
 });
 
 const pendingChangesArraySchema = z.array(pendingChangeEntrySchema);
@@ -916,6 +917,14 @@ export class PendingChangesStore {
 			// reported success while the applied content sat at the new path.
 			if (entry.status !== "pending" && !this.hasUnrevertedApplication(entry)) continue;
 			if (entry.change.path === oldPath) {
+				// Keep the path we are leaving. `change.path` is overwritten in place,
+				// so otherwise the entry retains no trace of where it was staged —
+				// while the model still knows it only by that original path. An
+				// agent-side `discard` of a since-renamed note would then be
+				// unresolvable whenever the rename also changed the basename.
+				// Appended (not replaced) so a twice-renamed note stays reachable by
+				// the name the model actually saw.
+				entry.formerPaths = [...(entry.formerPaths ?? []), oldPath];
 				entry.change.path = newPath;
 				changed = true;
 			}

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -791,6 +791,44 @@ export class PendingChangesStore {
 		);
 	}
 
+	/**
+	 * Reject this thread's pending entries for `filePath` — the agent's own
+	 * retraction path (`manage_notes` `discard`), so it can withdraw a proposal
+	 * it no longer stands behind instead of only ever stacking new ones on top.
+	 *
+	 * Scoped to `threadId` deliberately: another chat's proposal is not this
+	 * agent's to drop, matching how `resolveUpdateBases` and the update-dedup
+	 * both refuse to reach across threads.
+	 *
+	 * Entries holding unreverted partially-applied content are SKIPPED, not
+	 * rejected. That content is on disk because the user accepted a diff group;
+	 * silently reverting it (or marking it resolved while it sits there) would
+	 * undo their own decision. They are returned separately so the caller can
+	 * tell the model, which must then leave them to the user.
+	 *
+	 * @returns the number discarded, plus the paths' entry count that was skipped.
+	 */
+	discardPendingForPath(filePath: string, threadId: string): { discarded: number; skippedApplied: number } {
+		let discarded = 0;
+		let skippedApplied = 0;
+		for (const entry of this.#entries) {
+			if (entry.threadId !== threadId) continue;
+			if (entry.status !== "pending") continue;
+			if (entry.change.path !== filePath) continue;
+			if (this.hasUnrevertedApplication(entry)) {
+				skippedApplied++;
+				continue;
+			}
+			entry.status = "rejected";
+			discarded++;
+		}
+		if (discarded > 0) {
+			this.scheduleSave();
+			this.notifyChange();
+		}
+		return { discarded, skippedApplied };
+	}
+
 	/** Count distinct OTHER threads that also have a pending update to `filePath`.
 	 * `exceptThreadId` is the thread being viewed/staged; it's excluded so the
 	 * result is "how many *other* chats are editing this same file". Used by the

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -286,6 +286,13 @@ export class PendingChangesStore {
 					existing.change.type === "update"
 				) {
 					existing.status = "rejected";
+					// Any `initialOriginalContent` snapshot is deliberately LEFT SET here.
+					// It means "applied content the user has not signed off on", and
+					// superseding the proposal does not make that content reviewed — the
+					// text is still in the note, so the undo path must stay reachable via
+					// `getActionableForThread`. Clearing it strands the applied text with
+					// its only undo record discarded. Pinned by "keeps an entry actionable
+					// when superseded by a newer proposal" in the store's tests.
 				}
 			}
 		}

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -114,6 +114,17 @@ export interface PendingChangeEntry {
 	 * (in a later user turn's context block). Resolved-but-unreported entries are
 	 * reported exactly once; pending ones are re-reported until resolved. */
 	reportedToModel?: boolean;
+	/** Paths this entry previously lived at, oldest first, recorded whenever a
+	 * vault rename re-keys `change.path`.
+	 *
+	 * The rename handler overwrites `change.path` in place, so without this the
+	 * entry keeps no trace of where it was staged — and the model only ever knows
+	 * the original path. That makes an agent-side `discard` of a since-renamed
+	 * note unresolvable: neither the path nor (after a rename that also changes
+	 * the basename) the basename can reach it. Kept as history rather than a
+	 * single previous path so a note renamed twice is still reachable by the name
+	 * the model actually saw. */
+	formerPaths?: string[];
 }
 
 /**

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -114,17 +114,19 @@ export interface PendingChangeEntry {
 	 * (in a later user turn's context block). Resolved-but-unreported entries are
 	 * reported exactly once; pending ones are re-reported until resolved. */
 	reportedToModel?: boolean;
-	/** Paths this entry previously lived at, oldest first, recorded whenever a
-	 * vault rename re-keys `change.path`.
+	/** Short, stable handle the model names this proposal by (`manage_notes`
+	 * `discard`).
 	 *
-	 * The rename handler overwrites `change.path` in place, so without this the
-	 * entry keeps no trace of where it was staged — and the model only ever knows
-	 * the original path. That makes an agent-side `discard` of a since-renamed
-	 * note unresolvable: neither the path nor (after a rename that also changes
-	 * the basename) the basename can reach it. Kept as history rather than a
-	 * single previous path so a note renamed twice is still reachable by the name
-	 * the model actually saw. */
-	formerPaths?: string[];
+	 * A proposal is an object with its own lifetime; its path is a mutable label
+	 * that can move, be reused, or name two proposals at once — so paths cannot
+	 * identify one. `id` already provides identity but is a 36-char UUID whose
+	 * members differ only in their last characters within a batch, which is
+	 * error-prone for a model to reproduce. This is the same identity in a form
+	 * that survives being copied by hand.
+	 *
+	 * Optional only for entries persisted before this existed; one is minted on
+	 * load so every entry has one in memory. */
+	shortId?: string;
 }
 
 /**
@@ -147,5 +149,15 @@ export interface ReviewOutcomeRef {
  * appended context block can be exactly reconstructed and stripped for display. */
 export interface ReviewStatusRef {
 	outcomes: ReviewOutcomeRef[];
-	pendingPaths: string[];
+	/** Proposals still awaiting review, with the short id the model discards by.
+	 *
+	 * Re-listed on every turn, which is what makes an id durable: the tool result
+	 * that first reported it eventually falls out of context, and without an id
+	 * the model cannot name the proposal to withdraw it. */
+	pendingProposals: { path: string; shortId: string }[];
+	/** Pre-`pendingProposals` shape, still read when reconstructing the context
+	 * block of a message persisted before ids existed. The block is stripped from
+	 * the displayed message by exact string match, so an old message must still
+	 * render byte-identically or its suffix leaks into the UI. Never written. */
+	pendingPaths?: string[];
 }

--- a/test/agent/editNote.test.ts
+++ b/test/agent/editNote.test.ts
@@ -3,7 +3,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("obsidian", () => import("../__mocks__/obsidian"));
 
 // Mock pendingChangesStore
-const mockAddChanges = vi.fn();
+// Returns entry ids like the real store, which the summary reads back to report
+// each staged proposal's discard id.
+const mockAddChanges = vi.fn().mockReturnValue([]);
 const mockIsPathAllowed = vi.fn().mockReturnValue(true);
 const mockShouldBlockFile = vi.fn().mockReturnValue(false);
 const mockCountOtherThreads = vi.fn().mockReturnValue(0);
@@ -15,6 +17,7 @@ vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({
 		shouldBlockFile: mockShouldBlockFile,
 		countOtherThreadsPendingUpdate: mockCountOtherThreads,
 		getPendingUpdatesForPath: (...args: unknown[]) => mockGetPendingUpdatesForPath(...args),
+		getEntry: () => undefined,
 	}),
 }));
 
@@ -87,6 +90,7 @@ describe("manageNotes tool (update operations)", () => {
 		mockShouldBlockFile.mockReturnValue(false);
 		mockGetPendingUpdatesForPath.mockReturnValue([]);
 		mockCountOtherThreads.mockReturnValue(0);
+		mockAddChanges.mockReturnValue([]);
 		app = createMockApp();
 		tool = createManageNotesTool(app);
 	});

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -7,6 +7,7 @@ const mockIsPathAllowed = vi.fn().mockReturnValue(true);
 const mockCountOtherThreads = vi.fn().mockReturnValue(0);
 const mockShouldBlockFile = vi.fn().mockReturnValue(false);
 const mockGetPendingUpdatesForPath = vi.fn().mockReturnValue([]);
+const mockDiscardPendingForPath = vi.fn().mockReturnValue({ discarded: 0, skippedApplied: 0 });
 
 vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({
 	getPendingChangesStore: () => ({
@@ -15,6 +16,7 @@ vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({
 		countOtherThreadsPendingUpdate: mockCountOtherThreads,
 		shouldBlockFile: (...args: unknown[]) => mockShouldBlockFile(...args),
 		getPendingUpdatesForPath: (...args: unknown[]) => mockGetPendingUpdatesForPath(...args),
+		discardPendingForPath: (...args: unknown[]) => mockDiscardPendingForPath(...args),
 	}),
 }));
 
@@ -100,6 +102,8 @@ describe("manageNotes tool", () => {
 		mockCountOtherThreads.mockReturnValue(0);
 		mockShouldBlockFile.mockReturnValue(false);
 		mockGetPendingUpdatesForPath.mockReturnValue([]);
+		mockDiscardPendingForPath.mockReturnValue({ discarded: 0, skippedApplied: 0 });
+		mockAddChanges.mockReturnValue(["mock-id"]);
 		mockGetIndexableVaultFiles.mockReturnValue([]);
 		setManageNotesPermissions();
 		app = createMockApp();
@@ -673,7 +677,7 @@ describe("manageNotes tool", () => {
 				THREAD_CONFIG,
 			);
 
-			expect(result).toContain("superseded");
+			expect(result).toContain("contains BOTH");
 			const staged = mockAddChanges.mock.calls[0][0][0];
 			// Conflict baseline stays disk; the proposal carries both rounds of edits.
 			expect(staged.originalContent).toBe(DISK);
@@ -716,7 +720,7 @@ describe("manageNotes tool", () => {
 			);
 
 			expect(result).toContain("Proposed");
-			expect(result).not.toContain("superseded");
+			expect(result).not.toContain("contains BOTH");
 			const staged = mockAddChanges.mock.calls[0][0][0];
 			expect(staged.originalContent).toBe(DISK);
 			expect(staged.newContent).toBe("line one\nline two rewritten\nline three\n");
@@ -761,7 +765,7 @@ describe("manageNotes tool", () => {
 				THREAD_CONFIG,
 			);
 
-			expect(result).toContain("superseded");
+			expect(result).toContain("contains BOTH");
 			const staged = mockAddChanges.mock.calls[0][0][0];
 			// Both edits present — disk-first would have lost "line one edited".
 			expect(staged.newContent).toBe("line one edited\nline two\nline three edited\n");
@@ -796,7 +800,7 @@ describe("manageNotes tool", () => {
 			);
 
 			// Pending base can't match, so disk wins and the model's intent stands.
-			expect(result).not.toContain("superseded");
+			expect(result).not.toContain("contains BOTH");
 			const staged = mockAddChanges.mock.calls[0][0][0];
 			expect(staged.newContent).toBe("line one\nMODEL VERSION\nline three\n");
 		});
@@ -822,9 +826,7 @@ describe("manageNotes tool", () => {
 		});
 
 		it("falls back to disk when the pending proposal is stale against disk", async () => {
-			mockGetPendingUpdatesForPath.mockReturnValue([
-				pendingEntry("test-thread-id", "some older disk content\n"),
-			]);
+			mockGetPendingUpdatesForPath.mockReturnValue([pendingEntry("test-thread-id", "some older disk content\n")]);
 
 			const result = await tool.invoke(
 				{
@@ -860,7 +862,7 @@ describe("manageNotes tool", () => {
 				THREAD_CONFIG,
 			);
 
-			expect(result).not.toContain("superseded");
+			expect(result).not.toContain("contains BOTH");
 			const staged = mockAddChanges.mock.calls[0][0][0];
 			expect(staged.newContent).toBe("line one\nline 2\nline three\n");
 		});
@@ -877,7 +879,7 @@ describe("manageNotes tool", () => {
 				THREAD_CONFIG,
 			);
 
-			expect(result).toContain("superseded");
+			expect(result).toContain("contains BOTH");
 			const staged = mockAddChanges.mock.calls[0][0][0];
 			expect(staged.originalContent).toBe(DISK);
 			expect(staged.newContent).toBe("line one\nline two changed\nline three\n");
@@ -1072,6 +1074,200 @@ describe("manageNotes tool", () => {
 
 			expect(result).toContain("update permission");
 			expect(mockAddChanges).not.toHaveBeenCalled();
+		});
+	});
+
+	/**
+	 * The agent's retraction path. Before this, `manage_notes` could only stage,
+	 * so an agent correcting itself ("i meant at the bottom") could do nothing but
+	 * stage a second proposal — which the rebase then merged with the first,
+	 * leaving BOTH edits in the review queue while the agent told the user the
+	 * earlier one had been superseded.
+	 */
+	describe("discard withdraws this thread's pending proposals", () => {
+		beforeEach(() => {
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
+		});
+
+		it("withdraws pending proposals for the path and stages nothing", async () => {
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 2, skippedApplied: 0 });
+
+			const result = await tool.invoke(
+				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
+				THREAD_CONFIG,
+			);
+
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
+			expect(result).toContain("Withdrew 2 pending proposal(s)");
+			expect(result).toContain("Notes/doc.md");
+			// A discard proposes nothing — it must not inflate the operation tally.
+			expect(result).not.toContain("Proposed");
+			expect(mockAddChanges).toHaveBeenCalledWith([], expect.anything(), "test-thread-id");
+		});
+
+		it("is a neutral no-op rather than an error when nothing is pending", async () => {
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 0, skippedApplied: 0 });
+
+			const result = await tool.invoke(
+				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
+				THREAD_CONFIG,
+			);
+
+			expect(result).not.toContain("Error");
+			expect(result).toContain("Nothing to withdraw");
+			// The model must not claim a retraction that never happened.
+			expect(result).toContain("Do not tell the user you took anything back");
+		});
+
+		it("reports proposals it could not withdraw because the user already applied part", async () => {
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 0, skippedApplied: 1 });
+
+			const result = await tool.invoke(
+				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("Could not withdraw 1 proposal(s)");
+			expect(result).toContain("Leave it to them to undo");
+		});
+
+		it("allows discard and update for the same path in one batch", async () => {
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+			vi.mocked(app.vault.read).mockResolvedValue("line one\nline two\n");
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{ type: "discard", path: "Notes/doc.md" },
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							edits: [{ oldText: "line two", newText: "line two edited" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			// The one-target-per-path guard must not fire — this pair is the
+			// correction idiom the discard operation exists to enable.
+			expect(result).not.toContain("targeted more than once");
+			expect(result).toContain("Withdrew 1 pending proposal(s)");
+			const staged = mockAddChanges.mock.calls[0][0][0];
+			expect(staged.newContent).toBe("line one\nline two edited\n");
+		});
+
+		it("still discards when the note no longer resolves in the vault", async () => {
+			// Entries are keyed by path, so a proposal for a note that has since been
+			// renamed or deleted must remain withdrawable.
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			const result = await tool.invoke(
+				{ operations: [{ type: "discard", path: "Notes/gone.md" }] },
+				THREAD_CONFIG,
+			);
+
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/gone.md", "test-thread-id");
+			expect(result).toContain("Withdrew 1 pending proposal(s)");
+		});
+
+		it("does not require update permission", async () => {
+			// Discarding only ever REMOVES a proposed write, so a permission change
+			// must not strand proposals the agent could otherwise clean up.
+			setManageNotesPermissions({ allowCreate: false, allowUpdate: false, allowDelete: false, allowMove: false });
+			tool = createManageNotesTool(app);
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			const result = await tool.invoke(
+				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
+				THREAD_CONFIG,
+			);
+
+			expect(result).not.toContain("disabled for this agent");
+			expect(result).toContain("Withdrew 1 pending proposal(s)");
+		});
+	});
+
+	describe("replace_pending opts out of the rebase", () => {
+		const DISK = "line one\nline two\nline three\n";
+
+		beforeEach(() => {
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
+			vi.mocked(app.vault.read).mockResolvedValue(DISK);
+			// A pending proposal that the default rebase WOULD have merged with:
+			// its edit is orthogonal, so both bases match.
+			mockGetPendingUpdatesForPath.mockReturnValue([
+				{
+					id: "prior-id",
+					status: "pending",
+					toolCallId: "tc-prior",
+					threadId: "test-thread-id",
+					createdAt: 1,
+					change: {
+						type: "update",
+						path: "Notes/doc.md",
+						originalContent: DISK,
+						newContent: "line one edited\nline two\nline three\n",
+					},
+				},
+			]);
+		});
+
+		it("stages an update against disk and drops the earlier proposal", async () => {
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							replace_pending: true,
+							edits: [{ oldText: "line three", newText: "line three edited" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			// No merge note: this REPLACES the earlier proposal rather than adding to it.
+			expect(result).not.toContain("contains BOTH");
+			const staged = mockAddChanges.mock.calls[0][0][0];
+			// "line one edited" is absent — the earlier round was deliberately dropped.
+			expect(staged.newContent).toBe("line one\nline two\nline three edited\n");
+		});
+
+		it("merges instead when the flag is omitted", async () => {
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							edits: [{ oldText: "line three", newText: "line three edited" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("contains BOTH");
+			const staged = mockAddChanges.mock.calls[0][0][0];
+			expect(staged.newContent).toBe("line one edited\nline two\nline three edited\n");
+		});
+
+		it("applies to a vault-wide replace too", async () => {
+			mockGetIndexableVaultFiles.mockReturnValue([makeFile("Notes/doc.md")]);
+
+			const result = await tool.invoke(
+				{
+					operations: [{ type: "replace", find: "line two", replace: "LINE 2", replace_pending: true }],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).not.toContain("contains BOTH");
+			const staged = mockAddChanges.mock.calls[0][0][0];
+			expect(staged.newContent).toBe("line one\nLINE 2\nline three\n");
 		});
 	});
 });

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -1239,6 +1239,42 @@ describe("manageNotes tool", () => {
 			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/final.md", "test-thread-id");
 		});
 
+		/**
+		 * Regression (PR #429 review, third pass): vault resolution short-circuited
+		 * ahead of `formerPaths`. Once a proposal's note is renamed away, a NEW file
+		 * can occupy the path it was staged under — the vault resolves that file,
+		 * which has no pending entry, so the discard missed the re-keyed proposal.
+		 */
+		it("ignores a vault match that is not one of this thread's proposals", async () => {
+			// A different note now sits at the path the proposal was staged under.
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
+			mockGetPendingForThread.mockReturnValue([
+				{ change: { path: "Notes/renamed.md" }, formerPaths: ["Notes/doc.md"] },
+			]);
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			const result = await tool.invoke(
+				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
+				THREAD_CONFIG,
+			);
+
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/renamed.md", "test-thread-id");
+			expect(mockDiscardPendingForPath).not.toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
+			expect(result).toContain("Withdrew 1 pending proposal(s)");
+		});
+
+		it("names the canonical path when the vault resolves but nothing is pending", async () => {
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
+			mockGetPendingForThread.mockReturnValue([]);
+
+			const result = await tool.invoke({ operations: [{ type: "discard", path: "[[doc]]" }] }, THREAD_CONFIG);
+
+			// Reported by real path, not the bare "doc" the wiki-link normalizes to.
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
+			expect(result).toContain("Nothing to withdraw");
+			expect(result).toContain("Notes/doc.md");
+		});
+
 		it("prefers a former-path match over a looser basename match", async () => {
 			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
 			mockGetPendingForThread.mockReturnValue([
@@ -1256,7 +1292,11 @@ describe("manageNotes tool", () => {
 
 		it("prefers the vault-resolved path over a looser basename match", async () => {
 			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
-			mockGetPendingForThread.mockReturnValue([{ change: { path: "Archive/doc.md" } }]);
+			// Both are this thread's proposals; the vault-resolved one must win.
+			mockGetPendingForThread.mockReturnValue([
+				{ change: { path: "Notes/doc.md" } },
+				{ change: { path: "Archive/doc.md" } },
+			]);
 			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
 
 			await tool.invoke({ operations: [{ type: "discard", path: "Notes/doc.md" }] }, THREAD_CONFIG);

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -1275,6 +1275,68 @@ describe("manageNotes tool", () => {
 			expect(result).toContain("Notes/doc.md");
 		});
 
+		/**
+		 * Regression (PR #429 review, fourth pass): when a renamed proposal's former
+		 * path is reused by a NEW note that also has a live proposal, the name
+		 * truthfully identifies both. Every ranking tried here silently withdrew one
+		 * proposal while leaving the other, so the tool now asks instead.
+		 */
+		it("refuses to guess when the name identifies two live proposals", async () => {
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
+			mockGetPendingForThread.mockReturnValue([
+				// Staged as Notes/doc.md, since renamed away.
+				{ change: { path: "Notes/renamed.md" }, formerPaths: ["Notes/doc.md"] },
+				// A different note now at Notes/doc.md, with its own proposal.
+				{ change: { path: "Notes/doc.md" } },
+			]);
+
+			const result = await tool.invoke(
+				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain("matches more than one pending proposal");
+			expect(result).toContain("Notes/doc.md");
+			expect(result).toContain("Notes/renamed.md");
+			// Nothing withdrawn — guessing either way loses a proposal.
+			expect(mockDiscardPendingForPath).not.toHaveBeenCalled();
+		});
+
+		it("withdraws normally once the ambiguity is gone", async () => {
+			// Same shape, but the new note has no proposal of its own.
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
+			mockGetPendingForThread.mockReturnValue([
+				{ change: { path: "Notes/renamed.md" }, formerPaths: ["Notes/doc.md"] },
+			]);
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			const result = await tool.invoke(
+				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
+				THREAD_CONFIG,
+			);
+
+			expect(result).not.toContain("matches more than one");
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/renamed.md", "test-thread-id");
+		});
+
+		it("is not ambiguous when both tiers name the same proposal", async () => {
+			// A note renamed away and back: `formerPaths` and the current path agree.
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
+			mockGetPendingForThread.mockReturnValue([
+				{ change: { path: "Notes/doc.md" }, formerPaths: ["Notes/doc.md"] },
+			]);
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			const result = await tool.invoke(
+				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
+				THREAD_CONFIG,
+			);
+
+			expect(result).not.toContain("matches more than one");
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
+			expect(mockDiscardPendingForPath).toHaveBeenCalledTimes(1);
+		});
+
 		it("prefers a former-path match over a looser basename match", async () => {
 			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
 			mockGetPendingForThread.mockReturnValue([

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -7,8 +7,9 @@ const mockIsPathAllowed = vi.fn().mockReturnValue(true);
 const mockCountOtherThreads = vi.fn().mockReturnValue(0);
 const mockShouldBlockFile = vi.fn().mockReturnValue(false);
 const mockGetPendingUpdatesForPath = vi.fn().mockReturnValue([]);
-const mockDiscardPendingForPath = vi.fn().mockReturnValue({ discarded: 0, skippedApplied: 0 });
-const mockGetPendingForThread = vi.fn().mockReturnValue([]);
+const mockDiscardPendingById = vi.fn().mockReturnValue("not_found");
+const mockGetPendingByShortId = vi.fn().mockReturnValue(undefined);
+const mockGetEntry = vi.fn().mockReturnValue(undefined);
 
 vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({
 	getPendingChangesStore: () => ({
@@ -17,8 +18,9 @@ vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({
 		countOtherThreadsPendingUpdate: mockCountOtherThreads,
 		shouldBlockFile: (...args: unknown[]) => mockShouldBlockFile(...args),
 		getPendingUpdatesForPath: (...args: unknown[]) => mockGetPendingUpdatesForPath(...args),
-		discardPendingForPath: (...args: unknown[]) => mockDiscardPendingForPath(...args),
-		getPendingForThread: (...args: unknown[]) => mockGetPendingForThread(...args),
+		discardPendingById: (...args: unknown[]) => mockDiscardPendingById(...args),
+		getPendingByShortId: (...args: unknown[]) => mockGetPendingByShortId(...args),
+		getEntry: (...args: unknown[]) => mockGetEntry(...args),
 	}),
 }));
 
@@ -104,8 +106,9 @@ describe("manageNotes tool", () => {
 		mockCountOtherThreads.mockReturnValue(0);
 		mockShouldBlockFile.mockReturnValue(false);
 		mockGetPendingUpdatesForPath.mockReturnValue([]);
-		mockDiscardPendingForPath.mockReturnValue({ discarded: 0, skippedApplied: 0 });
-		mockGetPendingForThread.mockReturnValue([]);
+		mockDiscardPendingById.mockReturnValue("not_found");
+		mockGetPendingByShortId.mockReturnValue(undefined);
+		mockGetEntry.mockReturnValue(undefined);
 		mockAddChanges.mockReturnValue(["mock-id"]);
 		mockGetIndexableVaultFiles.mockReturnValue([]);
 		setManageNotesPermissions();
@@ -1086,62 +1089,62 @@ describe("manageNotes tool", () => {
 	 * stage a second proposal — which the rebase then merged with the first,
 	 * leaving BOTH edits in the review queue while the agent told the user the
 	 * earlier one had been superseded.
+	 *
+	 * Keyed by id, not path. Resolving a proposal from a path went through four
+	 * rounds of tie-breaking and still had a case where every choice was wrong: a
+	 * path moves with a rename, can be reused by another note, and can name two
+	 * live proposals at once. An id has none of that.
 	 */
-	describe("discard withdraws this thread's pending proposals", () => {
-		beforeEach(() => {
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
-		});
+	describe("discard withdraws a pending proposal by id", () => {
+		it("withdraws the proposal with that id and stages nothing", async () => {
+			mockGetPendingByShortId.mockReturnValue({ change: { path: "Notes/doc.md" } });
+			mockDiscardPendingById.mockReturnValue("discarded");
 
-		it("withdraws pending proposals for the path and stages nothing", async () => {
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 2, skippedApplied: 0 });
+			const result = await tool.invoke({ operations: [{ type: "discard", id: "4f2a9c" }] }, THREAD_CONFIG);
 
-			const result = await tool.invoke(
-				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
-				THREAD_CONFIG,
-			);
-
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
-			expect(result).toContain("Withdrew 2 pending proposal(s)");
+			expect(mockDiscardPendingById).toHaveBeenCalledWith("4f2a9c", "test-thread-id");
+			expect(result).toContain("Withdrew 1 pending proposal(s)");
+			// Reported by path — that is what the user sees in the review bar.
 			expect(result).toContain("Notes/doc.md");
-			// A discard proposes nothing — it must not inflate the operation tally.
+			// A discard proposes nothing, so it must not inflate the operation tally.
 			expect(result).not.toContain("Proposed");
 			expect(mockAddChanges).toHaveBeenCalledWith([], expect.anything(), "test-thread-id");
 		});
 
-		it("is a neutral no-op rather than an error when nothing is pending", async () => {
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 0, skippedApplied: 0 });
+		it("is a neutral report rather than an error for an unknown id", async () => {
+			mockDiscardPendingById.mockReturnValue("not_found");
 
-			const result = await tool.invoke(
-				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
-				THREAD_CONFIG,
-			);
+			const result = await tool.invoke({ operations: [{ type: "discard", id: "nosuch" }] }, THREAD_CONFIG);
 
 			expect(result).not.toContain("Error");
-			expect(result).toContain("Nothing to withdraw");
+			expect(result).toContain("No pending proposal in this chat with id");
+			expect(result).toContain("nosuch");
 			// The model must not claim a retraction that never happened.
-			expect(result).toContain("Do not tell the user you took anything back");
+			expect(result).toContain("do not tell the user you took anything back");
 		});
 
-		it("reports proposals it could not withdraw because the user already applied part", async () => {
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 0, skippedApplied: 1 });
+		it("refuses a proposal the user has already partly applied", async () => {
+			mockGetPendingByShortId.mockReturnValue({ change: { path: "Notes/doc.md" } });
+			mockDiscardPendingById.mockReturnValue("partially_applied");
 
-			const result = await tool.invoke(
-				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
-				THREAD_CONFIG,
-			);
+			const result = await tool.invoke({ operations: [{ type: "discard", id: "4f2a9c" }] }, THREAD_CONFIG);
 
 			expect(result).toContain("Could not withdraw 1 proposal(s)");
 			expect(result).toContain("Leave it to them to undo");
 		});
 
-		it("allows discard and update for the same path in one batch", async () => {
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+		it("allows discard and update for the same note in one batch", async () => {
+			// The batch's one-target-per-path guard keys on paths; a discard names
+			// an id, so this correction idiom must not trip it.
+			mockGetPendingByShortId.mockReturnValue({ change: { path: "Notes/doc.md" } });
+			mockDiscardPendingById.mockReturnValue("discarded");
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
 			vi.mocked(app.vault.read).mockResolvedValue("line one\nline two\n");
 
 			const result = await tool.invoke(
 				{
 					operations: [
-						{ type: "discard", path: "Notes/doc.md" },
+						{ type: "discard", id: "4f2a9c" },
 						{
 							type: "update",
 							path: "Notes/doc.md",
@@ -1152,247 +1155,20 @@ describe("manageNotes tool", () => {
 				THREAD_CONFIG,
 			);
 
-			// The one-target-per-path guard must not fire — this pair is the
-			// correction idiom the discard operation exists to enable.
 			expect(result).not.toContain("targeted more than once");
 			expect(result).toContain("Withdrew 1 pending proposal(s)");
 			const staged = mockAddChanges.mock.calls[0][0][0];
 			expect(staged.newContent).toBe("line one\nline two edited\n");
 		});
 
-		it("still discards when the note no longer resolves in the vault", async () => {
-			// Entries are keyed by path, so a proposal for a note that has since been
-			// renamed or deleted must remain withdrawable.
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
-			mockGetPendingForThread.mockReturnValue([{ change: { path: "Notes/gone.md" } }]);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+		it("is scoped to this thread", async () => {
+			// The store does the scoping; assert the tool passes the thread through
+			// rather than letting one chat withdraw another's proposal.
+			mockDiscardPendingById.mockReturnValue("not_found");
 
-			const result = await tool.invoke(
-				{ operations: [{ type: "discard", path: "Notes/gone.md" }] },
-				THREAD_CONFIG,
-			);
+			await tool.invoke({ operations: [{ type: "discard", id: "4f2a9c" }] }, THREAD_CONFIG);
 
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/gone.md", "test-thread-id");
-			expect(result).toContain("Withdrew 1 pending proposal(s)");
-		});
-
-		/**
-		 * Regression (PR #429 review): a wiki-link normalizes to a bare basename
-		 * that can never equal the canonical path an entry is keyed by, so the
-		 * discard matched nothing and wrongly reported "nothing to withdraw".
-		 */
-		it("resolves an unresolvable wiki-link against the thread's own entries", async () => {
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
-			mockGetPendingForThread.mockReturnValue([{ change: { path: "Notes/todo.md" } }]);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
-
-			const result = await tool.invoke({ operations: [{ type: "discard", path: "[[todo]]" }] }, THREAD_CONFIG);
-
-			// Not the bare "todo" the reference normalizes to.
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/todo.md", "test-thread-id");
-			expect(result).toContain("Withdrew 1 pending proposal(s)");
-		});
-
-		it("withdraws a moved note's proposal via its current entry path", async () => {
-			// #handleFileRename re-keys the entry, so the path the model remembers
-			// no longer resolves — but the basename still identifies the proposal.
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
-			mockGetPendingForThread.mockReturnValue([{ change: { path: "Archive/doc.md" } }]);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
-
-			await tool.invoke({ operations: [{ type: "discard", path: "Notes/doc.md" }] }, THREAD_CONFIG);
-
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Archive/doc.md", "test-thread-id");
-		});
-
-		/**
-		 * Regression (PR #429 review, second pass): a rename that also changes the
-		 * BASENAME leaves nothing for the name-based tiers to match — the model
-		 * knows only the staged path, and the entry was re-keyed in place. The
-		 * store now records the path it leaves in `formerPaths`.
-		 */
-		it("withdraws a renamed note's proposal via the path it was staged under", async () => {
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
-			mockGetPendingForThread.mockReturnValue([
-				{ change: { path: "Notes/renamed.md" }, formerPaths: ["Notes/doc.md"] },
-			]);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
-
-			const result = await tool.invoke(
-				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
-				THREAD_CONFIG,
-			);
-
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/renamed.md", "test-thread-id");
-			expect(result).toContain("Withdrew 1 pending proposal(s)");
-		});
-
-		it("follows a note renamed more than once back to the staged name", async () => {
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
-			mockGetPendingForThread.mockReturnValue([
-				{ change: { path: "Notes/final.md" }, formerPaths: ["Notes/doc.md", "Notes/interim.md"] },
-			]);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
-
-			await tool.invoke({ operations: [{ type: "discard", path: "Notes/doc.md" }] }, THREAD_CONFIG);
-
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/final.md", "test-thread-id");
-		});
-
-		/**
-		 * Regression (PR #429 review, third pass): vault resolution short-circuited
-		 * ahead of `formerPaths`. Once a proposal's note is renamed away, a NEW file
-		 * can occupy the path it was staged under — the vault resolves that file,
-		 * which has no pending entry, so the discard missed the re-keyed proposal.
-		 */
-		it("ignores a vault match that is not one of this thread's proposals", async () => {
-			// A different note now sits at the path the proposal was staged under.
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
-			mockGetPendingForThread.mockReturnValue([
-				{ change: { path: "Notes/renamed.md" }, formerPaths: ["Notes/doc.md"] },
-			]);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
-
-			const result = await tool.invoke(
-				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
-				THREAD_CONFIG,
-			);
-
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/renamed.md", "test-thread-id");
-			expect(mockDiscardPendingForPath).not.toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
-			expect(result).toContain("Withdrew 1 pending proposal(s)");
-		});
-
-		it("names the canonical path when the vault resolves but nothing is pending", async () => {
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
-			mockGetPendingForThread.mockReturnValue([]);
-
-			const result = await tool.invoke({ operations: [{ type: "discard", path: "[[doc]]" }] }, THREAD_CONFIG);
-
-			// Reported by real path, not the bare "doc" the wiki-link normalizes to.
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
-			expect(result).toContain("Nothing to withdraw");
-			expect(result).toContain("Notes/doc.md");
-		});
-
-		/**
-		 * Regression (PR #429 review, fourth pass): when a renamed proposal's former
-		 * path is reused by a NEW note that also has a live proposal, the name
-		 * truthfully identifies both. Every ranking tried here silently withdrew one
-		 * proposal while leaving the other, so the tool now asks instead.
-		 */
-		it("refuses to guess when the name identifies two live proposals", async () => {
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
-			mockGetPendingForThread.mockReturnValue([
-				// Staged as Notes/doc.md, since renamed away.
-				{ change: { path: "Notes/renamed.md" }, formerPaths: ["Notes/doc.md"] },
-				// A different note now at Notes/doc.md, with its own proposal.
-				{ change: { path: "Notes/doc.md" } },
-			]);
-
-			const result = await tool.invoke(
-				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
-				THREAD_CONFIG,
-			);
-
-			expect(result).toContain("matches more than one pending proposal");
-			expect(result).toContain("Notes/doc.md");
-			expect(result).toContain("Notes/renamed.md");
-			// Nothing withdrawn — guessing either way loses a proposal.
-			expect(mockDiscardPendingForPath).not.toHaveBeenCalled();
-		});
-
-		it("withdraws normally once the ambiguity is gone", async () => {
-			// Same shape, but the new note has no proposal of its own.
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
-			mockGetPendingForThread.mockReturnValue([
-				{ change: { path: "Notes/renamed.md" }, formerPaths: ["Notes/doc.md"] },
-			]);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
-
-			const result = await tool.invoke(
-				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
-				THREAD_CONFIG,
-			);
-
-			expect(result).not.toContain("matches more than one");
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/renamed.md", "test-thread-id");
-		});
-
-		it("is not ambiguous when both tiers name the same proposal", async () => {
-			// A note renamed away and back: `formerPaths` and the current path agree.
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
-			mockGetPendingForThread.mockReturnValue([
-				{ change: { path: "Notes/doc.md" }, formerPaths: ["Notes/doc.md"] },
-			]);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
-
-			const result = await tool.invoke(
-				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
-				THREAD_CONFIG,
-			);
-
-			expect(result).not.toContain("matches more than one");
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
-			expect(mockDiscardPendingForPath).toHaveBeenCalledTimes(1);
-		});
-
-		it("prefers a former-path match over a looser basename match", async () => {
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
-			mockGetPendingForThread.mockReturnValue([
-				{ change: { path: "Notes/renamed.md" }, formerPaths: ["Notes/doc.md"] },
-				// Same basename as the reference, but never staged under that path.
-				{ change: { path: "Archive/doc.md" } },
-			]);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
-
-			await tool.invoke({ operations: [{ type: "discard", path: "Notes/doc.md" }] }, THREAD_CONFIG);
-
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/renamed.md", "test-thread-id");
-			expect(mockDiscardPendingForPath).not.toHaveBeenCalledWith("Archive/doc.md", "test-thread-id");
-		});
-
-		it("prefers the vault-resolved path over a looser basename match", async () => {
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
-			// Both are this thread's proposals; the vault-resolved one must win.
-			mockGetPendingForThread.mockReturnValue([
-				{ change: { path: "Notes/doc.md" } },
-				{ change: { path: "Archive/doc.md" } },
-			]);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
-
-			await tool.invoke({ operations: [{ type: "discard", path: "Notes/doc.md" }] }, THREAD_CONFIG);
-
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
-			expect(mockDiscardPendingForPath).not.toHaveBeenCalledWith("Archive/doc.md", "test-thread-id");
-		});
-
-		it("withdraws every same-named proposal and names each in full", async () => {
-			// Two pending proposals share a basename; withdrawing only one would
-			// leave the other stuck with no way for the model to name it.
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
-			mockGetPendingForThread.mockReturnValue([
-				{ change: { path: "Notes/doc.md" } },
-				{ change: { path: "Archive/doc.md" } },
-			]);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
-
-			const result = await tool.invoke({ operations: [{ type: "discard", path: "[[doc]]" }] }, THREAD_CONFIG);
-
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Archive/doc.md", "test-thread-id");
-			expect(result).toContain("Notes/doc.md");
-			expect(result).toContain("Archive/doc.md");
-		});
-
-		it("reports honestly against the model's own reference when nothing matches", async () => {
-			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
-			mockGetPendingForThread.mockReturnValue([{ change: { path: "Notes/unrelated.md" } }]);
-
-			const result = await tool.invoke({ operations: [{ type: "discard", path: "[[absent]]" }] }, THREAD_CONFIG);
-
-			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("absent", "test-thread-id");
-			expect(result).toContain("Nothing to withdraw");
+			expect(mockDiscardPendingById).toHaveBeenCalledWith("4f2a9c", "test-thread-id");
 		});
 
 		it("does not require update permission", async () => {
@@ -1400,15 +1176,75 @@ describe("manageNotes tool", () => {
 			// must not strand proposals the agent could otherwise clean up.
 			setManageNotesPermissions({ allowCreate: false, allowUpdate: false, allowDelete: false, allowMove: false });
 			tool = createManageNotesTool(app);
-			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+			mockGetPendingByShortId.mockReturnValue({ change: { path: "Notes/doc.md" } });
+			mockDiscardPendingById.mockReturnValue("discarded");
 
-			const result = await tool.invoke(
-				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
-				THREAD_CONFIG,
-			);
+			const result = await tool.invoke({ operations: [{ type: "discard", id: "4f2a9c" }] }, THREAD_CONFIG);
 
 			expect(result).not.toContain("disabled for this agent");
 			expect(result).toContain("Withdrew 1 pending proposal(s)");
+		});
+	});
+
+	/**
+	 * The ids are the whole retraction mechanism: `discard` takes one, and the
+	 * model has no other way to name a proposal. If staging stops reporting them
+	 * the feature is unreachable, so this is pinned separately.
+	 */
+	describe("staged proposals are reported with their ids", () => {
+		it("lists each pending proposal's path and id", async () => {
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
+			vi.mocked(app.vault.read).mockResolvedValue("line one\n");
+			mockAddChanges.mockReturnValue(["uuid-1"]);
+			mockGetEntry.mockReturnValue({
+				status: "pending",
+				shortId: "4f2a9c",
+				change: { path: "Notes/doc.md" },
+			});
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							edits: [{ oldText: "line one", newText: "line one edited" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).toContain('"Notes/doc.md" (id: 4f2a9c)');
+			expect(result).toContain("discard");
+		});
+
+		it("omits ids for changes that were auto-applied rather than staged", async () => {
+			// A memory write applies immediately, so it is never awaiting review and
+			// has no id to withdraw — listing one would invite a discard that fails.
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
+			vi.mocked(app.vault.read).mockResolvedValue("line one\n");
+			mockAddChanges.mockReturnValue(["uuid-1"]);
+			mockGetEntry.mockReturnValue({
+				status: "accepted",
+				shortId: "4f2a9c",
+				change: { path: "Notes/doc.md" },
+			});
+
+			const result = await tool.invoke(
+				{
+					operations: [
+						{
+							type: "update",
+							path: "Notes/doc.md",
+							edits: [{ oldText: "line one", newText: "line one edited" }],
+						},
+					],
+				},
+				THREAD_CONFIG,
+			);
+
+			expect(result).not.toContain("(id: 4f2a9c)");
 		});
 	});
 

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -8,6 +8,7 @@ const mockCountOtherThreads = vi.fn().mockReturnValue(0);
 const mockShouldBlockFile = vi.fn().mockReturnValue(false);
 const mockGetPendingUpdatesForPath = vi.fn().mockReturnValue([]);
 const mockDiscardPendingForPath = vi.fn().mockReturnValue({ discarded: 0, skippedApplied: 0 });
+const mockGetPendingForThread = vi.fn().mockReturnValue([]);
 
 vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({
 	getPendingChangesStore: () => ({
@@ -17,6 +18,7 @@ vi.mock("../../src/stores/pendingChangesStore.svelte", () => ({
 		shouldBlockFile: (...args: unknown[]) => mockShouldBlockFile(...args),
 		getPendingUpdatesForPath: (...args: unknown[]) => mockGetPendingUpdatesForPath(...args),
 		discardPendingForPath: (...args: unknown[]) => mockDiscardPendingForPath(...args),
+		getPendingForThread: (...args: unknown[]) => mockGetPendingForThread(...args),
 	}),
 }));
 
@@ -103,6 +105,7 @@ describe("manageNotes tool", () => {
 		mockShouldBlockFile.mockReturnValue(false);
 		mockGetPendingUpdatesForPath.mockReturnValue([]);
 		mockDiscardPendingForPath.mockReturnValue({ discarded: 0, skippedApplied: 0 });
+		mockGetPendingForThread.mockReturnValue([]);
 		mockAddChanges.mockReturnValue(["mock-id"]);
 		mockGetIndexableVaultFiles.mockReturnValue([]);
 		setManageNotesPermissions();
@@ -1161,6 +1164,7 @@ describe("manageNotes tool", () => {
 			// Entries are keyed by path, so a proposal for a note that has since been
 			// renamed or deleted must remain withdrawable.
 			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
+			mockGetPendingForThread.mockReturnValue([{ change: { path: "Notes/gone.md" } }]);
 			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
 
 			const result = await tool.invoke(
@@ -1170,6 +1174,74 @@ describe("manageNotes tool", () => {
 
 			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/gone.md", "test-thread-id");
 			expect(result).toContain("Withdrew 1 pending proposal(s)");
+		});
+
+		/**
+		 * Regression (PR #429 review): a wiki-link normalizes to a bare basename
+		 * that can never equal the canonical path an entry is keyed by, so the
+		 * discard matched nothing and wrongly reported "nothing to withdraw".
+		 */
+		it("resolves an unresolvable wiki-link against the thread's own entries", async () => {
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
+			mockGetPendingForThread.mockReturnValue([{ change: { path: "Notes/todo.md" } }]);
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			const result = await tool.invoke({ operations: [{ type: "discard", path: "[[todo]]" }] }, THREAD_CONFIG);
+
+			// Not the bare "todo" the reference normalizes to.
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/todo.md", "test-thread-id");
+			expect(result).toContain("Withdrew 1 pending proposal(s)");
+		});
+
+		it("withdraws a renamed note's proposal via its current entry path", async () => {
+			// #handleFileRename re-keys the entry, so the path the model remembers
+			// no longer resolves — but the basename still identifies the proposal.
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
+			mockGetPendingForThread.mockReturnValue([{ change: { path: "Archive/doc.md" } }]);
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			await tool.invoke({ operations: [{ type: "discard", path: "Notes/doc.md" }] }, THREAD_CONFIG);
+
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Archive/doc.md", "test-thread-id");
+		});
+
+		it("prefers the vault-resolved path over a looser basename match", async () => {
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "found", file: makeFile("Notes/doc.md") });
+			mockGetPendingForThread.mockReturnValue([{ change: { path: "Archive/doc.md" } }]);
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			await tool.invoke({ operations: [{ type: "discard", path: "Notes/doc.md" }] }, THREAD_CONFIG);
+
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
+			expect(mockDiscardPendingForPath).not.toHaveBeenCalledWith("Archive/doc.md", "test-thread-id");
+		});
+
+		it("withdraws every same-named proposal and names each in full", async () => {
+			// Two pending proposals share a basename; withdrawing only one would
+			// leave the other stuck with no way for the model to name it.
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
+			mockGetPendingForThread.mockReturnValue([
+				{ change: { path: "Notes/doc.md" } },
+				{ change: { path: "Archive/doc.md" } },
+			]);
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			const result = await tool.invoke({ operations: [{ type: "discard", path: "[[doc]]" }] }, THREAD_CONFIG);
+
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/doc.md", "test-thread-id");
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Archive/doc.md", "test-thread-id");
+			expect(result).toContain("Notes/doc.md");
+			expect(result).toContain("Archive/doc.md");
+		});
+
+		it("reports honestly against the model's own reference when nothing matches", async () => {
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
+			mockGetPendingForThread.mockReturnValue([{ change: { path: "Notes/unrelated.md" } }]);
+
+			const result = await tool.invoke({ operations: [{ type: "discard", path: "[[absent]]" }] }, THREAD_CONFIG);
+
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("absent", "test-thread-id");
+			expect(result).toContain("Nothing to withdraw");
 		});
 
 		it("does not require update permission", async () => {

--- a/test/agent/manageNotes.test.ts
+++ b/test/agent/manageNotes.test.ts
@@ -1193,7 +1193,7 @@ describe("manageNotes tool", () => {
 			expect(result).toContain("Withdrew 1 pending proposal(s)");
 		});
 
-		it("withdraws a renamed note's proposal via its current entry path", async () => {
+		it("withdraws a moved note's proposal via its current entry path", async () => {
 			// #handleFileRename re-keys the entry, so the path the model remembers
 			// no longer resolves — but the basename still identifies the proposal.
 			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
@@ -1203,6 +1203,55 @@ describe("manageNotes tool", () => {
 			await tool.invoke({ operations: [{ type: "discard", path: "Notes/doc.md" }] }, THREAD_CONFIG);
 
 			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Archive/doc.md", "test-thread-id");
+		});
+
+		/**
+		 * Regression (PR #429 review, second pass): a rename that also changes the
+		 * BASENAME leaves nothing for the name-based tiers to match — the model
+		 * knows only the staged path, and the entry was re-keyed in place. The
+		 * store now records the path it leaves in `formerPaths`.
+		 */
+		it("withdraws a renamed note's proposal via the path it was staged under", async () => {
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
+			mockGetPendingForThread.mockReturnValue([
+				{ change: { path: "Notes/renamed.md" }, formerPaths: ["Notes/doc.md"] },
+			]);
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			const result = await tool.invoke(
+				{ operations: [{ type: "discard", path: "Notes/doc.md" }] },
+				THREAD_CONFIG,
+			);
+
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/renamed.md", "test-thread-id");
+			expect(result).toContain("Withdrew 1 pending proposal(s)");
+		});
+
+		it("follows a note renamed more than once back to the staged name", async () => {
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
+			mockGetPendingForThread.mockReturnValue([
+				{ change: { path: "Notes/final.md" }, formerPaths: ["Notes/doc.md", "Notes/interim.md"] },
+			]);
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			await tool.invoke({ operations: [{ type: "discard", path: "Notes/doc.md" }] }, THREAD_CONFIG);
+
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/final.md", "test-thread-id");
+		});
+
+		it("prefers a former-path match over a looser basename match", async () => {
+			mockResolveVaultFileDetailed.mockReturnValue({ status: "not_found" });
+			mockGetPendingForThread.mockReturnValue([
+				{ change: { path: "Notes/renamed.md" }, formerPaths: ["Notes/doc.md"] },
+				// Same basename as the reference, but never staged under that path.
+				{ change: { path: "Archive/doc.md" } },
+			]);
+			mockDiscardPendingForPath.mockReturnValue({ discarded: 1, skippedApplied: 0 });
+
+			await tool.invoke({ operations: [{ type: "discard", path: "Notes/doc.md" }] }, THREAD_CONFIG);
+
+			expect(mockDiscardPendingForPath).toHaveBeenCalledWith("Notes/renamed.md", "test-thread-id");
+			expect(mockDiscardPendingForPath).not.toHaveBeenCalledWith("Archive/doc.md", "test-thread-id");
 		});
 
 		it("prefers the vault-resolved path over a looser basename match", async () => {

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -1136,4 +1136,42 @@ describe("PendingChangesStore", () => {
 			expect(store.getEntry(id)?.status).toBe("pending");
 		});
 	});
+
+	/**
+	 * Raised in the PR #429 review as "replacement leaves a stuck entry". It is
+	 * not a defect: the applied text is still in the note, so the superseded entry
+	 * must stay actionable to keep the undo reachable — see "keeps an entry
+	 * actionable when superseded by a newer proposal" above, and the
+	 * `initialOriginalContent` audit block it belongs to.
+	 *
+	 * Pinned from the `replace_pending` side too, since that flag exists to
+	 * supersede and is the likeliest route back to clearing this by mistake.
+	 */
+	describe("replace_pending-style supersede keeps the undo reachable", () => {
+		it("keeps the superseded entry's applied content resolvable", async () => {
+			const original = "a\nkeep\nb\n";
+			const [id] = store.addChanges(
+				[{ type: "update", path: "note.md", originalContent: original, newContent: "A\nkeep\nB\n" }],
+				"tc-1",
+				"thread-1",
+			);
+			vi.mocked(plugin.app.vault.getAbstractFileByPath).mockReturnValue(makeTFile("note.md"));
+			vi.mocked(plugin.app.vault.read).mockResolvedValue(original);
+			await store.acceptChangeGroup(id, 0);
+
+			// What `replace_pending` produces: a proposal staged against DISK, which
+			// already contains the accepted group.
+			store.addChanges(
+				[{ type: "update", path: "note.md", originalContent: "A\nkeep\nb\n", newContent: "A\nkeep\nZ\n" }],
+				"tc-2",
+				"thread-1",
+			);
+
+			const superseded = store.getEntry(id)!;
+			expect(superseded.status).toBe("rejected");
+			// Both invariants: the text is on disk, so the undo record must survive.
+			expect(store.hasUnrevertedApplication(superseded)).toBe(true);
+			expect(store.getActionableForThread("thread-1").map((e) => e.id)).toContain(id);
+		});
+	});
 });

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -880,7 +880,7 @@ describe("PendingChangesStore", () => {
 	 * ------------------------------------------------------------------------*/
 
 	describe("takeReviewOutcomesForThread", () => {
-		it("reports resolved entries once and pending paths every time", async () => {
+		it("reports resolved entries once and pending proposals every time", async () => {
 			const file = makeTFile("a.md");
 			(plugin.app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(file);
 			(plugin.app.vault.read as ReturnType<typeof vi.fn>).mockResolvedValue("x");
@@ -903,12 +903,15 @@ describe("PendingChangesStore", () => {
 				{ path: "a.md", outcome: "accepted" },
 				{ path: "b.md", outcome: "rejected" },
 			]);
-			expect(first.pendingPaths).toEqual(["c.md"]);
+			// Pending proposals carry the id the model discards by — this repeating
+			// every turn is what keeps an id reachable once the staging tool result
+			// has fallen out of context.
+			expect(first.pendingProposals).toEqual([{ path: "c.md", shortId: expect.any(String) }]);
 
 			// Resolved outcomes are delivered exactly once; pending repeats.
 			const second = store.takeReviewOutcomesForThread("thread-1");
 			expect(second.outcomes).toEqual([]);
-			expect(second.pendingPaths).toEqual(["c.md"]);
+			expect(second.pendingProposals).toEqual(first.pendingProposals);
 		});
 
 		it("reports a group-resolved entry with applied text as partially applied", async () => {
@@ -1061,160 +1064,149 @@ describe("PendingChangesStore", () => {
 	});
 
 	/* ----------------------------------------------------------------------
-	 * discardPendingForPath — the agent's retraction path (manage_notes discard)
+	 * discardPendingById — the agent's retraction path (manage_notes discard)
 	 * --------------------------------------------------------------------*/
 
-	describe("discardPendingForPath", () => {
-		it("rejects this thread's pending entries for the path", () => {
-			const [id] = store.addChanges(
-				[{ type: "update", path: "note.md", originalContent: "old", newContent: "new" }],
-				"tc-1",
-				"thread-1",
-			);
+	describe("discardPendingById", () => {
+		function stage(path: string, threadId = "thread-1") {
+			const [id] = store.addChanges([{ type: "create", path, content: "x" }], "tc-1", threadId);
+			return store.getEntry(id)!;
+		}
 
-			expect(store.discardPendingForPath("note.md", "thread-1")).toEqual({ discarded: 1, skippedApplied: 0 });
-			expect(store.getEntry(id)?.status).toBe("rejected");
+		it("withdraws the entry with that short id", () => {
+			const entry = stage("note.md");
+
+			expect(store.discardPendingById(entry.shortId!, "thread-1")).toBe("discarded");
+			expect(store.getEntry(entry.id)?.status).toBe("rejected");
 			expect(store.getPendingCount("thread-1")).toBe(0);
 		});
 
-		it("leaves other threads' proposals alone", () => {
-			const [mine] = store.addChanges(
-				[{ type: "update", path: "note.md", originalContent: "old", newContent: "a" }],
-				"tc-1",
-				"thread-1",
-			);
-			const [theirs] = store.addChanges(
-				[{ type: "update", path: "note.md", originalContent: "old", newContent: "b" }],
-				"tc-2",
-				"thread-2",
-			);
+		it("withdraws only that entry, not others in the thread", () => {
+			const target = stage("a.md");
+			const other = stage("b.md");
 
-			expect(store.discardPendingForPath("note.md", "thread-1").discarded).toBe(1);
-			expect(store.getEntry(mine)?.status).toBe("rejected");
-			// Another chat's proposal is never this agent's to withdraw.
-			expect(store.getEntry(theirs)?.status).toBe("pending");
+			store.discardPendingById(target.shortId!, "thread-1");
+
+			expect(store.getEntry(other.id)?.status).toBe("pending");
 		});
 
-		it("leaves other paths in the same thread alone", () => {
-			store.addChanges([{ type: "create", path: "a.md", content: "A" }], "tc-1", "thread-1");
-			const [b] = store.addChanges([{ type: "create", path: "b.md", content: "B" }], "tc-2", "thread-1");
+		it("will not reach another thread's proposal", () => {
+			const theirs = stage("note.md", "thread-2");
 
-			expect(store.discardPendingForPath("a.md", "thread-1").discarded).toBe(1);
-			expect(store.getEntry(b)?.status).toBe("pending");
+			// Correct id, wrong thread — another chat's proposal is not ours to drop.
+			expect(store.discardPendingById(theirs.shortId!, "thread-1")).toBe("not_found");
+			expect(store.getEntry(theirs.id)?.status).toBe("pending");
 		});
 
-		it("reports zero rather than throwing when nothing is pending", () => {
-			expect(store.discardPendingForPath("absent.md", "thread-1")).toEqual({
-				discarded: 0,
-				skippedApplied: 0,
-			});
+		it("reports not_found for an unknown id rather than throwing", () => {
+			expect(store.discardPendingById("nosuch", "thread-1")).toBe("not_found");
 		});
 
-		it("skips entries whose groups the user already partly applied", async () => {
+		it("refuses an entry whose groups the user already partly applied", async () => {
 			// Two separated change groups, so accepting one leaves the entry pending
-			// with applied content on disk (a single group would accept the whole
-			// entry and clear the snapshot).
+			// with applied content on disk (a single group would accept it outright).
 			const original = "a\nkeep\nb\n";
 			const [id] = store.addChanges(
 				[{ type: "update", path: "note.md", originalContent: original, newContent: "A\nkeep\nB\n" }],
 				"tc-1",
 				"thread-1",
 			);
-
-			// Accept one group so real content lands in the note — the user's own
-			// decision, which a later agent-side discard must not quietly undo.
-			const file = makeTFile("note.md");
-			vi.mocked(plugin.app.vault.getAbstractFileByPath).mockReturnValue(file);
+			vi.mocked(plugin.app.vault.getAbstractFileByPath).mockReturnValue(makeTFile("note.md"));
 			vi.mocked(plugin.app.vault.read).mockResolvedValue(original);
 			await store.acceptChangeGroup(id, 0);
-			expect(store.hasUnrevertedApplication(store.getEntry(id)!)).toBe(true);
 
-			expect(store.discardPendingForPath("note.md", "thread-1")).toEqual({
-				discarded: 0,
-				skippedApplied: 1,
-			});
+			const entry = store.getEntry(id)!;
+			expect(store.hasUnrevertedApplication(entry)).toBe(true);
+			// That text is on disk because the USER accepted it; resolving the entry
+			// would discard their only undo record.
+			expect(store.discardPendingById(entry.shortId!, "thread-1")).toBe("partially_applied");
 			expect(store.getEntry(id)?.status).toBe("pending");
+		});
+
+		it("getPendingByShortId is scoped the same way", () => {
+			const entry = stage("note.md");
+
+			expect(store.getPendingByShortId(entry.shortId!, "thread-1")?.id).toBe(entry.id);
+			expect(store.getPendingByShortId(entry.shortId!, "other-thread")).toBeUndefined();
+
+			store.discardPendingById(entry.shortId!, "thread-1");
+			// Resolved entries are not pending, so they are no longer addressable.
+			expect(store.getPendingByShortId(entry.shortId!, "thread-1")).toBeUndefined();
 		});
 	});
 
 	/**
-	 * Raised in the PR #429 review as "replacement leaves a stuck entry". It is
-	 * not a defect: the applied text is still in the note, so the superseded entry
-	 * must stay actionable to keep the undo reachable — see "keeps an entry
-	 * actionable when superseded by a newer proposal" above, and the
-	 * `initialOriginalContent` audit block it belongs to.
-	 *
-	 * Pinned from the `replace_pending` side too, since that flag exists to
-	 * supersede and is the likeliest route back to clearing this by mistake.
+	 * Short ids ARE the retraction mechanism — `discard` takes one and the model
+	 * has no other handle on a proposal. A collision would aim a discard at the
+	 * wrong note; a missing id would make one unreachable.
 	 */
-	/**
-	 * Regression (PR #429 review, second pass): the rename handler overwrote
-	 * `change.path` in place, leaving the entry with no trace of where it was
-	 * staged — while the model knows it only by that original path. An
-	 * agent-side `discard` was then unresolvable whenever a rename also changed
-	 * the basename.
-	 */
-	describe("rename records the path it leaves", () => {
-		async function renameTo(newPath: string, oldPath: string) {
-			const renameCb = (plugin.app.vault.on as ReturnType<typeof vi.fn>).mock.calls.find(
-				(c) => c[0] === "rename",
-			)?.[1];
-			renameCb({ path: newPath }, oldPath);
-		}
+	describe("short ids", () => {
+		it("are unique across a same-millisecond batch", () => {
+			// UUIDv7's leading bits are a timestamp, so entries staged together share
+			// a long prefix — a leading-slice id would collide on every one of these.
+			const ids = store.addChanges(
+				Array.from({ length: 25 }, (_, i) => ({
+					type: "create" as const,
+					path: `note-${i}.md`,
+					content: "x",
+				})),
+				"tc-1",
+				"thread-1",
+			);
 
-		beforeEach(async () => {
+			const shortIds = ids.map((id) => store.getEntry(id)?.shortId);
+			expect(shortIds.every(Boolean)).toBe(true);
+			expect(new Set(shortIds).size).toBe(ids.length);
+		});
+
+		it("do not collide with ids staged in an earlier batch", () => {
+			const first = store.addChanges([{ type: "create", path: "a.md", content: "x" }], "tc-1", "thread-1");
+			const second = store.addChanges([{ type: "create", path: "b.md", content: "x" }], "tc-2", "thread-1");
+
+			expect(store.getEntry(first[0])?.shortId).not.toBe(store.getEntry(second[0])?.shortId);
+		});
+
+		it("survive a save/load round-trip", async () => {
 			await store.load();
-		});
+			const [id] = store.addChanges([{ type: "create", path: "a.md", content: "x" }], "tc-1", "thread-1");
+			const shortId = store.getEntry(id)?.shortId;
 
-		it("records the former path on the entry", async () => {
-			const [id] = store.addChanges(
-				[{ type: "update", path: "Notes/doc.md", originalContent: "a", newContent: "b" }],
-				"tc-1",
-				"thread-1",
-			);
-
-			await renameTo("Notes/renamed.md", "Notes/doc.md");
-
-			expect(store.getEntry(id)?.change.path).toBe("Notes/renamed.md");
-			expect(store.getEntry(id)?.formerPaths).toEqual(["Notes/doc.md"]);
-		});
-
-		it("accumulates across repeated renames, oldest first", async () => {
-			const [id] = store.addChanges(
-				[{ type: "update", path: "Notes/doc.md", originalContent: "a", newContent: "b" }],
-				"tc-1",
-				"thread-1",
-			);
-
-			await renameTo("Notes/interim.md", "Notes/doc.md");
-			await renameTo("Notes/final.md", "Notes/interim.md");
-
-			// The staged name must remain reachable however many renames follow.
-			expect(store.getEntry(id)?.formerPaths).toEqual(["Notes/doc.md", "Notes/interim.md"]);
-		});
-
-		it("survives a save/load round-trip", async () => {
-			store.addChanges(
-				[{ type: "update", path: "Notes/doc.md", originalContent: "a", newContent: "b" }],
-				"tc-1",
-				"thread-1",
-			);
-			await renameTo("Notes/renamed.md", "Notes/doc.md");
-
-			// Round-trip through the store's OWN save path and the persistence
-			// schema, which would silently strip an unknown key and make the discard
-			// unresolvable again after a reload.
-			store.cleanup(); // flushes the debounced save
+			// Through the store's OWN save path and the persistence schema, which
+			// would silently strip an unknown key and make the entry undiscardable.
+			store.cleanup();
 			await vi.waitFor(() => expect(plugin.app.vault.adapter.write).toHaveBeenCalled());
 			const written = vi.mocked(plugin.app.vault.adapter.write).mock.calls.at(-1)?.[1] as string;
-			expect(written).toContain("formerPaths");
+			expect(written).toContain("shortId");
 
 			const fresh = new PendingChangesStore(plugin);
 			vi.mocked(plugin.app.vault.adapter.exists).mockResolvedValue(true);
 			vi.mocked(plugin.app.vault.adapter.read).mockResolvedValue(written);
 			await fresh.load();
 
-			expect(fresh.getPendingForThread("thread-1")[0]?.formerPaths).toEqual(["Notes/doc.md"]);
+			expect(fresh.getPendingByShortId(shortId!, "thread-1")).toBeDefined();
+		});
+
+		it("are backfilled for entries persisted before short ids existed", async () => {
+			// Without this such an entry could never be named, so it would sit in the
+			// review queue permanently undiscardable.
+			const legacy = JSON.stringify([
+				{
+					id: "01a0430a-d52a-702a-8711-8436ab485534",
+					change: { type: "create", path: "old.md", content: "x" },
+					status: "pending",
+					toolCallId: "tc-old",
+					threadId: "thread-1",
+					createdAt: 1,
+				},
+			]);
+			vi.mocked(plugin.app.vault.adapter.exists).mockResolvedValue(true);
+			vi.mocked(plugin.app.vault.adapter.read).mockResolvedValue(legacy);
+
+			await store.load();
+
+			const entry = store.getPendingForThread("thread-1")[0];
+			expect(entry?.shortId).toBeTruthy();
+			expect(store.discardPendingById(entry.shortId!, "thread-1")).toBe("discarded");
 		});
 	});
 

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -1147,6 +1147,77 @@ describe("PendingChangesStore", () => {
 	 * Pinned from the `replace_pending` side too, since that flag exists to
 	 * supersede and is the likeliest route back to clearing this by mistake.
 	 */
+	/**
+	 * Regression (PR #429 review, second pass): the rename handler overwrote
+	 * `change.path` in place, leaving the entry with no trace of where it was
+	 * staged — while the model knows it only by that original path. An
+	 * agent-side `discard` was then unresolvable whenever a rename also changed
+	 * the basename.
+	 */
+	describe("rename records the path it leaves", () => {
+		async function renameTo(newPath: string, oldPath: string) {
+			const renameCb = (plugin.app.vault.on as ReturnType<typeof vi.fn>).mock.calls.find(
+				(c) => c[0] === "rename",
+			)?.[1];
+			renameCb({ path: newPath }, oldPath);
+		}
+
+		beforeEach(async () => {
+			await store.load();
+		});
+
+		it("records the former path on the entry", async () => {
+			const [id] = store.addChanges(
+				[{ type: "update", path: "Notes/doc.md", originalContent: "a", newContent: "b" }],
+				"tc-1",
+				"thread-1",
+			);
+
+			await renameTo("Notes/renamed.md", "Notes/doc.md");
+
+			expect(store.getEntry(id)?.change.path).toBe("Notes/renamed.md");
+			expect(store.getEntry(id)?.formerPaths).toEqual(["Notes/doc.md"]);
+		});
+
+		it("accumulates across repeated renames, oldest first", async () => {
+			const [id] = store.addChanges(
+				[{ type: "update", path: "Notes/doc.md", originalContent: "a", newContent: "b" }],
+				"tc-1",
+				"thread-1",
+			);
+
+			await renameTo("Notes/interim.md", "Notes/doc.md");
+			await renameTo("Notes/final.md", "Notes/interim.md");
+
+			// The staged name must remain reachable however many renames follow.
+			expect(store.getEntry(id)?.formerPaths).toEqual(["Notes/doc.md", "Notes/interim.md"]);
+		});
+
+		it("survives a save/load round-trip", async () => {
+			store.addChanges(
+				[{ type: "update", path: "Notes/doc.md", originalContent: "a", newContent: "b" }],
+				"tc-1",
+				"thread-1",
+			);
+			await renameTo("Notes/renamed.md", "Notes/doc.md");
+
+			// Round-trip through the store's OWN save path and the persistence
+			// schema, which would silently strip an unknown key and make the discard
+			// unresolvable again after a reload.
+			store.cleanup(); // flushes the debounced save
+			await vi.waitFor(() => expect(plugin.app.vault.adapter.write).toHaveBeenCalled());
+			const written = vi.mocked(plugin.app.vault.adapter.write).mock.calls.at(-1)?.[1] as string;
+			expect(written).toContain("formerPaths");
+
+			const fresh = new PendingChangesStore(plugin);
+			vi.mocked(plugin.app.vault.adapter.exists).mockResolvedValue(true);
+			vi.mocked(plugin.app.vault.adapter.read).mockResolvedValue(written);
+			await fresh.load();
+
+			expect(fresh.getPendingForThread("thread-1")[0]?.formerPaths).toEqual(["Notes/doc.md"]);
+		});
+	});
+
 	describe("replace_pending-style supersede keeps the undo reachable", () => {
 		it("keeps the superseded entry's applied content resolvable", async () => {
 			const original = "a\nkeep\nb\n";

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -1059,4 +1059,81 @@ describe("PendingChangesStore", () => {
 			expect(store.isFilePrivate("Docs/spec.md")).toBe(false);
 		});
 	});
+
+	/* ----------------------------------------------------------------------
+	 * discardPendingForPath — the agent's retraction path (manage_notes discard)
+	 * --------------------------------------------------------------------*/
+
+	describe("discardPendingForPath", () => {
+		it("rejects this thread's pending entries for the path", () => {
+			const [id] = store.addChanges(
+				[{ type: "update", path: "note.md", originalContent: "old", newContent: "new" }],
+				"tc-1",
+				"thread-1",
+			);
+
+			expect(store.discardPendingForPath("note.md", "thread-1")).toEqual({ discarded: 1, skippedApplied: 0 });
+			expect(store.getEntry(id)?.status).toBe("rejected");
+			expect(store.getPendingCount("thread-1")).toBe(0);
+		});
+
+		it("leaves other threads' proposals alone", () => {
+			const [mine] = store.addChanges(
+				[{ type: "update", path: "note.md", originalContent: "old", newContent: "a" }],
+				"tc-1",
+				"thread-1",
+			);
+			const [theirs] = store.addChanges(
+				[{ type: "update", path: "note.md", originalContent: "old", newContent: "b" }],
+				"tc-2",
+				"thread-2",
+			);
+
+			expect(store.discardPendingForPath("note.md", "thread-1").discarded).toBe(1);
+			expect(store.getEntry(mine)?.status).toBe("rejected");
+			// Another chat's proposal is never this agent's to withdraw.
+			expect(store.getEntry(theirs)?.status).toBe("pending");
+		});
+
+		it("leaves other paths in the same thread alone", () => {
+			store.addChanges([{ type: "create", path: "a.md", content: "A" }], "tc-1", "thread-1");
+			const [b] = store.addChanges([{ type: "create", path: "b.md", content: "B" }], "tc-2", "thread-1");
+
+			expect(store.discardPendingForPath("a.md", "thread-1").discarded).toBe(1);
+			expect(store.getEntry(b)?.status).toBe("pending");
+		});
+
+		it("reports zero rather than throwing when nothing is pending", () => {
+			expect(store.discardPendingForPath("absent.md", "thread-1")).toEqual({
+				discarded: 0,
+				skippedApplied: 0,
+			});
+		});
+
+		it("skips entries whose groups the user already partly applied", async () => {
+			// Two separated change groups, so accepting one leaves the entry pending
+			// with applied content on disk (a single group would accept the whole
+			// entry and clear the snapshot).
+			const original = "a\nkeep\nb\n";
+			const [id] = store.addChanges(
+				[{ type: "update", path: "note.md", originalContent: original, newContent: "A\nkeep\nB\n" }],
+				"tc-1",
+				"thread-1",
+			);
+
+			// Accept one group so real content lands in the note — the user's own
+			// decision, which a later agent-side discard must not quietly undo.
+			const file = makeTFile("note.md");
+			vi.mocked(plugin.app.vault.getAbstractFileByPath).mockReturnValue(file);
+			vi.mocked(plugin.app.vault.read).mockResolvedValue(original);
+			await store.acceptChangeGroup(id, 0);
+			expect(store.hasUnrevertedApplication(store.getEntry(id)!)).toBe(true);
+
+			expect(store.discardPendingForPath("note.md", "thread-1")).toEqual({
+				discarded: 0,
+				skippedApplied: 1,
+			});
+			expect(store.getEntry(id)?.status).toBe("pending");
+		});
+	});
 });


### PR DESCRIPTION
## The bug

Asked to add a line to `Welcome.md`, then corrected with "i meant at the bottom of the note", the agent staged a follow-up and told the user it **superseded** the first — while the review bar showed *both* insertions. Confirmed against `data/pending-changes.json`: one entry, two hunks.

```
@@ -3,2 +3,4 @@   +This is a new test line added for testing purposes.   ← after the intro
@@ -51 +53,3 @@   +This is a new test line added for testing purposes.   ← at the bottom
```

Two independent causes.

**1. The agent had no way to retract.** `manage_notes` only stages, and `pendingChangesStore` exposes rejection to UI callers only. Its sole lever was the implicit same-thread dedup in `addChanges` — which *did* fire (hence "1 update pending"), but was not enough.

**2. The rebase kept both edits anyway.** `resolveUpdateBases` offers the pending proposal's `newContent` as the preferred edit base so an unreviewed edit is never silently dropped. But it infers "orthogonal addition" purely from *whether the anchor text still matches*, and a correction whose anchor survives is indistinguishable from an addition — so it merged the edit with the very one it was meant to replace.

## The change

Two ways for the model to say which it means:

- **`discard` operation** — withdraws a pending proposal by its **id**. Stages nothing, writes nothing.
- **`replace_pending` flag** on `update`/`replace` — pins the edit base to disk, so the existing dedup supersedes the earlier proposal.

### Why id and not path (see the four resolved threads)

`discard` originally took a path, and review found four real defects in a row, each fix exposing the next: wiki-links and moved notes; renames that changed the basename; vault resolution short-circuiting the rename history; and finally a former path reused by a note that *also* had a live proposal — where **no tie-break is correct**.

The premise was wrong. A proposal is an object with its own lifetime; a path is a mutable label that can move, be reused, or name two proposals at once. Entries have carried a stable UUID all along — it was simply never shown to the model.

So the resolution machinery is **deleted**: all four tiers, the ambiguity branch, `formerPaths`, and its rename bookkeeping. **Net −181 lines.** Reviewers following those threads should read the resolver as gone, not fixed again.

Two details worth a look:

- The model-facing id comes from the **end** of the UUID. UUIDv7 leads with a millisecond timestamp, so entries staged together share a long prefix — a leading 8-char slice collided on all 12 members of one burst when I probed it. Trailing bits are random but not collision-proof (~1 per 500 at 6 chars), so minting checks uniqueness against live entries and lengthens on collision.
- Ids reach the model **twice**: the staging result lists them, and the review-status block re-lists every pending proposal on *every* turn. The second is what makes an id durable once the tool result leaves the context window.

Other decisions:

- **No permission gate on `discard`.** It can only *remove* a proposed write; gating it on `allowUpdate` would strand proposals the agent could otherwise clean up.
- **Refuses to touch partially-applied entries.** That content is on disk because the user accepted a diff group; undoing their decision is not the agent's call.
- **Unknown id is a plain report, not an error**, so discarding before re-staging stays a safe habit.
- **Entries persisted without an id are backfilled on load** — otherwise they could never be named, leaving them permanently undiscardable while still queued.

## On the rebase notice

The notice already reached the model — it is the tool's return value — so the fix is *what it says and where*. It now leads the trailing clauses (it changes what the model tells the user, so it should not sit behind up to four other notes) and drops the word "superseded", which read as "only my new edit remains". It states the consequence first, points at both escape hatches, and forbids the exact misstatement observed.

The `edit-notes` core skill gains a matching "Correcting an Edit You Already Staged" section, with a 1.0 → 1.1 version bump so local edits stay detectable.

## Verification

- **1677 tests pass** across 102 files, covering id uniqueness within a same-millisecond batch, the save/load round-trip through the store's own persistence path, backfill of pre-id entries, thread scoping, the partial-application guard, the discard+update pair, and the permission exemption.
- `bun run check`: 0 errors, 0 warnings over 2749 files. Production build succeeds.
- Six existing assertions move from `"superseded"` to `"contains BOTH"` — the old string was about to pass by accident against "supersedes" in the new text.
- `ReviewStatusRef` keeps its old `pendingPaths` shape as a read-only fallback: the status block is byte-reconstructed to be stripped from the displayed message, so a message persisted before ids must still render identically or its suffix leaks into the UI.

Not yet exercised end-to-end in a live vault; the flow to try is the one above.

## Out of scope

`parseManageNotesSummary` (`src/components/chat/toolOutputRenderModel.ts`) has **never** matched any real summary — it anchors at `$` while every summary ends with a period plus prose clauses. `manage_notes` cards already fall back to a generic "Edited notes" label with live review chips. Untouched here and no worse; worth a separate fix.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._