### PR TITLE
fix(agent): abort context trim when summary generation fails

### DIFF
--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -32,6 +32,7 @@ import { type ThreadSnapshot, type ThreadStore, createSnapshot } from "./memory/
 import {
 	getSummarizationTriggerTokens,
 	getTrimTokensToSummarize,
+	guardSummarizationFailure,
 	SUMMARY_KEEP_MESSAGE_COUNT,
 	SUMMARY_PREFIX,
 	SUMMARY_PROMPT,
@@ -648,14 +649,18 @@ export class Agent {
 		const trimTokensToSummarize = getTrimTokensToSummarize(triggerTokens);
 
 		return [
-			summarizationMiddleware({
-				model,
-				trigger: { tokens: triggerTokens, messages: SUMMARY_KEEP_MESSAGE_COUNT + 2 },
-				keep: { messages: SUMMARY_KEEP_MESSAGE_COUNT },
-				summaryPrefix: SUMMARY_PREFIX,
-				summaryPrompt: SUMMARY_PROMPT,
-				trimTokensToSummarize,
-			}),
+			// Guarded so a failed summary aborts the trim instead of replacing the
+			// trimmed history with an error stub (#435).
+			guardSummarizationFailure(
+				summarizationMiddleware({
+					model,
+					trigger: { tokens: triggerTokens, messages: SUMMARY_KEEP_MESSAGE_COUNT + 2 },
+					keep: { messages: SUMMARY_KEEP_MESSAGE_COUNT },
+					summaryPrefix: SUMMARY_PREFIX,
+					summaryPrompt: SUMMARY_PROMPT,
+					trimTokensToSummarize,
+				}),
+			),
 		] as const;
 	}
 

--- a/src/agent/summarization.ts
+++ b/src/agent/summarization.ts
@@ -1,3 +1,5 @@
+import { Logger } from "../utils/logging";
+
 export const SUMMARY_TRIGGER_RATIO = 0.8;
 export const SUMMARY_KEEP_MESSAGE_COUNT = 12;
 export const SUMMARY_MIN_TRIGGER_TOKENS = 12_000;
@@ -35,4 +37,58 @@ export function getTrimTokensToSummarize(triggerTokens: number): number {
 export function shouldSummarizeForEstimatedTokens(estimatedTokens: number, contextWindow: number | undefined): boolean {
 	const triggerTokens = getSummarizationTriggerTokens(contextWindow);
 	return triggerTokens !== null && estimatedTokens >= triggerTokens;
+}
+
+/**
+ * LangChain's `summarizationMiddleware` swallows summary-model failures:
+ * `createSummary` catches the error and returns `"Error generating summary:
+ * ${e}"` (or "…: Invalid response format") as if it were the summary, and the
+ * middleware then commits the trim — permanently replacing the trimmed turns
+ * with an error stub in the model's context (#435, observed in a real thread
+ * where a mid-stream network error became the entire "memory" of 195
+ * messages). The summary message content is always
+ * `${SUMMARY_PREFIX}\n\n<createSummary result>`, so a failed one is
+ * identified by its exact prefix.
+ */
+export function isFailedSummaryContent(content: unknown): boolean {
+	return typeof content === "string" && content.startsWith(`${SUMMARY_PREFIX}\n\nError generating summary:`);
+}
+
+/**
+ * Whether a `beforeModel` state update from the summarization middleware
+ * carries a failed summary. The update's `messages` contain the synthetic
+ * summary `HumanMessage`, tagged `lc_source: "summarization"`.
+ */
+export function isFailedSummaryUpdate(update: unknown): boolean {
+	if (!update || typeof update !== "object") return false;
+	const messages = (update as { messages?: unknown }).messages;
+	if (!Array.isArray(messages)) return false;
+	return messages.some((msg) => {
+		const message = msg as { additional_kwargs?: Record<string, unknown>; content?: unknown } | null;
+		return message?.additional_kwargs?.lc_source === "summarization" && isFailedSummaryContent(message.content);
+	});
+}
+
+/**
+ * Wraps the summarization middleware's `beforeModel` hook so a failed summary
+ * aborts the trim instead of being committed: the turn runs with the full,
+ * untrimmed history (one turn over the trigger ratio is harmless) and
+ * summarization simply retries on the next turn. Success and no-op updates
+ * pass through untouched.
+ */
+export function guardSummarizationFailure<T extends { beforeModel?: unknown }>(middleware: T): T {
+	const inner = middleware.beforeModel;
+	if (typeof inner !== "function") return middleware;
+
+	middleware.beforeModel = async (...args: unknown[]) => {
+		const update = await inner.apply(middleware, args);
+		if (isFailedSummaryUpdate(update)) {
+			Logger.warn(
+				"[Agent] Summary generation failed — keeping the full history this turn; summarization retries next turn.",
+			);
+			return undefined;
+		}
+		return update;
+	};
+	return middleware;
 }

--- a/test/agent/summarizationFailureGuard.test.ts
+++ b/test/agent/summarizationFailureGuard.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { summarizationMiddleware } from "langchain";
+import {
+	guardSummarizationFailure,
+	isFailedSummaryContent,
+	isFailedSummaryUpdate,
+	SUMMARY_PREFIX,
+} from "../../src/agent/summarization";
+
+/* --------------------------------------------------------------------------
+ * Pure helpers
+ * ------------------------------------------------------------------------*/
+
+describe("isFailedSummaryContent", () => {
+	it("matches the middleware's swallowed-error stubs", () => {
+		expect(
+			isFailedSummaryContent(
+				`${SUMMARY_PREFIX}\n\nError generating summary: Error: net::ERR_INCOMPLETE_CHUNKED_ENCODING`,
+			),
+		).toBe(true);
+		expect(isFailedSummaryContent(`${SUMMARY_PREFIX}\n\nError generating summary: Invalid response format`)).toBe(
+			true,
+		);
+	});
+
+	it("does not match real summaries, even ones mentioning errors", () => {
+		expect(isFailedSummaryContent(`${SUMMARY_PREFIX}\n\nUser debugged an "Error generating summary" bug.`)).toBe(
+			false,
+		);
+		expect(isFailedSummaryContent(`${SUMMARY_PREFIX}\n\nUser is planning a thesis.`)).toBe(false);
+		expect(isFailedSummaryContent(undefined)).toBe(false);
+		expect(isFailedSummaryContent(42)).toBe(false);
+	});
+});
+
+describe("isFailedSummaryUpdate", () => {
+	it("detects a failed summary message inside a state update", () => {
+		const update = {
+			messages: [
+				new HumanMessage({
+					content: `${SUMMARY_PREFIX}\n\nError generating summary: Error: boom`,
+					additional_kwargs: { lc_source: "summarization" },
+				}),
+				new HumanMessage({ content: "kept" }),
+			],
+		};
+		expect(isFailedSummaryUpdate(update)).toBe(true);
+	});
+
+	it("passes successful updates, no-ops, and unrelated shapes", () => {
+		expect(
+			isFailedSummaryUpdate({
+				messages: [
+					new HumanMessage({
+						content: `${SUMMARY_PREFIX}\n\nA proper summary.`,
+						additional_kwargs: { lc_source: "summarization" },
+					}),
+				],
+			}),
+		).toBe(false);
+		expect(isFailedSummaryUpdate(undefined)).toBe(false);
+		expect(isFailedSummaryUpdate({})).toBe(false);
+		expect(isFailedSummaryUpdate({ messages: "not-an-array" })).toBe(false);
+	});
+});
+
+/* --------------------------------------------------------------------------
+ * Guard against the real middleware
+ * ------------------------------------------------------------------------*/
+
+function longConversation() {
+	return [
+		new HumanMessage({ content: "First question about the thesis plan, with plenty of words." }),
+		new AIMessage({ content: "A long first answer that costs a good number of tokens overall." }),
+		new HumanMessage({ content: "Second question, following up on supervisors." }),
+		new AIMessage({ content: "Second answer with more detail than strictly needed." }),
+		new HumanMessage({ content: "Third question about the timeline." }),
+		new AIMessage({ content: "Third answer, still fairly wordy." }),
+		new HumanMessage({ content: "Fourth question that overflows the tiny test budget." }),
+	];
+}
+
+function makeMiddleware(model: { invoke: (...args: unknown[]) => Promise<unknown> }) {
+	return summarizationMiddleware({
+		model: model as never,
+		trigger: { tokens: 10 },
+		keep: { messages: 2 },
+		summaryPrefix: SUMMARY_PREFIX,
+		summaryPrompt: "Summarize:\n{messages}",
+	});
+}
+
+const runtime = { context: {} } as never;
+
+describe("guardSummarizationFailure (real summarizationMiddleware)", () => {
+	it("without the guard, a model failure is committed as the summary (LangChain contract)", async () => {
+		const middleware = makeMiddleware({
+			invoke: async () => {
+				throw new Error("net::ERR_INCOMPLETE_CHUNKED_ENCODING");
+			},
+		});
+		const update = await (middleware.beforeModel as (s: unknown, r: unknown) => Promise<unknown>)(
+			{ messages: longConversation() },
+			runtime,
+		);
+
+		// If this stops matching, LangChain changed its swallowed-error format
+		// and isFailedSummaryContent must be updated with it.
+		expect(isFailedSummaryUpdate(update)).toBe(true);
+	});
+
+	it("aborts the trim when summary generation fails", async () => {
+		const middleware = guardSummarizationFailure(
+			makeMiddleware({
+				invoke: async () => {
+					throw new Error("net::ERR_INCOMPLETE_CHUNKED_ENCODING");
+				},
+			}),
+		);
+		const update = await (middleware.beforeModel as (s: unknown, r: unknown) => Promise<unknown>)(
+			{ messages: longConversation() },
+			runtime,
+		);
+
+		expect(update).toBeUndefined();
+	});
+
+	it("passes a successful summarization through untouched", async () => {
+		const middleware = guardSummarizationFailure(
+			makeMiddleware({
+				invoke: async () => new AIMessage({ content: "User is planning a thesis; supervisor search ongoing." }),
+			}),
+		);
+		const update = (await (middleware.beforeModel as (s: unknown, r: unknown) => Promise<unknown>)(
+			{ messages: longConversation() },
+			runtime,
+		)) as { messages: { content?: unknown; additional_kwargs?: Record<string, unknown> }[] };
+
+		expect(Array.isArray(update?.messages)).toBe(true);
+		const summary = update.messages.find((m) => m.additional_kwargs?.lc_source === "summarization");
+		expect(summary?.content).toBe(`${SUMMARY_PREFIX}\n\nUser is planning a thesis; supervisor search ongoing.`);
+	});
+
+	it("passes a below-trigger no-op through untouched", async () => {
+		const middleware = guardSummarizationFailure(
+			makeMiddleware({
+				invoke: async () => {
+					throw new Error("should not be called");
+				},
+			}),
+		);
+		const update = await (middleware.beforeModel as (s: unknown, r: unknown) => Promise<unknown>)(
+			{ messages: [new HumanMessage({ content: "hi" })] },
+			runtime,
+		);
+		expect(update).toBeUndefined();
+	});
+
+	it("leaves middleware without a beforeModel hook untouched", () => {
+		const bare = { name: "x" } as { name: string; beforeModel?: unknown };
+		expect(guardSummarizationFailure(bare)).toBe(bare);
+		expect(bare.beforeModel).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Closes #435. **Stacked on #436** (base `feat/recover-summarized-history`) so a single dev build carries the whole chain (#433 → #436 → this); retarget as the stack merges.

## Problem

LangChain's `summarizationMiddleware` swallows summary-model failures: `createSummary` catches the error and returns `"Error generating summary: ${e}"` *as the summary*, and the middleware commits the trim. Found in a real thread where a mid-stream `net::ERR_INCOMPLETE_CHUNKED_ENCODING` became the model's entire memory of the 195 trimmed messages.

## Fix

`guardSummarizationFailure` in `src/agent/summarization.ts` wraps the middleware's `beforeModel` hook (applied in `Agent.buildSummarizationMiddleware`):

- If the returned state update contains a summary `HumanMessage` (`lc_source: "summarization"`) whose content starts with the middleware's exact error-stub prefix (`${SUMMARY_PREFIX}\n\nError generating summary:` — covers both the caught-exception and "Invalid response format" variants), the update is dropped: no trim this turn, full history stays in context (one turn over the ~80% trigger ratio is harmless), and summarization retries on the next turn.
- Successful summaries, below-trigger no-ops, and middleware without a `beforeModel` hook pass through untouched. Real summaries that merely *mention* "Error generating summary" mid-text don't match the prefix check.

Threads already poisoned by a failed summary aren't rewritten here, but their trimmed turns remain recoverable from the checkpoint tree (#434/#436) and get re-summarized properly once context overflows again.

## Tests

9 new tests: prefix detection (both stub variants, no false positive on summaries mentioning errors), update-shape detection, and the guard run against the **real** `summarizationMiddleware` with a throwing model — the unguarded case asserts LangChain's swallowed-error contract, so an upstream change to that string fails the suite instead of silently reopening the bug. Full suite: 1722 passed; `check`/`format` clean.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._