### PR TITLE
feat(graph): size collapsed topics by member count, not crossing links

### DIFF
--- a/scripts/graph-layout-bench.ts
+++ b/scripts/graph-layout-bench.ts
@@ -222,6 +222,9 @@ function generateCollapsedVault(seed: number, shape: VaultShape): Pick<Scenario,
 		cluster: topic,
 		// Crossing-link count scales with topic size, heavy-tailed like reality.
 		degree: Math.round(size * shape.wikiLinksPerNote * shape.interTopicFraction * (2 + rng() * 3)),
+		// Member count drives the topic radius (and thus collide spacing) — the
+		// paths themselves are never dereferenced, only counted.
+		memberPaths: Array.from({ length: size }, (_, i) => `topic${topic}/note${i}`),
 		x: 0,
 		y: 0,
 	}));
@@ -521,8 +524,13 @@ function buildScenarios(): Scenario[] {
 			collapsed: true,
 		},
 		{
+			// breathe/gap bands sit near 1 like collapsed huge's: both are ratios
+			// over the topic radii, and member-count sizing draws this scenario's
+			// Zipf-tail mega-topics as much larger discs in a similar footprint —
+			// adjacent-but-not-overlapping is the intended reading (ovl% guards
+			// actual overlap).
 			name: "collapsed large",
-			expect: { breatheMin: 1.3, gapMin: 1.5, satMax: 1.1, fillMin: 0.55, wasteMax: 2.0 },
+			expect: { breatheMin: 1.0, gapMin: 1.1, satMax: 1.1, fillMin: 0.55, wasteMax: 2.0, ovlMax: 5 },
 			shape: {
 				noteCount: 2000,
 				topicCount: 14,

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -1259,7 +1259,7 @@ function render(mode: RenderMode) {
 	 * winning a cell is binary, two similar nodes drifting a pixel apart trade the
 	 * label back and forth every frame — that's the flicker, not the volume alone.
 	 *
-	 * Ranking by degree and captioning only the top slice fixes both: the hubs
+	 * Ranking by size and captioning only the top slice fixes both: the hubs
 	 * worth reading keep their labels (and keep them *stably*, since the ranking
 	 * only changes when the graph does), while the long tail stays quiet until you
 	 * hover it or zoom in far enough that few nodes are on screen at all.
@@ -1446,14 +1446,17 @@ function render(mode: RenderMode) {
 								? 3
 								: 4;
 			if (pa !== pb) return pa - pb;
-			return (b.degree ?? 0) - (a.degree ?? 0);
+			// Tie-break by the shared draw radius, so label priority always follows
+			// what size *means* for each kind — degree for notes, member count for
+			// topics — and the biggest circles claim label space first.
+			return getNodeRadius(b) - getNodeRadius(a);
 		});
 	}
 	const sortedLabelNodes = cachedSortedLabelNodes;
 
 	// Ordinary (untiered) labels placed so far this frame, against
-	// ORDINARY_LABEL_BUDGET. Nodes arrive degree-sorted, so the budget is spent on
-	// the most connected notes first.
+	// ORDINARY_LABEL_BUDGET. Nodes arrive size-sorted, so the budget is spent on
+	// the biggest (for notes: most connected) nodes first.
 	let ordinaryLabelsDrawn = 0;
 
 	const labelEntries: Array<{

--- a/src/utils/graphLayout.ts
+++ b/src/utils/graphLayout.ts
@@ -35,6 +35,8 @@ export interface LayoutNode extends SimulationNodeDatum {
 	degree?: number;
 	kind?: string;
 	cluster?: number;
+	/** For topic nodes — drives their draw (and thus collide) radius. */
+	memberPaths?: string[];
 }
 
 /** The link shape the physics needs — a structural subset of the canvas's SimLink. */

--- a/src/utils/graphUtils.ts
+++ b/src/utils/graphUtils.ts
@@ -18,33 +18,17 @@ export function splitEdgeKey(key: string): [string, string] {
 
 /**
  * Ceiling (in world px, on top of the base size) that a collapsed topic's
- * radius approaches asymptotically as its connection count grows.
+ * radius approaches asymptotically as its member count grows.
  */
 const TOPIC_RADIUS_CEILING = 26;
 /**
- * √degree at which a topic reaches half the ceiling. Chosen so the everyday
- * range differentiates most: half size at ~320 crossing links, with real
- * growth still visible out past a few thousand.
+ * √memberCount at which a topic reaches half the ceiling. Chosen so the
+ * everyday range differentiates most: half size at ~36 notes — the typical
+ * Leiden topic in a few-hundred-note vault — with real growth still visible
+ * out past a thousand-note mega-topic.
  */
-const TOPIC_RADIUS_HALF_POINT = 18;
+const TOPIC_RADIUS_HALF_POINT = 6;
 
-/**
- * Draw radius for a graph node, from its degree and the auto-tuned base size.
- *
- * Size encodes exactly one thing — connectedness — so it stays unambiguous.
- * The single source of truth shared by the canvas (hit-testing, collision
- * spacing, label offsets) and the Pixi renderer (sprite/ring radius); the two
- * must agree or hover targets drift off the drawn circles.
- *
- * Notes use a log curve under a hard cap: their degrees are small and
- * heavy-tailed, and past a point "very connected" is all a size can say.
- * Collapsed topics get their own curve because their degree is a *crossing
- * link count* spanning a few to several thousand — under the note formula
- * everything past ~55 links saturated, so a 180-note and a 2000-note topic
- * rendered identically. A smooth saturating curve over √degree keeps every
- * doubling of connections visible while approaching the ceiling
- * asymptotically instead of hitting it.
- */
 /**
  * Auto-tuned base node radius from how many notes the graph *represents* —
  * larger for small vaults, smaller for dense ones, on a continuous log scale.
@@ -55,13 +39,35 @@ export function autoNodeSize(representedNoteCount: number): number {
 	return Math.max(2, Math.round(7 - Math.log10(Math.max(representedNoteCount, 10)) * 1.8));
 }
 
-export function nodeDrawRadius(node: { degree?: number; kind?: string }, nodeSize: number): number {
+/**
+ * Draw radius for a graph node, from the auto-tuned base size plus what the
+ * node *is*. The single source of truth shared by the canvas (hit-testing,
+ * collision spacing, label offsets) and the Pixi renderer (sprite/ring
+ * radius); the two must agree or hover targets drift off the drawn circles.
+ *
+ * Each kind's size encodes exactly one thing, so it stays unambiguous:
+ *
+ * - **Notes** encode connectedness (degree), on a log curve under a hard cap —
+ *   degrees are small and heavy-tailed, and past a point "very connected" is
+ *   all a size can say.
+ * - **Collapsed topics** encode *member count* — how many notes the bubble
+ *   stands for, the natural "how big is this area of my vault" reading.
+ *   Connectivity is deliberately NOT in the radius: rolled-up edge width
+ *   already carries it, and encoding it twice left member count encoded
+ *   nowhere. Member counts span 1..thousands, so a smooth saturating curve
+ *   over √members keeps every doubling visible while approaching the ceiling
+ *   asymptotically instead of hitting it.
+ */
+export function nodeDrawRadius(
+	node: { degree?: number; kind?: string; memberPaths?: string[] },
+	nodeSize: number,
+): number {
 	const base = Math.max(1, nodeSize);
-	const degree = Math.max(0, node.degree ?? 0);
 	if (node.kind === "topic") {
-		const spread = Math.sqrt(degree);
+		const spread = Math.sqrt(Math.max(0, node.memberPaths?.length ?? 0));
 		return base + TOPIC_RADIUS_CEILING * (spread / (spread + TOPIC_RADIUS_HALF_POINT));
 	}
+	const degree = Math.max(0, node.degree ?? 0);
 	return base + Math.min(Math.log1p(degree) * 2.5, base * 5);
 }
 

--- a/src/utils/mergeNodes.ts
+++ b/src/utils/mergeNodes.ts
@@ -119,8 +119,8 @@ export function buildCollapsedGraph(graph: GraphData, options: CollapseOptions =
 		// Internal to a single collapsed topic — not a relationship between nodes.
 		if (source === target) continue;
 
-		// Track how many note-level links each collapsed topic sends outward, so a
-		// topic node can be sized by how connected it actually is.
+		// Track how many note-level links each collapsed topic sends outward, so
+		// the tooltip can report how connected it actually is.
 		if (source.startsWith("topic:")) crossingCount.set(source, (crossingCount.get(source) ?? 0) + 1);
 		if (target.startsWith("topic:")) crossingCount.set(target, (crossingCount.get(target) ?? 0) + 1);
 
@@ -168,9 +168,10 @@ export function buildCollapsedGraph(graph: GraphData, options: CollapseOptions =
 			y: positioned > 0 ? y / positioned : 0,
 			cluster,
 			color: isUnsorted ? (options.unsortedColor ?? members[0]?.color) : members[0]?.color,
-			// `degree` drives node radius, so a topic node sizes itself by how many
-			// note-level links cross its boundary — the existing renderer needs no
-			// change to make well-connected topics read as bigger.
+			// `degree` stays the crossing-link count — it feeds the tooltip's
+			// "N connections" line. Radius comes from `memberPaths` instead (see
+			// nodeDrawRadius): size says how many notes the topic holds, while
+			// connectivity is carried by the rolled-up edge widths.
 			degree: crossingCount.get(id) ?? 0,
 			highlighted: false,
 			kind: "topic",

--- a/test/utils/graphUtils.test.ts
+++ b/test/utils/graphUtils.test.ts
@@ -78,40 +78,51 @@ describe("graphTopologySignature", () => {
 describe("nodeDrawRadius", () => {
 	const NODE_SIZE = 2;
 
+	const memberPaths = (count: number) => Array.from({ length: count }, (_, i) => `note${i}.md`);
+	const topic = (members: number) => nodeDrawRadius({ kind: "topic", memberPaths: memberPaths(members) }, NODE_SIZE);
+
 	it("caps note radius but never a topic's (smooth saturation)", () => {
 		// Note formula saturates hard: past the cap, more degree changes nothing.
 		const note = (degree: number) => nodeDrawRadius({ degree }, NODE_SIZE);
 		expect(note(200)).toBe(note(2000));
 
-		// Topic curve keeps growing: every doubling of connections stays visible.
-		const topic = (degree: number) => nodeDrawRadius({ degree, kind: "topic" }, NODE_SIZE);
+		// Topic curve keeps growing: every doubling of members stays visible.
 		let previous = topic(0);
-		for (const degree of [10, 50, 100, 200, 400, 800, 1600, 3200]) {
-			const radius = topic(degree);
+		for (const members of [5, 10, 25, 50, 100, 200, 400, 800, 1600]) {
+			const radius = topic(members);
 			expect(radius).toBeGreaterThan(previous);
 			previous = radius;
 		}
 	});
 
-	it("differentiates topics across the realistic crossing-link range", () => {
-		// The regression this curve replaces: a 180-note and a 2000-note topic
-		// (hundreds vs thousands of crossing links) rendered identically.
-		const topic = (degree: number) => nodeDrawRadius({ degree, kind: "topic" }, NODE_SIZE);
-		expect(topic(2000) - topic(180)).toBeGreaterThan(5);
+	it("differentiates topics across the realistic member-count range", () => {
+		// The everyday spread in a few-hundred-note vault: a dozen-note topic vs
+		// a fifty-note one must read as visibly different bubbles.
+		expect(topic(50) - topic(12)).toBeGreaterThan(3);
+		// And a mega-topic still clearly outranks an everyday one.
+		expect(topic(1000) - topic(50)).toBeGreaterThan(5);
+	});
+
+	it("sizes topics by member count, not connectivity", () => {
+		// Same members, wildly different crossing-link counts — identical radius.
+		// Connectivity is edge width's job; encoding it here would double-encode.
+		const linkHeavy = nodeDrawRadius({ kind: "topic", degree: 2000, memberPaths: memberPaths(30) }, NODE_SIZE);
+		const linkLight = nodeDrawRadius({ kind: "topic", degree: 3, memberPaths: memberPaths(30) }, NODE_SIZE);
+		expect(linkHeavy).toBe(linkLight);
 	});
 
 	it("stays bounded for a degenerate mega-topic", () => {
-		const huge = nodeDrawRadius({ degree: 1_000_000, kind: "topic" }, NODE_SIZE);
+		const huge = topic(1_000_000);
 		expect(huge).toBeLessThan(NODE_SIZE + 26);
 	});
 
 	it("keeps a small topic near note size", () => {
-		const smallTopic = nodeDrawRadius({ degree: 5, kind: "topic" }, NODE_SIZE);
+		const smallTopic = topic(4);
 		const hubNote = nodeDrawRadius({ degree: 20 }, NODE_SIZE);
 		expect(smallTopic).toBeLessThan(hubNote);
 	});
 
-	it("treats missing degree as zero and enforces the minimum base", () => {
+	it("treats missing degree/members as zero and enforces the minimum base", () => {
 		expect(nodeDrawRadius({}, 0)).toBe(1);
 		expect(nodeDrawRadius({ kind: "topic" }, 0)).toBe(1);
 	});


### PR DESCRIPTION
## Rationale

In the collapsed graph view a topic node's radius encoded its **crossing-link count** — but rolled-up topic-edge width already encodes exactly that coupling, so connectivity was double-encoded while **member count** (the natural "how big is this area of my vault" reading of a topic bubble) was encoded nowhere.

Now:
- **Topic radius = member count** (`memberPaths.length`), on the same saturating compressive curve (`base + 26·√m/(√m+H)`), retuned for the member-count range: half the ceiling at ~36 notes (H = 6), with growth still visible past a thousand-note mega-topic.
- **`degree` on topic nodes keeps its crossing-link meaning** — it feeds the tooltip's "N connections" line; comments no longer claim it drives the radius.
- **Edge width alone carries connectivity** — the existing `1 + log2(weight)·0.45` (cap 4×) scaling is untouched; verified live that weak/strong pairs still differentiate, no alpha pairing needed.
- **Label priority** tie-breaks on the shared `nodeDrawRadius` instead of raw degree, so "biggest claims label space first" follows what size means per kind (degree for notes, members for topics). Cluster anchor pills already ranked by member count — unchanged.
- Physics, hit-testing, collision spacing and label offsets all flow through the shared `nodeDrawRadius` (LayoutNode gained `memberPaths`), so they stay in agreement with the drawn circle.

## bench:layout before/after

Collapsed scenarios (all others byte-identical):

| scenario | before | after |
|---|---|---|
| collapsed small | nodePx 9.5 · breathe 4.52 · gap 5.65 · ovl 0 · fill 0.44 | nodePx 19 · breathe 2.51 · gap 2.83 · ovl 0 · fill 0.44 |
| collapsed large | nodePx 2.4 · breathe 2.07 · gap 2.26 · ovl 0 · fill 0.65 | nodePx 2.4 · breathe 1.14 · gap 1.25 · ovl 0 · fill 0.65 |
| collapsed huge | nodePx 2.4 · breathe 1.1 · gap 1.28 · ovl 0 · fill 0.67 | nodePx 2.4 · breathe 1.0 · gap 1.09 · ovl 0 · fill 0.73 |

`breathe`/`gap` are **ratios over the topic radii** — member-count sizing draws the Zipf-tail mega-topics as much larger discs in a similar footprint, so the ratios compress while absolute spacing adapts (surfaceFloor + collide both follow the new radius; `ovl%` stays 0 everywhere). The collapsed-large bands were recalibrated to match collapsed huge's regime — "adjacent but never overlapping" is the documented intended reading of near-complete coupling graphs — and an `ovlMax` guard was added there. `bun run bench:layout --assert` passes.

## Live verification (S2B WT1)

- Collapse-all: bubbles rank by note count — anchor pills give exact members (Marine Ecology · 80, Fermentation Control · 79, Monetary Policy · 78, Typography · 77, Work Management · 47, Smart City · 20, Unsorted · 3) and the collapsed sizes match that order. Notably Work Management has only **11 crossing links** yet draws mid-size for its 47 notes — the reorder this change is about.
- Tooltip still reads "N connections"; hover ring and hit target align with the new radii; expand/collapse round-trip returns bubbles to their centroids; no console errors.

## Tests

- `nodeDrawRadius` topic-branch tests rewritten for member counts, including a new invariant: same members + wildly different crossing links ⇒ identical radius.
- `bun run check` / `format` / `lint` / `test` (1574 tests) all green.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._