### PR TITLE
feat(chat): keep the context-usage ring always visible on desktop

### DIFF
--- a/src/components/chat/ContextUsageCircle.svelte
+++ b/src/components/chat/ContextUsageCircle.svelte
@@ -19,17 +19,30 @@ interface Props {
 
 const { usagePercent, used, limit, breakdown, canSummarizeNow = false, onSummarizeNow }: Props = $props();
 
-const radius = 20; // Slightly larger radius for better visibility
+// Geometry in a 100-unit viewBox. The ring is sized so its outer edge (radius +
+// half the stroke) fills ~73% of the 36px trigger, close to the 28px send button
+// beside it: a ring that small next to a solid disc read as an ornament.
+const radius = 33;
+const strokeWidth = 8;
 const circumference = 2 * Math.PI * radius;
-const strokeDashoffset = $derived(circumference - (usagePercent / 100) * circumference);
+
+// The ring is always rendered on desktop, so its low-usage state has to read as
+// a gauge at rest rather than an idle spinner. Two things do that: the arc never
+// drops below this floor (a round-capped pip at 12 o'clock, clearly "a little"
+// rather than "nothing"), and the track behind it is fainter than the arc so the
+// arc, not the track, is the shape the eye lands on.
+const MIN_ARC_PERCENT = 4;
+const arcPercent = $derived(Math.max(usagePercent, MIN_ARC_PERCENT));
+const strokeDashoffset = $derived(circumference - (arcPercent / 100) * circumference);
 const hasKnownLimit = $derived(limit !== undefined && limit > 0);
 
-// Determine color based on usage level
-const colorClass = $derived.by(() => {
-	if (!hasKnownLimit) return "text-[--text-muted]";
-	if (usagePercent >= 95) return "text-red-500"; // Critical
-	if (usagePercent >= 80) return "text-yellow-500"; // Warning
-	return "text-green-500"; // Normal
+// Arc colour by usage level, via Obsidian's palette variables so themes can
+// restyle it. The unknown-limit state is monochrome: there is no level to encode.
+const arcClass = $derived.by(() => {
+	if (!hasKnownLimit) return "s2b-context-ring-arc-unknown";
+	if (usagePercent >= 95) return "s2b-context-ring-arc-critical";
+	if (usagePercent >= 80) return "s2b-context-ring-arc-warning";
+	return "s2b-context-ring-arc-normal";
 });
 
 const centerLabel = $derived.by(() => {
@@ -97,20 +110,14 @@ const maxContextLabel = $derived.by(() => {
 >
   {#snippet trigger()}
     <svg class="w-full h-full -rotate-90" viewBox="0 0 100 100" aria-label="Open context token distribution">
-      <!-- Background circle -->
+      <!-- Track -->
+      <circle class="s2b-context-ring-track" fill="none" stroke-width={strokeWidth} cx="50" cy="50" r={radius} />
+      <!-- Usage arc -->
       <circle
-        class="stroke-current text-[--background-modifier-border]"
+        class="s2b-context-ring-arc transition-all duration-300 {arcClass}"
         fill="none"
-        stroke-width="8"
-        cx="50"
-        cy="50"
-        r={radius}
-      />
-      <!-- Progress circle -->
-      <circle
-        class="stroke-current transition-all duration-300 {colorClass}"
-        fill="none"
-        stroke-width="8"
+        stroke-width={strokeWidth}
+        stroke-linecap="round"
         cx="50"
         cy="50"
         r={radius}
@@ -118,9 +125,12 @@ const maxContextLabel = $derived.by(() => {
         style="stroke-dashoffset: {strokeDashoffset};"
       />
     </svg>
-    <!-- Show value only on hover to keep the icon visually quiet by default -->
+    <!-- Live value in the centre: the number is what makes the ring a gauge
+         rather than a decoration, and at this size a quiet muted label costs
+         nothing visually. Brightens on hover with the rest of the control. -->
     <div
-      class="s2b-hover-reveal absolute text-[12px] font-semibold opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+      class="s2b-context-ring-label absolute font-semibold tabular-nums transition-colors duration-150"
+      class:s2b-context-ring-label-wide={centerLabel.length > 3}
     >
       {centerLabel}
     </div>
@@ -177,6 +187,47 @@ const maxContextLabel = $derived.by(() => {
     background: transparent !important;
     box-shadow: none !important;
     border: none !important;
+  }
+
+  .s2b-context-ring-track {
+    /* Fainter than the arc: `--background-modifier-border` at full strength is
+       the same grey as a spinner's idle track. */
+    stroke: color-mix(in srgb, var(--background-modifier-border) 60%, transparent);
+  }
+
+  .s2b-context-ring-arc-normal {
+    stroke: var(--color-green);
+  }
+
+  .s2b-context-ring-arc-warning {
+    stroke: var(--color-yellow);
+  }
+
+  .s2b-context-ring-arc-critical {
+    stroke: var(--color-red);
+  }
+
+  .s2b-context-ring-arc-unknown {
+    stroke: var(--text-faint);
+  }
+
+  .s2b-context-ring-label {
+    font-size: 8px;
+    letter-spacing: -0.02em;
+    line-height: 1;
+    color: var(--text-muted);
+  }
+
+  /* "100%" is the one value that doesn't fit the hole at 8px; at that point the
+     arc is a full ring, so overrunning it would put dark text on red. */
+  .s2b-context-ring-label-wide {
+    font-size: 6.5px;
+    letter-spacing: -0.05em;
+  }
+
+  :global(.context-usage-trigger:hover) .s2b-context-ring-label,
+  :global(.context-usage-trigger[data-state="open"]) .s2b-context-ring-label {
+    color: var(--text-normal);
   }
 
   :global(.context-usage-popover) {

--- a/src/components/chat/ContextUsageCircle.svelte
+++ b/src/components/chat/ContextUsageCircle.svelte
@@ -92,16 +92,28 @@ const usageLine = $derived.by(() => {
 });
 
 // The real trigger, not a rounded "about 80%": it is max(80% of the window, 12k),
-// so on a small window the number is the only honest thing to show.
-const compactionNote = $derived.by(() => {
+// so on a small window the number is the only honest thing to show. The footer
+// carries the short form beside the Summarize button (the note and the button are
+// the same concern: automatic vs manual); the full sentence is its tooltip.
+const compaction = $derived.by(() => {
 	const trigger = getSummarizationTriggerTokens(limit);
 	if (trigger === null || limit === undefined) {
-		return "Automatic summarization needs a model with a known context limit.";
+		return {
+			short: "Auto-compaction needs a known limit",
+			long: "Automatic summarization needs a model with a known context limit.",
+		};
 	}
 	const percent = Math.round((trigger / limit) * 100);
-	const at = percent <= 100 ? `${formatNumber(trigger)} tokens (${percent}%)` : `${formatNumber(trigger)} tokens`;
-	return `Older messages are summarized automatically at ${at}.`;
+	const withPercent = percent <= 100 ? ` (${percent}%)` : "";
+	return {
+		short: `Auto-compacts at ${formatCompact(trigger)}${withPercent}`,
+		long: `Older messages are summarized automatically at ${formatNumber(trigger)} tokens${withPercent}.`,
+	};
 });
+
+function formatCompact(value: number): string {
+	return value >= 1000 ? `${Math.round(value / 1000)}k` : formatNumber(value);
+}
 </script>
 
 <PickerPopover
@@ -168,9 +180,8 @@ const compactionNote = $derived.by(() => {
       {/each}
     </div>
 
-    <div class="context-usage-note">{compactionNote}</div>
-
-    <div class="context-usage-actions">
+    <div class="context-usage-footer">
+      <span class="context-usage-note" aria-label={compaction.long}>{compaction.short}</span>
       <Button
         buttonText="Summarize now"
         disabled={!canSummarizeNow}
@@ -343,14 +354,21 @@ const compactionNote = $derived.by(() => {
     min-width: 3ch;
   }
 
-  .context-usage-note {
+  /* Note left, action right. The note is short enough to stay on one line at
+     the panel's width; `flex-wrap` is the safety net for a narrow panel, where
+     it drops under the button rather than being truncated. */
+  .context-usage-footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--size-4-2);
     margin-top: var(--size-4-3);
-    color: var(--text-faint);
   }
 
-  .context-usage-actions {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: var(--size-4-2);
+  .context-usage-note {
+    flex: 1 1 auto;
+    min-width: 0;
+    color: var(--text-faint);
   }
 </style>

--- a/src/components/chat/ContextUsageCircle.svelte
+++ b/src/components/chat/ContextUsageCircle.svelte
@@ -2,6 +2,7 @@
 import PickerPopover from "../ui/PickerPopover.svelte";
 import Button from "../ui/Button.svelte";
 import type { ContextUsageBreakdown } from "../../utils/tokenEstimator";
+import { getSummarizationTriggerTokens } from "../../agent/summarization";
 
 /**
  * Displays estimated context usage as a small circular progress indicator.
@@ -50,30 +51,21 @@ const centerLabel = $derived.by(() => {
 	return `${usagePercent.toFixed(0)}%`;
 });
 
-const distributionRows = $derived.by(() => {
+// Composition of what is in the window, in a fixed order so a category keeps its
+// colour whether or not its neighbours are present (an empty category is dropped,
+// never recoloured). Draft & pending is part of the total, so it is a row like the
+// others rather than a footnote; its neutral swatch says "not sent yet".
+const compositionRows = $derived.by(() => {
 	const total = Math.max(breakdown.totalTokens, 1);
 	return [
-		{
-			label: "System Prompt",
-			tokens: breakdown.systemPromptTokens,
-			percent: (breakdown.systemPromptTokens / total) * 100,
-		},
-		{
-			label: "Human",
-			tokens: breakdown.humanTokens,
-			percent: (breakdown.humanTokens / total) * 100,
-		},
-		{
-			label: "AI",
-			tokens: breakdown.assistantTokens,
-			percent: (breakdown.assistantTokens / total) * 100,
-		},
-		{
-			label: "Tool Messages",
-			tokens: breakdown.toolTokens,
-			percent: (breakdown.toolTokens / total) * 100,
-		},
-	].filter((row) => row.tokens > 0);
+		{ id: "system", label: "System prompt", tokens: breakdown.systemPromptTokens },
+		{ id: "human", label: "Your messages", tokens: breakdown.humanTokens },
+		{ id: "assistant", label: "Assistant", tokens: breakdown.assistantTokens },
+		{ id: "tool", label: "Tool results", tokens: breakdown.toolTokens },
+		{ id: "draft", label: "Draft & pending", tokens: breakdown.draftAndPendingTokens },
+	]
+		.filter((row) => row.tokens > 0)
+		.map((row) => ({ ...row, share: (row.tokens / total) * 100 }));
 });
 
 // Format tooltip text
@@ -92,11 +84,23 @@ function formatNumber(value: number): string {
 	return value.toLocaleString();
 }
 
-const maxContextLabel = $derived.by(() => {
+const usageLine = $derived.by(() => {
 	// Tested directly rather than via `hasKnownLimit`: narrowing does not flow through a
 	// derived boolean, which is the only reason this needed an assertion. Same condition.
-	if (limit === undefined || limit <= 0) return "Unknown";
-	return formatNumber(limit);
+	if (limit === undefined || limit <= 0) return `${formatNumber(breakdown.totalTokens)} tokens · limit unknown`;
+	return `${formatNumber(breakdown.totalTokens)} of ${formatNumber(limit)} tokens`;
+});
+
+// The real trigger, not a rounded "about 80%": it is max(80% of the window, 12k),
+// so on a small window the number is the only honest thing to show.
+const compactionNote = $derived.by(() => {
+	const trigger = getSummarizationTriggerTokens(limit);
+	if (trigger === null || limit === undefined) {
+		return "Automatic summarization needs a model with a known context limit.";
+	}
+	const percent = Math.round((trigger / limit) * 100);
+	const at = percent <= 100 ? `${formatNumber(trigger)} tokens (${percent}%)` : `${formatNumber(trigger)} tokens`;
+	return `Older messages are summarized automatically at ${at}.`;
 });
 </script>
 
@@ -137,40 +141,40 @@ const maxContextLabel = $derived.by(() => {
   {/snippet}
 
   <div class="context-usage-panel">
-    <div class="context-usage-heading">Token Distribution (est.)</div>
+    <div class="context-usage-header">
+      <span class="context-usage-heading">Context usage (est.)</span>
+      <span class="context-usage-percent">{hasKnownLimit ? centerLabel : "—"}</span>
+    </div>
+    <div class="context-usage-line">{usageLine}</div>
 
-    <div class="context-usage-summary">
-      <span>Used</span>
-      <span class="context-usage-summary-value">{formatNumber(breakdown.totalTokens)}</span>
-      <span>Max</span>
-      <span class="context-usage-summary-value">{maxContextLabel}</span>
+    <!-- Composition bar: 100% = what is in the window now. Usage against the
+         limit is what the ring and the header already show; the bar answers
+         the other question, "what is it made of". Segments keep a 2px surface
+         gap and a minimum width so a small category still registers. -->
+    <div class="context-usage-bar" aria-hidden="true">
+      {#each compositionRows as row (row.id)}
+        <span class="context-usage-segment context-usage-swatch-{row.id}" style="flex-grow: {row.tokens};"></span>
+      {/each}
     </div>
 
-    <div class="picker-popover-separator menu-separator"></div>
-
     <div class="context-usage-rows">
-      {#each distributionRows as row}
+      {#each compositionRows as row (row.id)}
         <div class="context-usage-row">
+          <span class="context-usage-swatch context-usage-swatch-{row.id}"></span>
           <span class="context-usage-row-label">{row.label}</span>
-          <span class="context-usage-row-percent">{row.percent.toFixed(0)}%</span>
           <span class="context-usage-row-tokens">{formatNumber(row.tokens)}</span>
+          <span class="context-usage-row-percent">{row.share.toFixed(0)}%</span>
         </div>
       {/each}
     </div>
 
-    {#if breakdown.draftAndPendingTokens > 0}
-      <div class="context-usage-note">
-        Draft + pending context: {formatNumber(breakdown.draftAndPendingTokens)}
-      </div>
-    {/if}
-
-    <div class="context-usage-note">Older context is automatically compacted at about 80% usage.</div>
+    <div class="context-usage-note">{compactionNote}</div>
 
     <div class="context-usage-actions">
       <Button
         buttonText="Summarize now"
-        cta
         disabled={!canSummarizeNow}
+        tooltip={canSummarizeNow ? "Summarize older messages now" : "Nothing to summarize yet"}
         onClick={() => onSummarizeNow?.()}
       />
     </div>
@@ -238,29 +242,48 @@ const maxContextLabel = $derived.by(() => {
   .context-usage-panel {
     display: flex;
     flex-direction: column;
-    min-width: 220px;
+    min-width: 240px;
     padding: var(--size-4-3);
+    font-size: var(--font-ui-smaller);
+  }
+
+  .context-usage-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--size-4-2);
   }
 
   .context-usage-heading {
-    font-size: var(--font-ui-smaller);
     font-weight: var(--font-semibold);
     color: var(--text-normal);
-    margin-bottom: var(--size-4-2);
   }
 
-  .context-usage-summary {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    column-gap: var(--size-4-2);
-    row-gap: 2px;
-    font-size: var(--font-ui-smaller);
-    color: var(--text-muted);
-    margin-bottom: var(--size-4-2);
-  }
-
-  .context-usage-summary-value {
+  .context-usage-percent {
+    font-size: var(--font-ui-medium);
+    font-weight: var(--font-semibold);
+    font-variant-numeric: tabular-nums;
     color: var(--text-normal);
+  }
+
+  .context-usage-line {
+    margin-top: 2px;
+    color: var(--text-muted);
+  }
+
+  .context-usage-bar {
+    display: flex;
+    gap: 2px;
+    height: 6px;
+    margin: var(--size-4-2) 0 var(--size-4-2);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .context-usage-segment {
+    flex: 0 1 auto;
+    min-width: 3px;
+    border-radius: 1px;
   }
 
   .context-usage-rows {
@@ -271,31 +294,63 @@ const maxContextLabel = $derived.by(() => {
 
   .context-usage-row {
     display: grid;
-    grid-template-columns: 1fr auto auto;
+    grid-template-columns: auto 1fr auto auto;
     column-gap: var(--size-4-2);
     align-items: center;
-    font-size: var(--font-ui-smaller);
+  }
+
+  .context-usage-swatch {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+  }
+
+  /* Categorical hues in a fixed order from Obsidian's palette, so themes restyle
+     them. Green/yellow/red are reserved for the ring's usage-level status and are
+     deliberately not reused here. */
+  .context-usage-swatch-system {
+    background: var(--color-blue);
+  }
+
+  .context-usage-swatch-human {
+    background: var(--color-orange);
+  }
+
+  .context-usage-swatch-assistant {
+    background: var(--color-purple);
+  }
+
+  .context-usage-swatch-tool {
+    background: var(--color-cyan);
+  }
+
+  .context-usage-swatch-draft {
+    background: var(--text-faint);
   }
 
   .context-usage-row-label {
     color: var(--text-normal);
   }
 
-  .context-usage-row-percent,
-  .context-usage-row-tokens {
+  .context-usage-row-tokens,
+  .context-usage-row-percent {
     color: var(--text-muted);
     text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .context-usage-row-percent {
+    min-width: 3ch;
   }
 
   .context-usage-note {
-    margin-top: var(--size-4-1);
-    font-size: var(--font-ui-smaller);
+    margin-top: var(--size-4-3);
     color: var(--text-faint);
   }
 
   .context-usage-actions {
     display: flex;
     justify-content: flex-end;
-    margin-top: var(--size-4-3);
+    margin-top: var(--size-4-2);
   }
 </style>

--- a/src/components/chat/ContextUsageCircle.svelte
+++ b/src/components/chat/ContextUsageCircle.svelte
@@ -51,12 +51,18 @@ const centerLabel = $derived.by(() => {
 	return `${usagePercent.toFixed(0)}%`;
 });
 
-// Composition of what is in the window, in a fixed order so a category keeps its
-// colour whether or not its neighbours are present (an empty category is dropped,
-// never recoloured). Draft & pending is part of the total, so it is a row like the
-// others rather than a footnote; its neutral swatch says "not sent yet".
-const compositionRows = $derived.by(() => {
-	const total = Math.max(breakdown.totalTokens, 1);
+// Every percentage in the panel shares one denominator: the context limit when it
+// is known, so the header, the bar and the rows all agree on what 100% means and
+// the bar reads like a storage gauge (how full, and who is using it). Without a
+// limit the denominator is what is in the window now, and the bar degrades to a
+// composition view.
+const scaleTokens = $derived(limit !== undefined && limit > 0 ? limit : Math.max(breakdown.totalTokens, 1));
+
+// Rows in a fixed order so a category keeps its colour whether or not its
+// neighbours are present (an empty category is dropped, never recoloured).
+// Draft & pending is part of the total, so it is a row like the others rather
+// than a footnote; its neutral swatch says "not sent yet".
+const usageRows = $derived.by(() => {
 	return [
 		{ id: "system", label: "System prompt", tokens: breakdown.systemPromptTokens },
 		{ id: "human", label: "Your messages", tokens: breakdown.humanTokens },
@@ -65,8 +71,23 @@ const compositionRows = $derived.by(() => {
 		{ id: "draft", label: "Draft & pending", tokens: breakdown.draftAndPendingTokens },
 	]
 		.filter((row) => row.tokens > 0)
-		.map((row) => ({ ...row, share: (row.tokens / total) * 100 }));
+		.map((row) => ({ ...row, share: (row.tokens / scaleTokens) * 100 }));
 });
+
+// Where automatic compaction kicks in, as a position on the bar. Omitted when the
+// trigger is not inside the bar (unknown limit, or a window so small that the 12k
+// floor exceeds it).
+const compactionTickPercent = $derived.by(() => {
+	const trigger = getSummarizationTriggerTokens(limit);
+	if (trigger === null || limit === undefined || trigger >= limit) return null;
+	return (trigger / limit) * 100;
+});
+
+// A category can be real but tiny against a 200k window; "<1%" says so without
+// rounding it away to "0%".
+function formatShare(share: number): string {
+	return share >= 1 ? `${share.toFixed(0)}%` : "<1%";
+}
 
 // Format tooltip text
 const tooltipText = $derived.by(() => {
@@ -159,23 +180,26 @@ function formatCompact(value: number): string {
     </div>
     <div class="context-usage-line">{usageLine}</div>
 
-    <!-- Composition bar: 100% = what is in the window now. Usage against the
-         limit is what the ring and the header already show; the bar answers
-         the other question, "what is it made of". Segments keep a 2px surface
-         gap and a minimum width so a small category still registers. -->
+    <!-- The bar is the context window: segments are each category's share of the
+         limit, on a faint track, with a tick where automatic compaction starts.
+         A non-empty category keeps a minimum width so it still registers against
+         a large window. -->
     <div class="context-usage-bar" aria-hidden="true">
-      {#each compositionRows as row (row.id)}
-        <span class="context-usage-segment context-usage-swatch-{row.id}" style="flex-grow: {row.tokens};"></span>
+      {#each usageRows as row (row.id)}
+        <span class="context-usage-segment context-usage-swatch-{row.id}" style="width: {row.share}%;"></span>
       {/each}
+      {#if compactionTickPercent !== null}
+        <span class="context-usage-tick" style="left: {compactionTickPercent}%;"></span>
+      {/if}
     </div>
 
     <div class="context-usage-rows">
-      {#each compositionRows as row (row.id)}
+      {#each usageRows as row (row.id)}
         <div class="context-usage-row">
           <span class="context-usage-swatch context-usage-swatch-{row.id}"></span>
           <span class="context-usage-row-label">{row.label}</span>
           <span class="context-usage-row-tokens">{formatNumber(row.tokens)}</span>
-          <span class="context-usage-row-percent">{row.share.toFixed(0)}%</span>
+          <span class="context-usage-row-percent">{formatShare(row.share)}</span>
         </div>
       {/each}
     </div>
@@ -283,18 +307,28 @@ function formatCompact(value: number): string {
   }
 
   .context-usage-bar {
+    position: relative;
     display: flex;
     gap: 2px;
     height: 6px;
     margin: var(--size-4-2) 0 var(--size-4-2);
     border-radius: 3px;
     overflow: hidden;
+    background: color-mix(in srgb, var(--background-modifier-border) 60%, transparent);
   }
 
   .context-usage-segment {
-    flex: 0 1 auto;
+    flex: 0 0 auto;
     min-width: 3px;
     border-radius: 1px;
+  }
+
+  .context-usage-tick {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--text-faint);
   }
 
   .context-usage-rows {

--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -46,8 +46,6 @@ const acceptedFileTypes =
 const MAX_FILE_SIZE_BYTES = 15 * 1024 * 1024; // 15 MB per file
 const MAX_TOTAL_ATTACHMENTS_BYTES = 25 * 1024 * 1024; // 25 MB per message
 const FULLSCREEN_TRANSITION_MS = 220;
-/** Usage % below which the context circle stays hidden (see the action row). */
-const CONTEXT_USAGE_VISIBLE_THRESHOLD = 50;
 
 const {
 	registry,
@@ -1356,12 +1354,17 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
       <AgentPopover {threadPath} />
       <ModelSelectButton {threadPath} />
       <div class="ml-auto flex items-center gap-2">
-        <!-- Threshold-gated: at low usage the ring is an empty grey track that
-             reads as a loading spinner next to the send button, and the number
-             it encodes isn't actionable. Appearing at 50% is itself the signal
-             ("context is filling up"), and puts the popover's Summarize action
-             in reach exactly when a user starts wanting it. -->
-        {#if !isMobileUI() && contextUsage.usagePercent >= CONTEXT_USAGE_VISIBLE_THRESHOLD}
+        <!-- Always on for desktop: the ring is the only place the running
+             context estimate (and the Summarize action in its popover) lives,
+             so it stays in view at every usage level. It used to appear only
+             from 50% because an empty grey track next to the send button read
+             as a loading spinner; ContextUsageCircle now draws a minimum arc,
+             a faint track and the live percentage, so low usage reads as a
+             gauge at rest. Hidden on mobile: it is the only thing in the row
+             that isn't a control, and the phone action row has no width to
+             spare for it (the same reason the narrowest container query below
+             sheds it first on desktop). -->
+        {#if !isMobileUI()}
           <ContextUsageCircle
             usagePercent={contextUsage.usagePercent}
             used={contextUsage.estimatedUsedTokens}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1103,8 +1103,7 @@ button.s2b-pill--interactive:hover {
 	}
 
 	/* Generic hover-reveal hook: any element that fades in on group-hover
-	   (context-usage %, collapse chevron, …) tagged with this class shows on
-	   touch. */
+	   (collapse chevron, …) tagged with this class shows on touch. */
 	.s2b-hover-reveal {
 		opacity: 1 !important;
 	}


### PR DESCRIPTION
## What

The chat composer's context-usage ring was hidden until estimated usage reached 50% and never shown on mobile. It is now **always visible on desktop**; mobile keeps hiding it.

## Why the gate existed, and what replaces it

The 50% threshold came from the composer rework (2fdc432): at low usage the ring was an empty grey track next to the send button and read as a loading spinner. Removing the gate alone would bring that back, so `ContextUsageCircle` now makes the low state read as a gauge at rest:

- **Minimum arc.** The arc never drops below a 4% floor: a round-capped pip at 12 o'clock, clearly "a little" rather than "nothing".
- **Fainter track.** `--background-modifier-border` at 60% via `color-mix`, so the arc is the shape the eye lands on, not the track.
- **Percentage in the centre, always.** Muted 8px label that brightens on hover, instead of hover-only. "100%" drops to 6.5px so it stays inside the hole rather than sitting on the red ring.
- **Ring matches the send button.** r=33 / stroke 8 in the 100-unit viewBox puts the outer edge at ~26px, next to the 28px send button. The 36px trigger box is unchanged, so the action row does not shift.
- **Native palette.** Arc colours move from Tailwind `text-green-500` etc. to Obsidian's `--color-green` / `--color-yellow` / `--color-red`, so themes restyle them.

The unused `CONTEXT_USAGE_VISIBLE_THRESHOLD` constant is gone and the comment above the `{#if}` now explains why the ring is always-on on desktop and hidden on mobile (it is the only non-control in the row, and the phone action row has no width to spare; same reason the narrowest container query sheds it first on desktop).

## Screenshots (slot vault S2B WT2, default light theme)

Fresh thread, 1%:

<img width="565" alt="Composer action row at 1% usage: faint track, green pip at 12 o'clock, 1% in the centre" src="https://raw.githubusercontent.com/s2b-dev/smart-second-brain/fe1bcaeba281da568a31e19ce054f128b333e668/context-ring-low.png" />

Long pasted draft, 66%:

<img width="565" alt="Composer action row at 66% usage: green arc two-thirds around, 66% in the centre" src="https://raw.githubusercontent.com/s2b-dev/smart-second-brain/fe1bcaeba281da568a31e19ce054f128b333e668/context-ring-66.png" />

Over the limit, 100% (critical colour):

<img width="565" alt="Composer action row at 100% usage: full red ring, 100% in the centre" src="https://raw.githubusercontent.com/s2b-dev/smart-second-brain/fe1bcaeba281da568a31e19ce054f128b333e668/context-ring-100.png" />

Zoomed:

<img width="320" alt="Zoomed ring at 1%" src="https://raw.githubusercontent.com/s2b-dev/smart-second-brain/fe1bcaeba281da568a31e19ce054f128b333e668/context-ring-low-zoom.png" /> <img width="320" alt="Zoomed ring at 66%" src="https://raw.githubusercontent.com/s2b-dev/smart-second-brain/fe1bcaeba281da568a31e19ce054f128b333e668/context-ring-66-zoom.png" />

The images live on the orphan branch `assets/pr-context-ring` (pinned by commit SHA above); delete the branch after merge.

## Popover rework (second commit)

Leo asked for the popover itself to be improved too. Before, it was a loose list: "Used / Max" with no percentage, a "94%" share column directly under "Used" that read as context usage, the draft demoted to a footnote although it is part of the total, a rounded "about 80%" note, and an accent CTA dominating a panel of numbers.

Now:

- **Header** with the usage percentage and one line "1,841 of 200,000 tokens" (or "… · limit unknown").
- **Composition bar**: 100% = what is in the window now, one segment per category with 2px surface gaps and a 3px minimum so a small category still shows. Usage against the limit is what the ring and header already say; the bar answers "what is it made of".
- **Legend rows** in a fixed order (system prompt, your messages, assistant, tool results, draft & pending) with swatch, tokens and share. An absent category is dropped, never recoloured. Draft & pending is a normal row with a neutral swatch.
- **Hues from Obsidian's palette** (`--color-blue/orange/purple/cyan`) so themes restyle them; green/yellow/red stay reserved for the ring's status colours. This order is the one whose adjacent pairs pass deutan/protan/tritan separation in both default themes (checked with a palette validator; the dark palette only fails a lightness-band check that belongs to Obsidian's own values).
- **Compaction note** states the real trigger from `summarization.ts` (max of 80% of the window and 12k tokens) instead of "about 80%".
- **Summarize now** is a plain button with a tooltip that explains the disabled state ("Nothing to summarize yet").

Fresh thread with a short draft:

<img width="380" alt="Popover at 1%: header with percentage, composition bar, system prompt and draft rows, compaction note, Summarize now" src="https://raw.githubusercontent.com/s2b-dev/smart-second-brain/3eda31fdf7b27664a722a3e756bf61f341ad219b/context-popover-low.png" />

Existing thread (four categories), light and dark:

<img width="380" alt="Popover on a thread in light theme: system prompt, your messages, assistant, draft rows" src="https://raw.githubusercontent.com/s2b-dev/smart-second-brain/3eda31fdf7b27664a722a3e756bf61f341ad219b/context-popover-thread.png" /> <img width="380" alt="Same popover in the dark theme" src="https://raw.githubusercontent.com/s2b-dev/smart-second-brain/3eda31fdf7b27664a722a3e756bf61f341ad219b/context-popover-dark.png" />

## Footer row (third commit)

Leo asked whether the compaction note and the Summarize button could share a row. They can once the note is short: "Auto-compacts at 160k (80%)" beside the button, full sentence in its tooltip, the panel about 40px shorter. The note flexes and the footer wraps, so a larger theme font drops it under the button rather than truncating it.

<img width="380" alt="Popover footer: Auto-compacts at 160k (80%) on the left, Summarize now button on the right, same row" src="https://raw.githubusercontent.com/s2b-dev/smart-second-brain/64e5acc79799f4cbc8996afb08b699a79313fc57/context-popover-footer.png" />

## Absolute bar (fourth commit)

Leo found it odd that the bar showed only the relative share of each consumer and not the limit. It is now a storage-style gauge: the bar is the context window, each segment is that category's share of the **limit** on a faint track, and a tick marks where automatic compaction starts. Row percentages use the same denominator, so the bar, the header and the rows agree on what 100% means; a real but tiny category shows "<1%" rather than "0%". Without a known limit it falls back to the composition view with no tick.

Fresh thread at 1% and a long draft at 66% (tick at 80%):

<img width="380" alt="Popover at 1%: tiny segments at the left of a faint full-width track, tick at 80%" src="https://raw.githubusercontent.com/s2b-dev/smart-second-brain/0503d55f8709b247b250a110e8c5cca6ea499e08/context-popover-abs-low.png" /> <img width="380" alt="Popover at 66%: segments fill two thirds of the track, draft dominates, tick at 80%" src="https://raw.githubusercontent.com/s2b-dev/smart-second-brain/0503d55f8709b247b250a110e8c5cca6ea499e08/context-popover-abs-high.png" />

The composition-bar screenshots above are superseded by these.

## Verification

- `bun run check`, `format`, `lint`: clean. `bun run test`: 1574 passed.
- Live in S2B WT2: fresh thread (1%), 66% and 100% via a long draft inserted into the composer; `dev:errors` clean throughout.
- Popover verified live in S2B WT1 on a fresh thread and on an existing thread, light and dark theme; `bun run test` 1574 passed after the second commit.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._