### PR TITLE
fix(graph): stop Escape in the graph view jumping to a random note

### DIFF
--- a/src/views/smart-graph/SmartGraphView.ts
+++ b/src/views/smart-graph/SmartGraphView.ts
@@ -9,6 +9,12 @@ export const VIEW_TYPE_SMART_GRAPH = "smart-second-brain-graph";
 export class SmartGraphView extends ItemView {
 	plugin: SecondBrainPlugin;
 	component: ReturnType<typeof mount> | null = null;
+	// A main-area tab, like Obsidian's core graph (which also sets this). Left at
+	// ItemView's default (false), Obsidian classifies the view as a sidebar
+	// utility: its window-level Escape handler then yanks focus to the
+	// most-recently-active navigation leaf, so pressing Escape in the graph
+	// appeared to open a random note.
+	navigation = true;
 
 	constructor(leaf: WorkspaceLeaf, plugin: SecondBrainPlugin) {
 		super(leaf);

--- a/test/__mocks__/obsidian.ts
+++ b/test/__mocks__/obsidian.ts
@@ -169,6 +169,9 @@ export class ItemView {
 	containerEl = document.createElement("div");
 	contentEl = document.createElement("div");
 	leaf: WorkspaceLeaf;
+	// Real Obsidian defaults this to false; the workspace treats non-navigation
+	// views as sidebar utilities (its Escape handler jumps away from them).
+	navigation = false;
 
 	constructor(leaf: WorkspaceLeaf) {
 		this.leaf = leaf;
@@ -183,6 +186,7 @@ export class ItemView {
 
 export class FileView extends ItemView {
 	file: TFile | null = null;
+	navigation = true;
 
 	getViewType = vi.fn().mockReturnValue("file-view");
 	canAcceptExtension = vi.fn().mockReturnValue(true);

--- a/test/views/smartGraphView.test.ts
+++ b/test/views/smartGraphView.test.ts
@@ -1,0 +1,16 @@
+import { WorkspaceLeaf } from "obsidian";
+import { describe, expect, it } from "vitest";
+import type SecondBrainPlugin from "../../src/main";
+import { SmartGraphView } from "../../src/views/smart-graph/SmartGraphView";
+
+describe("SmartGraphView", () => {
+	it("is a navigation view, so Obsidian's Escape handler leaves it alone", () => {
+		// Obsidian's workspace binds a window-level Escape listener that moves
+		// focus to the most-recently-active navigation leaf whenever the active
+		// view has navigation=false (the "escape from sidebar back to editor"
+		// behavior). The graph is a main-area tab like the core graph view;
+		// without this flag, pressing Escape in it appeared to open a random note.
+		const view = new SmartGraphView(new WorkspaceLeaf(), {} as SecondBrainPlugin);
+		expect(view.navigation).toBe(true);
+	});
+});


### PR DESCRIPTION
## Bug

Pressing Escape while the smart graph view was focused appeared to navigate the workspace to seemingly random notes.

## Root cause

Obsidian's `Workspace` constructor installs a **window-level keydown listener** for bare `Escape` (no modifiers, not `defaultPrevented`). When the active leaf's view has `navigation === false`, Obsidian classifies it as a sidebar utility view and implements 'escape from the sidebar back to your editor': it scans for the most-recently-active leaf whose view has `navigation === true` and calls `setActiveLeaf(leaf, { focus: true })`.

`SmartGraphView` is an `ItemView` and never set `navigation`, so it inherited the default `false` — even though it lives in the root split as a main-area tab. Every Escape press therefore yanked focus to whichever note leaf had the freshest `activeTime`, which reads as 'opens a random note'. The plugin's own `handleKeyDown` couldn't intercept this: with the graph leaf active, DOM focus commonly sits on `document.body`, so the event never passes through the view subtree where the handler is bound.

Verified live by tracing the `setActiveLeaf` call triggered by an Escape keydown back to this handler in `app.js`, and by confirming Obsidian's core graph view sets `navigation = true`.

## Fix

Set `navigation = true` on `SmartGraphView` — the same classification Obsidian's core graph view uses. Obsidian's Escape handler now returns early for the graph leaf, and Escape only performs its graph-local actions (cancel lasso, clear selection, exit immerse, clear focused clusters), which are untouched by this change.

Known (intended) side effect: as a navigation view the graph tab now behaves like the core graph tab for file opens — opening a note while the graph tab is active navigates that tab. This matches native Obsidian semantics for main-area views.

## Testing

- New unit test pins `navigation === true` on the view; the obsidian mock's `ItemView`/`FileView` now carry the real defaults (`false`/`true`) so the assertion is meaningful.
- `bun run check` / `format` / `lint` / `test` all clean (1550 tests).
- Live in slot vault: before the fix, a dispatched Escape with the graph leaf active switched the active leaf away; after, the graph leaf stays active and graph keyboard handling still fires.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._