### PR TITLE
fix(chat): stop the run timer resetting when the message list rebuilds

### DIFF
--- a/src/components/chat/MessageContainer.svelte
+++ b/src/components/chat/MessageContainer.svelte
@@ -878,6 +878,7 @@ $effect(() => {
                     contentAiMessageId={messagePair.assistantMessage.contentAiMessageId}
                     isStreaming={messagePair.assistantMessage.state === AssistantState.streaming}
                     thinkingDurationMs={messagePair.assistantMessage.thinkingDurationMs}
+                    runStartedAtMs={messagePair.assistantMessage.runStartedAtMs}
                     summarizingHistory={index === messages.length - 1 &&
                       !!session?.summarizingHistory}
                     {isLocalModel}

--- a/src/components/chat/ToolCallsSection.svelte
+++ b/src/components/chat/ToolCallsSection.svelte
@@ -25,6 +25,12 @@ interface Props {
 	isStreaming?: boolean;
 	/** Persisted wall-clock duration of the turn (ms), for the "Thought for Ns" label. */
 	thinkingDurationMs?: number;
+	/** Epoch ms the in-flight run began; present only while this turn is streaming.
+	 *  The live timer counts from this. It comes from the store rather than being
+	 *  captured here so it survives a remount — the pair object is replaced (with a
+	 *  fresh `id`) whenever the checkpoint graph is rebuilt, which can happen
+	 *  mid-stream via a branch switch or reload. */
+	runStartedAtMs?: number;
 	/** The session is running its pre-flight context summarization pass. */
 	summarizingHistory?: boolean;
 	/** The chat model runs on this machine (Ollama/oMLX), so a slow first token is a
@@ -41,6 +47,7 @@ const {
 	contentAiMessageId,
 	isStreaming,
 	thinkingDurationMs,
+	runStartedAtMs,
 	summarizingHistory,
 	isLocalModel,
 	ontoggle,
@@ -334,25 +341,24 @@ const summaryRunning = $derived(!!isStreaming);
 // phases that genuinely have nothing more specific to report.
 let runningSeconds = $state(0);
 
-// Drive the timer from a wall-clock anchor captured once on the rising edge of the
-// stream, so elapsed is monotonic and can't drift or reset on mid-stream state
-// churn. The anchor is set on the isStreaming rising edge; the interval ticks while
-// summaryRunning (i.e. the whole stream) and stops when streaming ends, at which
-// point the precise persisted duration takes over via settledSeconds below.
-let runStartMs = 0;
-let wasStreaming = false;
-
+// Drive the timer from the run's wall-clock start as recorded BY THE STORE, so
+// elapsed is monotonic across everything the UI does to this row. An anchor captured
+// here on the isStreaming rising edge was not enough: a rebuild of the checkpoint
+// graph replaces the pair object and gives it a fresh `id`, so the keyed {#each}
+// destroys and recreates this component — and because that can happen mid-stream (a
+// branch switch is explicitly allowed while streaming, and a reload can land any
+// time), the remounted component re-armed its own anchor and the timer restarted
+// from 0 in the middle of a run. Reading the anchor as a prop makes a remount a
+// no-op: the new instance computes the same elapsed value as the old one.
+//
+// The interval ticks while summaryRunning (i.e. the whole stream) and stops when
+// streaming ends, at which point the precise persisted duration takes over via
+// settledSeconds below.
 $effect(() => {
-	if (isStreaming && !wasStreaming) {
-		runStartMs = Date.now();
-		runningSeconds = 0;
-	}
-	wasStreaming = !!isStreaming;
-
-	if (!summaryRunning) return;
+	if (!summaryRunning || runStartedAtMs === undefined) return;
 
 	const tick = () => {
-		runningSeconds = Math.floor((Date.now() - runStartMs) / 1000);
+		runningSeconds = Math.max(0, Math.floor((Date.now() - runStartedAtMs) / 1000));
 	};
 	tick();
 	const timer = setInterval(tick, 1000);

--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -125,6 +125,15 @@ export interface AssistantMessage {
 	// Ns" label survives reload. Absent for turns predating this / restored history
 	// with no stored duration (the UI falls back to the step count).
 	thinkingDurationMs?: number;
+	// Wall-clock epoch ms at which the CURRENT run began, present only while this
+	// message is streaming (cleared when the run settles, is cancelled, or errors).
+	// The live "Running… Ns" timer is computed from this rather than from a
+	// component-local anchor, because `syncGraphAfterRun` replaces every pair object
+	// mid-flight and `MessagePair.id` is a fresh UUID on each rebuild — a remount of
+	// the header would otherwise restart the timer from 0 in the middle of a run.
+	// Stamped on the pair AND re-stamped after the rebuild, exactly as
+	// `thinkingDurationMs` is, so it survives that replacement.
+	runStartedAtMs?: number;
 	// The aiMessageId of the text currently in `content` (streaming only). The UI uses
 	// this to decide when the last tool step folds into the thinking process: the step
 	// stays "current" (rendered below the label with its tools) until live content
@@ -1655,6 +1664,11 @@ export class ChatSession {
 	 * and target id, shared with MessageContainer.svelte so both react to it. */
 	editingPairId = $state<UUIDv7 | null>(null);
 
+	/** The in-flight run's identity + wall-clock start, held outside `messages` so
+	 * it survives the pair-object replacement a rebuild performs. Set when a run
+	 * starts, cleared in the run's `finally`. See `restoreLiveRunAnchor`. */
+	private liveRun: { pairId: UUIDv7; stableKey?: string; startedAtMs: number } | null = null;
+
 	private graphState: CheckpointGraphState;
 	private errorCount: number;
 	private lastErrorMessage: string | undefined;
@@ -1736,6 +1750,31 @@ export class ChatSession {
 			this.bootstrapMessages,
 			this.lastErrorMessage,
 		);
+		this.restoreLiveRunAnchor();
+	}
+
+	/**
+	 * Re-apply the in-flight run's start anchor onto the freshly derived pair.
+	 *
+	 * A rebuild replaces every `MessagePair` with a new object derived from the
+	 * checkpoint graph, which knows nothing about a run still in flight. That can
+	 * happen mid-stream — `switchToBranch` is explicitly allowed while streaming,
+	 * and a reload can land at any time — so without this the live timer's anchor
+	 * is dropped and the header restarts counting from 0 in the middle of a run.
+	 * Re-derived pairs also carry fresh `id`s, so the anchor is keyed on the run's
+	 * own pair id, resolved through `stableKey` when the rebuild renumbered it.
+	 */
+	private restoreLiveRunAnchor(): void {
+		const live = this.liveRun;
+		if (!live) return;
+		// `stableKey` is only compared when the run actually has one: an undefined
+		// key would otherwise match the first pair that also lacks one, stamping the
+		// anchor onto an unrelated turn.
+		const pair = this.messages.find(
+			(m) => m.id === live.pairId || (live.stableKey !== undefined && m.stableKey === live.stableKey),
+		);
+		if (!pair) return;
+		pair.assistantMessage.runStartedAtMs = live.startedAtMs;
 	}
 
 	/** Find a message pair by id */
@@ -2070,8 +2109,11 @@ export class ChatSession {
 			pair.assistantMessage.state = AssistantState.streaming;
 
 			// Wall-clock start of the turn — used to compute the run duration stamped on
-			// the message (live) and persisted onto the checkpoint below.
+			// the message (live) and persisted onto the checkpoint below, and stamped on
+			// the message itself so the live timer has a remount-proof anchor.
 			const runStartedAtMs = Date.now();
+			pair.assistantMessage.runStartedAtMs = runStartedAtMs;
+			this.liveRun = { pairId, stableKey: pair.stableKey, startedAtMs: runStartedAtMs };
 
 			await this.consumeStream(pair.assistantMessage, getStream(signal));
 			pair.assistantMessage.state = AssistantState.success;
@@ -2146,6 +2188,14 @@ export class ChatSession {
 				Logger.error("[ChatSession] Run failed:", _err);
 			}
 		} finally {
+			// Drop the live anchor on every exit path — success, cancel and error
+			// alike. A stale anchor left on a cancelled/errored pair would make a
+			// later retry count from the abandoned run's start.
+			this.liveRun = null;
+			const settledPair = this.findPair(pairId);
+			if (settledPair) {
+				settledPair.assistantMessage.runStartedAtMs = undefined;
+			}
 			this.abortController = null;
 			this.running = false;
 			this.cancelled = false;


### PR DESCRIPTION
## Problem

The `Running… Ns` timer in the thinking-process header could restart from 0 partway through a run.

The anchor lived in a component-local `runStartMs`, armed on the `isStreaming` rising edge. The existing comment claimed this made elapsed "monotonic and can't drift or reset on mid-stream state churn" — true only for as long as the component stays mounted, and its lifetime is not tied to the run:

- `MessageContainer` keys its `{#each}` on `stableKey ?? id`.
- `id` is a fresh UUID on every `rebuildMessagePairs()` pass (as `MessagePair.stableKey`'s own doc comment notes).
- A rebuild can land **mid-stream** — `switchToBranch` is explicitly documented as "allowed even while a chat is streaming", and a reload can arrive at any time.

A mid-run rebuild therefore destroyed and recreated `ToolCallsSection`; the new instance re-armed its own anchor and the timer reset.

## Fix

Move the anchor to the store, so it belongs to the run rather than to the view.

- `AssistantMessage.runStartedAtMs` — the run's wall-clock start, present only while streaming.
- `ChatSession.liveRun` — keeps that anchor outside `messages`, so the pair-object replacement a rebuild performs cannot drop it.
- `rebuildMessagePairs()` re-applies it via a new `restoreLiveRunAnchor()`, matching on `id` or (only when present) `stableKey`. Hooking the rebuild site covers all four `applyGraphState` callers at once rather than patching each.
- The run's `finally` clears it on every exit path — success, cancel and error — so an abandoned run cannot leak its start time into a later retry.

`ToolCallsSection` now takes the anchor as a prop and computes elapsed from it, making a remount a no-op: the new instance derives the same value as the old one. The local `runStartMs` / `wasStreaming` machinery is deleted.

Settled behaviour is untouched — `Thought for Ns` still prefers the persisted `thinkingDurationMs`.

## Verification

`bun run check` (0 errors, both tsconfigs), `bun run format`, `bun run lint` clean; 1533 unit tests across 99 files pass; production build succeeds.

Not verified by me, and worth a live look:

- **The real-world trigger.** I confirmed the mechanism by reading the rebuild/keying paths, not by reproducing it. The reproduction to try is switching branches mid-stream. If the reset you saw happened on a plain long run with no branch switch or reload, there may be a second remount path this doesn't cover.
- **`stableKey` coverage.** It's assigned at only one construction site, so pairs derived through other paths fall back to the volatile `id`. The matcher handles both, but a pair that has neither stable would still remount.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._