### PR TITLE
fix(chat): withdraw abandoned pending changes on edit/rerun; make edit attachments visible

### DIFF
--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -272,14 +272,25 @@ let stashedDraft: string | null = null;
  * can remove exactly these and leave the user's own attachments alone. */
 let seededEditPaths = new Set<string>();
 
+/** Invalidates an in-flight `seedEditAttachments` pass. Seeding awaits vault
+ * reads (image previews), so the edit can end — save, cancel, or a new edit —
+ * while the loop is suspended; without this the resumed loop would inject the
+ * abandoned edit's remaining attachments into a tray that was already cleared,
+ * and they'd ride along into a later, unrelated message. Bumped wherever the
+ * seeded state is reset, checked after every await. Same last-started-wins
+ * idiom as `assembledPromptRequestVersion` above. */
+let seedEditToken = 0;
+
 /** Seed the edited message's attachments into the composer tray so they are
  * visible and removable during the edit — previously they rode along
  * invisibly, and anything the user attached during the edit was silently
  * dropped from the save. Seeded chips are not "managed" (removing one never
  * deletes the underlying vault file). Image previews load best-effort. */
 async function seedEditAttachments(restored: ChatAttachment[]) {
+	const token = ++seedEditToken;
 	const plugin = getPlugin();
 	for (const att of restored) {
+		if (token !== seedEditToken) return; // the edit ended mid-seed — stop
 		if (attachments.some((a) => a.vaultPath === att.vaultPath)) continue;
 		const file = plugin.app.vault.getAbstractFileByPath(att.vaultPath);
 		if (!(file instanceof TFile)) {
@@ -295,6 +306,10 @@ async function seedEditAttachments(restored: ChatAttachment[]) {
 		if (att.mimeType.startsWith("image/")) {
 			try {
 				const buffer = await plugin.app.vault.readBinary(file);
+				// Re-check before publishing: the URL would leak (nothing left to
+				// revoke it) and the map write would resurrect a removed chip's
+				// preview if the edit ended during the read.
+				if (token !== seedEditToken) return;
 				previewUrls.set(att.vaultPath, URL.createObjectURL(new Blob([buffer], { type: att.mimeType })));
 				previewUrls = new Map(previewUrls);
 			} catch {
@@ -329,6 +344,7 @@ $effect(() => {
 					inputValue = draft;
 					markdownEditor?.setValue(draft);
 				}
+				seedEditToken++;
 				for (const path of seededEditPaths) {
 					removeAttachmentByPath(path);
 				}
@@ -433,6 +449,9 @@ $effect(() => {
 });
 
 onDestroy(() => {
+	// Stop any in-flight edit-attachment seeding; its writes would land on a
+	// dead component's state (and mint object URLs nothing revokes).
+	seedEditToken++;
 	editorContainer?.removeEventListener("touchend", handleMobileTapFocus);
 	markdownEditor?.destroy();
 	// Clean up object URLs
@@ -651,6 +670,7 @@ function saveEdit() {
 	// cancel-restore from firing on this transition.
 	session.editingPairId = null;
 	stashedDraft = null;
+	seedEditToken++;
 	seededEditPaths = new Set();
 	// The tray's attachments were consumed into the edited message — clear them
 	// exactly as sendMessage does (files stay in the vault; they're now sent).

--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -331,25 +331,34 @@ async function seedEditAttachments(restored: ChatAttachment[]) {
 // cancel path puts the stashed draft back and clears the seeded attachment
 // chips; a successful saveEdit clears the stash first, so this no-ops there.
 let lastSeededEditId: string | null = null;
+
+/** Unwind one edit's seeding: stop any in-flight attachment seeding, put the
+ * pre-edit draft back, and remove the chips the edit seeded (the user's own
+ * attachments stay). Shared by the `editingPairId → null` cleanup and the
+ * direct A→B edit switch below — the two paths must stay identical, or
+ * whichever one drifts leaks the previous edit's text/attachments into
+ * whatever the composer does next. */
+function restorePreEditComposerState() {
+	seedEditToken++;
+	if (stashedDraft !== null) {
+		const draft = stashedDraft;
+		stashedDraft = null;
+		inputValue = draft;
+		markdownEditor?.setValue(draft);
+	}
+	for (const path of seededEditPaths) {
+		removeAttachmentByPath(path);
+	}
+	seededEditPaths = new Set();
+}
+
 $effect(() => {
 	if (editingPairId === null) {
 		if (lastSeededEditId !== null) {
 			lastSeededEditId = null;
 			// Untracked: the restore reads/writes composer state that must not
 			// become a dependency of this effect (it only reacts to the edit target).
-			untrack(() => {
-				if (stashedDraft !== null) {
-					const draft = stashedDraft;
-					stashedDraft = null;
-					inputValue = draft;
-					markdownEditor?.setValue(draft);
-				}
-				seedEditToken++;
-				for (const path of seededEditPaths) {
-					removeAttachmentByPath(path);
-				}
-				seededEditPaths = new Set();
-			});
+			untrack(() => restorePreEditComposerState());
 		}
 		return;
 	}
@@ -358,6 +367,14 @@ $effect(() => {
 	if (!pair) {
 		session?.cancelEdit();
 		return;
+	}
+	// Switching straight from editing one message to another never passes
+	// through null, so unwind the previous edit here first — otherwise its
+	// seeded attachments stay in the tray and get saved onto the new target,
+	// and its message text (stashed below as the "draft") would later be
+	// restored as if the user had typed it.
+	if (lastSeededEditId !== null) {
+		untrack(() => restorePreEditComposerState());
 	}
 	lastSeededEditId = editingPairId;
 	stashedDraft = inputValue;

--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Notice, Platform, TFile, normalizePath } from "obsidian";
 import { selectChatModelAction, showActionNotice } from "../../utils/actionNotice";
-import { onDestroy, onMount } from "svelte";
+import { onDestroy, onMount, untrack } from "svelte";
 import { useAvailableModels } from "../../hooks/useAvailableModels.svelte";
 import { EmbeddableMarkdownEditor } from "../../lib/editor";
 import { MessageState, type SessionRegistry } from "../../stores/chatStore.svelte";
@@ -267,14 +267,74 @@ $effect(() => {
 // component is the only thing that holds `inputValue`/the CodeMirror instance.
 let stashedDraft: string | null = null;
 
+/** Attachment paths the edit seeded into the tray (the edited message's own
+ * attachments, minus any the user already had attached). Tracked so a cancel
+ * can remove exactly these and leave the user's own attachments alone. */
+let seededEditPaths = new Set<string>();
+
+/** Seed the edited message's attachments into the composer tray so they are
+ * visible and removable during the edit — previously they rode along
+ * invisibly, and anything the user attached during the edit was silently
+ * dropped from the save. Seeded chips are not "managed" (removing one never
+ * deletes the underlying vault file). Image previews load best-effort. */
+async function seedEditAttachments(restored: ChatAttachment[]) {
+	const plugin = getPlugin();
+	for (const att of restored) {
+		if (attachments.some((a) => a.vaultPath === att.vaultPath)) continue;
+		const file = plugin.app.vault.getAbstractFileByPath(att.vaultPath);
+		if (!(file instanceof TFile)) {
+			new Notice(
+				`Attachment "${att.name}" no longer exists in the vault — it won't be part of the edited message.`,
+			);
+			continue;
+		}
+		attachments.push({ name: att.name, mimeType: att.mimeType, vaultPath: att.vaultPath });
+		attachmentSizes.set(att.vaultPath, file.stat.size);
+		attachmentSizes = new Map(attachmentSizes);
+		seededEditPaths.add(att.vaultPath);
+		if (att.mimeType.startsWith("image/")) {
+			try {
+				const buffer = await plugin.app.vault.readBinary(file);
+				previewUrls.set(att.vaultPath, URL.createObjectURL(new Blob([buffer], { type: att.mimeType })));
+				previewUrls = new Map(previewUrls);
+			} catch {
+				// preview only — the chip still renders without it
+			}
+		}
+	}
+}
+
 // Seed the composer with the target message's content when an edit starts.
 // Mirrors the `pendingInput` pattern above: write `inputValue` synchronously
 // so `canSendMessage` reflects it immediately, defer the CodeMirror write to
 // the next frame so its DOM is laid out before the transaction dispatches.
+//
+// The `editingPairId → null` transition is ALSO handled here (not only in
+// cancelActiveEdit): an edit can end from outside the composer — tapping the
+// highlighted bubble calls `session.cancelEdit()` directly, and a branch
+// switch can drop the edited pair. Restoring in the effect means every
+// cancel path puts the stashed draft back and clears the seeded attachment
+// chips; a successful saveEdit clears the stash first, so this no-ops there.
 let lastSeededEditId: string | null = null;
 $effect(() => {
 	if (editingPairId === null) {
-		lastSeededEditId = null;
+		if (lastSeededEditId !== null) {
+			lastSeededEditId = null;
+			// Untracked: the restore reads/writes composer state that must not
+			// become a dependency of this effect (it only reacts to the edit target).
+			untrack(() => {
+				if (stashedDraft !== null) {
+					const draft = stashedDraft;
+					stashedDraft = null;
+					inputValue = draft;
+					markdownEditor?.setValue(draft);
+				}
+				for (const path of seededEditPaths) {
+					removeAttachmentByPath(path);
+				}
+				seededEditPaths = new Set();
+			});
+		}
 		return;
 	}
 	if (editingPairId === lastSeededEditId) return;
@@ -287,6 +347,9 @@ $effect(() => {
 	stashedDraft = inputValue;
 	const text = pair.userMessage.content;
 	inputValue = text;
+	// Untracked: seeding reads/writes the attachment state, which must not
+	// become a dependency of this effect (it only reacts to the edit target).
+	untrack(() => void seedEditAttachments(session?.getEditAttachments(pair.id) ?? []));
 	requestAnimationFrame(() => {
 		markdownEditor?.setValue(text);
 		markdownEditor?.focus();
@@ -550,21 +613,23 @@ function attemptSend() {
 	}
 }
 
-/** Cancel the active edit, restoring whatever draft was in the composer
- * before the edit started. No-op when not editing. */
+/** Cancel the active edit. The seeding effect above reacts to the
+ * `editingPairId → null` transition and restores the stashed draft and
+ * pre-edit attachments — shared with the out-of-composer cancel paths.
+ * No-op when not editing. */
 function cancelActiveEdit() {
 	if (!isEditing) return;
 	session?.cancelEdit();
-	const draft = stashedDraft ?? "";
-	stashedDraft = null;
-	inputValue = draft;
-	markdownEditor?.setValue(draft);
 }
 
 function saveEdit() {
 	if (!session || editingPairId === null) return;
+	if (savingFiles) {
+		new Notice("Please wait for attachments to finish saving");
+		return;
+	}
 	if (!hasContentToSend) {
-		new Notice("Add text before saving");
+		new Notice("Add text or attach a file before saving");
 		return;
 	}
 	if (!hasChatModel) {
@@ -573,15 +638,29 @@ function saveEdit() {
 	}
 
 	const pairId = editingPairId;
-	const contentToSave = inputValue;
-	session.editMessage(pairId, contentToSave).catch((error) => {
+	// Same attachment-only fallback as sendMessage — the tray IS the edited
+	// message's attachment list, so text is optional exactly as it is on send.
+	const contentToSave = inputValue.trim().length > 0 ? inputValue : "Please analyze the attached files.";
+	session.editMessage(pairId, contentToSave, [...attachments]).catch((error) => {
 		new Notice(error instanceof Error ? error.message : "Failed to save edit");
 	});
 	// Not session.cancelEdit() — that's for an abandoned edit; this one succeeded.
 	// The draft that was stashed before the edit began is simply gone: the user
 	// asked to save the edit, not to restore what they'd been typing before it.
+	// Clearing the stash BEFORE editingPairId also keeps the seeding effect's
+	// cancel-restore from firing on this transition.
 	session.editingPairId = null;
 	stashedDraft = null;
+	seededEditPaths = new Set();
+	// The tray's attachments were consumed into the edited message — clear them
+	// exactly as sendMessage does (files stay in the vault; they're now sent).
+	attachments = [];
+	attachmentSizes = new Map();
+	managedAttachmentPaths = new Set();
+	for (const url of previewUrls.values()) {
+		URL.revokeObjectURL(url);
+	}
+	previewUrls = new Map();
 	inputValue = "";
 	markdownEditor?.clear();
 	onMessageSent?.();

--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -7,7 +7,7 @@ import {
 	isHumanMessage,
 	isToolMessage,
 } from "@langchain/core/messages";
-import { type TFile } from "obsidian";
+import { Notice, type TFile } from "obsidian";
 import { SvelteMap } from "svelte/reactivity";
 import type { AgentStreamChunk, CheckpointHistoryItem, ThreadHistory } from "../agent/Agent";
 import type { AgentManager } from "../agent/AgentManager";
@@ -1567,6 +1567,35 @@ export function baseMessagesToMessagePairs(
 }
 
 /**
+ * Tool-call ids present in `tipMessages` but not in `forkMessages` — the calls
+ * made by the turns an edit/regenerate is about to abandon.
+ *
+ * Both lists are full checkpoint channels (the channel is cumulative), so the
+ * fork checkpoint contains every call up to the fork and the difference is
+ * exactly the segment being replaced. Summarization can only TRIM messages from
+ * the later tip, which keeps this conservative: a call trimmed from the tip is
+ * absent from the diff and its proposals are left alone rather than withdrawn.
+ */
+export function collectAbandonedToolCallIds(forkMessages: BaseMessage[], tipMessages: BaseMessage[]): Set<string> {
+	const keptIds = new Set<string>();
+	for (const msg of forkMessages) {
+		if (!isAIMessage(msg)) continue;
+		for (const tc of (msg as AIMessage).tool_calls ?? []) {
+			if (tc.id) keptIds.add(tc.id);
+		}
+	}
+
+	const abandoned = new Set<string>();
+	for (const msg of tipMessages) {
+		if (!isAIMessage(msg)) continue;
+		for (const tc of (msg as AIMessage).tool_calls ?? []) {
+			if (tc.id && !keptIds.has(tc.id)) abandoned.add(tc.id);
+		}
+	}
+	return abandoned;
+}
+
+/**
  * Get the timestamp for when this message pair was created.
  * Returns the stable createdAt (derived from checkpoint ts), or null if unavailable.
  */
@@ -1914,6 +1943,51 @@ export class ChatSession {
 		return recovered?.length ? recovered : undefined;
 	}
 
+	/** The attachments an edit of this pair starts from — what the message being
+	 * edited carried. The composer seeds its tray with these so they're visible
+	 * and removable during the edit instead of riding along invisibly. */
+	getEditAttachments(pairId: UUIDv7): ChatAttachment[] {
+		const pair = this.findPair(pairId);
+		if (!pair) return [];
+		return this.resolveEditAttachments(pair) ?? [];
+	}
+
+	/**
+	 * Withdraw pending note proposals staged by the turns this fork abandons.
+	 *
+	 * Called by editMessage/regenerateResponse BEFORE the fork: the proposals
+	 * belong to an answer the user is replacing, and leaving them pending is what
+	 * produced orphaned review-bar rows, duplicated creates on rerun, and reruns
+	 * rebasing their updates onto the abandoned answer's content. Deliberately
+	 * NOT called on switchToBranch — switching is reversible navigation, so the
+	 * other branch's proposals stay reviewable.
+	 *
+	 * Partially-applied entries are kept (see the store method); a Notice tells
+	 * the user what was withdrawn so proposals never vanish silently.
+	 */
+	private withdrawAbandonedPendingChanges(forkCheckpointId: string): void {
+		const forkNode = this.graphState.nodes.get(forkCheckpointId);
+		if (!forkNode) return;
+		const abandoned = collectAbandonedToolCallIds(forkNode.messages, this.getActiveCheckpointMessages());
+		if (abandoned.size === 0) return;
+
+		try {
+			const { withdrawn, keptPartiallyApplied } = getPendingChangesStore().withdrawForToolCalls(
+				String(this.id),
+				abandoned,
+			);
+			if (withdrawn > 0) {
+				const kept =
+					keptPartiallyApplied > 0
+						? ` ${keptPartiallyApplied} partially applied change(s) were kept — resolve them in the review bar.`
+						: "";
+				new Notice(`Withdrew ${withdrawn} pending note change(s) proposed by the replaced response.${kept}`);
+			}
+		} catch {
+			// store not initialized (e.g. very early in startup) — nothing staged yet
+		}
+	}
+
 	/** Enter edit mode for a message pair. The composer reacts to
 	 * `editingPairId` changing to stash its draft and seed the message's text. */
 	beginEdit(pairId: UUIDv7): void {
@@ -1935,14 +2009,31 @@ export class ChatSession {
 	/**
 	 * Edit a user message and get a new AI response.
 	 * This creates a new branch from the checkpoint before the original message.
+	 *
+	 * `attachments` is what the edited message should carry. The composer always
+	 * passes it (the tray's contents at save time, `[]` meaning the user removed
+	 * them all); `undefined` means the caller doesn't manage attachments, so the
+	 * original message's own attachments are restored from the checkpoint.
 	 */
-	async editMessage(pairId: UUIDv7, newContent: string): Promise<void> {
+	async editMessage(pairId: UUIDv7, newContent: string, attachments?: ChatAttachment[]): Promise<void> {
 		const pair = this.findPair(pairId);
 		if (!pair) {
 			throw new Error("Message pair not found");
 		}
 
-		const attachments = this.resolveEditAttachments(pair);
+		// Same guard runStream applies, but BEFORE the withdrawal and the
+		// optimistic fork: reaching it only there would first withdraw pending
+		// proposals and mutate the graph for a run that is then refused.
+		if (this.running) {
+			throw new Error("A response is already in progress for this chat.");
+		}
+
+		const resolvedAttachments =
+			attachments === undefined
+				? this.resolveEditAttachments(pair)
+				: attachments.length > 0
+					? attachments
+					: undefined;
 
 		// Get the checkpoint to fork from for editing
 		const checkpointId = pair.editFromCheckpointId;
@@ -1952,18 +2043,20 @@ export class ChatSession {
 			);
 		}
 
+		this.withdrawAbandonedPendingChanges(checkpointId);
+
 		const parentMessages = this.graphState.nodes.get(checkpointId)?.messages ?? [];
 		const optimisticMessages = [
 			...parentMessages,
 			new HumanMessage({
 				content: newContent,
 				id: genUUIDv7(),
-				additional_kwargs: attachments?.length ? { attachments } : undefined,
+				additional_kwargs: resolvedAttachments?.length ? { attachments: resolvedAttachments } : undefined,
 			}),
 		];
 		const optimisticPair = this.applyOptimisticFork(checkpointId, optimisticMessages);
 		optimisticPair.userMessage.content = newContent;
-		optimisticPair.userMessage.attachments = attachments;
+		optimisticPair.userMessage.attachments = resolvedAttachments;
 		optimisticPair.assistantMessage.state = AssistantState.idle;
 		optimisticPair.assistantMessage.content = "";
 		optimisticPair.assistantMessage.toolCalls = undefined;
@@ -1972,7 +2065,7 @@ export class ChatSession {
 		optimisticPair.regenerateFromCheckpointId = undefined;
 
 		// Stream the edited response
-		await this.processEditReply(optimisticPair.id, newContent, checkpointId, attachments);
+		await this.processEditReply(optimisticPair.id, newContent, checkpointId, resolvedAttachments);
 	}
 
 	/**
@@ -1985,6 +2078,12 @@ export class ChatSession {
 			throw new Error("Message pair not found");
 		}
 
+		// Before the withdrawal/fork, for the same reason as editMessage: the
+		// regenerate affordance stays visible on earlier turns while a run streams.
+		if (this.running) {
+			throw new Error("A response is already in progress for this chat.");
+		}
+
 		// Get the checkpoint to fork from for regeneration
 		const checkpointId = pair.regenerateFromCheckpointId;
 		if (!checkpointId) {
@@ -1992,6 +2091,8 @@ export class ChatSession {
 				"Cannot regenerate: no checkpoint available for this message. Checkpoint graph may not be loaded.",
 			);
 		}
+
+		this.withdrawAbandonedPendingChanges(checkpointId);
 
 		const parentMessages = this.graphState.nodes.get(checkpointId)?.messages ?? [];
 		const optimisticPair = this.applyOptimisticFork(checkpointId, [...parentMessages]);

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -714,6 +714,47 @@ export class PendingChangesStore {
 		return skipped;
 	}
 
+	/**
+	 * Withdraw the pending proposals staged by specific tool calls — the
+	 * edit/regenerate path. When the user replaces a turn, the proposals its
+	 * response staged belong to an answer that no longer exists on the active
+	 * branch; leaving them pending orphans them in the review bar and makes the
+	 * rerun re-stage on top of them (duplicated creates, updates rebased onto an
+	 * abandoned answer's content).
+	 *
+	 * Withdrawn entries are marked `reportedToModel`: the model on the NEW branch
+	 * never made these proposals, so telling it "rejected by the user" in the next
+	 * review-outcome block would be both noise and false — the user replaced the
+	 * turn, they didn't review anything.
+	 *
+	 * Entries holding unreverted partially-applied content are left untouched
+	 * (still pending/actionable): the user accepted part of them, that content is
+	 * on disk, and this path must never discard their only undo record.
+	 */
+	withdrawForToolCalls(
+		threadId: string,
+		toolCallIds: ReadonlySet<string>,
+	): { withdrawn: number; keptPartiallyApplied: number } {
+		let withdrawn = 0;
+		let keptPartiallyApplied = 0;
+		for (const entry of this.#entries) {
+			if (entry.threadId !== threadId || entry.status !== "pending") continue;
+			if (!toolCallIds.has(entry.toolCallId)) continue;
+			if (this.hasUnrevertedApplication(entry)) {
+				keptPartiallyApplied++;
+				continue;
+			}
+			entry.status = "rejected";
+			entry.reportedToModel = true;
+			withdrawn++;
+		}
+		if (withdrawn > 0) {
+			this.scheduleSave();
+			this.notifyChange();
+		}
+		return { withdrawn, keptPartiallyApplied };
+	}
+
 	/** Reject all pending changes for a thread, reverting any partially-applied group writes.
 	 *
 	 *  Returns the paths whose revert was skipped because the file no longer matched what

--- a/test/stores/chatSessionEditRerun.test.ts
+++ b/test/stores/chatSessionEditRerun.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AIMessage, type BaseMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
+import { ChatSession, buildCheckpointGraph, type CheckpointGraphState } from "../../src/stores/chatStore.svelte";
+import { PendingChangesStore, initPendingChangesStore } from "../../src/stores/pendingChangesStore.svelte";
+import type { ChatAttachment } from "../../src/types/shared";
+import type { CheckpointHistoryItem } from "../../src/agent/Agent";
+
+/* --------------------------------------------------------------------------
+ * ChatSession × pendingChangesStore — edit/regenerate withdraws the replaced
+ * response's pending proposals, and edits carry explicit attachments.
+ *
+ * The streaming methods are stubbed out (no live agent in unit tests); what is
+ * exercised is everything editMessage/regenerateResponse does BEFORE streaming:
+ * the pending-change withdrawal and the optimistic fork's message content.
+ * ------------------------------------------------------------------------*/
+
+const THREAD_ID = "Chats/Session Test.chat";
+
+function humanMsg(content: string, id: string, attachments?: ChatAttachment[]) {
+	return new HumanMessage({
+		content,
+		id,
+		additional_kwargs: attachments ? { attachments } : undefined,
+	});
+}
+
+function aiToolMsg(id: string, toolCallId: string) {
+	return new AIMessage({ content: "", id, tool_calls: [{ id: toolCallId, name: "manage_notes", args: {} }] });
+}
+
+function toolMsg(toolCallId: string) {
+	return new ToolMessage({ content: "staged", tool_call_id: toolCallId });
+}
+
+function checkpoint(
+	checkpointId: string,
+	step: number,
+	messages: BaseMessage[],
+	parentCheckpointId?: string,
+): CheckpointHistoryItem {
+	return { checkpointId, step, messages, parentCheckpointId, ts: new Date(2026, 0, 1, 0, step + 2).toISOString() };
+}
+
+const ATTACHMENT: ChatAttachment = { name: "Doc.md", mimeType: "text/markdown", vaultPath: "Doc.md" };
+
+/**
+ * Two full turns:
+ *   turn 1 (h1) → ai1 stages via tc-1 → answer ai2
+ *   turn 2 (h2, carries an attachment) → ai3 stages via tc-2 → answer ai4
+ */
+function buildTwoTurnGraph(): CheckpointGraphState {
+	const h1 = humanMsg("turn one", "h1");
+	const ai1 = aiToolMsg("ai1", "tc-1");
+	const t1 = toolMsg("tc-1");
+	const ai2 = new AIMessage({ content: "answer 1", id: "ai2" });
+	const h2 = humanMsg("turn two", "h2", [ATTACHMENT]);
+	const ai3 = aiToolMsg("ai3", "tc-2");
+	const t2 = toolMsg("tc-2");
+	const ai4 = new AIMessage({ content: "answer 2", id: "ai4" });
+
+	const graph = buildCheckpointGraph([
+		checkpoint("r", -1, []),
+		checkpoint("a", 0, [h1], "r"),
+		checkpoint("b", 1, [h1, ai1, t1, ai2], "a"),
+		checkpoint("c", 2, [h1, ai1, t1, ai2, h2], "b"),
+		checkpoint("d", 3, [h1, ai1, t1, ai2, h2, ai3, t2, ai4], "c"),
+	]);
+	graph.activeCheckpointId = "d";
+	return graph;
+}
+
+function makeSession(): ChatSession {
+	const session = new ChatSession(THREAD_ID, {
+		graphState: buildTwoTurnGraph(),
+		errorCount: 0,
+		selectedAgentId: "",
+	});
+	// Stub the streaming tail — these tests end at the optimistic fork.
+	const internals = session as unknown as {
+		processEditReply: (...args: unknown[]) => Promise<void>;
+		processRegenerateReply: (...args: unknown[]) => Promise<void>;
+	};
+	internals.processEditReply = vi.fn().mockResolvedValue(undefined);
+	internals.processRegenerateReply = vi.fn().mockResolvedValue(undefined);
+	return session;
+}
+
+function makeStore(): PendingChangesStore {
+	const plugin = {
+		manifest: { dir: "test-plugin" },
+		app: {
+			vault: {
+				adapter: {
+					exists: vi.fn().mockResolvedValue(false),
+					mkdir: vi.fn().mockResolvedValue(undefined),
+					write: vi.fn().mockResolvedValue(undefined),
+				},
+				on: vi.fn(),
+			},
+		},
+		registerEvent: vi.fn(),
+	} as unknown as ConstructorParameters<typeof PendingChangesStore>[0];
+	return new PendingChangesStore(plugin);
+}
+
+describe("ChatSession edit/regenerate × pending changes", () => {
+	let session: ChatSession;
+	let store: PendingChangesStore;
+
+	beforeEach(() => {
+		store = makeStore();
+		initPendingChangesStore(store);
+		store.addChanges([{ type: "create", path: "turn-one.md", content: "1" }], "tc-1", THREAD_ID);
+		store.addChanges([{ type: "create", path: "turn-two.md", content: "2" }], "tc-2", THREAD_ID);
+		session = makeSession();
+	});
+
+	afterEach(() => {
+		store.cleanup();
+	});
+
+	it("regenerating a turn withdraws the proposals its response staged, keeping earlier turns'", async () => {
+		const pair2 = session.messages.at(-1)!;
+		expect(pair2.regenerateFromCheckpointId).toBe("c");
+
+		await session.regenerateResponse(pair2.id);
+
+		const [e1] = store.getEntriesByToolCallId("tc-1");
+		const [e2] = store.getEntriesByToolCallId("tc-2");
+		expect(e1.status).toBe("pending");
+		expect(e2.status).toBe("rejected");
+		expect(e2.reportedToModel).toBe(true);
+	});
+
+	it("editing an earlier message withdraws every abandoned turn's proposals", async () => {
+		const pair1 = session.messages[0];
+		expect(pair1.editFromCheckpointId).toBe("r");
+
+		await session.editMessage(pair1.id, "turn one, edited");
+
+		const [e1] = store.getEntriesByToolCallId("tc-1");
+		const [e2] = store.getEntriesByToolCallId("tc-2");
+		expect(e1.status).toBe("rejected");
+		expect(e2.status).toBe("rejected");
+	});
+
+	it("refuses to fork while a run is in flight, leaving proposals untouched", async () => {
+		const pair2 = session.messages.at(-1)!;
+		const internals = session as unknown as { abortController: AbortController | null; running: boolean };
+		internals.abortController = new AbortController();
+		internals.running = true;
+
+		await expect(session.regenerateResponse(pair2.id)).rejects.toThrow(/already in progress/);
+		await expect(session.editMessage(pair2.id, "edited")).rejects.toThrow(/already in progress/);
+
+		expect(store.getEntriesByToolCallId("tc-1")[0].status).toBe("pending");
+		expect(store.getEntriesByToolCallId("tc-2")[0].status).toBe("pending");
+	});
+
+	it("editing the last message keeps the shared prefix's proposals", async () => {
+		const pair2 = session.messages.at(-1)!;
+		expect(pair2.editFromCheckpointId).toBe("b");
+
+		await session.editMessage(pair2.id, "turn two, edited");
+
+		expect(store.getEntriesByToolCallId("tc-1")[0].status).toBe("pending");
+		expect(store.getEntriesByToolCallId("tc-2")[0].status).toBe("rejected");
+	});
+});
+
+describe("ChatSession edit × attachments", () => {
+	let session: ChatSession;
+	let store: PendingChangesStore;
+
+	beforeEach(() => {
+		store = makeStore();
+		initPendingChangesStore(store);
+		session = makeSession();
+	});
+
+	afterEach(() => {
+		store.cleanup();
+	});
+
+	function lastOptimisticHuman(): HumanMessage {
+		const last = session.getActiveCheckpointMessages().at(-1);
+		expect(last).toBeInstanceOf(HumanMessage);
+		return last as HumanMessage;
+	}
+
+	it("getEditAttachments returns the edited message's attachments", () => {
+		const pair2 = session.messages.at(-1)!;
+		expect(session.getEditAttachments(pair2.id)).toEqual([ATTACHMENT]);
+		expect(session.getEditAttachments(session.messages[0].id)).toEqual([]);
+	});
+
+	it("getEditAttachments falls back to the checkpoint when the pair lost them", () => {
+		const pair2 = session.messages.at(-1)!;
+		pair2.userMessage.attachments = undefined;
+		expect(session.getEditAttachments(pair2.id)).toEqual([ATTACHMENT]);
+	});
+
+	it("an explicit attachment list is what the edited message carries", async () => {
+		const pair2 = session.messages.at(-1)!;
+		const replacement: ChatAttachment = { name: "Other.md", mimeType: "text/markdown", vaultPath: "Other.md" };
+
+		await session.editMessage(pair2.id, "edited", [replacement]);
+
+		expect(lastOptimisticHuman().additional_kwargs?.attachments).toEqual([replacement]);
+	});
+
+	it("an explicit empty list removes the attachments from the edited message", async () => {
+		const pair2 = session.messages.at(-1)!;
+
+		await session.editMessage(pair2.id, "edited", []);
+
+		expect(lastOptimisticHuman().additional_kwargs?.attachments).toBeUndefined();
+		expect(session.messages.at(-1)?.userMessage.attachments).toBeUndefined();
+	});
+
+	it("omitting the list restores the original message's attachments (legacy callers)", async () => {
+		const pair2 = session.messages.at(-1)!;
+
+		await session.editMessage(pair2.id, "edited");
+
+		expect(lastOptimisticHuman().additional_kwargs?.attachments).toEqual([ATTACHMENT]);
+		expect(session.messages.at(-1)?.userMessage.attachments).toEqual([ATTACHMENT]);
+	});
+});

--- a/test/stores/chatStore.test.ts
+++ b/test/stores/chatStore.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { AIMessage, type BaseMessage, HumanMessage, ToolMessage } from "@langchain/core/messages";
 import {
 	buildCheckpointGraph,
+	collectAbandonedToolCallIds,
 	deriveMessagePairsFromActiveCheckpoint,
 	baseMessagesToMessagePairs,
 	baseMessageToAssistantMessage,
@@ -1011,5 +1012,70 @@ describe("message pair identity across rebuilds", () => {
 
 		const after = deriveMessagePairsFromActiveCheckpoint(persisted, "cp-2");
 		expect(after[0].assistantMessage.thinkingDurationMs).toBe(42_000);
+	});
+});
+
+/* --------------------------------------------------------------------------
+ * collectAbandonedToolCallIds — the tool calls an edit/regenerate abandons
+ * ------------------------------------------------------------------------*/
+
+describe("collectAbandonedToolCallIds", () => {
+	it("returns tool calls present at the tip but not at the fork checkpoint", () => {
+		const h1 = humanMsg("q1", "h1");
+		const ai1 = aiMsgWithToolCalls("", [{ id: "tc-1", name: "manage_notes", args: {} }], "ai1");
+		const t1 = toolMsg("staged", "tc-1");
+		const ai2 = aiMsg("answer 1", "ai2");
+		const h2 = humanMsg("q2", "h2");
+		const ai3 = aiMsgWithToolCalls("", [{ id: "tc-2", name: "manage_notes", args: {} }], "ai3");
+
+		const forkMessages = [h1, ai1, t1, ai2, h2]; // regenerate turn 2: fork where h2 is last
+		const tipMessages = [h1, ai1, t1, ai2, h2, ai3, toolMsg("staged", "tc-2"), aiMsg("answer 2", "ai4")];
+
+		expect(collectAbandonedToolCallIds(forkMessages, tipMessages)).toEqual(new Set(["tc-2"]));
+	});
+
+	it("keeps every call when the fork point is the tip (nothing abandoned)", () => {
+		const msgs = [
+			humanMsg("q", "h1"),
+			aiMsgWithToolCalls("", [{ id: "tc-1", name: "manage_notes", args: {} }], "ai1"),
+			toolMsg("ok", "tc-1"),
+			aiMsg("done", "ai2"),
+		];
+		expect(collectAbandonedToolCallIds(msgs, msgs)).toEqual(new Set());
+	});
+
+	it("abandons the whole branch when forking from the root (editing the first message)", () => {
+		const tipMessages = [
+			humanMsg("q1", "h1"),
+			aiMsgWithToolCalls("", [{ id: "tc-1", name: "manage_notes", args: {} }], "ai1"),
+			toolMsg("ok", "tc-1"),
+			humanMsg("q2", "h2"),
+			aiMsgWithToolCalls("", [{ id: "tc-2", name: "manage_notes", args: {} }], "ai2"),
+		];
+		expect(collectAbandonedToolCallIds([], tipMessages)).toEqual(new Set(["tc-1", "tc-2"]));
+	});
+
+	it("stays conservative when summarization trimmed old calls from the tip", () => {
+		const h1 = humanMsg("q1", "h1");
+		const ai1 = aiMsgWithToolCalls("", [{ id: "tc-old", name: "manage_notes", args: {} }], "ai1");
+		const forkMessages = [h1, ai1, toolMsg("ok", "tc-old"), aiMsg("a", "ai2")];
+		// Summarization dropped ai1 from the tip channel; only the new call remains.
+		const tipMessages = [
+			humanMsg("summary", "sum"),
+			humanMsg("q2", "h2"),
+			aiMsgWithToolCalls("", [{ id: "tc-new", name: "manage_notes", args: {} }], "ai3"),
+		];
+		// tc-old is absent from the tip, so it is NOT reported as abandoned — its
+		// proposals are left alone rather than withdrawn on a guess.
+		expect(collectAbandonedToolCallIds(forkMessages, tipMessages)).toEqual(new Set(["tc-new"]));
+	});
+
+	it("ignores messages without tool calls and calls without ids", () => {
+		const tipMessages = [
+			humanMsg("q", "h1"),
+			aiMsg("plain answer", "ai1"),
+			new AIMessage({ content: "", id: "ai2", tool_calls: [{ name: "manage_notes", args: {} }] }),
+		];
+		expect(collectAbandonedToolCallIds([], tipMessages)).toEqual(new Set());
 	});
 });

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -1249,4 +1249,79 @@ describe("PendingChangesStore", () => {
 			expect(store.getActionableForThread("thread-1").map((e) => e.id)).toContain(id);
 		});
 	});
+
+	describe("withdrawForToolCalls (edit/regenerate fork)", () => {
+		it("rejects pending entries staged by the abandoned tool calls and marks them reported", () => {
+			const [id] = store.addChanges(
+				[{ type: "update", path: "a.md", originalContent: "x", newContent: "y" }],
+				"tc-abandoned",
+				"thread-1",
+			);
+
+			const result = store.withdrawForToolCalls("thread-1", new Set(["tc-abandoned"]));
+
+			expect(result).toEqual({ withdrawn: 1, keptPartiallyApplied: 0 });
+			const entry = store.getEntry(id)!;
+			expect(entry.status).toBe("rejected");
+			// The new branch's model never made this proposal, so it must NOT be
+			// told "rejected by the user" in the next review-outcome block.
+			expect(entry.reportedToModel).toBe(true);
+			expect(store.takeReviewOutcomesForThread("thread-1")).toEqual({ outcomes: [], pendingProposals: [] });
+		});
+
+		it("leaves other threads' and other tool calls' entries pending", () => {
+			const [keptSameThread] = store.addChanges(
+				[{ type: "create", path: "kept.md", content: "c" }],
+				"tc-kept",
+				"thread-1",
+			);
+			const [otherThread] = store.addChanges(
+				[{ type: "create", path: "other.md", content: "c" }],
+				"tc-abandoned",
+				"thread-2",
+			);
+			const [withdrawnId] = store.addChanges(
+				[{ type: "create", path: "gone.md", content: "c" }],
+				"tc-abandoned",
+				"thread-1",
+			);
+
+			const result = store.withdrawForToolCalls("thread-1", new Set(["tc-abandoned"]));
+
+			expect(result.withdrawn).toBe(1);
+			expect(store.getEntry(keptSameThread)!.status).toBe("pending");
+			expect(store.getEntry(otherThread)!.status).toBe("pending");
+			expect(store.getEntry(withdrawnId)!.status).toBe("rejected");
+		});
+
+		it("keeps entries holding unreverted partially-applied content untouched", async () => {
+			const original = "a\nkeep\nb\n";
+			const [id] = store.addChanges(
+				[{ type: "update", path: "note.md", originalContent: original, newContent: "A\nkeep\nB\n" }],
+				"tc-abandoned",
+				"thread-1",
+			);
+			vi.mocked(plugin.app.vault.getAbstractFileByPath).mockReturnValue(makeTFile("note.md"));
+			vi.mocked(plugin.app.vault.read).mockResolvedValue(original);
+			await store.acceptChangeGroup(id, 0);
+
+			const result = store.withdrawForToolCalls("thread-1", new Set(["tc-abandoned"]));
+
+			expect(result).toEqual({ withdrawn: 0, keptPartiallyApplied: 1 });
+			// Still pending: the user accepted part of it, so it stays theirs to
+			// resolve — withdrawing would discard the only undo record.
+			expect(store.getEntry(id)!.status).toBe("pending");
+			expect(store.hasUnrevertedApplication(store.getEntry(id)!)).toBe(true);
+		});
+
+		it("does not bump the revision when nothing matches", () => {
+			store.addChanges([{ type: "create", path: "kept.md", content: "c" }], "tc-kept", "thread-1");
+			const before = store.revision;
+
+			const result = store.withdrawForToolCalls("thread-1", new Set(["tc-unknown"]));
+
+			expect(result).toEqual({ withdrawn: 0, keptPartiallyApplied: 0 });
+			expect(store.revision).toBe(before);
+		});
+	});
 });


### PR DESCRIPTION
## Problem

Editing a message or regenerating a response forks a new branch of the checkpoint tree, but the pending note proposals (`pendingChangesStore`) staged by the replaced turns stayed `pending`. All three failure modes below were **reproduced live** against a slot vault (driven through a local mock OpenAI-compatible server so real checkpoints/tool calls were produced):

1. **Compounded proposals on edit.** Turn stages `Alpha → Gamma`; user edits the message to ask for `Beta → Delta` instead. `manage_notes`' rebase-onto-pending logic applied the new edit on the abandoned proposal's `newContent`, so the staged diff became `Gamma … Delta` — the new branch's proposal silently carried an edit from a response that no longer exists on the active path.
2. **Duplicated creates/deletes/moves on rerun.** Regenerating a turn that staged a create left two identical pending "Create" rows (only *updates* have same-thread dedup); accepting the second then fails with "file already exists".
3. **False review outcomes.** Where dedup did fire, the auto-rejected leftover was unreported, so the next turn's review-status block told the **new** branch's model `"…: rejected by the user — NOT applied"` for a proposal it never made and the user never reviewed. And with no re-stage at all, the abandoned proposals lingered in the review bar indefinitely, advertised to the new model as its own pending proposals.

Separately, **attachments**: editing a message with attachments carried them along invisibly (nothing in the composer showed them, no way to remove them), anything attached to the composer during an edit was silently *excluded* from the save, and cancelling an edit by tapping the highlighted bubble bypassed the composer's restore — the stashed draft was orphaned and the old message text stayed in the input.

## Intended behavior (implemented)

| Case | Behavior |
|---|---|
| Regenerate a turn whose response staged still-pending proposals | Proposals staged by the replaced response are **withdrawn before the fork** (status `rejected`, `reportedToModel` set) and a Notice tells the user; the rerun stages fresh proposals against disk |
| Edit an earlier message | Same withdrawal for **every** abandoned turn after the fork point; proposals from turns before the fork are kept |
| Entry with partially-applied content (user accepted a diff group) | **Never** withdrawn — stays actionable so Undo Applied / Reject All can still revert what's on disk; the Notice says it was kept |
| Review-outcome context block | Withdrawn entries never surface as outcomes — the new branch's model is not told "rejected by the user" for proposals it never made |
| Branch **switching** | Withdraws nothing — navigation is reversible browsing; proposals follow the thread |
| Edit/regenerate while a run is in flight | Refused up front (same error as `runStream`), *before* the withdrawal and the optimistic fork — previously the fork mutated the graph before the guard fired |
| Edit a message that had attachments | They seed the composer tray as visible, removable chips (recovered from the checkpoint if the pair lost them); missing files get a Notice |
| Attachments added/removed during an edit | The tray's contents at save time are exactly what the edited message carries (attachment-only edits allowed, same fallback text as send) |
| Un-sent composer attachments when an edit starts | Merged into the tray (deduped by path); on cancel, only the edit-seeded chips are removed and the user's own attachments and stashed draft are restored — on every cancel path, including bubble-tap and losing the pair to a branch switch |
| Regenerate a turn with attachments | Unchanged (the human message lives in the fork checkpoint) — live-verified |

## Implementation

- `PendingChangesStore.withdrawForToolCalls(threadId, toolCallIds)` — rejects+marks-reported matching pending entries, skips partially-applied ones, returns counts.
- `collectAbandonedToolCallIds(forkMessages, tipMessages)` (pure, exported) — tool-call ids at the tip but not at the fork checkpoint. The channel is cumulative, so this is exactly the replaced segment; summarization can only trim the tip, which keeps it conservative (a trimmed old call is never withdrawn on a guess).
- `ChatSession.editMessage`/`regenerateResponse` call the withdrawal before `applyOptimisticFork`, and now refuse while `running`.
- `editMessage(pairId, content, attachments?)` — explicit list wins (`[]` = user removed all); `undefined` keeps the old restore-from-checkpoint behavior for callers that don't manage attachments. `ChatSession.getEditAttachments` exposes the restore for the composer.
- `Input.svelte` — edit-seeding effect also seeds attachment chips (untracked, so attachment state doesn't become an effect dependency) and now owns the `editingPairId → null` cleanup, unifying all cancel paths; `saveEdit` passes the tray and consumes it like `sendMessage`.

## Testing

- **Unit** (`bun run test`, 1567 pass): new `test/stores/chatSessionEditRerun.test.ts` (withdrawal wiring on a real two-turn checkpoint graph, shared-prefix preservation, in-flight guard, all four attachment-resolution modes); `withdrawForToolCalls` suite in `pendingChangesStore.test.ts` (incl. partially-applied skip and no-false-outcome); `collectAbandonedToolCallIds` suite in `chatStore.test.ts` (incl. summarization-trim conservatism).
- **Live** (slot vault `S2B WT2`, per AGENTS.md slot protocol): all three failure modes reproduced on `dev`, then re-run on this branch — old proposal withdrawn+reported, orthogonal edit stages pure `Delta` (no leaked `Gamma`), single pending create after rerun; attachment chip appears in the tray on edit, is carried through a UI-button save, and is removed with the draft restored on an out-of-composer cancel. `bun run check` / `format` / `lint` clean.
- **Not exercised:** flows needing a real LLM's judgment (the mock deterministically emits `manage_notes` calls), and the full integration suite (skipped in favor of live CLI verification, the parallel-slot-safe path). No integration tests added — every new behavior is store/session-level and covered headless.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._