### PR TITLE
fix(chat): stop "Thought for Ns" collapsing to 1s on long runs

### DIFF
--- a/src/agent/ObsidianChatManager.ts
+++ b/src/agent/ObsidianChatManager.ts
@@ -819,6 +819,50 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 		return false;
 	}
 
+	/**
+	 * The payload of a serialized message, which lives under `kwargs` (LangChain's
+	 * Serializable form), `data` (the older envelope), or on the record itself.
+	 * Mirrors the shapes `getOrCreateResponseMetadata` writes through.
+	 */
+	private getSerializedPayload(message: Record<string, unknown>): Record<string, unknown> {
+		if (this.isRecord(message.kwargs)) return message.kwargs;
+		if (this.isRecord(message.data)) return message.data;
+		return message;
+	}
+
+	/** True when a serialized AI message carries tool calls (dispatch/subagent turn). */
+	private hasSerializedToolCalls(message: Record<string, unknown>): boolean {
+		const payload = this.getSerializedPayload(message);
+		if (Array.isArray(payload.tool_calls) && payload.tool_calls.length > 0) return true;
+		// Anthropic-style block content records the call as a `tool_use` block.
+		const content = payload.content;
+		if (Array.isArray(content)) {
+			return content.some((block) => this.isRecord(block) && block.type === "tool_use");
+		}
+		return false;
+	}
+
+	/**
+	 * True when a serialized AI message has non-whitespace text, matching the read
+	 * side's `converted.content.trim()` test. Content is either a flat string (a
+	 * replayed checkpoint) or an array of blocks (a live Anthropic response), in
+	 * which case only `text` blocks count.
+	 */
+	private hasSerializedTextContent(message: Record<string, unknown>): boolean {
+		const content = this.getSerializedPayload(message).content;
+		if (typeof content === "string") return content.trim().length > 0;
+		if (Array.isArray(content)) {
+			return content.some(
+				(block) =>
+					this.isRecord(block) &&
+					block.type === "text" &&
+					typeof block.text === "string" &&
+					block.text.trim().length > 0,
+			);
+		}
+		return false;
+	}
+
 	private getOrCreateResponseMetadata(message: Record<string, unknown>): Record<string, unknown> | undefined {
 		if (this.isRecord(message.kwargs)) {
 			const kwargs = message.kwargs;
@@ -887,9 +931,24 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 	 * survives reload. Mirrors annotateCheckpointMessagesWithGeneration: writes a
 	 * scalar into the message's response_metadata, which round-trips through the
 	 * NDJSON checkpoint. Called post-completion from ChatSession (the duration isn't
-	 * known during the graph's own `put`). Targets the LAST AI serialized message in
-	 * the checkpoint — the final answer — matching the read side, which takes the
-	 * last top-level non-empty AI message as the duration carrier.
+	 * known during the graph's own `put`).
+	 *
+	 * The target must be the message the READ side will look at, which is the last
+	 * top-level AI message with NON-EMPTY content (`mergeAssistantMessages` skips
+	 * empty turns, since their text is not the answer, and subagent turns, whose
+	 * text is intermediate reasoning). Targeting the last AI message outright — as
+	 * this did — disagreed with that rule whenever the checkpoint ended with a
+	 * tool-calling turn that had no prose, or with a subagent's own turn. The write
+	 * then landed on a message the reader ignores, the duration came back undefined
+	 * on reload, and the UI fell to its 1s floor: a long run redisplayed as
+	 * "Thought for 1s" after a restart.
+	 *
+	 * A subagent turn is identified the same way the reader identifies it: an AI
+	 * message carrying tool calls, none of which are `task`, that follows a closed
+	 * `task` call. Rather than duplicate that state machine here, we approximate it
+	 * conservatively — skip trailing AI messages that carry tool calls — which lands
+	 * on the same message for every shape the reader accepts, because any AI message
+	 * the reader treats as the answer carries prose and no pending tool calls.
 	 */
 	async annotateThinkingDuration(threadId: string, checkpointId: string, durationMs: number): Promise<void> {
 		if (!threadId || !checkpointId || !Number.isFinite(durationMs) || durationMs < 0) return;
@@ -898,14 +957,17 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 		if (!entry) return;
 
 		const messages = this.getCheckpointMessages(entry.checkpoint);
-		// Find the last AI message in the checkpoint (the final answer).
+		// Walk backwards for the last AI message the reader would accept as the
+		// answer: non-empty content, and no tool calls (which mark a dispatch or a
+		// subagent turn rather than the final answer).
 		let target: Record<string, unknown> | undefined;
 		for (let i = messages.length - 1; i >= 0; i--) {
 			const message = messages[i];
-			if (this.isRecord(message) && this.isAiSerializedMessage(message)) {
-				target = message;
-				break;
-			}
+			if (!this.isRecord(message) || !this.isAiSerializedMessage(message)) continue;
+			if (this.hasSerializedToolCalls(message)) continue;
+			if (!this.hasSerializedTextContent(message)) continue;
+			target = message;
+			break;
 		}
 		if (!target) return;
 

--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -1767,12 +1767,7 @@ export class ChatSession {
 	private restoreLiveRunAnchor(): void {
 		const live = this.liveRun;
 		if (!live) return;
-		// `stableKey` is only compared when the run actually has one: an undefined
-		// key would otherwise match the first pair that also lacks one, stamping the
-		// anchor onto an unrelated turn.
-		const pair = this.messages.find(
-			(m) => m.id === live.pairId || (live.stableKey !== undefined && m.stableKey === live.stableKey),
-		);
+		const pair = this.findPairAcrossRebuild(live.pairId, live.stableKey);
 		if (!pair) return;
 		pair.assistantMessage.runStartedAtMs = live.startedAtMs;
 	}
@@ -1780,6 +1775,20 @@ export class ChatSession {
 	/** Find a message pair by id */
 	private findPair(id: UUIDv7): MessagePair | undefined {
 		return this.messages.find((m) => m.id === id);
+	}
+
+	/**
+	 * Find a message pair that may have been re-derived since its id was captured.
+	 *
+	 * `rebuildMessagePairs()` mints a fresh `MessagePair.id` for every pair, so a
+	 * plain `findPair(id)` silently returns undefined for any id captured before a
+	 * rebuild — and callers that stamp post-run state onto the pair then no-op
+	 * without a sound. `stableKey` survives the rebuild, so prefer it, and only
+	 * compare it when the caller actually has one: an undefined key would otherwise
+	 * match the first pair that also lacks one, stamping an unrelated turn.
+	 */
+	private findPairAcrossRebuild(id: UUIDv7, stableKey: string | undefined): MessagePair | undefined {
+		return this.messages.find((m) => m.id === id || (stableKey !== undefined && m.stableKey === stableKey));
 	}
 
 	private cloneGraphState(): CheckpointGraphState {
@@ -2152,8 +2161,14 @@ export class ChatSession {
 			// replaces the pair object we stamped above with a fresh one whose
 			// thinkingDurationMs is read from response_metadata — not yet written (that
 			// happens below). Without this re-stamp the label flips from "Thought for Ns"
-			// back to the step-count fallback the instant the stream settles.
-			const rebuiltPair = this.findPair(pairId);
+			// back to the 1s floor the instant the stream settles.
+			//
+			// The lookup must tolerate the rebuild: it also mints a fresh `MessagePair.id`,
+			// so matching on the pre-run `pairId` alone found nothing and this re-stamp
+			// silently no-opped — which is exactly how a long run came to report
+			// "Thought for 1s" (undefined duration → the UI's `Math.max(1, runningSeconds)`
+			// fallback, with runningSeconds already back to 0).
+			const rebuiltPair = this.findPairAcrossRebuild(pairId, pair.stableKey);
 			if (rebuiltPair) {
 				rebuiltPair.assistantMessage.thinkingDurationMs = thinkingDurationMs;
 			}
@@ -2192,7 +2207,7 @@ export class ChatSession {
 			// alike. A stale anchor left on a cancelled/errored pair would make a
 			// later retry count from the abandoned run's start.
 			this.liveRun = null;
-			const settledPair = this.findPair(pairId);
+			const settledPair = this.findPairAcrossRebuild(pairId, pair.stableKey);
 			if (settledPair) {
 				settledPair.assistantMessage.runStartedAtMs = undefined;
 			}

--- a/test/agent/ObsidianChatManager.test.ts
+++ b/test/agent/ObsidianChatManager.test.ts
@@ -588,4 +588,86 @@ describe("ObsidianChatManager", () => {
 			expect(aiMessage.kwargs.response_metadata.model).toBe("gpt-4");
 		});
 	});
+
+	describe("thinking duration annotation", () => {
+		async function annotateAndRead(cpId: string, messages: unknown[]) {
+			const threadId = `Chats/thread-${cpId}.chat`;
+			const checkpoint = makeCheckpoint(cpId, "2024-01-01T00:00:00Z");
+			(checkpoint.channel_values as Record<string, unknown>).messages = messages;
+			await manager.put({ configurable: { thread_id: threadId } }, checkpoint, makeMetadata(0), {});
+			await manager.annotateThinkingDuration(threadId, cpId, 42_000);
+
+			const tuple = await manager.getTuple({ configurable: { thread_id: threadId, checkpoint_id: cpId } });
+			const stored = (tuple!.checkpoint.channel_values as Record<string, unknown[]>).messages;
+			return stored.map(
+				(m) =>
+					((m as Record<string, Record<string, Record<string, unknown>>>).kwargs?.response_metadata
+						?.thinking_duration_ms as number | undefined) ?? undefined,
+			);
+		}
+
+		const human = { type: "human", kwargs: { content: "Hello" } };
+
+		it("stamps the final answer when it is the last AI message", async () => {
+			const durations = await annotateAndRead("cp-dur-plain", [
+				human,
+				{ type: "ai", kwargs: { content: "The answer" } },
+			]);
+			expect(durations[1]).toBe(42_000);
+		});
+
+		it("skips a trailing tool-calling turn with no prose, stamping the answer instead", async () => {
+			// The reader ignores empty-content AI messages, so stamping the trailing
+			// one lost the duration on reload ("Thought for 1s").
+			const durations = await annotateAndRead("cp-dur-empty", [
+				human,
+				{ type: "ai", kwargs: { content: "The answer" } },
+				{ type: "ai", kwargs: { content: "", tool_calls: [{ id: "c-1", name: "manage_notes", args: {} }] } },
+			]);
+			expect(durations[1]).toBe(42_000);
+			expect(durations[2]).toBeUndefined();
+		});
+
+		it("skips a trailing subagent turn, stamping the parent answer instead", async () => {
+			const durations = await annotateAndRead("cp-dur-sub", [
+				human,
+				{ type: "ai", kwargs: { content: "The answer" } },
+				{
+					type: "ai",
+					kwargs: {
+						content: "subagent reasoning",
+						tool_calls: [{ id: "c-9", name: "search_notes", args: {} }],
+					},
+				},
+			]);
+			expect(durations[1]).toBe(42_000);
+			expect(durations[2]).toBeUndefined();
+		});
+
+		it("skips a trailing tool_use block turn (Anthropic block content)", async () => {
+			const durations = await annotateAndRead("cp-dur-blocks", [
+				human,
+				{ type: "ai", kwargs: { content: "The answer" } },
+				{
+					type: "ai",
+					kwargs: {
+						content: [
+							{ type: "text", text: "Let me check" },
+							{ type: "tool_use", id: "c-2" },
+						],
+					},
+				},
+			]);
+			expect(durations[1]).toBe(42_000);
+			expect(durations[2]).toBeUndefined();
+		});
+
+		it("stamps nothing when no AI message qualifies as the answer", async () => {
+			const durations = await annotateAndRead("cp-dur-none", [
+				human,
+				{ type: "ai", kwargs: { content: "", tool_calls: [{ id: "c-1", name: "manage_notes", args: {} }] } },
+			]);
+			expect(durations.every((d) => d === undefined)).toBe(true);
+		});
+	});
 });

--- a/test/stores/chatStore.test.ts
+++ b/test/stores/chatStore.test.ts
@@ -944,3 +944,72 @@ describe("baseMessageToAssistantMessage — preamble extraction from content blo
 		expect(preambleEvent?.toolCallId).toBe("call-x");
 	});
 });
+
+/* --------------------------------------------------------------------------
+ * Pair identity across rebuilds ("Thought for 1s")
+ *
+ * A rebuild mints a fresh `MessagePair.id` for every pair, so post-run code that
+ * re-finds its pair by the id captured BEFORE the rebuild finds nothing and
+ * silently no-ops. That is what dropped `thinkingDurationMs` on settle: the UI
+ * then fell back to its 1s floor and a long run reported "Thought for 1s".
+ * `stableKey` is the identity that survives, so these pin both halves.
+ * ------------------------------------------------------------------------*/
+
+describe("message pair identity across rebuilds", () => {
+	function buildTwoTurnGraph() {
+		const h = humanMsg("Hello", "h-1");
+		const a = aiMsg("Hi!", "a-1");
+		const graph = buildCheckpointGraph([
+			makeCheckpoint("cp-root", -1, []),
+			makeCheckpoint("cp-1", 0, [h], "cp-root", "2024-01-01T00:01:00Z"),
+			makeCheckpoint("cp-2", 1, [h, a], "cp-1", "2024-01-01T00:02:00Z"),
+		]);
+		graph.activeCheckpointId = "cp-2";
+		return graph;
+	}
+
+	it("mints a fresh pair id on every rebuild, so ids must not be held across one", () => {
+		const graph = buildTwoTurnGraph();
+
+		const first = deriveMessagePairsFromActiveCheckpoint(graph, "cp-2");
+		const second = deriveMessagePairsFromActiveCheckpoint(graph, "cp-2");
+
+		expect(first).toHaveLength(1);
+		expect(second).toHaveLength(1);
+		// The regression: same turn, same checkpoint, different id.
+		expect(second[0].id).not.toBe(first[0].id);
+	});
+
+	it("keeps stableKey identical across rebuilds so a pair stays findable", () => {
+		const graph = buildTwoTurnGraph();
+
+		const first = deriveMessagePairsFromActiveCheckpoint(graph, "cp-2");
+		const second = deriveMessagePairsFromActiveCheckpoint(graph, "cp-2");
+
+		expect(first[0].stableKey).toBeDefined();
+		expect(second[0].stableKey).toBe(first[0].stableKey);
+	});
+
+	it("derives no thinking duration until it is persisted, then reads it back", () => {
+		// Mirrors the settle ordering: the rebuild runs BEFORE the duration is
+		// written to response_metadata, so the rebuilt pair has none. Only the
+		// in-memory re-stamp bridges that window — hence it must actually find
+		// the pair.
+		const graph = buildTwoTurnGraph();
+		const before = deriveMessagePairsFromActiveCheckpoint(graph, "cp-2");
+		expect(before[0].assistantMessage.thinkingDurationMs).toBeUndefined();
+
+		const h = humanMsg("Hello", "h-1");
+		const annotated = new AIMessage({ content: "Hi!", id: "a-1" });
+		annotated.response_metadata = { thinking_duration_ms: 42_000 };
+		const persisted = buildCheckpointGraph([
+			makeCheckpoint("cp-root", -1, []),
+			makeCheckpoint("cp-1", 0, [h], "cp-root", "2024-01-01T00:01:00Z"),
+			makeCheckpoint("cp-2", 1, [h, annotated], "cp-1", "2024-01-01T00:02:00Z"),
+		]);
+		persisted.activeCheckpointId = "cp-2";
+
+		const after = deriveMessagePairsFromActiveCheckpoint(persisted, "cp-2");
+		expect(after[0].assistantMessage.thinkingDurationMs).toBe(42_000);
+	});
+});


### PR DESCRIPTION
Follow-up to #439. A finished turn reported **"Thought for 1s"** regardless of how long it actually ran.

Two independent defects, both dropping `thinkingDurationMs` and leaving the UI on its `Math.max(1, runningSeconds)` floor — with `runningSeconds` already back to `0`, since the timer effect stops when streaming ends. Either one alone produces the symptom, which is why fixing the first didn't clear it on reload.

## 1. The in-memory re-stamp never found its pair

`syncGraphAfterRun` rebuilds `messages` *before* the duration is persisted, so the rebuilt pair carries none and a re-stamp is meant to bridge that window. It used `findPair(pairId)`, which matches on `id` — but a rebuild mints a **fresh `MessagePair.id`** for every pair, so it returned `undefined` and the assignment silently no-opped.

This is the same identity trap #439 fixed for the run-timer anchor. I patched the anchor's lookup there but missed that the neighbouring duration re-stamp had it too — as did the anchor clear in the run's `finally`, so cancelled and errored runs weren't getting their anchor cleared either.

Adds `findPairAcrossRebuild(id, stableKey)`, falling back to the rebuild-stable `stableKey` and only comparing it when the caller actually has one (an undefined key would otherwise match the first pair that also lacks one). Applied at all three post-rebuild sites. `findPair` stays for the five synchronous lookups with no intervening rebuild.

## 2. The persisted duration was written where the reader never looks

`annotateThinkingDuration` targeted the last AI message outright. `mergeAssistantMessages` only accepts a duration from a top-level AI message with **non-empty content** — it skips empty turns (their text isn't the answer) and subagent turns (intermediate reasoning). The writer's own doc comment claimed it matched that rule; it didn't.

So whenever a turn ended with a tool-calling message carrying no prose, or with a subagent's own turn, the write landed on a message the reader ignores — the duration came back `undefined` after a restart, losing the label **on reload** even with (1) fixed.

The writer now walks back to the message the reader would accept: skipping AI messages that carry tool calls or have no text, across all three serialized envelopes (`kwargs` / `data` / top-level) and both content forms (flat string, Anthropic block array).

## Verification

`bun run check` (0 errors, both tsconfigs), `format`, `lint` clean; **1541** tests pass (up from 1533); production build succeeds.

The new tests were checked to actually fail against the old code, not just pass against the new:

- Store tests pin the identity invariants — `id` changes across a rebuild, `stableKey` doesn't, duration absent until persisted then read back. Inverting the assertions fails them.
- Manager tests drive the **real** writer through `put` → `annotate` → `getTuple`. Reverting the writer to its old targeting fails 4 of 5, with the control case still passing.

## One judgment call worth a reviewer's eye

The reader identifies a subagent turn with a state machine (`buildSubAgentParentMap`: an AI message with tool calls, none named `task`, following a closed `task` call). The writer does **not** duplicate it — it uses the coarser "skip AI messages carrying tool calls."

These agree on every shape the reader accepts as an answer, since a final answer has prose and no pending tool calls. But they are not the same rule: if the reader ever accepts a tool-calling message as the answer, they diverge. Sharing the real predicate would mean threading that state machine through the serialized-message layer — a larger refactor than this bug warrants, but the seam is worth knowing about.

Also unverified by me: I reproduced both defects through tests rather than in a live vault, so a run against a real long turn (and a restart afterwards, to exercise the reload path) is still worth doing.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._