### PR TITLE
feat(chat): restore summarization-trimmed turns in the transcript

### DIFF
--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -710,6 +710,78 @@ function buildCheckpointMessageMappingFromGraph(
 	};
 }
 
+/**
+ * Rebuild the full visible history for a branch whose context was summarized.
+ *
+ * Summarization trims the LangGraph `messages` channel (summary + last few
+ * messages survive), so the active checkpoint no longer contains the earlier
+ * turns — but the checkpoint *tree* still does: every pre-summarization
+ * checkpoint on the active path keeps the messages that were removed (#434).
+ * Walk the path root→tip and collect each message the first time it appears;
+ * because the channel only ever grows except at summarization steps, this
+ * reproduces the conversation in order with the trimmed turns restored.
+ * Messages that survived into the tip keep the tip's copy, so the live window
+ * renders exactly as before.
+ *
+ * Marker placement: automatic summarization runs *mid-turn* (before the model
+ * answers the message that overflowed the context), so its summary message is
+ * moved in front of that turn's human message — otherwise the badge would
+ * split a turn between question and answer. Manual compaction runs between
+ * turns and stays at its chronological position.
+ *
+ * Only the rendered transcript changes; what the model sees on the next turn
+ * is still the tip's trimmed channel.
+ */
+function recoverSummarizedHistory(
+	graph: CheckpointGraphState,
+	activeCheckpointId: string,
+	tipMessages: BaseMessage[],
+): BaseMessage[] {
+	const hasSummary = tipMessages.some(
+		(msg) => isHumanMessage(msg) && isHiddenHumanSource(msg.additional_kwargs?.lc_source),
+	);
+	if (!hasSummary) return tipMessages;
+
+	const path = getPathToRoot(graph, activeCheckpointId)
+		.map((id) => graph.nodes.get(id))
+		.filter((node): node is CheckpointNode => !!node)
+		.sort(comparePathOrder);
+
+	const tipById = new Map<string, BaseMessage>();
+	for (const msg of tipMessages) {
+		if (msg.id) tipById.set(msg.id, msg);
+	}
+
+	const seen = new Set<string>();
+	const display: BaseMessage[] = [];
+	for (const node of path) {
+		for (const msg of node.messages) {
+			// Every message that went through LangGraph's reducer carries an id.
+			// If one doesn't, occurrences can't be deduplicated across
+			// checkpoints — bail out to the plain tip rather than risk
+			// rendering duplicated turns.
+			if (!msg.id) return tipMessages;
+			if (seen.has(msg.id)) continue;
+			seen.add(msg.id);
+
+			const rendered = tipById.get(msg.id) ?? msg;
+			if (isHumanMessage(msg) && msg.additional_kwargs?.lc_source === "summarization") {
+				let insertAt = display.length;
+				for (let i = display.length - 1; i >= 0; i--) {
+					if (isHumanMessage(display[i])) {
+						insertAt = i;
+						break;
+					}
+				}
+				display.splice(insertAt, 0, rendered);
+				continue;
+			}
+			display.push(rendered);
+		}
+	}
+	return display;
+}
+
 export function deriveMessagePairsFromActiveCheckpoint(
 	graph: CheckpointGraphState,
 	activeCheckpointId: string | undefined,
@@ -727,7 +799,8 @@ export function deriveMessagePairsFromActiveCheckpoint(
 	}
 
 	const checkpointMapping = buildCheckpointMessageMappingFromGraph(graph, activeCheckpointId);
-	return baseMessagesToMessagePairs(activeNode.messages, errorCount, checkpointMapping, lastErrorMessage);
+	const displayMessages = recoverSummarizedHistory(graph, activeCheckpointId, activeNode.messages);
+	return baseMessagesToMessagePairs(displayMessages, errorCount, checkpointMapping, lastErrorMessage);
 }
 
 /* -----------------------------------------------------------------------------

--- a/test/stores/chatStore.test.ts
+++ b/test/stores/chatStore.test.ts
@@ -474,6 +474,136 @@ describe("deriveMessagePairsFromActiveCheckpoint", () => {
 });
 
 /* --------------------------------------------------------------------------
+ * Summarized history recovery (#434)
+ * ------------------------------------------------------------------------*/
+
+describe("summarized history recovery", () => {
+	function autoSummary(id: string) {
+		return new HumanMessage({
+			content: "Previous conversation summary\n\nUser is planning a thesis.",
+			id,
+			additional_kwargs: { lc_source: "summarization" },
+		});
+	}
+
+	/**
+	 * Simulates the middleware's effect: the summarization checkpoint's channel
+	 * is [summary, ...kept window], while earlier checkpoints keep the full
+	 * history. Summarization runs mid-turn, after h3 was asked but before a3.
+	 */
+	function summarizedGraph() {
+		const h1 = humanMsg("q1", "h-1");
+		const a1 = aiMsg("ans1", "a-1");
+		const h2 = humanMsg("q2", "h-2");
+		const a2 = aiMsg("ans2", "a-2");
+		const h3 = humanMsg("q3", "h-3");
+		const a3 = aiMsg("ans3", "a-3");
+		const summary = autoSummary("summary-1");
+
+		const graph = buildCheckpointGraph([
+			makeCheckpoint("cp-root", -1, []),
+			makeCheckpoint("cp-h1", 0, [h1], "cp-root", "2024-01-01T00:01:00Z"),
+			makeCheckpoint("cp-a1", 1, [h1, a1], "cp-h1", "2024-01-01T00:02:00Z"),
+			makeCheckpoint("cp-h2", 2, [h1, a1, h2], "cp-a1", "2024-01-01T00:03:00Z"),
+			makeCheckpoint("cp-a2", 3, [h1, a1, h2, a2], "cp-h2", "2024-01-01T00:04:00Z"),
+			makeCheckpoint("cp-h3", 4, [h1, a1, h2, a2, h3], "cp-a2", "2024-01-01T00:05:00Z"),
+			makeCheckpoint("cp-sum", 5, [summary, h2, a2, h3], "cp-h3", "2024-01-01T00:06:00Z"),
+			makeCheckpoint("cp-a3", 6, [summary, h2, a2, h3, a3], "cp-sum", "2024-01-01T00:07:00Z"),
+		]);
+		graph.activeCheckpointId = "cp-a3";
+		return graph;
+	}
+
+	it("restores turns trimmed by summarization from earlier checkpoints", () => {
+		const pairs = deriveMessagePairsFromActiveCheckpoint(summarizedGraph(), "cp-a3");
+
+		expect(pairs).toHaveLength(4);
+		expect(pairs[0].userMessage.content).toBe("q1");
+		expect(pairs[0].assistantMessage.content).toBe("ans1");
+		expect(pairs[1].userMessage.content).toBe("q2");
+		expect(pairs[1].assistantMessage.content).toBe("ans2");
+		// The marker sits before the turn that triggered summarization, not
+		// between its question and answer.
+		expect(pairs[2].transcriptEvent?.type).toBe("summarization_marker");
+		expect(pairs[3].userMessage.content).toBe("q3");
+		expect(pairs[3].assistantMessage.content).toBe("ans3");
+	});
+
+	it("keeps branching metadata on recovered turns", () => {
+		const pairs = deriveMessagePairsFromActiveCheckpoint(summarizedGraph(), "cp-a3");
+
+		// q1 exists only in pre-summarization checkpoints; edit/regenerate must
+		// still resolve to those checkpoints so forking from it works.
+		expect(pairs[0].regenerateFromCheckpointId).toBe("cp-h1");
+		expect(pairs[0].editFromCheckpointId).toBe("cp-root");
+		// h3 is also the last message of the summarization checkpoint, which
+		// wins as the later fork point — regenerating uses the summarized
+		// context, matching what the model actually sees.
+		expect(pairs[3].regenerateFromCheckpointId).toBe("cp-sum");
+	});
+
+	it("falls back to the tip's trimmed view when earlier checkpoints are missing", () => {
+		const h3 = humanMsg("q3", "h-3");
+		const a3 = aiMsg("ans3", "a-3");
+		const graph = buildCheckpointGraph([
+			makeCheckpoint("cp-a3", 6, [autoSummary("summary-1"), h3, a3], undefined, "2024-01-01T00:07:00Z"),
+		]);
+
+		const pairs = deriveMessagePairsFromActiveCheckpoint(graph, "cp-a3");
+		expect(pairs).toHaveLength(2);
+		expect(pairs[0].transcriptEvent?.type).toBe("summarization_marker");
+		expect(pairs[1].userMessage.content).toBe("q3");
+		expect(pairs[1].assistantMessage.content).toBe("ans3");
+	});
+
+	it("keeps a manual compaction marker at its chronological position and hides its ack", () => {
+		const h1 = humanMsg("Hello", "h-1");
+		const a1 = aiMsg("Hi", "a-1");
+		const compactPrompt = new HumanMessage({
+			content: "Summarize older conversation history now.",
+			id: "compact-1",
+			additional_kwargs: { lc_source: "manual_summarization" },
+		});
+		const ack = aiMsg("Context compacted.", "ack-1");
+		const h2 = humanMsg("Continue", "h-2");
+		const a2 = aiMsg("Done", "a-2");
+
+		const graph = buildCheckpointGraph([
+			makeCheckpoint("cp-root", -1, []),
+			makeCheckpoint("cp-h1", 0, [h1], "cp-root", "2024-01-01T00:01:00Z"),
+			makeCheckpoint("cp-a1", 1, [h1, a1], "cp-h1", "2024-01-01T00:02:00Z"),
+			makeCheckpoint("cp-compact", 2, [h1, a1, compactPrompt, ack], "cp-a1", "2024-01-01T00:03:00Z"),
+			makeCheckpoint("cp-trim", 3, [compactPrompt, ack], "cp-compact", "2024-01-01T00:04:00Z"),
+			makeCheckpoint("cp-h2", 4, [compactPrompt, ack, h2], "cp-trim", "2024-01-01T00:05:00Z"),
+			makeCheckpoint("cp-a2", 5, [compactPrompt, ack, h2, a2], "cp-h2", "2024-01-01T00:06:00Z"),
+		]);
+
+		const pairs = deriveMessagePairsFromActiveCheckpoint(graph, "cp-a2");
+		expect(pairs).toHaveLength(3);
+		expect(pairs[0].userMessage.content).toBe("Hello");
+		expect(pairs[0].assistantMessage.content).toBe("Hi");
+		expect(pairs[1].transcriptEvent?.type).toBe("summarization_marker");
+		expect(pairs[1].transcriptEvent?.source).toBe("manual_summarization");
+		expect(pairs[2].userMessage.content).toBe("Continue");
+		expect(pairs[2].assistantMessage.content).toBe("Done");
+	});
+
+	it("does not alter threads that were never summarized", () => {
+		const h = humanMsg("Hello", "h-1");
+		const a = aiMsg("Hi!", "a-1");
+		const graph = buildCheckpointGraph([
+			makeCheckpoint("cp-root", -1, []),
+			makeCheckpoint("cp-1", 0, [h], "cp-root", "2024-01-01T00:01:00Z"),
+			makeCheckpoint("cp-2", 1, [h, a], "cp-1", "2024-01-01T00:02:00Z"),
+		]);
+
+		const pairs = deriveMessagePairsFromActiveCheckpoint(graph, "cp-2");
+		expect(pairs).toHaveLength(1);
+		expect(pairs[0].userMessage.content).toBe("Hello");
+	});
+});
+
+/* --------------------------------------------------------------------------
  * Branch info derivation
  * ------------------------------------------------------------------------*/
 


### PR DESCRIPTION
Closes #434. **Stacked on #433** (base branch `fix/chat-file-quadratic-growth`) — the feature itself is independent, but a build without #433's codec cannot read vaults whose `.chat` files have already migrated to the v2 format; retarget to `dev` once #433 merges.

## Problem

After context summarization, the chat view shows the "Earlier messages were summarized here" badge and nothing before it. The timeline renders only the active checkpoint's message list, and the middleware trims that list to summary + a small kept window — but the checkpoint tree in the `.chat` file still holds every trimmed message (verified on a real thread: all 195 removed messages present in the pre-summarization checkpoint).

## Fix

`recoverSummarizedHistory` in `chatStore.svelte.ts`, applied during timeline derivation when the tip contains a summarization marker:

- Walk the active path root→tip and collect each message the **first** time it appears (by LangChain message id). Since the channel only grows except at summarization steps, this reproduces the full conversation in order with trimmed turns restored. Multiple summarization rounds produce multiple badges at their correct positions.
- Messages that survived into the tip keep the tip's copy, so the live window renders exactly as before; unsummarized threads take a cheap early-out and are untouched.
- **Marker placement:** auto-summarization runs *mid-turn* (before the model answers the message that overflowed context), so its marker is moved in front of that turn — a purely chronological badge would split question from answer. Manual compaction runs between turns and stays chronological, with its "Context compacted." ack still hidden.
- Branch/edit metadata comes from the existing active-path mapping, so regenerating or editing a recovered pre-summarization turn keeps working (regenerate of the triggering turn forks from the *summarized* checkpoint — matching what the model actually sees).
- Display-only: the model's context is still the tip's trimmed channel, and nothing is written to disk.

Memory cost of holding the older checkpoints is fine now that they share message objects (#431/#433).

## Tests

5 new tests: trimmed turns restored with correct marker position, branching metadata on recovered turns, graceful fallback to the trimmed view when earlier checkpoints are missing, manual-compaction placement + hidden ack, and no-op for unsummarized threads. Full suite: 1713 passed; `check`/`format` clean.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._