### PR TITLE
fix(graph): size collapsed topics by area, normalized to the vault's largest topic

### DIFF
--- a/scripts/graph-layout-bench.ts
+++ b/scripts/graph-layout-bench.ts
@@ -223,8 +223,10 @@ function generateCollapsedVault(seed: number, shape: VaultShape): Pick<Scenario,
 		// Crossing-link count scales with topic size, heavy-tailed like reality.
 		degree: Math.round(size * shape.wikiLinksPerNote * shape.interTopicFraction * (2 + rng() * 3)),
 		// Member count drives the topic radius (and thus collide spacing) — the
-		// paths themselves are never dereferenced, only counted.
+		// paths themselves are never dereferenced, only counted. The radius is
+		// normalized to the largest topic, exactly as buildCollapsedGraph stamps it.
 		memberPaths: Array.from({ length: size }, (_, i) => `topic${topic}/note${i}`),
+		largestTopicSize: Math.max(...sizes),
 		x: 0,
 		y: 0,
 	}));

--- a/src/components/graph/pixiRenderer.ts
+++ b/src/components/graph/pixiRenderer.ts
@@ -1451,7 +1451,16 @@ export class PixiRenderer {
 	// ── Node tooltip (screen-space) ────────────────────────
 
 	showNodeTooltip(
-		node: { label: string; cluster?: number; degree?: number; id: string; x: number; y: number },
+		node: {
+			label: string;
+			cluster?: number;
+			degree?: number;
+			id: string;
+			x: number;
+			y: number;
+			kind?: string;
+			memberPaths?: string[];
+		},
 		clusterLabels: Record<number, string>,
 		isPinned: boolean,
 		isForceMode: boolean,
@@ -1460,7 +1469,16 @@ export class PixiRenderer {
 		const screen = this.viewport.toScreen(node.x, node.y);
 
 		const lines: string[] = [node.label];
-		if (node.cluster != null) {
+		if (node.kind === "topic") {
+			// A collapsed topic's size says how many notes it holds; its `degree`
+			// is the number of note-level links crossing its boundary (set by
+			// buildCollapsedGraph). Report both — the bubble encodes only the first.
+			const notes = node.memberPaths?.length ?? 0;
+			const links = node.degree ?? 0;
+			lines.push(
+				`${notes.toLocaleString()} ${notes === 1 ? "note" : "notes"}  ·  ${links.toLocaleString()} ${links === 1 ? "link" : "links"}`,
+			);
+		} else if (node.cluster != null) {
 			const clusterLabel = clusterLabels[node.cluster] ?? `Cluster ${node.cluster}`;
 			lines.push(`${clusterLabel}  ·  ${node.degree ?? 0} connections`);
 		} else {

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -86,6 +86,14 @@ export interface GraphNode {
 	kind?: "note" | "topic";
 	/** For `kind: "topic"` — the vault paths this node stands for. */
 	memberPaths?: string[];
+	/**
+	 * For `kind: "topic"` — member count of the *largest* topic in the current
+	 * segmentation, collapsed or not. The normalizer for the topic's draw radius
+	 * (see `nodeDrawRadius`): bubble area is `memberPaths.length` as a share of
+	 * this, so sizes are relative to the vault rather than to a fixed constant,
+	 * and a topic keeps its size whether or not the biggest one is folded.
+	 */
+	largestTopicSize?: number;
 }
 
 /**

--- a/src/utils/graphLayout.ts
+++ b/src/utils/graphLayout.ts
@@ -37,6 +37,8 @@ export interface LayoutNode extends SimulationNodeDatum {
 	cluster?: number;
 	/** For topic nodes — drives their draw (and thus collide) radius. */
 	memberPaths?: string[];
+	/** For topic nodes — the vault's largest topic, which the radius is normalized to. */
+	largestTopicSize?: number;
 }
 
 /** The link shape the physics needs — a structural subset of the canvas's SimLink. */

--- a/src/utils/graphUtils.ts
+++ b/src/utils/graphUtils.ts
@@ -17,17 +17,17 @@ export function splitEdgeKey(key: string): [string, string] {
 }
 
 /**
- * Ceiling (in world px, on top of the base size) that a collapsed topic's
- * radius approaches asymptotically as its member count grows.
+ * Radius (in world px, on top of the base size) of the vault's *largest*
+ * collapsed topic — the top of the bubble scale. Keeps the biggest topic sane
+ * at fit-to-view: ~5× a hub note, not a disc that swallows the layout.
  */
 const TOPIC_RADIUS_CEILING = 26;
 /**
- * √memberCount at which a topic reaches half the ceiling. Chosen so the
- * everyday range differentiates most: half size at ~36 notes — the typical
- * Leiden topic in a few-hundred-note vault — with real growth still visible
- * out past a thousand-note mega-topic.
+ * Radius (in world px, on top of the base size) of the *smallest* possible
+ * topic — the bottom of the bubble scale. Visibly larger than a plain note so
+ * a tiny topic still reads as a group and stays an easy hover/click target.
  */
-const TOPIC_RADIUS_HALF_POINT = 6;
+const TOPIC_RADIUS_FLOOR = 6;
 
 /**
  * Auto-tuned base node radius from how many notes the graph *represents* —
@@ -54,18 +54,40 @@ export function autoNodeSize(representedNoteCount: number): number {
  *   stands for, the natural "how big is this area of my vault" reading.
  *   Connectivity is deliberately NOT in the radius: rolled-up edge width
  *   already carries it, and encoding it twice left member count encoded
- *   nowhere. Member counts span 1..thousands, so a smooth saturating curve
- *   over √members keeps every doubling visible while approaching the ceiling
- *   asymptotically instead of hitting it.
+ *   nowhere.
+ *
+ * Topics follow the bubble-chart convention: circle **area** is proportional
+ * to member count, so radius grows with √members. The scale is normalized
+ * **per vault** — `√(members / largestTopicSize)` maps the biggest topic in
+ * the current segmentation to the ceiling and everything else to its true
+ * share of that, between the floor and the ceiling. The normalizer is stamped
+ * on the node at merge time from ALL topics, not just the collapsed ones, so a
+ * bubble never changes size because a *different* topic was expanded.
+ *
+ * Why not a fixed curve: an earlier version used a saturating
+ * `√n / (√n + halfPoint)` with the half-point tuned on a few-hundred-note test
+ * corpus (~36 notes). Real vaults have topics of 1000–2000 notes, where that
+ * curve was already flat: an 8-note topic drew at a third the size of a
+ * 1000-note one, and 1000 vs 2000 were indistinguishable. Any fixed constant
+ * fails the same way for *some* vault size — only the vault's own maximum can
+ * anchor the scale.
+ *
+ * The auto-tuned `nodeSize` (see {@link autoNodeSize}) is still the base for
+ * every kind: note radii sit on it directly, and the topic floor/ceiling are
+ * offsets from it, so folding a vault doesn't change the sizing regime.
  */
 export function nodeDrawRadius(
-	node: { degree?: number; kind?: string; memberPaths?: string[] },
+	node: { degree?: number; kind?: string; memberPaths?: string[]; largestTopicSize?: number },
 	nodeSize: number,
 ): number {
 	const base = Math.max(1, nodeSize);
 	if (node.kind === "topic") {
-		const spread = Math.sqrt(Math.max(0, node.memberPaths?.length ?? 0));
-		return base + TOPIC_RADIUS_CEILING * (spread / (spread + TOPIC_RADIUS_HALF_POINT));
+		const members = Math.max(0, node.memberPaths?.length ?? 0);
+		// A node carrying no normalizer (built outside the merge pass) is its own
+		// maximum, which puts it at the ceiling — the single-topic case.
+		const largest = Math.max(members, node.largestTopicSize ?? 0);
+		const share = largest > 0 ? Math.min(1, members / largest) : 0;
+		return base + TOPIC_RADIUS_FLOOR + (TOPIC_RADIUS_CEILING - TOPIC_RADIUS_FLOOR) * Math.sqrt(share);
 	}
 	const degree = Math.max(0, node.degree ?? 0);
 	return base + Math.min(Math.log1p(degree) * 2.5, base * 5);

--- a/src/utils/mergeNodes.ts
+++ b/src/utils/mergeNodes.ts
@@ -98,6 +98,19 @@ export function buildCollapsedGraph(graph: GraphData, options: CollapseOptions =
 	// Nothing is collapsed — hand back the original graph untouched.
 	if (membersByTopic.size === 0) return graph;
 
+	// Normalizer for topic radii: the member count of the largest topic in the
+	// whole segmentation, folded or not. Counting only the collapsed set would
+	// make every remaining bubble jump in size the moment the biggest topic is
+	// expanded. Unsorted notes count only when they can be folded into a bubble
+	// of their own — otherwise they are loose notes, not a topic.
+	const sizeByTopic = new Map<number, number>();
+	for (const node of graph.nodes) {
+		const group = node.cluster ?? UNSORTED_CLUSTER;
+		if (group === UNSORTED_CLUSTER && !collapseUnsorted) continue;
+		sizeByTopic.set(group, (sizeByTopic.get(group) ?? 0) + 1);
+	}
+	const largestTopicSize = Math.max(0, ...sizeByTopic.values());
+
 	/** Resolve a node id to whatever represents it in the collapsed graph. */
 	const representativeOf = new Map<string, string>();
 	for (const [cluster, members] of membersByTopic) {
@@ -169,13 +182,14 @@ export function buildCollapsedGraph(graph: GraphData, options: CollapseOptions =
 			cluster,
 			color: isUnsorted ? (options.unsortedColor ?? members[0]?.color) : members[0]?.color,
 			// `degree` stays the crossing-link count — it feeds the tooltip's
-			// "N connections" line. Radius comes from `memberPaths` instead (see
+			// "N links" line. Radius comes from `memberPaths` instead (see
 			// nodeDrawRadius): size says how many notes the topic holds, while
 			// connectivity is carried by the rolled-up edge widths.
 			degree: crossingCount.get(id) ?? 0,
 			highlighted: false,
 			kind: "topic",
 			memberPaths: members.map((member) => member.path),
+			largestTopicSize,
 		});
 	}
 

--- a/test/utils/graphUtils.test.ts
+++ b/test/utils/graphUtils.test.ts
@@ -77,54 +77,98 @@ describe("graphTopologySignature", () => {
 
 describe("nodeDrawRadius", () => {
 	const NODE_SIZE = 2;
+	/** The floor/ceiling offsets from graphUtils, restated so the tests pin the contract. */
+	const FLOOR = NODE_SIZE + 6;
+	const CEILING = NODE_SIZE + 26;
 
 	const memberPaths = (count: number) => Array.from({ length: count }, (_, i) => `note${i}.md`);
-	const topic = (members: number) => nodeDrawRadius({ kind: "topic", memberPaths: memberPaths(members) }, NODE_SIZE);
+	const topic = (members: number, largestTopicSize: number) =>
+		nodeDrawRadius({ kind: "topic", memberPaths: memberPaths(members), largestTopicSize }, NODE_SIZE);
 
-	it("caps note radius but never a topic's (smooth saturation)", () => {
-		// Note formula saturates hard: past the cap, more degree changes nothing.
+	it("caps note radius: past the cap, more degree changes nothing", () => {
 		const note = (degree: number) => nodeDrawRadius({ degree }, NODE_SIZE);
 		expect(note(200)).toBe(note(2000));
-
-		// Topic curve keeps growing: every doubling of members stays visible.
-		let previous = topic(0);
-		for (const members of [5, 10, 25, 50, 100, 200, 400, 800, 1600]) {
-			const radius = topic(members);
-			expect(radius).toBeGreaterThan(previous);
-			previous = radius;
-		}
 	});
 
-	it("differentiates topics across the realistic member-count range", () => {
-		// The everyday spread in a few-hundred-note vault: a dozen-note topic vs
-		// a fifty-note one must read as visibly different bubbles.
-		expect(topic(50) - topic(12)).toBeGreaterThan(3);
-		// And a mega-topic still clearly outranks an everyday one.
-		expect(topic(1000) - topic(50)).toBeGreaterThan(5);
+	it("scales topic area with member count, normalized to the vault's largest topic", () => {
+		// Leo's vault: topics of 1000–2000 notes next to 8-note ones. The old
+		// fixed-half-point curve drew 1000 and 2000 identically and 8 at a third
+		// of them; area-proportional sizing keeps the whole range spread out.
+		const N_MAX = 2000;
+		const small = topic(8, N_MAX);
+		const big = topic(1000, N_MAX);
+		const biggest = topic(2000, N_MAX);
+
+		expect(small).toBeLessThan(big);
+		expect(big).toBeLessThan(biggest);
+		// 1000 vs 2000 must be visibly different — √2 apart on the scale, ≈6px.
+		expect(biggest - big).toBeGreaterThan(4);
+		// The largest topic sits exactly at the ceiling, the smallest near the floor.
+		expect(biggest).toBe(CEILING);
+		expect(small - FLOOR).toBeLessThan(2);
+		// Area ∝ members: radius offset above the floor grows with √members.
+		const offset = (members: number) => topic(members, N_MAX) - FLOOR;
+		expect(offset(2000) / offset(500)).toBeCloseTo(2, 5);
+	});
+
+	it("is invariant to which topics are collapsed", () => {
+		// The normalizer is the largest topic in the *segmentation*, stamped on
+		// every topic node — so a 300-note bubble draws the same whether the
+		// 2000-note topic beside it is folded or expanded (it stays in nMax).
+		const withBiggestCollapsed = topic(300, 2000);
+		const withBiggestExpanded = nodeDrawRadius(
+			{ kind: "topic", memberPaths: memberPaths(300), largestTopicSize: 2000 },
+			NODE_SIZE,
+		);
+		expect(withBiggestExpanded).toBe(withBiggestCollapsed);
+		// And the radius depends on nothing but members and the normalizer.
+		expect(topic(300, 2000)).not.toBe(topic(300, 400));
+	});
+
+	it("spreads the everyday range of a few-hundred-note vault too", () => {
+		// Normalization is what makes this vault-size-agnostic: with a 60-note
+		// largest topic, a dozen-note topic vs a fifty-note one still read apart.
+		expect(topic(50, 60) - topic(12, 60)).toBeGreaterThan(3);
 	});
 
 	it("sizes topics by member count, not connectivity", () => {
 		// Same members, wildly different crossing-link counts — identical radius.
 		// Connectivity is edge width's job; encoding it here would double-encode.
-		const linkHeavy = nodeDrawRadius({ kind: "topic", degree: 2000, memberPaths: memberPaths(30) }, NODE_SIZE);
-		const linkLight = nodeDrawRadius({ kind: "topic", degree: 3, memberPaths: memberPaths(30) }, NODE_SIZE);
+		const linkHeavy = nodeDrawRadius(
+			{ kind: "topic", degree: 2000, memberPaths: memberPaths(30), largestTopicSize: 100 },
+			NODE_SIZE,
+		);
+		const linkLight = nodeDrawRadius(
+			{ kind: "topic", degree: 3, memberPaths: memberPaths(30), largestTopicSize: 100 },
+			NODE_SIZE,
+		);
 		expect(linkHeavy).toBe(linkLight);
 	});
 
-	it("stays bounded for a degenerate mega-topic", () => {
-		const huge = topic(1_000_000);
-		expect(huge).toBeLessThan(NODE_SIZE + 26);
+	it("never exceeds the ceiling, even for a degenerate normalizer", () => {
+		// A stale/undersized normalizer must not push the radius past the ceiling.
+		expect(topic(1_000_000, 10)).toBe(CEILING);
+		expect(topic(1_000_000, 1_000_000)).toBe(CEILING);
 	});
 
-	it("keeps a small topic near note size", () => {
-		const smallTopic = topic(4);
-		const hubNote = nodeDrawRadius({ degree: 20 }, NODE_SIZE);
-		expect(smallTopic).toBeLessThan(hubNote);
+	it("puts a topic with no normalizer at the ceiling (single-topic case)", () => {
+		const alone = nodeDrawRadius({ kind: "topic", memberPaths: memberPaths(7) }, NODE_SIZE);
+		expect(alone).toBe(CEILING);
+		expect(topic(7, 7)).toBe(CEILING);
+		expect(topic(7, 0)).toBe(CEILING);
+	});
+
+	it("keeps even the smallest topic visibly larger than a plain note", () => {
+		const tiny = topic(1, 2000);
+		const plainNote = nodeDrawRadius({ degree: 0 }, NODE_SIZE);
+		expect(tiny).toBeGreaterThanOrEqual(FLOOR);
+		expect(tiny - plainNote).toBeGreaterThan(4);
 	});
 
 	it("treats missing degree/members as zero and enforces the minimum base", () => {
 		expect(nodeDrawRadius({}, 0)).toBe(1);
-		expect(nodeDrawRadius({ kind: "topic" }, 0)).toBe(1);
+		// An empty topic has no members and no maximum: it sits on the floor.
+		expect(nodeDrawRadius({ kind: "topic" }, 0)).toBe(1 + 6);
 	});
 });
 

--- a/test/utils/mergeNodes.test.ts
+++ b/test/utils/mergeNodes.test.ts
@@ -78,6 +78,40 @@ describe("buildCollapsedGraph", () => {
 		expect(topicA?.degree).toBe(2);
 	});
 
+	it("stamps every topic node with the size of the largest topic in the segmentation", () => {
+		const graph: GraphData = {
+			nodes: [note("a1", 0), note("a2", 0), note("a3", 0), note("b1", 1), note("c1", 2), note("c2", 2)],
+			edges: [],
+		};
+
+		const all = buildCollapsedGraph(graph, { collapsedTopics: new Set([0, 1, 2]) });
+		for (const node of all.nodes) expect(node.largestTopicSize).toBe(3);
+
+		// Expanding the largest topic must not change the others' normalizer —
+		// otherwise every remaining bubble would resize when it is unfolded.
+		const withoutBiggest = buildCollapsedGraph(graph, { collapsedTopics: new Set([1, 2]) });
+		const topicB = withoutBiggest.nodes.find((n) => n.id === topicNodeId(1));
+		expect(topicB?.largestTopicSize).toBe(3);
+		expect(withoutBiggest.nodes.find((n) => n.kind !== "topic")?.largestTopicSize).toBeUndefined();
+	});
+
+	it("counts unsorted notes toward the largest topic only when they fold into a bubble", () => {
+		const graph: GraphData = {
+			nodes: [note("a1", 0), note("a2", 0), note("u1"), note("u2"), note("u3")],
+			edges: [],
+		};
+
+		const loose = buildCollapsedGraph(graph, { collapsedTopics: new Set([0]) });
+		expect(loose.nodes.find((n) => n.id === topicNodeId(0))?.largestTopicSize).toBe(2);
+
+		const folded = buildCollapsedGraph(graph, {
+			collapsedTopics: new Set([0, UNSORTED_CLUSTER]),
+			collapseUnsorted: true,
+		});
+		expect(folded.nodes.find((n) => n.id === topicNodeId(0))?.largestTopicSize).toBe(3);
+		expect(folded.nodes.find((n) => n.id === topicNodeId(UNSORTED_CLUSTER))?.largestTopicSize).toBe(3);
+	});
+
 	it("records every member path", () => {
 		const collapsed = buildCollapsedGraph(twoTopicGraph(), { collapsedTopics: new Set([0, 1]) });
 		const topicA = collapsed.nodes.find((n) => n.id === topicNodeId(0));


### PR DESCRIPTION
Follow-up to #446 after Leo's live test in his real vault. Two decided problems, both fixed here.

## 1. Sizing curve saturated on real vaults

#446 sized a collapsed topic with `base + 26·√n / (√n + 6)`: half size at 36 notes, tuned on the test corpus. In a vault whose topics hold 1000–2000 notes that curve is already flat. Any fixed half-point has this failure for *some* vault size, so the constant was not retuned — the scale is now normalized per vault.

**New rule (bubble-chart convention, area ∝ member count):**

```
radius = base + FLOOR + (CEILING − FLOOR) · √(n / nMax)      FLOOR = 6, CEILING = 26
```

- `nMax` is the member count of the **largest topic in the current segmentation, collapsed or not**. `buildCollapsedGraph` computes it over every cluster and stamps it on each topic node as `GraphNode.largestTopicSize`, so a bubble never changes size because a *different* topic was expanded. Unsorted notes count only when they fold into a bubble of their own (`collapseUnsorted`).
- `nodeDrawRadius` remains the single source of truth: canvas hit-testing, d3 collision, label offsets and the Pixi sprite radius all still go through it, so drawn circle == hit target == collision radius.
- `FLOOR` keeps the smallest topic visibly larger than a plain note (clickable, reads as a group); `CEILING` is the same `base + 26` top as before. A topic with no normalizer (built outside the merge pass) is its own maximum → ceiling; `n = nMax = 0` → floor.
- The auto-tuned `base` (`autoNodeSize`) still underlies every kind; the topic floor/ceiling are offsets from it.

**Worked example** — Leo's vault, `nMax = 2000`, `base = 2` (radius in world px above nothing, i.e. total):

| members | #446 (fixed half-point) | this PR |
|---|---|---|
| 8 | 10.3 | 9.3 |
| 1000 | 23.9 | 22.1 |
| 2000 | 24.9 | **28.0** |

Before: the 8-note topic was ~⅓ of the 1000-note one and 1000 vs 2000 differed by 1 px. After: 8 sits just above the floor, 1000 is √½ of the way up, 2000 is the ceiling, 1000 vs 2000 differ by ~6 px.

## 2. Topic tooltip

`showNodeTooltip` said `<cluster>  ·  N connections` for every node. For a collapsed topic (`kind === "topic"`) it now shows both counts:

```
Marine Ecology
80 notes  ·  1 link
```

`degree` on a topic node is the crossing-link count set by `buildCollapsedGraph`, hence "links". Note nodes keep their existing line.

## Verification

- `bun run check` / `format` / `lint` / `test` (1579 tests) clean. New unit tests: 8 : 1000 : 2000 members give strictly ordered radii with 1000 vs 2000 > 4 px apart, area ∝ members (offset ratio 2000/500 = 2), invariance to which topics are collapsed, ceiling clamp for a stale normalizer, floor > plain note; `mergeNodes` tests pin that `largestTopicSize` is stamped from *all* topics and survives expanding the largest one.
- `bun run bench:layout` before → after (radius feeds collision spacing; all scenarios stay within bands; only the collapsed rows move):

| scenario | nodePx | breathe | gap | fill |
|---|---|---|---|---|
| collapsed small | 19 → 20.9 | 2.51 → 2.17 | 2.83 → 2.41 | 0.44 → 0.44 |
| collapsed large | 2.4 → 2.4 | 1.14 → 1.26 | 1.25 → 1.3 | 0.65 → 0.64 |
| collapsed huge | 2.4 → 2.4 | 1.00 → 1.00 | 1.09 → 1.14 | 0.73 → 0.69 |

  Note-level scenarios are byte-identical.
- Live in `S2B WT1` (collapse all, 6 topics + Unsorted·3): bubbles rank 80 ≈ 78 > 20 > 3 with the largest at the ceiling and Unsorted·3 at the floor; expanding the 80-note topic left the other bubbles' measured diameters unchanged (≤1 CSS px, anti-aliasing under selection dimming); hover shows `80 notes · 1 link`, `20 notes · 5 links`, `3 notes · 0 links`; a cursor sweep of the canvas found hit targets exactly on the drawn circles.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._