### PR TITLE
feat(vectorstore): mobile lazy-open, paced/checkpointed embed build, orphaned-DB cleanup (part 2 of #432)

### DIFF
--- a/scripts/vector-memory-bench.ts
+++ b/scripts/vector-memory-bench.ts
@@ -18,6 +18,12 @@
  *                             the `Float32Array` nodes `fromJSON` builds from it.
  *   after                   — v3: one `Float32Array` per node, the same array that
  *                             came out of IndexedDB, and nothing else.
+ *   after (open only)       — what `HNSWVectorStore.open()` alone keeps resident:
+ *                             the two id maps (chunk id ↔ numeric id), no graph
+ *                             and no vectors. This is the cost of an index that is
+ *                             open but has not been searched or written yet — the
+ *                             state the mobile lazy-open (#432 part 2) leaves an
+ *                             index in after the boot catch-up finds nothing to do.
  *
  * Each shape is measured in its own child process (resident-set delta over the
  * process's baseline, after a forced GC), because an allocator hands freed
@@ -27,7 +33,12 @@
  * index alone.
  */
 
-const SHAPES = ["before (build session)", "before (load peak)", "after (v3, Float32Array)"] as const;
+const SHAPES = [
+	"before (build session)",
+	"before (load peak)",
+	"after (v3, Float32Array)",
+	"after (v3, open only: id maps)",
+] as const;
 type Shape = (typeof SHAPES)[number];
 
 const chunkCount = Number(process.argv[2] ?? 20_000);
@@ -121,6 +132,18 @@ function buildLegacyLoadPeak(): { blob: unknown; nodes: Map<number, NodeShape> }
 	return { blob, nodes };
 }
 
+/** The `idToNumeric` / `numericToId` maps `open()` loads, with realistic chunk ids. */
+function buildIdMaps(): { idToNumeric: Map<string, number>; numericToId: Map<number, string> } {
+	const idToNumeric = new Map<string, number>();
+	const numericToId = new Map<number, string>();
+	for (let id = 0; id < chunkCount; id++) {
+		const stringId = `Notes/Area ${id % 97}/Project ${id % 613}/Meeting notes ${id}.md#${id % 8}`;
+		idToNumeric.set(stringId, id);
+		numericToId.set(id, stringId);
+	}
+	return { idToNumeric, numericToId };
+}
+
 function mb(bytes: number): string {
 	return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
@@ -133,6 +156,8 @@ function buildShape(shape: Shape): unknown {
 			return buildLegacyLoadPeak();
 		case "after (v3, Float32Array)":
 			return buildNodes("float32");
+		case "after (v3, open only: id maps)":
+			return buildIdMaps();
 	}
 }
 
@@ -166,13 +191,13 @@ if (shapeArg) {
 			throw new Error(`Measuring "${shape}" failed: ${child.stderr.toString() || output}`);
 		}
 		results.set(shape, bytes);
-		console.log(`${shape.padEnd(28)} ${mb(bytes).padStart(10)}`);
+		console.log(`${shape.padEnd(32)} ${mb(bytes).padStart(10)}`);
 	}
 
 	const after = results.get("after (v3, Float32Array)") ?? 0;
 	console.log("");
 	for (const shape of SHAPES.slice(0, 2)) {
 		const before = results.get(shape) ?? 0;
-		console.log(`${shape.padEnd(28)} → after: ${((100 * after) / before).toFixed(0)}% of before`);
+		console.log(`${shape.padEnd(32)} → after: ${((100 * after) / before).toFixed(0)}% of before`);
 	}
 }

--- a/src/components/settings/EmbeddingIndexSection.svelte
+++ b/src/components/settings/EmbeddingIndexSection.svelte
@@ -5,6 +5,8 @@ import { EmbeddingIndexSetupModal } from "../modal/EmbeddingIndexSetupModal";
 import { IndexingReportModal } from "../modal/IndexingReportModal";
 import ManagedEntityItem from "./ManagedEntityItem.svelte";
 import ManagedEntitySection from "./ManagedEntitySection.svelte";
+import OrphanedVectorDatabases from "./OrphanedVectorDatabases.svelte";
+import SettingContainer from "./SettingContainer.svelte";
 import Button from "../ui/Button.svelte";
 import ProgressBar from "../ui/ProgressBar.svelte";
 import GenericAIIcon from "../ui/logos/GenericAIIcon.svelte";
@@ -14,6 +16,7 @@ import { getProviderDefinition } from "../../providers/index";
 import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
 import { isVectorStoreInitialized, getVectorStoreService, formatEta, type IndexingProgress } from "../../vectorstore";
+import { largeDimensionHint } from "../../vectorstore/embeddingMemoryHint";
 
 interface Props {
 	/** Which feature this embedding index is for */
@@ -41,6 +44,12 @@ let indexProgress = $state<IndexingProgress>({
 // Document count derived from reactive pluginData
 const documentCount = $derived(indexConfig?.documentCount ?? 0);
 const indexes = $derived(pluginData.embeddingIndexes);
+// Mobile only: a wide-vector model costs memory in proportion once its index is
+// loaded (#432). The width is recorded from the first stored vector, so the hint
+// appears once the index has been built or opened at least once.
+const memoryHint = $derived(
+	Platform.isMobile && indexConfig ? largeDimensionHint(indexConfig.model, indexConfig.dimensions) : null,
+);
 
 let unsubscribeProgress: (() => void) | null = null;
 
@@ -296,7 +305,13 @@ function getSelectionGroupLabel(): string {
       {/each}
     </div>
   {/if}
+
+  {#if memoryHint}
+    <SettingContainer name="Memory on mobile" desc={memoryHint} />
+  {/if}
 </ManagedEntitySection>
+
+<OrphanedVectorDatabases />
 
 <style>
   .embedding-index-list {

--- a/src/components/settings/OrphanedVectorDatabases.svelte
+++ b/src/components/settings/OrphanedVectorDatabases.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+import { untrack } from "svelte";
+import { Notice } from "obsidian";
+import SettingContainer from "./SettingContainer.svelte";
+import Button from "../ui/Button.svelte";
+import { ConfirmModal } from "../modal/ConfirmModal";
+import { getData } from "../../stores/dataStore.svelte";
+import { getPlugin } from "../../stores/state.svelte";
+import { Logger } from "../../utils/logging";
+import {
+	deleteOrphanedDatabases,
+	estimateOriginStorage,
+	formatBytes,
+	listOrphanedVectorDatabases,
+	type OrphanedDatabase,
+} from "../../vectorstore/orphanedDatabases";
+
+/*
+ * Vector databases outlive their index configuration by design (#432, step 5):
+ * removing a provider or an index config leaves its vectors on disk until an
+ * explicit delete. This row lists the leftovers for this vault and deletes them
+ * after confirmation. It renders nothing when there is nothing to clean up or
+ * when the runtime cannot enumerate databases.
+ */
+
+const pluginData = getData();
+const plugin = getPlugin();
+
+let orphans = $state<OrphanedDatabase[]>([]);
+let originUsage = $state<number | null>(null);
+let deleting = $state(false);
+
+const configuredIds = $derived(pluginData.embeddingIndexes.map((index) => index.id));
+// A value signature: `embeddingIndexes` is a fresh array on every store write,
+// and keying the effect on its identity would rescan on unrelated saves.
+const configuredSignature = $derived(configuredIds.join("|"));
+
+async function scan(): Promise<void> {
+	try {
+		const found = await listOrphanedVectorDatabases(pluginData.vaultSlug, configuredIds);
+		orphans = found ?? [];
+		originUsage = (await estimateOriginStorage())?.usage ?? null;
+	} catch (error) {
+		Logger.error("[OrphanedVectorDatabases] Scan failed:", error);
+		orphans = [];
+	}
+}
+
+$effect(() => {
+	// Rescan whenever the configured set changes (an index was deleted or added).
+	void configuredSignature;
+	untrack(() => void scan());
+});
+
+const totalEstimatedBytes = $derived(orphans.reduce((sum, orphan) => sum + (orphan.estimatedBytes ?? 0), 0));
+
+function describe(orphan: OrphanedDatabase): string {
+	if (orphan.kind === "legacy-sidecar") return "legacy graph data";
+	const chunks = orphan.chunkCount ?? 0;
+	return `${orphan.indexId} (${chunks} ${chunks === 1 ? "chunk" : "chunks"})`;
+}
+
+const description = $derived.by(() => {
+	const count = orphans.length;
+	const parts = [
+		`${count} stored ${count === 1 ? "database" : "databases"} no longer ${count === 1 ? "belongs" : "belong"} to a configured embedding index${
+			totalEstimatedBytes > 0 ? ` (at least ${formatBytes(totalEstimatedBytes)} of vectors)` : ""
+		}: ${orphans.map(describe).join(", ")}.`,
+	];
+	if (originUsage !== null) {
+		parts.push(`Obsidian's storage on this device totals ${formatBytes(originUsage)} across all vaults.`);
+	}
+	return parts.join(" ");
+});
+
+async function deleteOrphans(): Promise<void> {
+	const names = orphans.map((orphan) => orphan.name);
+	if (names.length === 0) return;
+	const modal = new ConfirmModal(
+		plugin.app,
+		"Delete orphaned indexes?",
+		`This permanently removes ${names.length} stored ${names.length === 1 ? "database" : "databases"} that no configured embedding index uses. Re-adding one of these models later will rebuild its index from scratch.`,
+		"Delete",
+	);
+	modal.open();
+	const { confirmed } = await modal.promise;
+	if (!confirmed) return;
+
+	deleting = true;
+	try {
+		const outcome = await deleteOrphanedDatabases(names);
+		if (outcome.failed.length === 0) {
+			new Notice(
+				`Deleted ${outcome.deleted.length} orphaned ${outcome.deleted.length === 1 ? "index" : "indexes"}.`,
+			);
+		} else {
+			for (const failure of outcome.failed) {
+				Logger.error(`[OrphanedVectorDatabases] Could not delete ${failure.name}: ${failure.reason}`);
+			}
+			new Notice(
+				`Deleted ${outcome.deleted.length}, could not delete ${outcome.failed.length}: ${outcome.failed[0].reason}`,
+			);
+		}
+	} finally {
+		deleting = false;
+		await scan();
+	}
+}
+</script>
+
+{#if orphans.length > 0}
+  <SettingContainer name="Orphaned vector databases" desc={description}>
+    <Button buttonText="Delete orphaned indexes" disabled={deleting} onClick={() => void deleteOrphans()} />
+  </SettingContainer>
+{/if}

--- a/src/components/settings/OrphanedVectorDatabases.svelte
+++ b/src/components/settings/OrphanedVectorDatabases.svelte
@@ -1,3 +1,14 @@
+<script module lang="ts">
+/*
+ * Scan results live at module level: the row is rendered once per settings
+ * tab that embeds `EmbeddingIndexSection` (search and graph), and a deletion
+ * from one tab must not leave the other showing databases that are gone.
+ */
+let orphans = $state<OrphanedDatabase[]>([]);
+let originUsage = $state<number | null>(null);
+let deleting = $state(false);
+</script>
+
 <script lang="ts">
 import { untrack } from "svelte";
 import { Notice } from "obsidian";
@@ -26,10 +37,6 @@ import {
 const pluginData = getData();
 const plugin = getPlugin();
 
-let orphans = $state<OrphanedDatabase[]>([]);
-let originUsage = $state<number | null>(null);
-let deleting = $state(false);
-
 const configuredIds = $derived(pluginData.embeddingIndexes.map((index) => index.id));
 // A value signature: `embeddingIndexes` is a fresh array on every store write,
 // and keying the effect on its identity would rescan on unrelated saves.
@@ -55,7 +62,7 @@ $effect(() => {
 const totalEstimatedBytes = $derived(orphans.reduce((sum, orphan) => sum + (orphan.estimatedBytes ?? 0), 0));
 
 function describe(orphan: OrphanedDatabase): string {
-	if (orphan.kind === "legacy-sidecar") return "legacy graph data";
+	if (orphan.kind === "legacy-sidecar") return `${orphan.label} (legacy graph data)`;
 	const chunks = orphan.chunkCount ?? 0;
 	return `${orphan.indexId} (${chunks} ${chunks === 1 ? "chunk" : "chunks"})`;
 }

--- a/src/search/LexicalSearchService.ts
+++ b/src/search/LexicalSearchService.ts
@@ -1,5 +1,14 @@
-import { Notice, Platform, TFile, getAllTags, type CachedMetadata } from "obsidian";
+import { Notice, TFile, getAllTags, type CachedMetadata } from "obsidian";
 import type SecondBrainPlugin from "../main";
+import {
+	BULK_CHECKPOINT_INTERVAL,
+	BulkAttemptMarker,
+	bulkBatchPauseMs,
+	bulkCheckpointPauseMs,
+	bulkPause,
+	orderForBulkIndexing,
+	scheduleBulkRun,
+} from "./bulkPacing";
 import { compileFilter, matchesPathFilter, matchesSearchFilter } from "../search/searchFilters";
 import { extractSearchTerms } from "../search/searchTermUtils";
 import { createQueryPlan, type QueryPlan } from "../search/queryPlan";
@@ -12,12 +21,7 @@ import {
 } from "../search/lexicalScoring";
 import { Logger } from "../utils/logging";
 import { StartupProfiler } from "../utils/startupProfiler";
-import {
-	getIndexableVaultFiles,
-	isBinaryTextFile,
-	isIndexableFile,
-	readIndexableContent,
-} from "../utils/fileFiltering";
+import { getIndexableVaultFiles, isIndexableFile, readIndexableContent } from "../utils/fileFiltering";
 import {
 	MiniSearchService,
 	type AutocompleteCacheSnapshot,
@@ -61,11 +65,14 @@ export class LexicalSearchService {
 	private readonly plugin: SecondBrainPlugin;
 	private readonly miniSearch: MiniSearchService;
 	private readonly vaultId: string;
+	/** Crash-backoff marker for scheduled bulk runs (`s2b-lexical-bulk-attempts:<vaultId>`). */
+	private readonly bulkAttempts: BulkAttemptMarker;
 
 	private constructor(plugin: SecondBrainPlugin) {
 		this.plugin = plugin;
 		this.vaultId = getData().vaultSlug;
 		this.miniSearch = new MiniSearchService(this.vaultId);
+		this.bulkAttempts = new BulkAttemptMarker("lexical", this.vaultId);
 	}
 
 	static async initialize(plugin: SecondBrainPlugin): Promise<LexicalSearchService> {
@@ -148,11 +155,11 @@ export class LexicalSearchService {
 			}
 			if (loaded) {
 				this.plugin.app.workspace.onLayoutReady(() => {
-					this.scheduleBulkRun(() => this.validateIndex());
+					scheduleBulkRun("LexicalSearch", this.bulkAttempts, () => this.validateIndex());
 				});
 			} else {
 				this.plugin.app.workspace.onLayoutReady(() => {
-					this.scheduleBulkRun(() => this.buildIndex());
+					scheduleBulkRun("LexicalSearch", this.bulkAttempts, () => this.buildIndex());
 				});
 			}
 
@@ -209,113 +216,26 @@ export class LexicalSearchService {
 	}
 
 	/**
-	 * How many documents a bulk run indexes between IndexedDB checkpoints.
-	 *
-	 * Each checkpoint serializes the whole index, so the interval trades save cost
-	 * against how much progress a crash can lose. On mobile the process can be
-	 * killed by the OS mid-build; a checkpoint every few hundred documents lets the
-	 * next boot's validateIndex resume roughly where this run died instead of
-	 * starting over.
+	 * Files indexed between pacing pauses during a bulk run. The pause lengths,
+	 * the checkpoint interval and the crash backoff are shared with the embedding
+	 * indexer — see `bulkPacing.ts` for the measurements behind them.
 	 */
-	private static readonly BULK_CHECKPOINT_INTERVAL = 250;
-
-	/** Files indexed between pacing pauses during a bulk run. */
 	private static readonly BULK_BATCH_SIZE = 25;
 
-	/**
-	 * Pause between bulk batches, and after each checkpoint.
-	 *
-	 * Tokenizing text files back-to-back allocates garbage faster than the mobile
-	 * WebView's GC reclaims it, so an unthrottled loop balloons the footprint until
-	 * the OS kills the process — measured as a reload every ~10 s on a large vault.
-	 * (PDF extraction used to throttle the loop by accident; ordering PDFs last
-	 * removed that brake.) Real pauses give the collector room to keep up. Desktop
-	 * has no memory ceiling and only yields the event loop.
-	 */
-	private static readonly BULK_BATCH_PAUSE_MS = Platform.isMobile ? 100 : 0;
-
-	/** Extra pause after a checkpoint's full-index serialization, for the same reason. */
-	private static readonly BULK_CHECKPOINT_PAUSE_MS = Platform.isMobile ? 250 : 0;
-
-	/**
-	 * How long after layout-ready a bulk run may start on mobile, before backoff.
-	 *
-	 * Boot is the highest-pressure window — the vault, the metadata cache, and
-	 * every plugin allocate at once, and the OS kill ceiling is effectively lower
-	 * because of it. Starting the indexer into that spike is what turned one kill
-	 * into a kill loop: each reload restarted indexing at second zero and died
-	 * again. Waiting lets the boot spike drain first; steady state idles at ~2% CPU.
-	 */
-	private static readonly MOBILE_BULK_BASE_DELAY_MS = 15_000;
-
-	/** Upper bound for the crash-backoff delay. */
-	private static readonly MOBILE_BULK_MAX_DELAY_MS = 300_000;
-
-	private static bulkPause(ms: number): Promise<void> {
-		return new Promise((resolve) => setTimeout(resolve, ms));
-	}
-
-	/**
-	 * How boot pressure varies is unknowable from inside the WebView (there is no
-	 * JS memory-pressure API), so no fixed delay can be right on every device: 15 s
-	 * was measured to land inside the boot spike on a phone already under system
-	 * pressure, where the OS killed the process seconds into the run. Instead the
-	 * delay adapts to observed deaths: every bulk attempt writes this marker and a
-	 * completed run clears it, so a marker still present at boot means the last
-	 * attempt died mid-run — and the next one waits twice as long. localStorage,
-	 * not plugin data: it survives the kill (the plugin's data debounce may not)
-	 * and stays out of sync.
-	 */
-	private bulkAttemptKey(): string {
-		return `s2b-lexical-bulk-attempts:${this.vaultId}`;
-	}
-
-	private readCrashedBulkAttempts(): number {
-		const raw = Number(window.localStorage.getItem(this.bulkAttemptKey()));
-		return Number.isFinite(raw) && raw > 0 ? raw : 0;
-	}
-
-	/** Run `work` after the platform-appropriate bulk start delay. */
-	private scheduleBulkRun(work: () => Promise<void>): void {
-		const attempts = this.readCrashedBulkAttempts();
-		const delay = Platform.isMobile
-			? Math.min(
-					LexicalSearchService.MOBILE_BULK_BASE_DELAY_MS * 2 ** attempts,
-					LexicalSearchService.MOBILE_BULK_MAX_DELAY_MS,
-				)
-			: 0;
-		if (attempts > 0) {
-			Logger.warn(
-				`[LexicalSearch] Last bulk index attempt did not complete (${attempts} in a row) — delaying the next by ${Math.round(delay / 1000)}s`,
-			);
-		}
-		window.setTimeout(() => void work(), delay);
-	}
-
-	/**
-	 * Bulk-indexing file order: cheap text files first, binary-extraction files
-	 * (PDFs) last. PDF text extraction is minutes of work on a large vault, and
-	 * putting it first held the whole searchable corpus hostage to it — this way
-	 * every note is searchable early even if the PDF tail never finishes.
-	 */
-	private static orderForBulkIndexing(files: TFile[]): TFile[] {
-		return [...files].sort((a, b) => Number(isBinaryTextFile(a)) - Number(isBinaryTextFile(b)));
-	}
-
-	/** Index `files`, paced in batches and checkpointing every {@link BULK_CHECKPOINT_INTERVAL} additions. */
 	/**
 	 * Runs below this size stay silent: routine validateIndex catch-ups (a few
 	 * changed notes) shouldn't flash a progress notice on every boot.
 	 */
 	private static readonly PROGRESS_NOTICE_MIN_FILES = 100;
 
+	/** Index `files`, paced in batches and checkpointing every {@link BULK_CHECKPOINT_INTERVAL} additions. */
 	private async bulkIndexFiles(files: TFile[]): Promise<number> {
 		const { vault } = this.plugin.app;
 		let added = 0;
 		let processed = 0;
 		// Mark the attempt before the first read; cleared below only when the whole
-		// run survives. See bulkAttemptKey for why this drives the start backoff.
-		window.localStorage.setItem(this.bulkAttemptKey(), String(this.readCrashedBulkAttempts() + 1));
+		// run survives. See BulkAttemptMarker for why this drives the start backoff.
+		this.bulkAttempts.markAttempt();
 		const notice = files.length >= LexicalSearchService.PROGRESS_NOTICE_MIN_FILES ? new Notice("", 0) : null;
 		if (notice) this.updateProgressNotice(notice, 0, files.length);
 		this.miniSearch.suspendScheduledSaves();
@@ -330,18 +250,18 @@ export class LexicalSearchService {
 				}
 				processed++;
 
-				if (added > 0 && added % LexicalSearchService.BULK_CHECKPOINT_INTERVAL === 0) {
+				if (added > 0 && added % BULK_CHECKPOINT_INTERVAL === 0) {
 					await this.miniSearch.flush();
-					await LexicalSearchService.bulkPause(LexicalSearchService.BULK_CHECKPOINT_PAUSE_MS);
+					await bulkPause(bulkCheckpointPauseMs());
 				} else if (processed % LexicalSearchService.BULK_BATCH_SIZE === 0) {
-					await LexicalSearchService.bulkPause(LexicalSearchService.BULK_BATCH_PAUSE_MS);
+					await bulkPause(bulkBatchPauseMs());
 				}
 				if (notice && processed % LexicalSearchService.BULK_BATCH_SIZE === 0) {
 					this.updateProgressNotice(notice, processed, files.length);
 				}
 			}
 			await this.miniSearch.flush();
-			window.localStorage.removeItem(this.bulkAttemptKey());
+			this.bulkAttempts.clear();
 			if (notice) {
 				notice.setMessage(`✓ Search index updated: ${added} notes`);
 				setTimeout(() => notice.hide(), 3000);
@@ -384,7 +304,7 @@ export class LexicalSearchService {
 
 	private async buildIndex(): Promise<void> {
 		await StartupProfiler.logDuration("lexical:buildIndex", async () => {
-			const files = LexicalSearchService.orderForBulkIndexing(getIndexableVaultFiles(this.plugin.app.vault));
+			const files = orderForBulkIndexing(getIndexableVaultFiles(this.plugin.app.vault));
 			await this.bulkIndexFiles(files);
 			Logger.log(`[LexicalSearch] Built lexical index: ${this.miniSearch.documentCount} documents`);
 		});
@@ -402,9 +322,7 @@ export class LexicalSearchService {
 			}
 		}
 
-		const missing = LexicalSearchService.orderForBulkIndexing(
-			files.filter((file) => !this.miniSearch.hasDocument(file.path)),
-		);
+		const missing = orderForBulkIndexing(files.filter((file) => !this.miniSearch.hasDocument(file.path)));
 		const added = await this.bulkIndexFiles(missing);
 
 		if (added > 0 || removed > 0) {

--- a/src/search/bulkPacing.ts
+++ b/src/search/bulkPacing.ts
@@ -1,0 +1,151 @@
+/**
+ * Pacing and crash-backoff shared by the two bulk indexers — the lexical build
+ * (`LexicalSearchService.bulkIndexFiles`) and the embedding build
+ * (`VectorStoreService.embedFilesInBatches`).
+ *
+ * Everything here encodes behaviour measured on a phone during the #430 / #432
+ * investigations, not preferences. The comments on each value say what was
+ * observed; change the value only with a new measurement.
+ */
+
+import { Platform, type TFile } from "obsidian";
+import { isBinaryTextFile } from "../utils/fileFiltering";
+import { Logger } from "../utils/logging";
+
+/**
+ * How many notes a bulk run indexes between durable checkpoints.
+ *
+ * Each checkpoint persists the whole in-memory index (the lexical index is
+ * serialised in full; the HNSW graph's topology is rewritten in full), so the
+ * interval trades save cost against how much progress a crash can lose. On
+ * mobile the process can be killed by the OS mid-build; a checkpoint every few
+ * hundred notes lets the next boot's validation resume roughly where this run
+ * died instead of starting over.
+ */
+export const BULK_CHECKPOINT_INTERVAL = 250;
+
+/**
+ * Pause between bulk batches, and after each checkpoint.
+ *
+ * Tokenizing text files back-to-back allocates garbage faster than the mobile
+ * WebView's GC reclaims it, so an unthrottled loop balloons the footprint until
+ * the OS kills the process — measured as a reload every ~10 s on a large vault.
+ * (PDF extraction used to throttle the loop by accident; ordering PDFs last
+ * removed that brake.) Real pauses give the collector room to keep up. Desktop
+ * has no memory ceiling and only yields the event loop.
+ *
+ * Read at call time (not module load) so the platform can be flipped in tests.
+ */
+export function bulkBatchPauseMs(): number {
+	return Platform.isMobile ? 100 : 0;
+}
+
+/** Extra pause after a checkpoint's full-index serialization, for the same reason. */
+export function bulkCheckpointPauseMs(): number {
+	return Platform.isMobile ? 250 : 0;
+}
+
+/**
+ * How long after layout-ready a bulk run may start on mobile, before backoff.
+ *
+ * Boot is the highest-pressure window — the vault, the metadata cache, and
+ * every plugin allocate at once, and the OS kill ceiling is effectively lower
+ * because of it. Starting an indexer into that spike is what turned one kill
+ * into a kill loop: each reload restarted indexing at second zero and died
+ * again. Waiting lets the boot spike drain first; steady state idles at ~2% CPU.
+ */
+export const MOBILE_BULK_BASE_DELAY_MS = 15_000;
+
+/** Upper bound for the crash-backoff delay. */
+export const MOBILE_BULK_MAX_DELAY_MS = 300_000;
+
+/** Yield the event loop for `ms` (a real pause on mobile, a bare yield on desktop). */
+export function bulkPause(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Start delay for a scheduled bulk run, given how many previous attempts died
+ * mid-run: the mobile base delay doubled per crashed attempt, capped. Desktop
+ * never waits.
+ */
+export function bulkStartDelayMs(crashedAttempts: number): number {
+	if (!Platform.isMobile) return 0;
+	return Math.min(MOBILE_BULK_BASE_DELAY_MS * 2 ** Math.max(0, crashedAttempts), MOBILE_BULK_MAX_DELAY_MS);
+}
+
+/**
+ * Counts bulk runs that did not complete, so the next scheduled run can wait
+ * longer before starting.
+ *
+ * How boot pressure varies is unknowable from inside the WebView (there is no
+ * JS memory-pressure API), so no fixed delay can be right on every device: 15 s
+ * was measured to land inside the boot spike on a phone already under system
+ * pressure, where the OS killed the process seconds into the run. Instead the
+ * delay adapts to observed deaths: every bulk attempt writes this marker and a
+ * completed run clears it, so a marker still present at boot means the last
+ * attempt died mid-run — and the next one waits twice as long. localStorage,
+ * not plugin data: it survives the kill (the plugin's data debounce may not)
+ * and stays out of sync.
+ *
+ * One marker per indexer per vault (`s2b-<indexer>-bulk-attempts:<vaultId>`):
+ * the two indexers die independently and back off independently.
+ */
+export class BulkAttemptMarker {
+	private readonly key: string;
+
+	constructor(indexer: string, vaultId: string) {
+		this.key = `s2b-${indexer}-bulk-attempts:${vaultId}`;
+	}
+
+	private get storage(): Storage | null {
+		try {
+			return typeof window !== "undefined" ? (window.localStorage ?? null) : null;
+		} catch {
+			// Accessing localStorage throws in some sandboxed contexts; treat as absent.
+			return null;
+		}
+	}
+
+	/** Number of consecutive attempts that died mid-run (0 when the last run completed). */
+	read(): number {
+		const raw = Number(this.storage?.getItem(this.key));
+		return Number.isFinite(raw) && raw > 0 ? raw : 0;
+	}
+
+	/** Record that a run is starting. Call before the first read of the run. */
+	markAttempt(): void {
+		this.storage?.setItem(this.key, String(this.read() + 1));
+	}
+
+	/** Record that the run survived (completed or was cancelled by the user). */
+	clear(): void {
+		this.storage?.removeItem(this.key);
+	}
+}
+
+/**
+ * Run `work` after the platform-appropriate bulk start delay, logging when the
+ * delay was lengthened by earlier crashed attempts. `label` names the indexer
+ * in that log line.
+ */
+export function scheduleBulkRun(label: string, marker: BulkAttemptMarker, work: () => Promise<void>): void {
+	const attempts = marker.read();
+	const delay = bulkStartDelayMs(attempts);
+	if (attempts > 0) {
+		Logger.warn(
+			`[${label}] Last bulk index attempt did not complete (${attempts} in a row) — delaying the next by ${Math.round(delay / 1000)}s`,
+		);
+	}
+	window.setTimeout(() => void work(), delay);
+}
+
+/**
+ * Bulk-indexing file order: cheap text files first, binary-extraction files
+ * (PDFs) last. PDF text extraction is minutes of work on a large vault, and
+ * putting it first held the whole searchable corpus hostage to it — this way
+ * every note is searchable early even if the PDF tail never finishes.
+ */
+export function orderForBulkIndexing(files: TFile[]): TFile[] {
+	return [...files].sort((a, b) => Number(isBinaryTextFile(a)) - Number(isBinaryTextFile(b)));
+}

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -1716,11 +1716,15 @@ export class PluginDataStore {
 	/**
 	 * Update cached stats for an embedding index.
 	 */
-	updateEmbeddingIndexStats(indexId: string, stats: { lastBuiltAt?: number; documentCount?: number }): void {
+	updateEmbeddingIndexStats(
+		indexId: string,
+		stats: { lastBuiltAt?: number; documentCount?: number; dimensions?: number },
+	): void {
 		const config = this.#data.embeddingIndexes.find((i) => i.id === indexId);
 		if (!config) return;
 		if (stats.lastBuiltAt !== undefined) config.lastBuiltAt = stats.lastBuiltAt;
 		if (stats.documentCount !== undefined) config.documentCount = stats.documentCount;
+		if (stats.dimensions !== undefined) config.dimensions = stats.dimensions;
 		this.saveSettings();
 	}
 

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -71,6 +71,8 @@ export interface EmbeddingIndexConfig {
 	documentCount: number;
 	/** Documents per embedding request when indexing this model */
 	batchSize?: number;
+	/** Vector width the model produced, recorded from the first stored vector */
+	dimensions?: number;
 }
 
 // ============================================================================

--- a/src/vectorstore/HNSWVectorStore.ts
+++ b/src/vectorstore/HNSWVectorStore.ts
@@ -43,6 +43,8 @@ const ID_MAPPING_STORE = "id_mapping";
 const GRAPH_STORE = "hnsw_graph";
 /** Compound index over `documents` so per-note mtimes can be read without touching a vector. */
 const PATH_MTIME_INDEX = "path_mtime";
+/** Chunk id suffix of a note's first chunk (`makeChunkId(path, 0)`), the row that marks a note complete. */
+const FIRST_CHUNK_SUFFIX = "#0";
 
 /**
  * Schema version of the per-index database.
@@ -865,13 +867,23 @@ export class HNSWVectorStore implements VectorStore {
 		const db = this.requireDb();
 
 		const tx = db.transaction(DOCUMENTS_STORE, "readonly");
-		const request = tx.objectStore(DOCUMENTS_STORE).index(PATH_MTIME_INDEX).openKeyCursor(null, "nextunique");
+		const request = tx.objectStore(DOCUMENTS_STORE).index(PATH_MTIME_INDEX).openKeyCursor();
 
+		// A note is listed only through its chunk-0 row. Bulk writers store a
+		// note's chunk 0 *last* (`VectorStoreService.embedFilesInBatches`), so a
+		// process killed between the chunks of a multi-chunk note leaves rows
+		// that carry the note's current mtime but no `#0` — and this read then
+		// reports the note as absent, which makes the next validation re-index
+		// it. Without that, the surviving chunks made the note look complete and
+		// its missing sections never came back. Key cursor only: `primaryKey`
+		// is the chunk id, so no row value (no vector) is ever deserialised.
 		const notes: NoteMeta[] = [];
 		return awaitCursor(tx, request, (cursor) => {
 			if (!cursor) return { done: true, value: notes };
-			const [path, mtime] = cursor.key as [string, number];
-			notes.push({ path, mtime });
+			if (typeof cursor.primaryKey === "string" && cursor.primaryKey.endsWith(FIRST_CHUNK_SUFFIX)) {
+				const [path, mtime] = cursor.key as [string, number];
+				notes.push({ path, mtime });
+			}
 			cursor.continue();
 			return undefined;
 		});

--- a/src/vectorstore/HNSWVectorStore.ts
+++ b/src/vectorstore/HNSWVectorStore.ts
@@ -478,15 +478,24 @@ export class HNSWVectorStore implements VectorStore {
 	 * A node whose document row is gone (removed after the last graph save) is
 	 * dropped, and every neighbour list is pruned of such ids so the library never
 	 * dereferences a missing node mid-search.
+	 *
+	 * The mirror case matters just as much: a document row with no topology node.
+	 * Rows are written durably on every `upsert`, but the graph is saved on a
+	 * debounce and at bulk checkpoints, so a process kill mid-build (the mobile
+	 * failure mode of #432) leaves the rows written since the last save with no
+	 * links. Before, such rows were silently unsearchable while still counting as
+	 * indexed — the completeness validation saw their `mtime` and skipped them, so
+	 * nothing ever repaired them. Now they are re-inserted into the graph here,
+	 * which makes the row the unit of durability; the checkpoint interval only
+	 * bounds how much re-linking a reopen has to do.
 	 */
 	private async loadGraph(index: HNSW): Promise<void> {
 		const db = this.requireDb();
 
 		const header = await this.getGraphHeader();
-		if (!header) return;
 
 		const topology = new Map<number, StoredGraphNode>();
-		{
+		if (header) {
 			const tx = db.transaction(GRAPH_STORE, "readonly");
 			const request = tx.objectStore(GRAPH_STORE).openCursor();
 			await awaitCursor<void>(tx, request, (cursor) => {
@@ -497,9 +506,10 @@ export class HNSWVectorStore implements VectorStore {
 				return undefined;
 			});
 		}
-		if (topology.size === 0) return;
 
 		const nodes = new Map<number, HnswNode>();
+		/** Rows the persisted graph does not know about — see the doc comment. */
+		const unlinked: Array<{ id: number; vector: Float32Array }> = [];
 		let dim: number | null = null;
 		{
 			const tx = db.transaction(DOCUMENTS_STORE, "readonly");
@@ -516,12 +526,17 @@ export class HNSWVectorStore implements VectorStore {
 						level: node.level,
 						neighbors: node.neighbors,
 					} as HnswNode);
+				} else if (this.numericToId.has(stored.hnswId)) {
+					// Only rows that still have an id mapping are live; a row whose
+					// mapping is gone is mid-removal and must not come back.
+					unlinked.push({ id: stored.hnswId, vector: stored.vector });
 				}
 				cursor.continue();
 				return undefined;
 			});
 		}
 		topology.clear();
+		if (nodes.size === 0 && unlinked.length === 0) return;
 
 		let pruned = 0;
 		let levelMax = -1;
@@ -535,7 +550,7 @@ export class HNSWVectorStore implements VectorStore {
 			}
 		}
 
-		let entryPointId = header.entryPointId;
+		let entryPointId = header?.entryPointId ?? -1;
 		if (!nodes.has(entryPointId)) {
 			// Any node on the top level is a valid entry point; take the smallest id
 			// so the choice is stable across loads.
@@ -546,12 +561,23 @@ export class HNSWVectorStore implements VectorStore {
 		}
 
 		index.nodes = nodes;
-		index.d = dim;
+		index.d = dim ?? (unlinked.length > 0 ? unlinked[0].vector.length : null);
 		index.levelMax = nodes.size > 0 ? levelMax : -1;
 		index.entryPointId = entryPointId;
 
 		if (pruned > 0) {
 			Logger.debug(`${LOG_PREFIX} Loaded graph (${nodes.size} nodes); pruned ${pruned} stale neighbour lists.`);
+		}
+
+		if (unlinked.length > 0) {
+			for (const row of unlinked) await index.addPoint(row.id, row.vector);
+			// The re-linked graph is only in memory; schedule the save so the next
+			// open does not have to redo this.
+			this.hasPendingIndexSave = true;
+			this.scheduleIndexSave();
+			Logger.log(
+				`${LOG_PREFIX} Re-linked ${unlinked.length} vectors that were written after the last graph save (interrupted build).`,
+			);
 		}
 	}
 
@@ -673,6 +699,7 @@ export class HNSWVectorStore implements VectorStore {
 			modelId: meta.modelId,
 			documentCount: count,
 			lastUpdated: meta.lastUpdated,
+			dimensions: meta.dimensions ?? 0,
 		};
 	}
 
@@ -728,6 +755,15 @@ export class HNSWVectorStore implements VectorStore {
 		// into one save; a clean close() flushes anything still pending.
 		this.hasPendingIndexSave = true;
 		this.scheduleIndexSave();
+	}
+
+	/** Checkpoint for bulk runs: persist the graph now rather than on the debounce. */
+	async flush(): Promise<void> {
+		if (this.saveIndexTimer !== null) {
+			clearTimeout(this.saveIndexTimer);
+			this.saveIndexTimer = null;
+		}
+		await this.flushIndex();
 	}
 
 	/**

--- a/src/vectorstore/HNSWWorkerProxy.ts
+++ b/src/vectorstore/HNSWWorkerProxy.ts
@@ -139,6 +139,10 @@ export class HNSWWorkerProxy implements VectorStore {
 		await this.call("bulkPut", [docs], vectorBuffers(docs));
 	}
 
+	async flush(): Promise<void> {
+		await this.call("flush", []);
+	}
+
 	async clear(): Promise<void> {
 		await this.call("clear", []);
 	}

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -8,13 +8,22 @@
 
 import type { EmbeddingsInterface } from "@langchain/core/embeddings";
 import { decode, encode } from "@msgpack/msgpack";
-import { Notice, TFile, getAllTags } from "obsidian";
+import { Notice, Platform, TFile, getAllTags } from "obsidian";
 import { hydrateEmbeddingModel } from "../lib/modelMetadataNormalizer";
 import type SecondBrainPlugin from "../main";
 import { fetchModelsDevData } from "../providers/modelsDevApi";
 import { getOllamaModelsCache } from "../providers/ollamaModels";
 import { fetchOpenRouterModels } from "../providers/openrouterModels";
 import { getRegistry } from "../providers/registry";
+import {
+	BULK_CHECKPOINT_INTERVAL,
+	BulkAttemptMarker,
+	bulkBatchPauseMs,
+	bulkCheckpointPauseMs,
+	bulkPause,
+	orderForBulkIndexing,
+	scheduleBulkRun,
+} from "../search/bulkPacing";
 import { ensureProviderRegistered } from "../providers/registrySync";
 import { getData } from "../stores/dataStore.svelte";
 import { chunkText } from "../utils/chunkText";
@@ -228,6 +237,9 @@ interface IndexInstance {
 	 */
 	currentAuthGeneration: number | null;
 	hasValidatedThisSession: boolean;
+	/** A startup validation is scheduled (see `scheduleValidation`) and has not run yet. */
+	validationScheduled: boolean;
+	/** A full build (`buildFullIndex`) is in progress. Validation runs set only `progress.isIndexing`. */
 	isIndexing: boolean;
 	progress: IndexingProgress;
 	/** Timestamp (ms) when the current indexing run started, for ETA estimation */
@@ -320,6 +332,38 @@ export function summarizeValidationProgressCounts({
 	};
 }
 
+/** One chunk of a note queued for embedding. */
+interface ChunkEntry {
+	file: TFile;
+	chunkIndex: number;
+	chunkCount: number;
+	checksum: string;
+	embedText: string;
+}
+
+/** Report accumulated by a full build; validation runs pass none. */
+interface BulkEmbedReport {
+	indexedFiles: string[];
+	skippedFiles: SkippedFile[];
+}
+
+interface BulkEmbedOptions {
+	/** Notes already indexed before this run; `indexed` starts here. */
+	startingIndexedCount: number;
+	/** Notes counted as skipped before the loop starts (excluded, privacy). */
+	preFilterSkipped: number;
+	/** Remove a note's stored chunks before writing new ones (re-index of a stale note). */
+	purgeExisting: boolean;
+	notice: Notice | null;
+	report?: BulkEmbedReport;
+}
+
+interface BulkEmbedOutcome {
+	indexedChunks: number;
+	/** The run was aborted (user cancel, index deleted, provider unreachable). */
+	cancelled: boolean;
+}
+
 /**
  * Main service for embedding-based vector search.
  * Manages multiple indexes, one per embedding model.
@@ -332,10 +376,13 @@ export class VectorStoreService {
 	private readonly modifyTimers = new Map<string, ReturnType<typeof setTimeout>>();
 	private isInitialized = false;
 	private readonly vaultId: string;
+	/** Crash-backoff marker for scheduled bulk runs (`s2b-embedding-bulk-attempts:<vaultId>`). */
+	private readonly bulkAttempts: BulkAttemptMarker;
 
 	private constructor(plugin: SecondBrainPlugin) {
 		this.plugin = plugin;
 		this.vaultId = getData().vaultSlug;
+		this.bulkAttempts = new BulkAttemptMarker("embedding", this.vaultId);
 	}
 
 	/** Promise tracking initialization, awaited by cleanup to avoid closing mid-init. */
@@ -355,6 +402,7 @@ export class VectorStoreService {
 			currentModelId: null,
 			currentAuthGeneration: null,
 			hasValidatedThisSession: false,
+			validationScheduled: false,
 			isIndexing: false,
 			progress: {
 				isIndexing: false,
@@ -445,7 +493,16 @@ export class VectorStoreService {
 
 	/**
 	 * Internal initialization.
-	 * Opens instances for currently-referenced indexes (search + graph).
+	 *
+	 * Desktop opens the currently-referenced indexes (search + graph) right away.
+	 * Mobile opens nothing at boot: opening an index spawns its worker and loads
+	 * the id maps, and the first write or search then rehydrates the HNSW graph —
+	 * the whole vector set, resident in the WebContent process — which is the
+	 * #432 kill zone when it lands in the boot spike. Every consumer already goes
+	 * through `getOrCreateInstance`, so whatever comes first opens it: the first
+	 * search, the graph's semantic-edge request, an explicit reindex, or the
+	 * delayed catch-up scheduled here (which waits out the boot spike and backs
+	 * off after crashed attempts, like the lexical build).
 	 */
 	private async init(): Promise<void> {
 		try {
@@ -459,7 +516,10 @@ export class VectorStoreService {
 			if (searchIndex) indexIds.add(searchIndex);
 			if (graphIndex) indexIds.add(graphIndex);
 
-			if (indexIds.size > 0) {
+			if (indexIds.size > 0 && Platform.isMobile) {
+				Logger.log(`[VectorStore] Mobile: deferring open of ${indexIds.size} index(es) to first use`);
+				scheduleBulkRun("VectorStore", this.bulkAttempts, () => this.catchUpDeferredIndexes(indexIds));
+			} else if (indexIds.size > 0) {
 				await Promise.all(Array.from(indexIds, (indexId) => this.initializeInstance(indexId)));
 			}
 
@@ -504,14 +564,11 @@ export class VectorStoreService {
 			if (runtimeMatches && runtimeMeta) {
 				inst.currentProviderId = runtimeMeta.providerId;
 				inst.currentModelId = runtimeMeta.modelId;
+				this.recordDimensions(indexId, runtimeMeta.dimensions);
 
 				Logger.log(
 					`[VectorStore] Loaded index for ${indexId} from IDB (${runtimeMeta.documentCount} documents)`,
 				);
-
-				this.plugin.app.workspace.onLayoutReady(() => {
-					this.validateIndexOnStartup(inst);
-				});
 			} else if (
 				runtimeMeta &&
 				(runtimeMeta.providerId !== provider || runtimeMeta.modelId !== model || !versionCurrent)
@@ -525,6 +582,9 @@ export class VectorStoreService {
 
 			this.instances.set(indexId, inst);
 			Logger.info(`[VectorStore] Init ${indexId}: ${Math.round(performance.now() - initStart)}ms`);
+			// Every opened instance gets validated against the vault (missing, stale
+			// and orphaned notes) — after the platform's bulk start delay.
+			this.scheduleValidation(inst);
 			return inst;
 		})();
 
@@ -544,6 +604,55 @@ export class VectorStoreService {
 		const existing = this.instances.get(indexId);
 		if (existing) return existing;
 		return this.initializeInstance(indexId);
+	}
+
+	/**
+	 * Schedule the startup completeness validation of an open instance.
+	 *
+	 * Desktop runs it at once (next macrotask, after layout-ready). Mobile waits
+	 * out the boot spike and backs off after crashed attempts — `scheduleBulkRun`
+	 * and `BulkAttemptMarker` explain the measurements. One pending validation per
+	 * instance; a no-op once the instance has validated this session.
+	 */
+	private scheduleValidation(inst: IndexInstance): void {
+		if (inst.hasValidatedThisSession || inst.validationScheduled) return;
+		inst.validationScheduled = true;
+		this.plugin.app.workspace.onLayoutReady(() => {
+			scheduleBulkRun("VectorStore", this.bulkAttempts, async () => {
+				inst.validationScheduled = false;
+				// Deleted or closed in the meantime.
+				if (this.instances.get(inst.indexId) !== inst) return;
+				await this.validateIndexOnStartup(inst);
+			});
+		});
+	}
+
+	/**
+	 * Mobile boot catch-up: open the indexes that were deferred at init and
+	 * validate them, in sequence so two graphs are never rehydrated at once. An
+	 * index deselected since boot is left closed. Runs after the bulk start delay.
+	 */
+	private async catchUpDeferredIndexes(indexIds: Iterable<string>): Promise<void> {
+		for (const indexId of indexIds) {
+			if (!this.isActiveIndex(indexId)) continue;
+			try {
+				const inst = await this.getOrCreateInstance(indexId);
+				await this.validateIndexOnStartup(inst);
+			} catch (error) {
+				Logger.error(`[VectorStore] Deferred open of ${indexId} failed:`, error);
+			}
+		}
+	}
+
+	/**
+	 * Remember an index's vector width in plugin data, where the settings UI can
+	 * read it without opening the index (on mobile that would spawn its worker).
+	 */
+	private recordDimensions(indexId: string, dimensions: number): void {
+		if (!(dimensions > 0)) return;
+		const data = getData();
+		if (data.getEmbeddingIndex(indexId)?.dimensions === dimensions) return;
+		data.updateEmbeddingIndexStats(indexId, { dimensions });
 	}
 
 	/**
@@ -688,6 +797,13 @@ export class VectorStoreService {
 		defaultModel: DefaultEmbedModel,
 	): Promise<void> {
 		if (inst.hasValidatedThisSession) return;
+		if (inst.isIndexing) {
+			// A full build is writing every note right now; validating alongside it
+			// would double-write the same chunks. `ensureIndex` marks the instance
+			// validated when the build completes.
+			Logger.log(`[VectorStore] Skipping validation of ${inst.indexId}: full build in progress`);
+			return;
+		}
 		inst.hasValidatedThisSession = true;
 
 		Logger.log(`[VectorStore] Validating index ${inst.indexId} against vault...`);
@@ -747,255 +863,62 @@ export class VectorStoreService {
 		}
 
 		const filesToIndex = [...missingFiles, ...staleFiles];
+		let cancelled = false;
 		if (filesToIndex.length > 0) {
-			const batchSize = this.getBatchSize(inst.indexId, defaultModel.provider);
+			const { startingIndexedCount, totalCount } = summarizeValidationProgressCounts({
+				eligibleFileCount: vaultFiles.length,
+				pendingFileCount: filesToIndex.length,
+				validPendingFileCount: filesToIndex.length,
+			});
+			// Routine catch-ups of a handful of notes stay silent.
+			const notice = filesToIndex.length > 5 ? new Notice("", 0) : null;
 
-			// Pre-read files and split them into chunks before setting up
-			// progress tracking so counts are accurate from the start. Large
-			// notes are chunked (not skipped); each chunk is embedded separately.
-			interface ChunkEntry {
-				file: TFile;
-				chunkIndex: number;
-				chunkCount: number;
-				checksum: string;
-				embedText: string;
-			}
-			const validChunks: ChunkEntry[] = [];
-			const maxContentLength = await this.getMaxEmbeddingContentLength(inst, defaultModel);
-			const skippedReadError: string[] = [];
-			let validFileCount = 0;
+			this.updateInstanceProgress(inst, {
+				isIndexing: true,
+				total: totalCount,
+				indexed: startingIndexedCount,
+				skipped: 0,
+				currentFile: null,
+			});
+			if (notice) this.updateNotice(notice, inst.progress);
+			inst.abortController = new AbortController();
 
-			for (const file of filesToIndex) {
-				try {
-					const content = await readIndexableContent(vault, file);
-					const checksum = this.hashContent(content);
-					const chunks = chunkText(content, file.basename, maxContentLength);
-					for (const chunk of chunks) {
-						validChunks.push({
-							file,
-							chunkIndex: chunk.chunkIndex,
-							chunkCount: chunks.length,
-							checksum,
-							embedText: chunk.content,
-						});
-					}
-					validFileCount++;
-				} catch (error) {
-					Logger.error(`[VectorStore] Failed to read ${file.path}:`, error);
-					skippedReadError.push(file.basename);
-				}
-			}
-
-			const preFilterSkipped = skippedReadError.length;
-
-			Logger.log(
-				`[VectorStore] ${inst.indexId}: pre-filter result: ${validFileCount} files (${validChunks.length} chunks), ${preFilterSkipped} skipped (maxContentLength=${maxContentLength})`,
-			);
-
-			if (preFilterSkipped > 0) {
-				// The filename list used to be inlined here and overflowed the toast on any
-				// real vault; the report lists them properly.
-				showActionNotice(
-					`Skipped indexing ${preFilterSkipped} ${preFilterSkipped === 1 ? "note" : "notes"} (unreadable).`,
-					indexingReportAction(inst.indexId, "View report"),
-					8000,
-				);
-			}
-
-			// If no files actually need indexing (all unreadable), skip entirely
-			if (validChunks.length === 0) {
-				Logger.log(
-					`[VectorStore] ${inst.indexId}: all ${filesToIndex.length} pending files were skipped (unreadable)`,
-				);
-			} else {
-				const pendingFileCount = filesToIndex.length;
-				const { startingIndexedCount, totalCount } = summarizeValidationProgressCounts({
-					eligibleFileCount: vaultFiles.length,
-					pendingFileCount,
-					validPendingFileCount: validFileCount,
+			let outcome: BulkEmbedOutcome;
+			try {
+				outcome = await this.embedFilesInBatches(inst, embeddings, defaultModel, filesToIndex, {
+					startingIndexedCount,
+					preFilterSkipped: 0,
+					// A stale note is re-indexed with a possibly different chunk count;
+					// its old chunks go first.
+					purgeExisting: true,
+					notice,
 				});
-				let indexed = 0;
-				// Progress is tracked in files (matching `total`), not chunks: a note is
-				// counted once its final chunk is written, so a multi-chunk note advances
-				// the bar by one, keeping `indexed <= total` and the ETA well-defined.
-				const indexedValidationPaths = new Set<string>();
-				const noteValidated = (path: string) => {
-					if (indexedValidationPaths.has(path)) return;
-					indexedValidationPaths.add(path);
-					this.updateInstanceProgress(inst, {
-						indexed: startingIndexedCount + indexedValidationPaths.size,
-					});
-				};
-				// `skipped` is likewise counted in files (starting from the pre-filter
-				// count) so it stays comparable with `total`/`indexed`; a note failing
-				// any chunk is counted once.
-				const skippedValidationPaths = new Set<string>();
-				const noteSkipped = (path: string) => {
-					if (skippedValidationPaths.has(path)) return;
-					skippedValidationPaths.add(path);
-					this.updateInstanceProgress(inst, {
-						skipped: preFilterSkipped + skippedValidationPaths.size,
-					});
-				};
-				const showNotice = validFileCount > 5;
-				let notice: Notice | null = null;
-				if (showNotice) {
-					notice = new Notice("", 0);
-				}
-
-				this.updateInstanceProgress(inst, {
-					isIndexing: true,
-					total: totalCount,
-					indexed: startingIndexedCount,
-					skipped: preFilterSkipped,
-					currentFile: null,
-				});
-				if (notice) this.updateNotice(notice, inst.progress);
-				inst.abortController = new AbortController();
-
-				// A note may have been indexed previously (stale re-index) with a
-				// different chunk count; drop its old chunks before writing new ones.
-				const purgedPaths = new Set<string>();
-				const purgeIfNeeded = async (entry: ChunkEntry) => {
-					if (entry.chunkIndex === 0 && !purgedPaths.has(entry.file.path)) {
-						await inst.store.remove(entry.file.path);
-						purgedPaths.add(entry.file.path);
-					}
-				};
-
-				// Consecutive transport-level failures. Reset on any success, so a
-				// flaky connection that recovers does not accumulate toward the limit.
-				let consecutiveUnreachable = 0;
-
-				for (let i = 0; i < validChunks.length; i += batchSize) {
-					if (inst.abortController?.signal.aborted) {
-						Logger.log(`[VectorStore] Validation indexing cancelled for ${inst.indexId}`);
-						break;
-					}
-
-					const batch = validChunks.slice(i, i + batchSize);
-
-					this.updateInstanceProgress(inst, {
-						currentFile:
-							batch.length === 1
-								? batch[0].file.path
-								: `Embedding batch ${Math.floor(i / batchSize) + 1}...`,
-					});
-
-					try {
-						const texts = batch.map((entry) => entry.embedText);
-						const vectors = await this.embedWithCancellation(inst, embeddings.embedDocuments(texts));
-						// The run may have been aborted (e.g. index deleted) while the
-						// embedding call was in flight; bail before writing to a store
-						// that could now be closed.
-						if (inst.abortController?.signal.aborted) break;
-						// The connection answered, so any earlier failure was transient.
-						consecutiveUnreachable = 0;
-						if (!vectors || vectors.length === 0) {
-							Logger.error(`[VectorStore] embedDocuments returned empty result for ${inst.indexId}`);
-							for (const entry of batch) noteSkipped(entry.file.path);
-							continue;
-						}
-						for (let j = 0; j < batch.length; j++) {
-							if (!vectors[j]) {
-								Logger.error(`[VectorStore] Empty vector for ${batch[j].file.path}`);
-								continue;
-							}
-							const entry = batch[j];
-							await purgeIfNeeded(entry);
-							const doc: DocumentVector = {
-								id: makeChunkId(entry.file.path, entry.chunkIndex),
-								path: entry.file.path,
-								mtime: entry.file.stat.mtime,
-								checksum: entry.checksum,
-								chunkIndex: entry.chunkIndex,
-								vector: new Float32Array(vectors[j]),
-							};
-							await inst.store.upsert(doc);
-							if (entry.chunkIndex === entry.chunkCount - 1) noteValidated(entry.file.path);
-						}
-						indexed += batch.length;
-						if (notice) this.updateNotice(notice, inst.progress);
-					} catch (error) {
-						// A cancelled batch must not fall through to the per-entry retry
-						// below: that would re-issue every request in the batch against a
-						// provider the user just asked us to stop talking to.
-						if (this.isUserCancellation(error)) break;
-						Logger.error("[VectorStore] Batch validation indexing failed:", error);
-						// A transport failure will hit every remaining chunk the same way,
-						// so retrying this batch entry-by-entry is pure waste. Give the
-						// connection one more chance, then stop the whole run.
-						if (this.isProviderUnreachable(error)) {
-							consecutiveUnreachable++;
-							if (this.abortForUnreachableProvider(inst, error, consecutiveUnreachable)) break;
-							// Account for the batch before skipping the per-entry retry.
-							// Without this the notes silently vanish from the index while
-							// the run still reports success.
-							for (const entry of batch) noteSkipped(entry.file.path);
-							continue;
-						}
-						consecutiveUnreachable = 0;
-						for (const entry of batch) {
-							if (inst.abortController?.signal.aborted) break;
-							try {
-								const vector = await this.embedWithCancellation(
-									inst,
-									embeddings.embedQuery(entry.embedText),
-								);
-								if (!vector || vector.length === 0) {
-									Logger.error(
-										`[VectorStore] embedQuery returned empty result for ${entry.file.path}`,
-									);
-									noteSkipped(entry.file.path);
-									continue;
-								}
-								await purgeIfNeeded(entry);
-								const doc: DocumentVector = {
-									id: makeChunkId(entry.file.path, entry.chunkIndex),
-									path: entry.file.path,
-									mtime: entry.file.stat.mtime,
-									checksum: entry.checksum,
-									chunkIndex: entry.chunkIndex,
-									vector: new Float32Array(vector),
-								};
-								await inst.store.upsert(doc);
-								indexed++;
-								if (entry.chunkIndex === entry.chunkCount - 1) noteValidated(entry.file.path);
-							} catch (entryError) {
-								// Cancellation is not a per-file failure. Without this guard,
-								// aborting mid-batch fires one error Notice per remaining
-								// file and buries the "cancelled" message under them.
-								if (this.isUserCancellation(entryError)) throw entryError;
-								Logger.error(`[VectorStore] Failed to index ${entry.file.path}:`, entryError);
-								const reason = entryError instanceof Error ? entryError.message : String(entryError);
-								new Notice(`Failed to embed ${entry.file.basename}: ${reason}`);
-								noteSkipped(entry.file.path);
-							}
-						}
-						if (notice) this.updateNotice(notice, inst.progress);
-					}
-				}
-
-				if (notice) {
-					const cancelled = inst.abortController?.signal.aborted;
-					notice.setMessage(
-						cancelled
-							? `Indexing cancelled (${indexed} chunks updated)`
-							: `✓ Index updated: ${indexed} chunks`,
-					);
-					setTimeout(() => notice.hide(), 3000);
-				}
-
+			} catch (error) {
+				// An unexpected abort (not a per-file failure) — don't leave a stuck
+				// notice behind on top of whatever surfaced the error.
+				notice?.hide();
+				throw error;
+			} finally {
 				inst.abortController = null;
 				this.updateInstanceProgress(inst, { isIndexing: false, currentFile: null });
-				Logger.log(`[VectorStore] Indexed ${indexed} chunks for ${inst.indexId}`);
-			} // end else (validChunks.length > 0)
+			}
+			cancelled = outcome.cancelled;
+
+			if (notice) {
+				notice.setMessage(
+					cancelled
+						? `Indexing cancelled (${outcome.indexedChunks} chunks updated)`
+						: `✓ Index updated: ${outcome.indexedChunks} chunks`,
+				);
+				setTimeout(() => notice.hide(), 3000);
+			}
+			Logger.log(`[VectorStore] Indexed ${outcome.indexedChunks} chunks for ${inst.indexId}`);
 		}
 
 		// Sync document count to pluginData for reactive UI updates. Skip when the
 		// run was aborted (e.g. the index was deleted mid-build) since the store
 		// may have been closed out from under us.
-		if (!inst.abortController?.signal.aborted && this.instances.has(inst.indexId)) {
+		if (!cancelled && this.instances.has(inst.indexId)) {
 			const noteCount = await inst.store.countNotes();
 			getData().updateEmbeddingIndexStats(inst.indexId, { documentCount: noteCount });
 		}
@@ -1205,7 +1128,9 @@ export class VectorStoreService {
 			await this.buildFullIndex(inst, embeddings, model);
 			inst.hasValidatedThisSession = true;
 		} else if (!inst.hasValidatedThisSession) {
-			this.validateIndexCompleteness(inst, embeddings, model);
+			// Not awaited: the search proceeds on the stored index while the catch-up
+			// runs after the platform's bulk start delay (immediate on desktop).
+			this.scheduleValidation(inst);
 		}
 
 		return true;
@@ -1333,14 +1258,15 @@ export class VectorStoreService {
 	}
 
 	/**
-	 * Build the full index for a specific instance.
+	 * Build the full index for a specific instance. The store has been cleared
+	 * (or is empty) when this is called, so chunks are written without purging.
 	 */
 	private async buildFullIndex(
 		inst: IndexInstance,
 		embeddings: EmbeddingsInterface,
 		model: DefaultEmbedModel,
 	): Promise<void> {
-		if (inst.isIndexing) {
+		if (inst.isIndexing || inst.progress.isIndexing) {
 			new Notice("Indexing already in progress...");
 			return;
 		}
@@ -1349,7 +1275,6 @@ export class VectorStoreService {
 		inst.abortController = new AbortController();
 		const { vault } = this.plugin.app;
 		const allFiles = getEmbeddableVaultFiles(vault);
-		const batchSize = this.getBatchSize(inst.indexId, model.provider);
 
 		// Categorize files by skip reason
 		const files: TFile[] = [];
@@ -1362,7 +1287,7 @@ export class VectorStoreService {
 				files.push(file);
 			}
 		}
-		const indexedFiles: string[] = [];
+		const report: BulkEmbedReport = { indexedFiles: [], skippedFiles };
 
 		this.updateInstanceProgress(inst, {
 			isIndexing: true,
@@ -1380,188 +1305,23 @@ export class VectorStoreService {
 		try {
 			await inst.store.setMetadata(model.provider, model.model, INDEX_VERSION);
 
-			this.updateInstanceProgress(inst, { currentFile: "Reading files..." });
-			this.updateNotice(notice, inst.progress);
-
-			interface ChunkEntry {
-				file: TFile;
-				chunkIndex: number;
-				checksum: string;
-				embedText: string;
-			}
-
-			const validChunks: ChunkEntry[] = [];
-			let validFileCount = 0;
-			const maxContentLength = await this.getMaxEmbeddingContentLength(inst, model);
-
-			for (const file of files) {
-				try {
-					const content = await readIndexableContent(vault, file);
-					const checksum = this.hashContent(content);
-					const chunks = chunkText(content, file.basename, maxContentLength);
-					for (const chunk of chunks) {
-						validChunks.push({
-							file,
-							chunkIndex: chunk.chunkIndex,
-							checksum,
-							embedText: chunk.content,
-						});
-					}
-					validFileCount++;
-				} catch (error) {
-					Logger.error(`[VectorStore] Failed to read ${file.path}:`, error);
-					skippedFiles.push({ path: file.path, reason: "read-error" });
-					this.updateInstanceProgress(inst, { skipped: inst.progress.skipped + 1 });
-				}
-			}
-
-			// Progress is tracked per file; the store was cleared before this loop
-			// so chunks can be inserted directly without purging prior versions.
-			this.updateInstanceProgress(inst, { total: validFileCount });
-			this.updateNotice(notice, inst.progress);
-			const indexedPaths = new Set<string>();
-			const noteIndexed = (path: string) => {
-				if (!indexedPaths.has(path)) {
-					indexedPaths.add(path);
-					indexedFiles.push(path);
-					this.updateInstanceProgress(inst, { indexed: indexedPaths.size });
-				}
-			};
-			// Track in-loop skips per distinct file so `skipped` stays in the same
-			// (file) units as `total`/`indexed`; a note failing any chunk is counted
-			// once. Starts from the pre-filter skip count captured above.
-			const preFilterSkippedCount = skippedFiles.length;
-			const skippedPaths = new Set<string>();
-			const noteSkipped = (path: string, reason: SkipReason) => {
-				skippedFiles.push({ path, reason });
-				if (!skippedPaths.has(path)) {
-					skippedPaths.add(path);
-					this.updateInstanceProgress(inst, { skipped: preFilterSkippedCount + skippedPaths.size });
-				}
-			};
-
-			// Consecutive transport-level failures; see the validation loop.
-			let consecutiveUnreachable = 0;
-
-			for (let i = 0; i < validChunks.length; i += batchSize) {
-				if (inst.abortController?.signal.aborted) {
-					Logger.log(`[VectorStore] Indexing cancelled for ${inst.indexId}`);
-					break;
-				}
-
-				const batch = validChunks.slice(i, i + batchSize);
-
-				this.updateInstanceProgress(inst, {
-					currentFile:
-						batch.length === 1 ? batch[0].file.path : `Embedding batch ${Math.floor(i / batchSize) + 1}...`,
-				});
-				this.updateNotice(notice, inst.progress);
-
-				try {
-					const texts = batch.map((entry) => entry.embedText);
-					const vectors = await this.embedWithCancellation(inst, embeddings.embedDocuments(texts));
-					// The run may have been aborted (e.g. index deleted) while the
-					// embedding call was in flight; bail before writing to a store
-					// that could now be closed.
-					if (inst.abortController?.signal.aborted) break;
-					// The connection answered, so any earlier failure was transient.
-					consecutiveUnreachable = 0;
-					if (!vectors || vectors.length === 0) {
-						Logger.error(`[VectorStore] embedDocuments returned empty result for ${inst.indexId}`);
-						for (const entry of batch) noteSkipped(entry.file.path, "embed-error");
-						this.updateNotice(notice, inst.progress);
-						continue;
-					}
-
-					for (let j = 0; j < batch.length; j++) {
-						if (!vectors[j]) {
-							Logger.error(`[VectorStore] Empty vector for ${batch[j].file.path}`);
-							noteSkipped(batch[j].file.path, "embed-error");
-							continue;
-						}
-						const entry = batch[j];
-						const doc: DocumentVector = {
-							id: makeChunkId(entry.file.path, entry.chunkIndex),
-							path: entry.file.path,
-							mtime: entry.file.stat.mtime,
-							checksum: entry.checksum,
-							chunkIndex: entry.chunkIndex,
-							vector: new Float32Array(vectors[j]),
-						};
-						await inst.store.upsert(doc);
-						noteIndexed(entry.file.path);
-					}
-
-					this.updateNotice(notice, inst.progress);
-				} catch (error) {
-					// See the matching guard in the validation loop: a cancelled batch
-					// must not fall through to the sequential retry.
-					if (this.isUserCancellation(error)) break;
-					Logger.warn(
-						`[VectorStore] Batch ${Math.floor(i / batchSize) + 1} failed, falling back to sequential:`,
-						error,
-					);
-					// Transport failure: the sequential retry below would hit the same
-					// dead connection once per chunk. Allow one retry, then stop.
-					if (this.isProviderUnreachable(error)) {
-						consecutiveUnreachable++;
-						if (this.abortForUnreachableProvider(inst, error, consecutiveUnreachable)) break;
-						// Account for the batch before skipping the per-entry retry, so
-						// the notes are reported as skipped rather than silently dropped
-						// from a run that still claims success.
-						for (const entry of batch) noteSkipped(entry.file.path, "embed-error");
-						continue;
-					}
-					consecutiveUnreachable = 0;
-
-					for (const entry of batch) {
-						if (inst.abortController?.signal.aborted) break;
-						try {
-							const vector = await this.embedWithCancellation(
-								inst,
-								embeddings.embedQuery(entry.embedText),
-							);
-							if (!vector || vector.length === 0) {
-								Logger.error(`[VectorStore] embedQuery returned empty result for ${entry.file.path}`);
-								noteSkipped(entry.file.path, "embed-error");
-								continue;
-							}
-							const doc: DocumentVector = {
-								id: makeChunkId(entry.file.path, entry.chunkIndex),
-								path: entry.file.path,
-								mtime: entry.file.stat.mtime,
-								checksum: entry.checksum,
-								chunkIndex: entry.chunkIndex,
-								vector: new Float32Array(vector),
-							};
-							await inst.store.upsert(doc);
-							noteIndexed(entry.file.path);
-						} catch (entryError) {
-							// See the matching guard in the validation loop: cancellation
-							// must not be reported as a per-file embedding failure.
-							if (this.isUserCancellation(entryError)) throw entryError;
-							Logger.error(`[VectorStore] Failed to index ${entry.file.path}:`, entryError);
-							const reason = entryError instanceof Error ? entryError.message : String(entryError);
-							new Notice(`Failed to embed ${entry.file.basename}: ${reason}`);
-							noteSkipped(entry.file.path, "embed-error");
-						}
-					}
-					this.updateNotice(notice, inst.progress);
-				}
-			}
+			const { cancelled } = await this.embedFilesInBatches(inst, embeddings, model, files, {
+				startingIndexedCount: 0,
+				preFilterSkipped: skippedFiles.length,
+				purgeExisting: false,
+				notice,
+				report,
+			});
 
 			// Save the indexing report
-			inst.report = { indexedFiles, skippedFiles, timestamp: Date.now() };
-
-			const cancelled = inst.abortController?.signal.aborted;
+			inst.report = { ...report, timestamp: Date.now() };
 
 			// A cancelled run may have had its store torn down (e.g. index deleted
 			// mid-build); skip the post-run store read/stats update in that case.
 			if (!cancelled) {
 				// Update cached stats in plugin data using the distinct-note count
 				const noteCount = await inst.store.countNotes();
-				const data = getData();
-				data.updateEmbeddingIndexStats(inst.indexId, {
+				getData().updateEmbeddingIndexStats(inst.indexId, {
 					lastBuiltAt: Date.now(),
 					documentCount: noteCount,
 				});
@@ -1569,18 +1329,275 @@ export class VectorStoreService {
 
 			const { indexed, skipped } = inst.progress;
 			const skippedText = skipped > 0 ? `, ${skipped} skipped` : "";
-			const noticeMessage = cancelled
-				? `Indexing cancelled (${indexed} notes indexed so far)`
-				: `✓ Indexed ${indexed} notes${skippedText}`;
-			notice.setMessage(noticeMessage);
+			notice.setMessage(
+				cancelled
+					? `Indexing cancelled (${indexed} notes indexed so far)`
+					: `✓ Indexed ${indexed} notes${skippedText}`,
+			);
 			setTimeout(() => notice.hide(), 3000);
 
 			Logger.log(`[VectorStore] Full index complete for ${inst.indexId}: ${indexed} indexed, ${skipped} skipped`);
+		} catch (error) {
+			notice.hide();
+			throw error;
 		} finally {
 			inst.isIndexing = false;
 			inst.abortController = null;
 			this.updateInstanceProgress(inst, { isIndexing: false, currentFile: null });
 		}
+	}
+
+	/**
+	 * Embed `files` into `inst`: the one bulk loop behind both the full build and
+	 * the startup validation (they used to be near-identical copies). Paced and
+	 * checkpointed the way the lexical build is — the constants and the
+	 * measurements behind them live in `bulkPacing.ts`:
+	 *
+	 * - Files are read one at a time as the next batch fills, cheap text first and
+	 *   PDFs last (`orderForBulkIndexing`), so the corpus text is never resident
+	 *   all at once. The previous pre-read held every note's content before the
+	 *   first embedding call — on the reference vault, the whole vault as strings.
+	 * - After every embedding batch the loop pauses (a real pause on mobile, a
+	 *   bare yield on desktop) so the WebView's GC keeps up.
+	 * - Every `upsert` is durable on its own; every {@link BULK_CHECKPOINT_INTERVAL}
+	 *   notes the graph topology is flushed too. A kill mid-run therefore costs at
+	 *   most one interval of re-linking on the next open (`HNSWVectorStore.loadGraph`),
+	 *   and the next validation resumes from what is stored — it compares per-note
+	 *   mtimes and only embeds what is missing or stale — instead of starting over.
+	 * - The crash marker is set before the first read and cleared when the run
+	 *   survives (completed or user-cancelled), so a run the OS killed lengthens
+	 *   the next scheduled start (`BulkAttemptMarker`).
+	 *
+	 * The caller owns `inst.abortController` (set before, cleared after) and the
+	 * surrounding progress state; this reports per-note `indexed`/`skipped`.
+	 */
+	private async embedFilesInBatches(
+		inst: IndexInstance,
+		embeddings: EmbeddingsInterface,
+		model: DefaultEmbedModel,
+		files: TFile[],
+		options: BulkEmbedOptions,
+	): Promise<BulkEmbedOutcome> {
+		const { vault } = this.plugin.app;
+		const { notice, report } = options;
+		const batchSize = this.getBatchSize(inst.indexId, model.provider);
+		const maxContentLength = await this.getMaxEmbeddingContentLength(inst, model);
+		const ordered = orderForBulkIndexing(files);
+
+		// Progress is tracked in files (matching `total`), not chunks: a note is
+		// counted once its final chunk is written, so a multi-chunk note advances
+		// the bar by one, keeping `indexed <= total` and the ETA well-defined.
+		// `skipped` is likewise counted in files; a note failing any chunk counts once.
+		const indexedPaths = new Set<string>();
+		const skippedPaths = new Set<string>();
+		let indexedChunks = 0;
+		let notesSinceCheckpoint = 0;
+		let dimensionsRecorded = false;
+		const noteIndexed = (path: string) => {
+			if (indexedPaths.has(path)) return;
+			indexedPaths.add(path);
+			report?.indexedFiles.push(path);
+			notesSinceCheckpoint++;
+			this.updateInstanceProgress(inst, { indexed: options.startingIndexedCount + indexedPaths.size });
+		};
+		const noteSkipped = (path: string, reason: SkipReason) => {
+			report?.skippedFiles.push({ path, reason });
+			if (skippedPaths.has(path)) return;
+			skippedPaths.add(path);
+			this.updateInstanceProgress(inst, { skipped: options.preFilterSkipped + skippedPaths.size });
+		};
+		const refreshNotice = () => {
+			if (notice) this.updateNotice(notice, inst.progress);
+		};
+		const aborted = () => inst.abortController?.signal.aborted === true;
+
+		// A note may have been indexed previously (stale re-index) with a
+		// different chunk count; drop its old chunks before writing new ones.
+		const purgedPaths = new Set<string>();
+		const writeVector = async (entry: ChunkEntry, vector: number[]) => {
+			if (options.purgeExisting && !purgedPaths.has(entry.file.path)) {
+				await inst.store.remove(entry.file.path);
+				purgedPaths.add(entry.file.path);
+			}
+			if (!dimensionsRecorded) {
+				dimensionsRecorded = true;
+				this.recordDimensions(inst.indexId, vector.length);
+			}
+			const doc: DocumentVector = {
+				id: makeChunkId(entry.file.path, entry.chunkIndex),
+				path: entry.file.path,
+				mtime: entry.file.stat.mtime,
+				checksum: entry.checksum,
+				chunkIndex: entry.chunkIndex,
+				vector: new Float32Array(vector),
+			};
+			await inst.store.upsert(doc);
+			indexedChunks++;
+			if (entry.chunkIndex === entry.chunkCount - 1) noteIndexed(entry.file.path);
+		};
+
+		// Consecutive transport-level failures. Reset on any success, so a flaky
+		// connection that recovers does not accumulate toward the limit.
+		let consecutiveUnreachable = 0;
+		let batchNumber = 0;
+
+		/** Embed and store one batch. Resolves false when the run must stop. */
+		const embedBatch = async (batch: ChunkEntry[]): Promise<boolean> => {
+			batchNumber++;
+			this.updateInstanceProgress(inst, {
+				currentFile: batch.length === 1 ? batch[0].file.path : `Embedding batch ${batchNumber}...`,
+			});
+			refreshNotice();
+
+			try {
+				const texts = batch.map((entry) => entry.embedText);
+				const vectors = await this.embedWithCancellation(inst, embeddings.embedDocuments(texts));
+				// The run may have been aborted (e.g. index deleted) while the
+				// embedding call was in flight; bail before writing to a store
+				// that could now be closed.
+				if (aborted()) return false;
+				// The connection answered, so any earlier failure was transient.
+				consecutiveUnreachable = 0;
+				if (!vectors || vectors.length === 0) {
+					Logger.error(`[VectorStore] embedDocuments returned empty result for ${inst.indexId}`);
+					for (const entry of batch) noteSkipped(entry.file.path, "embed-error");
+					return true;
+				}
+				for (let j = 0; j < batch.length; j++) {
+					if (!vectors[j]) {
+						Logger.error(`[VectorStore] Empty vector for ${batch[j].file.path}`);
+						noteSkipped(batch[j].file.path, "embed-error");
+						continue;
+					}
+					await writeVector(batch[j], vectors[j]);
+				}
+				return true;
+			} catch (error) {
+				// A cancelled batch must not fall through to the per-entry retry
+				// below: that would re-issue every request in the batch against a
+				// provider the user just asked us to stop talking to.
+				if (this.isUserCancellation(error)) return false;
+				Logger.warn(`[VectorStore] Batch ${batchNumber} failed, falling back to sequential:`, error);
+				// A transport failure will hit every remaining chunk the same way,
+				// so retrying this batch entry-by-entry is pure waste. Give the
+				// connection one more chance, then stop the whole run.
+				if (this.isProviderUnreachable(error)) {
+					consecutiveUnreachable++;
+					if (this.abortForUnreachableProvider(inst, error, consecutiveUnreachable)) return false;
+					// Account for the batch before skipping the per-entry retry, so
+					// the notes are reported as skipped rather than silently dropped
+					// from a run that still claims success.
+					for (const entry of batch) noteSkipped(entry.file.path, "embed-error");
+					return true;
+				}
+				consecutiveUnreachable = 0;
+
+				for (const entry of batch) {
+					if (aborted()) return false;
+					try {
+						const vector = await this.embedWithCancellation(inst, embeddings.embedQuery(entry.embedText));
+						if (!vector || vector.length === 0) {
+							Logger.error(`[VectorStore] embedQuery returned empty result for ${entry.file.path}`);
+							noteSkipped(entry.file.path, "embed-error");
+							continue;
+						}
+						await writeVector(entry, vector);
+					} catch (entryError) {
+						// Cancellation is not a per-file failure. Without this guard,
+						// aborting mid-batch fires one error Notice per remaining
+						// file and buries the "cancelled" message under them.
+						if (this.isUserCancellation(entryError)) return false;
+						Logger.error(`[VectorStore] Failed to index ${entry.file.path}:`, entryError);
+						const reason = entryError instanceof Error ? entryError.message : String(entryError);
+						new Notice(`Failed to embed ${entry.file.basename}: ${reason}`);
+						noteSkipped(entry.file.path, "embed-error");
+					}
+				}
+				return true;
+			}
+		};
+
+		/** Pacing after a batch: a checkpoint every interval of notes, a GC pause otherwise. */
+		const afterBatch = async (): Promise<void> => {
+			refreshNotice();
+			if (notesSinceCheckpoint >= BULK_CHECKPOINT_INTERVAL) {
+				notesSinceCheckpoint = 0;
+				await inst.store.flush();
+				await bulkPause(bulkCheckpointPauseMs());
+			} else {
+				await bulkPause(bulkBatchPauseMs());
+			}
+		};
+
+		// Mark the attempt before the first read; cleared below only when the run
+		// survives. See BulkAttemptMarker for why this drives the start backoff.
+		this.bulkAttempts.markAttempt();
+		let pending: ChunkEntry[] = [];
+		let stopped = false;
+
+		for (const file of ordered) {
+			if (aborted()) {
+				stopped = true;
+				break;
+			}
+			try {
+				const content = await readIndexableContent(vault, file);
+				const checksum = this.hashContent(content);
+				const chunks = chunkText(content, file.basename, maxContentLength);
+				for (const chunk of chunks) {
+					pending.push({
+						file,
+						chunkIndex: chunk.chunkIndex,
+						chunkCount: chunks.length,
+						checksum,
+						embedText: chunk.content,
+					});
+				}
+			} catch (error) {
+				Logger.error(`[VectorStore] Failed to read ${file.path}:`, error);
+				// An unreadable note leaves the run entirely: it is skipped, and
+				// `total` shrinks with it so the bar can still reach 100%.
+				this.updateInstanceProgress(inst, { total: Math.max(0, inst.progress.total - 1) });
+				noteSkipped(file.path, "read-error");
+				continue;
+			}
+
+			while (pending.length >= batchSize) {
+				const batch = pending.splice(0, batchSize);
+				if (!(await embedBatch(batch))) {
+					stopped = true;
+					break;
+				}
+				await afterBatch();
+			}
+			if (stopped) break;
+		}
+
+		if (!stopped && pending.length > 0) {
+			if (await embedBatch(pending)) await afterBatch();
+		}
+		pending = [];
+
+		const cancelled = aborted();
+		if (stopped && !cancelled) {
+			Logger.log(`[VectorStore] Bulk embedding for ${inst.indexId} stopped early`);
+		} else if (cancelled) {
+			Logger.log(`[VectorStore] Indexing cancelled for ${inst.indexId}`);
+		}
+		// Final checkpoint. The store may already be closed if the run was cancelled
+		// because the index was deleted; that is not a failure of this run.
+		if (this.instances.get(inst.indexId) === inst) {
+			try {
+				await inst.store.flush();
+			} catch (error) {
+				Logger.warn(`[VectorStore] Final graph flush for ${inst.indexId} failed:`, error);
+			}
+		}
+		// The run survived (a user cancel is not a crash); only an OS kill — or an
+		// error thrown past this point — leaves the marker in place.
+		this.bulkAttempts.clear();
+
+		return { indexedChunks, cancelled };
 	}
 
 	/**

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -332,11 +332,23 @@ export function summarizeValidationProgressCounts({
 	};
 }
 
+/**
+ * Write order for a note's chunks: everything after chunk 0 first, chunk 0
+ * last. `VectorStore.listNoteMeta` reports a note as indexed only through its
+ * chunk-0 row, so writing that row last turns "all chunks stored" into a single
+ * durable fact — a process killed part-way through a multi-chunk note leaves
+ * rows that validation treats as absent and re-indexes, instead of chunks that
+ * carry the current mtime and make the note look complete for good.
+ */
+export function orderChunksForWriting<T>(chunks: readonly T[]): T[] {
+	if (chunks.length <= 1) return [...chunks];
+	return [...chunks.slice(1), chunks[0]];
+}
+
 /** One chunk of a note queued for embedding. */
 interface ChunkEntry {
 	file: TFile;
 	chunkIndex: number;
-	chunkCount: number;
 	checksum: string;
 	embedText: string;
 }
@@ -1433,7 +1445,8 @@ export class VectorStoreService {
 			};
 			await inst.store.upsert(doc);
 			indexedChunks++;
-			if (entry.chunkIndex === entry.chunkCount - 1) noteIndexed(entry.file.path);
+			// Chunk 0 is written last (see `orderChunksForWriting`), so its write completes the note.
+			if (entry.chunkIndex === 0) noteIndexed(entry.file.path);
 		};
 
 		// Consecutive transport-level failures. Reset on any success, so a flaky
@@ -1544,11 +1557,10 @@ export class VectorStoreService {
 				const content = await readIndexableContent(vault, file);
 				const checksum = this.hashContent(content);
 				const chunks = chunkText(content, file.basename, maxContentLength);
-				for (const chunk of chunks) {
+				for (const chunk of orderChunksForWriting(chunks)) {
 					pending.push({
 						file,
 						chunkIndex: chunk.chunkIndex,
-						chunkCount: chunks.length,
 						checksum,
 						embedText: chunk.content,
 					});
@@ -1688,9 +1700,10 @@ export class VectorStoreService {
 				vectors.push(new Float32Array(vector));
 			}
 
-			// Replace any prior version's chunks, then write the new ones.
+			// Replace any prior version's chunks, then write the new ones — chunk 0
+			// last, so the note only reads as indexed once every chunk is stored.
 			await inst.store.remove(file.path);
-			for (let i = 0; i < chunks.length; i++) {
+			for (const i of orderChunksForWriting(chunks.map((_, index) => index))) {
 				const doc: DocumentVector = {
 					id: makeChunkId(file.path, chunks[i].chunkIndex),
 					path: file.path,

--- a/src/vectorstore/embeddingMemoryHint.ts
+++ b/src/vectorstore/embeddingMemoryHint.ts
@@ -1,0 +1,17 @@
+/**
+ * Vector width from which an index's resident memory becomes a concern on a
+ * phone. At 1024+ dimensions a 20k-chunk index is ~80–120 MB of vectors alone
+ * (Float32), on top of the WebContent process's ~1 GB baseline on the
+ * reference vault; a 384-dim model is a quarter of that.
+ */
+export const LARGE_EMBEDDING_DIMENSIONS = 1024;
+
+/**
+ * Settings hint for a mobile user whose selected model produces wide vectors,
+ * or `null` when no hint applies (unknown width, or a small model). Phrased as
+ * a hint, not a warning — the index works, it just costs memory.
+ */
+export function largeDimensionHint(model: string, dimensions: number | undefined): string | null {
+	if (dimensions === undefined || dimensions < LARGE_EMBEDDING_DIMENSIONS) return null;
+	return `${model} produces ${dimensions}-dimensional vectors. On a phone the loaded index costs memory in proportion; a small model (384 or 768 dimensions) keeps it at a fraction of that.`;
+}

--- a/src/vectorstore/hnswWorker.ts
+++ b/src/vectorstore/hnswWorker.ts
@@ -110,6 +110,10 @@ globalThis.onmessage = async (e: MessageEvent<HNSWWorkerRequest>) => {
 				result = await requireStore().bulkPut(args[0] as DocumentVector[]);
 				break;
 			}
+			case "flush": {
+				result = await requireStore().flush();
+				break;
+			}
 			case "clear": {
 				result = await requireStore().clear();
 				break;

--- a/src/vectorstore/orphanedDatabases.ts
+++ b/src/vectorstore/orphanedDatabases.ts
@@ -1,0 +1,270 @@
+/**
+ * Orphaned vector databases (#432, step 5).
+ *
+ * Vector databases are keyed by `provider:model` (`getDbName`) and deliberately
+ * survive provider/config deletion — only an explicit "delete index" destroys
+ * them. Every abandoned model therefore leaves its whole vector set behind; the
+ * reference device carried ~3 GB of IndexedDB, largely such leftovers. This
+ * module enumerates this vault's vector databases, diffs them against the
+ * configured indexes, and deletes the orphans on request.
+ *
+ * Ownership is not decided by name prefix alone. Database names are
+ * `s2b-hnsw-<vaultSlug>-<provider_model>` and a slug may be a prefix of another
+ * vault's slug on the same origin ("notes" / "notes-archive"), so a candidate is
+ * only attributed to this vault when the provider/model recorded *inside* it
+ * reproduces the candidate's exact name. A database that cannot be attributed is
+ * left alone: deleting a neighbouring vault's live index would be far worse
+ * than leaving a stray shell behind.
+ */
+
+import { Logger } from "../utils/logging";
+import { type DeleteDatabaseResult, deleteDatabase, getDbName } from "./types";
+
+/** Prefix shared by every HNSW vector database (`HNSWVectorStore`'s `DB_NAME_PREFIX`). */
+export const HNSW_DB_PREFIX = "s2b-hnsw";
+
+/**
+ * Suffix of the pre-schema-v3 sidecar database the `hnsw` library owned. Since
+ * v3 the graph lives in the main database and the sidecar is deleted on
+ * upgrade, but an index that was never reopened since still carries one — and
+ * it is the largest single object on disk (every vector, as doubles).
+ */
+export const LEGACY_SIDECAR_SUFFIX = "-hnsw-index";
+
+export interface OrphanedDatabase {
+	name: string;
+	/** A whole index for a model no longer configured, or a legacy graph sidecar. */
+	kind: "index" | "legacy-sidecar";
+	/** `provider:model` recorded inside the database (indexes only). */
+	indexId?: string;
+	/** Stored chunk rows (indexes only). */
+	chunkCount?: number;
+	/** Vector width (indexes only; 0 when the index was never written to). */
+	dimensions?: number;
+	/**
+	 * Raw vector payload, `chunkCount × dimensions × 4` bytes. A lower bound:
+	 * row keys, indexes and IndexedDB's own overhead come on top, and per-database
+	 * sizes are not exposed by any browser API.
+	 */
+	estimatedBytes?: number;
+}
+
+/** The names `deleteIndex` would remove for a configured index: the database and its legacy sidecar. */
+export function databaseNamesForIndex(vaultId: string, indexId: string): [main: string, sidecar: string] {
+	const main = getDbName(HNSW_DB_PREFIX, vaultId, indexId);
+	return [main, `${main}${LEGACY_SIDECAR_SUFFIX}`];
+}
+
+/** Whether this runtime can enumerate databases at all (`indexedDB.databases()` is optional). */
+export function canEnumerateDatabases(): boolean {
+	return typeof indexedDB !== "undefined" && typeof indexedDB.databases === "function";
+}
+
+/** Metadata record as both the v2 and v3 stores wrote it; only these keys are read. */
+interface ProbedMetadata {
+	providerId?: unknown;
+	modelId?: unknown;
+	dimensions?: unknown;
+}
+
+interface ProbeResult {
+	indexId: string | null;
+	chunkCount: number;
+	dimensions: number;
+}
+
+/**
+ * Open an existing database read-only and read what identifies it: the
+ * metadata record and the document count. Resolves `null` when the database
+ * has no readable metadata (a shell that was created but never written, or a
+ * layout this code does not know).
+ *
+ * Opening without a version never triggers an upgrade on an existing database.
+ * The name comes from `databases()`, so it exists — but if it were deleted in
+ * the meantime the open would *create* it; the `upgradeneeded` handler aborts
+ * that so nothing new is ever written here.
+ */
+async function probeDatabase(name: string): Promise<ProbeResult | null> {
+	const db = await new Promise<IDBDatabase | null>((resolve) => {
+		let request: IDBOpenDBRequest;
+		try {
+			request = indexedDB.open(name);
+		} catch {
+			resolve(null);
+			return;
+		}
+		request.onupgradeneeded = (event) => {
+			(event.target as IDBOpenDBRequest).transaction?.abort();
+		};
+		request.onerror = () => resolve(null);
+		request.onblocked = () => resolve(null);
+		request.onsuccess = () => {
+			const opened = request.result;
+			// Never be the connection that blocks another window's upgrade.
+			opened.onversionchange = () => opened.close();
+			resolve(opened);
+		};
+	});
+	if (!db) return null;
+
+	try {
+		if (!db.objectStoreNames.contains("metadata") || !db.objectStoreNames.contains("documents")) return null;
+		return await new Promise<ProbeResult | null>((resolve, reject) => {
+			const tx = db.transaction(["metadata", "documents"], "readonly");
+			let meta: ProbedMetadata | undefined;
+			let chunkCount = 0;
+			tx.onerror = () => reject(tx.error);
+			tx.onabort = () => reject(tx.error ?? new Error("IndexedDB transaction aborted."));
+			tx.oncomplete = () => {
+				if (!meta) {
+					resolve(null);
+					return;
+				}
+				const providerId = typeof meta.providerId === "string" ? meta.providerId : null;
+				const modelId = typeof meta.modelId === "string" ? meta.modelId : null;
+				resolve({
+					indexId: providerId && modelId ? `${providerId}:${modelId}` : null,
+					chunkCount,
+					dimensions: typeof meta.dimensions === "number" && meta.dimensions > 0 ? meta.dimensions : 0,
+				});
+			};
+			const metaRequest = tx.objectStore("metadata").get("metadata");
+			metaRequest.onsuccess = () => {
+				meta = (metaRequest.result as ProbedMetadata | undefined) ?? undefined;
+			};
+			const countRequest = tx.objectStore("documents").count();
+			countRequest.onsuccess = () => {
+				chunkCount = countRequest.result;
+			};
+		});
+	} catch (error) {
+		Logger.warn(`[VectorStore] Could not read vector database "${name}":`, error);
+		return null;
+	} finally {
+		db.close();
+	}
+}
+
+/**
+ * This vault's vector databases that no configured index accounts for.
+ *
+ * Resolves `null` when the runtime cannot enumerate databases. Candidates are
+ * every database under this vault's name prefix; each is attributed to this
+ * vault by the provider/model stored inside it (see the module comment), and
+ * legacy sidecars are attributed through their main database. Configured
+ * indexes and unattributable databases are excluded.
+ */
+export async function listOrphanedVectorDatabases(
+	vaultId: string,
+	configuredIndexIds: Iterable<string>,
+): Promise<OrphanedDatabase[] | null> {
+	if (!canEnumerateDatabases()) return null;
+
+	let infos: IDBDatabaseInfo[];
+	try {
+		infos = (await indexedDB.databases()) ?? [];
+	} catch (error) {
+		Logger.warn("[VectorStore] indexedDB.databases() failed:", error);
+		return null;
+	}
+
+	const configured = new Set<string>();
+	for (const indexId of configuredIndexIds) configured.add(getDbName(HNSW_DB_PREFIX, vaultId, indexId));
+
+	const prefix = `${getDbName(HNSW_DB_PREFIX, vaultId)}-`;
+	const candidates = new Set<string>();
+	for (const info of infos) {
+		if (info.name?.startsWith(prefix)) candidates.add(info.name);
+	}
+
+	/** name → belongs to this vault (attributed), for main databases. */
+	const ownership = new Map<string, { owned: boolean; probe: ProbeResult | null }>();
+	const mains = [...candidates].filter((name) => !name.endsWith(LEGACY_SIDECAR_SUFFIX));
+	for (const name of mains) {
+		const probe = await probeDatabase(name);
+		const owned =
+			probe?.indexId !== null && probe !== null && getDbName(HNSW_DB_PREFIX, vaultId, probe.indexId) === name;
+		ownership.set(name, { owned, probe });
+	}
+
+	const orphans: OrphanedDatabase[] = [];
+	for (const name of [...candidates].sort()) {
+		if (name.endsWith(LEGACY_SIDECAR_SUFFIX)) {
+			// Attributed through the main database when it still exists. A sidecar
+			// whose main database is gone is a deletion that was blocked mid-way;
+			// under this vault's prefix it is treated as ours.
+			const main = name.slice(0, -LEGACY_SIDECAR_SUFFIX.length);
+			const mainOwnership = ownership.get(main);
+			if (mainOwnership && !mainOwnership.owned) continue;
+			orphans.push({ name, kind: "legacy-sidecar" });
+			continue;
+		}
+		if (configured.has(name)) continue;
+		const entry = ownership.get(name);
+		if (!entry?.owned || !entry.probe?.indexId) continue;
+		const { indexId, chunkCount, dimensions } = entry.probe;
+		orphans.push({
+			name,
+			kind: "index",
+			indexId,
+			chunkCount,
+			dimensions,
+			estimatedBytes: chunkCount * dimensions * 4,
+		});
+	}
+	return orphans;
+}
+
+export interface DeleteOrphansOutcome {
+	deleted: string[];
+	/** Name → why it is still there. */
+	failed: Array<{ name: string; reason: string }>;
+}
+
+/** Delete the given databases, reporting per-database outcomes; never throws. */
+export async function deleteOrphanedDatabases(names: string[]): Promise<DeleteOrphansOutcome> {
+	const outcome: DeleteOrphansOutcome = { deleted: [], failed: [] };
+	for (const name of names) {
+		const result: DeleteDatabaseResult = await deleteDatabase(name);
+		if (result.status === "deleted") {
+			outcome.deleted.push(name);
+		} else if (result.status === "blocked") {
+			outcome.failed.push({
+				name,
+				reason: "blocked by another open connection (close other Obsidian windows for this vault and try again)",
+			});
+		} else {
+			outcome.failed.push({ name, reason: result.error.message });
+		}
+	}
+	return outcome;
+}
+
+/**
+ * Storage used by this origin (all of Obsidian's IndexedDB for every vault on
+ * this device, not just ours), when the runtime reports it. Per-database
+ * figures are not available anywhere.
+ */
+export async function estimateOriginStorage(): Promise<{ usage: number; quota: number } | null> {
+	const storage = typeof navigator !== "undefined" ? navigator.storage : undefined;
+	if (!storage || typeof storage.estimate !== "function") return null;
+	try {
+		const { usage, quota } = await storage.estimate();
+		if (typeof usage !== "number") return null;
+		return { usage, quota: typeof quota === "number" ? quota : 0 };
+	} catch {
+		return null;
+	}
+}
+
+export function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	const units = ["KB", "MB", "GB"];
+	let value = bytes / 1024;
+	let unit = 0;
+	while (value >= 1024 && unit < units.length - 1) {
+		value /= 1024;
+		unit++;
+	}
+	return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}

--- a/src/vectorstore/orphanedDatabases.ts
+++ b/src/vectorstore/orphanedDatabases.ts
@@ -33,6 +33,8 @@ export const LEGACY_SIDECAR_SUFFIX = "-hnsw-index";
 
 export interface OrphanedDatabase {
 	name: string;
+	/** `name` without the vault prefix and sidecar suffix — the `provider_model` part, for display. */
+	label: string;
 	/** A whole index for a model no longer configured, or a legacy graph sidecar. */
 	kind: "index" | "legacy-sidecar";
 	/** `provider:model` recorded inside the database (indexes only). */
@@ -196,7 +198,7 @@ export async function listOrphanedVectorDatabases(
 			const main = name.slice(0, -LEGACY_SIDECAR_SUFFIX.length);
 			const mainOwnership = ownership.get(main);
 			if (mainOwnership && !mainOwnership.owned) continue;
-			orphans.push({ name, kind: "legacy-sidecar" });
+			orphans.push({ name, label: main.slice(prefix.length), kind: "legacy-sidecar" });
 			continue;
 		}
 		if (configured.has(name)) continue;
@@ -205,6 +207,7 @@ export async function listOrphanedVectorDatabases(
 		const { indexId, chunkCount, dimensions } = entry.probe;
 		orphans.push({
 			name,
+			label: name.slice(prefix.length),
 			kind: "index",
 			indexId,
 			chunkCount,

--- a/src/vectorstore/orphanedDatabases.ts
+++ b/src/vectorstore/orphanedDatabases.ts
@@ -153,8 +153,9 @@ async function probeDatabase(name: string): Promise<ProbeResult | null> {
  * Resolves `null` when the runtime cannot enumerate databases. Candidates are
  * every database under this vault's name prefix; each is attributed to this
  * vault by the provider/model stored inside it (see the module comment), and
- * legacy sidecars are attributed through their main database. Configured
- * indexes and unattributable databases are excluded.
+ * legacy sidecars are attributed through their main database (a sidecar with no
+ * main database cannot be attributed and stays). Configured indexes and
+ * unattributable databases are excluded.
  */
 export async function listOrphanedVectorDatabases(
 	vaultId: string,
@@ -192,12 +193,13 @@ export async function listOrphanedVectorDatabases(
 	const orphans: OrphanedDatabase[] = [];
 	for (const name of [...candidates].sort()) {
 		if (name.endsWith(LEGACY_SIDECAR_SUFFIX)) {
-			// Attributed through the main database when it still exists. A sidecar
-			// whose main database is gone is a deletion that was blocked mid-way;
-			// under this vault's prefix it is treated as ours.
+			// Attributed through the main database. A sidecar holds only the graph
+			// blob — nothing inside it says which vault it belongs to — so one whose
+			// main database is gone (a deletion that was blocked half-way) cannot
+			// be told apart from a neighbouring vault's and is left alone, like any
+			// other unattributable database.
 			const main = name.slice(0, -LEGACY_SIDECAR_SUFFIX.length);
-			const mainOwnership = ownership.get(main);
-			if (mainOwnership && !mainOwnership.owned) continue;
+			if (!ownership.get(main)?.owned) continue;
 			orphans.push({ name, label: main.slice(prefix.length), kind: "legacy-sidecar" });
 			continue;
 		}

--- a/src/vectorstore/types.ts
+++ b/src/vectorstore/types.ts
@@ -416,11 +416,13 @@ export interface VectorStore {
 	getDocumentMtime(path: string): Promise<number | undefined>;
 
 	/**
-	 * `{ path, mtime }` of every indexed note, one entry per note, read without
-	 * deserialising a single vector. This is the read to use for "what is
-	 * indexed, and is it stale" questions — there is deliberately no whole-set
-	 * `getAll()`: materialising every vector on the main thread is the memory
-	 * spike #432 removes.
+	 * `{ path, mtime }` of every *completely* indexed note, one entry per note,
+	 * read without deserialising a single vector. A note counts as indexed only
+	 * once its chunk-0 row exists; bulk writers store that row last, so a note
+	 * whose write was interrupted is reported as absent and gets re-indexed.
+	 * This is the read to use for "what is indexed, and is it stale" questions —
+	 * there is deliberately no whole-set `getAll()`: materialising every vector
+	 * on the main thread is the memory spike #432 removes.
 	 */
 	listNoteMeta(): Promise<NoteMeta[]>;
 

--- a/src/vectorstore/types.ts
+++ b/src/vectorstore/types.ts
@@ -76,6 +76,8 @@ export interface IndexMetadata {
 	modelId: string;
 	documentCount: number;
 	lastUpdated: number;
+	/** Vector width of the stored embeddings; 0 until the first vector is written. */
+	dimensions: number;
 }
 
 /**
@@ -446,6 +448,14 @@ export interface VectorStore {
 	 * `doc.vector` the same way `upsert` does.
 	 */
 	bulkPut(docs: DocumentVector[]): Promise<void>;
+
+	/**
+	 * Persist any in-memory index state that is still pending (the HNSW graph
+	 * topology, which `upsert` saves on a debounce). A bulk run calls this as
+	 * its checkpoint so a process kill loses at most one interval's worth of
+	 * graph links; no-op when nothing is pending.
+	 */
+	flush(): Promise<void>;
 
 	/**
 	 * Clear all documents from the store.

--- a/test/__mocks__/obsidian.ts
+++ b/test/__mocks__/obsidian.ts
@@ -147,6 +147,10 @@ export class Notice {
 	}
 
 	hide = vi.fn();
+	setMessage = vi.fn((message: string) => {
+		this.message = message;
+		return this;
+	});
 }
 
 export class PluginSettingTab {

--- a/test/search/bulkPacing.test.ts
+++ b/test/search/bulkPacing.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Platform } from "obsidian";
+
+import {
+	BulkAttemptMarker,
+	MOBILE_BULK_BASE_DELAY_MS,
+	MOBILE_BULK_MAX_DELAY_MS,
+	bulkBatchPauseMs,
+	bulkCheckpointPauseMs,
+	bulkStartDelayMs,
+	orderForBulkIndexing,
+	scheduleBulkRun,
+} from "../../src/search/bulkPacing";
+
+/*
+ * The pacing and crash-backoff shared by the lexical and embedding bulk
+ * indexers (#430, #432). The values encode on-device measurements; these tests
+ * pin the *shape* — mobile-only pauses, delay doubling per crashed attempt with
+ * a cap, marker set on start and cleared on completion — so a refactor cannot
+ * silently drop the backoff.
+ */
+
+function memoryStorage(): Storage {
+	const map = new Map<string, string>();
+	return {
+		getItem: (key: string) => map.get(key) ?? null,
+		setItem: (key: string, value: string) => void map.set(key, value),
+		removeItem: (key: string) => void map.delete(key),
+		clear: () => map.clear(),
+		key: () => null,
+		get length() {
+			return map.size;
+		},
+	} as Storage;
+}
+
+const platform = Platform as { isMobile: boolean };
+
+beforeEach(() => {
+	vi.stubGlobal("localStorage", memoryStorage());
+});
+
+afterEach(() => {
+	platform.isMobile = false;
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+describe("pauses", () => {
+	it("are real on mobile and bare yields on desktop", () => {
+		platform.isMobile = false;
+		expect(bulkBatchPauseMs()).toBe(0);
+		expect(bulkCheckpointPauseMs()).toBe(0);
+		platform.isMobile = true;
+		expect(bulkBatchPauseMs()).toBeGreaterThan(0);
+		expect(bulkCheckpointPauseMs()).toBeGreaterThan(bulkBatchPauseMs());
+	});
+});
+
+describe("bulkStartDelayMs", () => {
+	it("never delays on desktop, whatever the crash history", () => {
+		platform.isMobile = false;
+		expect(bulkStartDelayMs(0)).toBe(0);
+		expect(bulkStartDelayMs(5)).toBe(0);
+	});
+
+	it("doubles the mobile base delay per crashed attempt, capped", () => {
+		platform.isMobile = true;
+		expect(bulkStartDelayMs(0)).toBe(MOBILE_BULK_BASE_DELAY_MS);
+		expect(bulkStartDelayMs(1)).toBe(MOBILE_BULK_BASE_DELAY_MS * 2);
+		expect(bulkStartDelayMs(2)).toBe(MOBILE_BULK_BASE_DELAY_MS * 4);
+		expect(bulkStartDelayMs(20)).toBe(MOBILE_BULK_MAX_DELAY_MS);
+	});
+});
+
+describe("BulkAttemptMarker", () => {
+	it("keys per indexer and vault, counts attempts, and clears on completion", () => {
+		const marker = new BulkAttemptMarker("embedding", "vault-1");
+		expect(marker.read()).toBe(0);
+		marker.markAttempt();
+		expect(localStorage.getItem("s2b-embedding-bulk-attempts:vault-1")).toBe("1");
+		marker.markAttempt();
+		expect(marker.read()).toBe(2);
+		// A different indexer on the same vault backs off independently.
+		expect(new BulkAttemptMarker("lexical", "vault-1").read()).toBe(0);
+		marker.clear();
+		expect(marker.read()).toBe(0);
+		expect(localStorage.getItem("s2b-embedding-bulk-attempts:vault-1")).toBeNull();
+	});
+
+	it("treats garbage as no crashed attempts", () => {
+		localStorage.setItem("s2b-embedding-bulk-attempts:vault-1", "nope");
+		expect(new BulkAttemptMarker("embedding", "vault-1").read()).toBe(0);
+	});
+});
+
+describe("scheduleBulkRun", () => {
+	it("waits the backed-off delay on mobile before starting the work", async () => {
+		vi.useFakeTimers();
+		platform.isMobile = true;
+		const marker = new BulkAttemptMarker("embedding", "vault-1");
+		marker.markAttempt();
+		marker.markAttempt(); // two crashed attempts → 4× base delay
+
+		const work = vi.fn(async () => {});
+		scheduleBulkRun("Test", marker, work);
+
+		await vi.advanceTimersByTimeAsync(MOBILE_BULK_BASE_DELAY_MS * 4 - 1);
+		expect(work).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(1);
+		expect(work).toHaveBeenCalledTimes(1);
+	});
+
+	it("starts at once on desktop", async () => {
+		vi.useFakeTimers();
+		platform.isMobile = false;
+		const marker = new BulkAttemptMarker("embedding", "vault-1");
+		marker.markAttempt();
+		const work = vi.fn(async () => {});
+		scheduleBulkRun("Test", marker, work);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(work).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("orderForBulkIndexing", () => {
+	it("moves binary-extraction files (PDFs) after text files, keeping relative order", () => {
+		const file = (path: string, extension: string) => ({ path, extension }) as never;
+		const ordered = orderForBulkIndexing([
+			file("a.pdf", "pdf"),
+			file("b.md", "md"),
+			file("c.pdf", "pdf"),
+			file("d.md", "md"),
+		]);
+		expect(ordered.map((f: { path: string }) => f.path)).toEqual(["b.md", "d.md", "a.pdf", "c.pdf"]);
+	});
+});

--- a/test/vectorstore/HNSWVectorStore.resume.test.ts
+++ b/test/vectorstore/HNSWVectorStore.resume.test.ts
@@ -80,6 +80,35 @@ describe("HNSWVectorStore — resuming after an interrupted build", () => {
 		await second.close();
 	});
 
+	it("listNoteMeta omits a note whose chunk-0 row is missing (write interrupted mid-note)", async () => {
+		const store = await openForBuild();
+		// Bulk writers store chunk 0 last; a kill after chunk 1 leaves exactly this.
+		await store.upsert({
+			id: "big.md#1",
+			path: "big.md",
+			mtime: 5,
+			checksum: "c",
+			chunkIndex: 1,
+			vector: new Float32Array([0, 1]),
+		});
+		await store.upsert(doc("small.md", [1, 0]));
+
+		expect((await store.listNoteMeta()).map((n) => n.path)).toEqual(["small.md"]);
+		expect(await store.countNotes()).toBe(2);
+		expect(await store.count()).toBe(2);
+
+		await store.upsert({
+			id: "big.md#0",
+			path: "big.md",
+			mtime: 5,
+			checksum: "c",
+			chunkIndex: 0,
+			vector: new Float32Array([1, 1]),
+		});
+		expect((await store.listNoteMeta()).map((n) => n.path).sort()).toEqual(["big.md", "small.md"]);
+		await store.close();
+	});
+
 	it("flush() persists the pending graph immediately instead of on the debounce", async () => {
 		const first = await openForBuild();
 		await first.upsert(doc("a.md", [1, 0]));

--- a/test/vectorstore/HNSWVectorStore.resume.test.ts
+++ b/test/vectorstore/HNSWVectorStore.resume.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { IDBFactory, IDBKeyRange } from "fake-indexeddb";
+
+/*
+ * #432 part 2: a bulk embed run can be killed by the OS mid-build. Document
+ * rows are durable on every `upsert`, but the graph topology is saved on a
+ * debounce and at checkpoints (`flush`). Rows written after the last save used
+ * to be silently unsearchable after a reopen while still counting as indexed,
+ * so nothing ever repaired them. `loadGraph` now re-links such rows.
+ */
+
+import { HNSWVectorStore } from "../../src/vectorstore/HNSWVectorStore";
+import type { DocumentVector } from "../../src/vectorstore/types";
+
+function doc(path: string, vector: number[]): DocumentVector {
+	return { id: `${path}#0`, path, mtime: 1, checksum: "c", chunkIndex: 0, vector: new Float32Array(vector) };
+}
+
+async function openStore(): Promise<HNSWVectorStore> {
+	const store = new HNSWVectorStore("vault-1", "index-1");
+	await store.open();
+	return store;
+}
+
+/** A build writes the metadata record first (`buildFullIndex` → `setMetadata`); mirror that. */
+async function openForBuild(): Promise<HNSWVectorStore> {
+	const store = await openStore();
+	await store.setMetadata("p", "m", 2);
+	return store;
+}
+
+/** Graph-side state, to prove hits came through the HNSW graph and not the brute-force fallback. */
+function graphNodeCount(store: HNSWVectorStore): number | undefined {
+	return (store as unknown as { hnswIndex: { nodes: Map<number, unknown> } | null }).hnswIndex?.nodes.size;
+}
+
+beforeEach(() => {
+	vi.stubGlobal("indexedDB", new IDBFactory());
+	vi.stubGlobal("IDBKeyRange", IDBKeyRange);
+	// Only the debounce timer is faked, so the pending graph save never fires —
+	// that is the "killed before the debounce" state. fake-indexeddb schedules
+	// its own work on setImmediate, which must keep running.
+	vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
+
+describe("HNSWVectorStore — resuming after an interrupted build", () => {
+	it("re-links rows written after the last checkpoint on the next open", async () => {
+		const first = await openForBuild();
+		await first.upsert(doc("a.md", [1, 0, 0]));
+		await first.upsert(doc("b.md", [0, 1, 0]));
+		await first.flush(); // checkpoint: a and b are in the persisted graph
+		await first.upsert(doc("c.md", [0, 0, 1])); // after the checkpoint; never saved
+		// No close(): the process died here.
+
+		const second = await openStore();
+		const hits = await second.search(new Float32Array([0, 0, 1]), 1);
+		expect(hits.map((h) => h.doc.path)).toEqual(["c.md"]);
+		expect(graphNodeCount(second)).toBe(3);
+		// And the earlier rows are still reachable through the graph.
+		const older = await second.search(new Float32Array([1, 0, 0]), 1);
+		expect(older.map((h) => h.doc.path)).toEqual(["a.md"]);
+		await second.close();
+	});
+
+	it("builds the graph from rows alone when no checkpoint was ever written", async () => {
+		const first = await openForBuild();
+		await first.upsert(doc("a.md", [1, 0]));
+		await first.upsert(doc("b.md", [0, 1]));
+
+		const second = await openStore();
+		expect(await second.count()).toBe(2);
+		const hits = await second.search(new Float32Array([0, 1]), 1);
+		expect(hits.map((h) => h.doc.path)).toEqual(["b.md"]);
+		expect(graphNodeCount(second)).toBe(2);
+		await second.close();
+	});
+
+	it("flush() persists the pending graph immediately instead of on the debounce", async () => {
+		const first = await openForBuild();
+		await first.upsert(doc("a.md", [1, 0]));
+		await first.flush();
+
+		// The persisted topology alone must describe the node — no re-link log.
+		const second = await openStore();
+		const persisted = second as unknown as { getGraphHeader: () => Promise<unknown> };
+		expect(await persisted.getGraphHeader()).not.toBeNull();
+		await second.search(new Float32Array([1, 0]), 1);
+		expect(graphNodeCount(second)).toBe(1);
+		await second.close();
+	});
+});

--- a/test/vectorstore/VectorStoreService.lazyOpen.test.ts
+++ b/test/vectorstore/VectorStoreService.lazyOpen.test.ts
@@ -64,10 +64,11 @@ class FakeStore implements VectorStore {
 	async getDocumentMtime(path: string): Promise<number | undefined> {
 		return (await this.getByPath(path))?.mtime;
 	}
+	/** Mirrors the real store: a note is listed only through its chunk-0 row. */
 	async listNoteMeta(): Promise<NoteMeta[]> {
-		const byPath = new Map<string, number>();
-		for (const doc of this.docs.values()) byPath.set(doc.path, doc.mtime);
-		return [...byPath].map(([path, mtime]) => ({ path, mtime }));
+		return [...this.docs.values()]
+			.filter((doc) => doc.chunkIndex === 0)
+			.map(({ path, mtime }) => ({ path, mtime }));
 	}
 	async semanticPairs() {
 		return [];
@@ -245,8 +246,18 @@ describe("bulk embed run", () => {
 		const svc = await startService();
 		const store = stores.get(INDEX);
 		if (!store) throw new Error("store not opened");
-		// a.md is current, c.md is stale (indexed at an older mtime), b.md is missing.
+		// a.md is current, c.md is stale (indexed at an older mtime), b.md is missing,
+		// and d.md was killed mid-write: a chunk-1 row with the current mtime but no chunk 0.
+		vaultFiles.push(file("d.md", 1_000));
 		await store.setMetadata("fake", "embed-model", 2);
+		await store.upsert({
+			id: "d.md#1",
+			path: "d.md",
+			mtime: 1_000,
+			checksum: "x",
+			chunkIndex: 1,
+			vector: new Float32Array(3),
+		});
 		await store.upsert({
 			id: "a.md#0",
 			path: "a.md",
@@ -277,10 +288,13 @@ describe("bulk embed run", () => {
 
 		// Chunking prefixes each chunk with the note title; the body is what matters.
 		const embedded = embedDocuments.mock.calls.flatMap(([texts]) => texts).sort();
-		expect(embedded).toHaveLength(2);
+		expect(embedded).toHaveLength(3);
 		expect(embedded[0]).toContain("content of b.md");
 		expect(embedded[1]).toContain("content of c.md");
-		expect((await store.listNoteMeta()).map((n) => n.path).sort()).toEqual(["a.md", "b.md", "c.md"]);
+		expect(embedded[2]).toContain("content of d.md");
+		expect((await store.listNoteMeta()).map((n) => n.path).sort()).toEqual(["a.md", "b.md", "c.md", "d.md"]);
+		// The stale chunk-1 row of d.md was purged before the rewrite.
+		expect([...store.docs.keys()].filter((id) => id.startsWith("d.md"))).toEqual(["d.md#0"]);
 		expect(store.flush).toHaveBeenCalled();
 		expect(indexStats.dimensions).toBe(3);
 	});

--- a/test/vectorstore/VectorStoreService.lazyOpen.test.ts
+++ b/test/vectorstore/VectorStoreService.lazyOpen.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Platform } from "obsidian";
+
+/*
+ * #432 part 2, steps 3 and 4, at the service level:
+ *
+ * - Mobile opens no index at boot; the first use (search / `ensureIndex` /
+ *   `getOrCreateInstance`) opens it exactly once, also under concurrent callers.
+ *   Desktop still opens configured indexes at init.
+ * - A bulk run resumes from what is stored: the completeness validation embeds
+ *   only notes that are missing or stale, never the ones already indexed.
+ * - The crash marker is set while a bulk run is in flight, cleared when it
+ *   completes, and lengthens the next scheduled start on mobile.
+ *
+ * The worker-backed store is replaced by an in-memory fake (the worker cannot
+ * run under jsdom), and the provider layer by a fake embeddings instance.
+ */
+
+import { MOBILE_BULK_BASE_DELAY_MS } from "../../src/search/bulkPacing";
+import type { DocumentVector, IndexMetadata, NoteMeta, VectorStore } from "../../src/vectorstore/types";
+
+// ---- fakes ------------------------------------------------------------------
+
+interface FakeFile {
+	path: string;
+	basename: string;
+	extension: string;
+	stat: { mtime: number; size: number };
+}
+
+function file(path: string, mtime = 1_000): FakeFile {
+	return { path, basename: path.replace(/\.md$/, ""), extension: "md", stat: { mtime, size: 10 } };
+}
+
+class FakeStore implements VectorStore {
+	docs = new Map<string, DocumentVector>();
+	meta: { providerId: string; modelId: string; version: number; dimensions: number } | null = null;
+	open = vi.fn(async () => {});
+	close = vi.fn(async () => {});
+	flush = vi.fn(async () => {});
+	providerId: string | null = null;
+	modelId: string | null = null;
+
+	async setMetadata(providerId: string, modelId: string, version: number): Promise<void> {
+		this.meta = { providerId, modelId, version, dimensions: this.meta?.dimensions ?? 0 };
+	}
+	async getMetadata(): Promise<IndexMetadata | null> {
+		if (!this.meta) return null;
+		return { ...this.meta, documentCount: this.docs.size, lastUpdated: 0 };
+	}
+	async upsert(doc: DocumentVector): Promise<void> {
+		this.docs.set(doc.id, doc);
+		if (this.meta) this.meta.dimensions = doc.vector.length;
+	}
+	async remove(path: string): Promise<void> {
+		for (const [id, doc] of this.docs) if (doc.path === path) this.docs.delete(id);
+	}
+	async getByPath(path: string): Promise<DocumentVector | undefined> {
+		return [...this.docs.values()].find((d) => d.path === path);
+	}
+	async getAllByPath(path: string): Promise<DocumentVector[]> {
+		return [...this.docs.values()].filter((d) => d.path === path);
+	}
+	async getDocumentMtime(path: string): Promise<number | undefined> {
+		return (await this.getByPath(path))?.mtime;
+	}
+	async listNoteMeta(): Promise<NoteMeta[]> {
+		const byPath = new Map<string, number>();
+		for (const doc of this.docs.values()) byPath.set(doc.path, doc.mtime);
+		return [...byPath].map(([path, mtime]) => ({ path, mtime }));
+	}
+	async semanticPairs() {
+		return [];
+	}
+	async noteNeighbors() {
+		return [];
+	}
+	async getAllSerialized() {
+		return [];
+	}
+	async bulkPut(docs: DocumentVector[]): Promise<void> {
+		for (const doc of docs) await this.upsert(doc);
+	}
+	async clear(): Promise<void> {
+		this.docs.clear();
+		this.meta = null;
+	}
+	async count(): Promise<number> {
+		return this.docs.size;
+	}
+	async countNotes(): Promise<number> {
+		return (await this.listNoteMeta()).length;
+	}
+	async search() {
+		return [];
+	}
+}
+
+const INDEX = "fake:embed-model";
+const stores = new Map<string, FakeStore>();
+let vaultFiles: FakeFile[] = [];
+const embedDocuments = vi.fn(async (texts: string[]) => texts.map(() => [1, 0, 0]));
+const embedQuery = vi.fn(async () => [1, 0, 0]);
+const indexStats: Record<string, unknown> = {};
+
+const fakeData = {
+	vaultSlug: "vault-1",
+	searchEmbedIndex: INDEX as string | null,
+	graphEmbedIndex: null as string | null,
+	getEmbeddingIndex: (id: string) =>
+		id === INDEX ? { id, provider: "fake", model: "embed-model", batchSize: 2 } : undefined,
+	updateEmbeddingIndexStats: vi.fn((_id: string, stats: Record<string, unknown>) => Object.assign(indexStats, stats)),
+	isProviderTrusted: () => true,
+	isFilePrivate: () => false,
+	getResolvedProviderAuth: () => null,
+};
+
+vi.mock("../../src/stores/dataStore.svelte", () => ({ getData: () => fakeData }));
+vi.mock("../../src/vectorstore/index", () => ({
+	createVectorStore: (_vaultId: string, indexId: string) => {
+		const store = new FakeStore();
+		stores.set(indexId, store);
+		return store;
+	},
+}));
+vi.mock("../../src/providers/registrySync", () => ({ ensureProviderRegistered: () => true }));
+vi.mock("../../src/providers/registry", () => ({
+	getRegistry: () => ({
+		getAuthGeneration: () => 1,
+		createEmbeddingInstance: () => ({ embedDocuments, embedQuery }),
+	}),
+}));
+vi.mock("../../src/providers/modelsDevApi", () => ({ fetchModelsDevData: async () => null }));
+vi.mock("../../src/providers/openrouterModels", () => ({ fetchOpenRouterModels: async () => null }));
+vi.mock("../../src/providers/ollamaModels", () => ({ getOllamaModelsCache: () => null }));
+vi.mock("../../src/lib/modelMetadataNormalizer", () => ({
+	hydrateEmbeddingModel: () => ({ maxInputTokens: 8191 }),
+}));
+vi.mock("../../src/utils/fileFiltering", () => ({
+	getEmbeddableVaultFiles: () => vaultFiles,
+	isEmbeddableFile: () => true,
+	isBinaryTextFile: (f: FakeFile) => f.extension === "pdf",
+	readIndexableContent: async (_vault: unknown, f: FakeFile) => `content of ${f.path}`,
+}));
+
+import { VectorStoreService, waitForVectorStore } from "../../src/vectorstore/VectorStoreService";
+
+function fakePlugin() {
+	return {
+		app: {
+			workspace: { onLayoutReady: (cb: () => void) => cb() },
+			vault: { getFiles: () => vaultFiles, on: () => ({}), getAbstractFileByPath: () => null },
+			metadataCache: { getFileCache: () => null },
+		},
+		registerEvent: () => {},
+	} as never;
+}
+
+function memoryStorage(): Storage {
+	const map = new Map<string, string>();
+	return {
+		getItem: (key: string) => map.get(key) ?? null,
+		setItem: (key: string, value: string) => void map.set(key, value),
+		removeItem: (key: string) => void map.delete(key),
+		clear: () => map.clear(),
+		key: () => null,
+		get length() {
+			return map.size;
+		},
+	} as Storage;
+}
+
+const platform = Platform as { isMobile: boolean };
+const MARKER_KEY = "s2b-embedding-bulk-attempts:vault-1";
+let service: VectorStoreService | null = null;
+
+async function startService(): Promise<VectorStoreService> {
+	// The progress notice renders into Obsidian's extended DOM (`createDiv`),
+	// which jsdom lacks; the notice is not what these tests assert on.
+	vi.spyOn(
+		VectorStoreService.prototype as unknown as { updateNotice: () => void },
+		"updateNotice",
+	).mockImplementation(() => {});
+	service = VectorStoreService.startInitialize(fakePlugin());
+	expect(await waitForVectorStore()).toBe(true);
+	return service;
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.stubGlobal("localStorage", memoryStorage());
+	stores.clear();
+	vaultFiles = [];
+	for (const key of Object.keys(indexStats)) delete indexStats[key];
+});
+
+afterEach(async () => {
+	await service?.cleanup();
+	service = null;
+	platform.isMobile = false;
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+describe("lazy open on mobile", () => {
+	it("opens nothing at boot, then exactly once on first use — even with concurrent callers", async () => {
+		platform.isMobile = true;
+		const svc = await startService();
+		expect(stores.size).toBe(0);
+
+		const [a, b] = await Promise.all([svc.getOrCreateInstance(INDEX), svc.getOrCreateInstance(INDEX)]);
+		expect(a).toBe(b);
+		expect(stores.size).toBe(1);
+		expect(stores.get(INDEX)?.open).toHaveBeenCalledTimes(1);
+
+		await svc.getStats(INDEX);
+		expect(stores.get(INDEX)?.open).toHaveBeenCalledTimes(1);
+	});
+
+	it("opens the configured index at boot on desktop", async () => {
+		platform.isMobile = false;
+		await startService();
+		expect(stores.get(INDEX)?.open).toHaveBeenCalledTimes(1);
+	});
+
+	it("catches up after the boot delay on mobile, and a crashed attempt lengthens that delay", async () => {
+		platform.isMobile = true;
+		localStorage.setItem(MARKER_KEY, "1"); // the previous run died
+		vaultFiles = [file("a.md")];
+		await startService();
+
+		await vi.advanceTimersByTimeAsync(MOBILE_BULK_BASE_DELAY_MS * 2 - 1);
+		expect(stores.size).toBe(0);
+		await vi.advanceTimersByTimeAsync(1);
+		// Opened by the catch-up, which found the index empty and left it to the
+		// first explicit use (an empty index is a build, not a validation).
+		expect(stores.get(INDEX)?.open).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("bulk embed run", () => {
+	it("resumes from the stored index: validation embeds only missing and stale notes", async () => {
+		platform.isMobile = false;
+		vaultFiles = [file("a.md", 1_000), file("b.md", 1_000), file("c.md", 5_000)];
+		const svc = await startService();
+		const store = stores.get(INDEX);
+		if (!store) throw new Error("store not opened");
+		// a.md is current, c.md is stale (indexed at an older mtime), b.md is missing.
+		await store.setMetadata("fake", "embed-model", 2);
+		await store.upsert({
+			id: "a.md#0",
+			path: "a.md",
+			mtime: 1_000,
+			checksum: "x",
+			chunkIndex: 0,
+			vector: new Float32Array(3),
+		});
+		await store.upsert({
+			id: "c.md#0",
+			path: "c.md",
+			mtime: 1_000,
+			checksum: "x",
+			chunkIndex: 0,
+			vector: new Float32Array(3),
+		});
+		await store.upsert({
+			id: "gone.md#0",
+			path: "gone.md",
+			mtime: 1_000,
+			checksum: "x",
+			chunkIndex: 0,
+			vector: new Float32Array(3),
+		});
+
+		expect(await svc.ensureIndex(INDEX)).toBe(true);
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		// Chunking prefixes each chunk with the note title; the body is what matters.
+		const embedded = embedDocuments.mock.calls.flatMap(([texts]) => texts).sort();
+		expect(embedded).toHaveLength(2);
+		expect(embedded[0]).toContain("content of b.md");
+		expect(embedded[1]).toContain("content of c.md");
+		expect((await store.listNoteMeta()).map((n) => n.path).sort()).toEqual(["a.md", "b.md", "c.md"]);
+		expect(store.flush).toHaveBeenCalled();
+		expect(indexStats.dimensions).toBe(3);
+	});
+
+	it("sets the crash marker while running and clears it on completion", async () => {
+		platform.isMobile = false;
+		vaultFiles = [file("a.md"), file("b.md"), file("c.md")];
+		let release: (() => void) | null = null;
+		embedDocuments.mockImplementationOnce(
+			(texts: string[]) =>
+				new Promise<number[][]>((resolve) => {
+					release = () => resolve(texts.map(() => [1, 0, 0]));
+				}),
+		);
+		const svc = await startService();
+
+		const run = svc.ensureIndex(INDEX); // empty index → full build
+		await vi.waitFor(() => expect(localStorage.getItem(MARKER_KEY)).toBe("1"));
+		if (!release) throw new Error("embedding call never started");
+		(release as () => void)();
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(await run).toBe(true);
+		expect(localStorage.getItem(MARKER_KEY)).toBeNull();
+		expect(await stores.get(INDEX)?.countNotes()).toBe(3);
+	});
+});

--- a/test/vectorstore/VectorStoreService.test.ts
+++ b/test/vectorstore/VectorStoreService.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	canReuseCachedEmbeddings,
 	formatEta,
+	orderChunksForWriting,
 	summarizeValidationProgressCounts,
 } from "../../src/vectorstore/VectorStoreService";
 import { getDefaultEmbeddingBatchSize, normalizeEmbeddingBatchSize } from "../../src/vectorstore/batchSize";
@@ -112,5 +113,13 @@ describe("canReuseCachedEmbeddings", () => {
 		// Guards the sentinel: `null` means "never built", which must not collide with
 		// the registry's initial generation of 0.
 		expect(canReuseCachedEmbeddings({ ...cached, authGeneration: null }, want, 0)).toBe(false);
+	});
+});
+
+describe("orderChunksForWriting", () => {
+	it("writes chunk 0 last so the note is complete exactly when its first row exists", () => {
+		expect(orderChunksForWriting([0, 1, 2, 3])).toEqual([1, 2, 3, 0]);
+		expect(orderChunksForWriting([0])).toEqual([0]);
+		expect(orderChunksForWriting([])).toEqual([]);
 	});
 });

--- a/test/vectorstore/embeddingMemoryHint.test.ts
+++ b/test/vectorstore/embeddingMemoryHint.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { LARGE_EMBEDDING_DIMENSIONS, largeDimensionHint } from "../../src/vectorstore/embeddingMemoryHint";
+
+describe("largeDimensionHint", () => {
+	it("hints only for wide vectors, and only once the width is known", () => {
+		expect(largeDimensionHint("nomic-embed-text", undefined)).toBeNull();
+		expect(largeDimensionHint("all-minilm", 384)).toBeNull();
+		expect(largeDimensionHint("nomic-embed-text", 768)).toBeNull();
+		expect(largeDimensionHint("text-embedding-3-small", LARGE_EMBEDDING_DIMENSIONS)).toContain(
+			"text-embedding-3-small",
+		);
+		expect(largeDimensionHint("text-embedding-3-large", 3072)).toContain("3072");
+	});
+});

--- a/test/vectorstore/orphanedDatabases.test.ts
+++ b/test/vectorstore/orphanedDatabases.test.ts
@@ -75,6 +75,11 @@ describe("listOrphanedVectorDatabases", () => {
 		const [orphanMain, orphanSidecar] = databaseNamesForIndex(VAULT, ORPHAN);
 		await createSidecar(orphanSidecar);
 		await createSidecar(`${databaseNamesForIndex("vault-1-archive", "openai:x")[0]}-hnsw-index`);
+		// A sidecar whose main database is gone: it could be ours (a half-blocked
+		// deletion) or a neighbouring vault's — nothing inside it says which, so
+		// it must not be offered for deletion.
+		await createSidecar(`${databaseNamesForIndex("vault-1-archive", "openai:gone")[0]}-hnsw-index`);
+		await createSidecar(`${databaseNamesForIndex(VAULT, "ollama:gone")[0]}-hnsw-index`);
 		// A shell that was opened but never written: no metadata record, so it
 		// cannot be attributed and is left alone.
 		const shell = new HNSWVectorStore(VAULT, "custom:never-built");

--- a/test/vectorstore/orphanedDatabases.test.ts
+++ b/test/vectorstore/orphanedDatabases.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { IDBFactory, IDBKeyRange } from "fake-indexeddb";
+
+/*
+ * #432 step 5: vector databases survive index/provider deletion by design, so a
+ * cleanup surface needs to find this vault's leftovers without touching a
+ * neighbouring vault whose slug extends ours ("vault-1" vs "vault-1-archive").
+ * Runs against a real in-memory IndexedDB so `databases()`, the metadata probe
+ * and the deletions are exercised for real.
+ */
+
+import { HNSWVectorStore } from "../../src/vectorstore/HNSWVectorStore";
+import {
+	databaseNamesForIndex,
+	deleteOrphanedDatabases,
+	formatBytes,
+	listOrphanedVectorDatabases,
+} from "../../src/vectorstore/orphanedDatabases";
+import type { DocumentVector } from "../../src/vectorstore/types";
+
+function doc(path: string, vector: number[]): DocumentVector {
+	return { id: `${path}#0`, path, mtime: 1, checksum: "c", chunkIndex: 0, vector: new Float32Array(vector) };
+}
+
+async function writeIndex(vaultId: string, indexId: string, docs: DocumentVector[]): Promise<void> {
+	const store = new HNSWVectorStore(vaultId, indexId);
+	await store.open();
+	const [provider, ...rest] = indexId.split(":");
+	await store.setMetadata(provider, rest.join(":"), 2);
+	for (const d of docs) await store.upsert(d);
+	await store.close();
+}
+
+/** A pre-v3 graph sidecar: a database with an unrelated schema. */
+function createSidecar(name: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const request = indexedDB.open(name, 1);
+		request.onupgradeneeded = () => request.result.createObjectStore("graph");
+		request.onsuccess = () => {
+			request.result.close();
+			resolve();
+		};
+		request.onerror = () => reject(request.error);
+	});
+}
+
+async function databaseNames(): Promise<string[]> {
+	return ((await indexedDB.databases()) ?? []).map((info) => info.name ?? "").sort();
+}
+
+const VAULT = "vault-1";
+const CONFIGURED = "openai:text-embedding-3-small";
+const ORPHAN = "ollama:nomic-embed-text";
+
+beforeEach(() => {
+	vi.stubGlobal("indexedDB", new IDBFactory());
+	vi.stubGlobal("IDBKeyRange", IDBKeyRange);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("listOrphanedVectorDatabases", () => {
+	it("reports databases of unconfigured models and legacy sidecars, leaving other vaults alone", async () => {
+		await writeIndex(VAULT, CONFIGURED, [doc("a.md", [1, 0, 0, 0])]);
+		await writeIndex(VAULT, ORPHAN, [
+			doc("a.md", [1, 0, 0, 0]),
+			doc("b.md", [0, 1, 0, 0]),
+			doc("c.md", [0, 0, 1, 0]),
+		]);
+		// A vault whose slug extends ours: its database shares our name prefix but
+		// the provider/model inside it does not reproduce the name under our slug.
+		await writeIndex("vault-1-archive", "openai:x", [doc("z.md", [1, 0])]);
+		const [orphanMain, orphanSidecar] = databaseNamesForIndex(VAULT, ORPHAN);
+		await createSidecar(orphanSidecar);
+		await createSidecar(`${databaseNamesForIndex("vault-1-archive", "openai:x")[0]}-hnsw-index`);
+		// A shell that was opened but never written: no metadata record, so it
+		// cannot be attributed and is left alone.
+		const shell = new HNSWVectorStore(VAULT, "custom:never-built");
+		await shell.open();
+		await shell.close();
+
+		const orphans = await listOrphanedVectorDatabases(VAULT, [CONFIGURED]);
+		expect(orphans).not.toBeNull();
+		expect(orphans?.map((o) => o.name)).toEqual([orphanMain, orphanSidecar]);
+		const index = orphans?.find((o) => o.kind === "index");
+		expect(index).toMatchObject({ indexId: ORPHAN, chunkCount: 3, dimensions: 4, estimatedBytes: 3 * 4 * 4 });
+	});
+
+	it("reports nothing when every database is configured", async () => {
+		await writeIndex(VAULT, CONFIGURED, [doc("a.md", [1, 0])]);
+		expect(await listOrphanedVectorDatabases(VAULT, [CONFIGURED])).toEqual([]);
+	});
+
+	it("resolves null when the runtime cannot enumerate databases", async () => {
+		vi.stubGlobal("indexedDB", { open: vi.fn(), deleteDatabase: vi.fn() });
+		expect(await listOrphanedVectorDatabases(VAULT, [CONFIGURED])).toBeNull();
+	});
+});
+
+describe("deleteOrphanedDatabases", () => {
+	it("removes the listed databases and nothing else", async () => {
+		await writeIndex(VAULT, CONFIGURED, [doc("a.md", [1, 0])]);
+		await writeIndex(VAULT, ORPHAN, [doc("a.md", [1, 0])]);
+		const [orphanMain, orphanSidecar] = databaseNamesForIndex(VAULT, ORPHAN);
+		await createSidecar(orphanSidecar);
+
+		const orphans = (await listOrphanedVectorDatabases(VAULT, [CONFIGURED])) ?? [];
+		const outcome = await deleteOrphanedDatabases(orphans.map((o) => o.name));
+		expect(outcome.failed).toEqual([]);
+		expect(outcome.deleted.sort()).toEqual([orphanMain, orphanSidecar].sort());
+		expect(await databaseNames()).toEqual([databaseNamesForIndex(VAULT, CONFIGURED)[0]]);
+		expect(await listOrphanedVectorDatabases(VAULT, [CONFIGURED])).toEqual([]);
+	});
+});
+
+describe("formatBytes", () => {
+	it("picks a readable unit", () => {
+		expect(formatBytes(512)).toBe("512 B");
+		expect(formatBytes(1536)).toBe("1.5 KB");
+		expect(formatBytes(120 * 1024 * 1024)).toBe("120 MB");
+		expect(formatBytes(3 * 1024 ** 3)).toBe("3.0 GB");
+	});
+});

--- a/test/vectorstore/orphanedDatabases.test.ts
+++ b/test/vectorstore/orphanedDatabases.test.ts
@@ -85,7 +85,14 @@ describe("listOrphanedVectorDatabases", () => {
 		expect(orphans).not.toBeNull();
 		expect(orphans?.map((o) => o.name)).toEqual([orphanMain, orphanSidecar]);
 		const index = orphans?.find((o) => o.kind === "index");
-		expect(index).toMatchObject({ indexId: ORPHAN, chunkCount: 3, dimensions: 4, estimatedBytes: 3 * 4 * 4 });
+		expect(index).toMatchObject({
+			indexId: ORPHAN,
+			label: "ollama_nomic-embed-text",
+			chunkCount: 3,
+			dimensions: 4,
+			estimatedBytes: 3 * 4 * 4,
+		});
+		expect(orphans?.find((o) => o.kind === "legacy-sidecar")?.label).toBe("ollama_nomic-embed-text");
 	});
 
 	it("reports nothing when every database is configured", async () => {


### PR DESCRIPTION
Part 2 of #432 — steps 3, 4 and 5. Builds on #450 (Float32Array end-to-end, schema v3). Closes #432, with the on-device caveat at the end.

## Step 3 — lazy-open the HNSW index on mobile

- `VectorStoreService.init()` opens nothing on `Platform.isMobile`. Every consumer already goes through `getOrCreateInstance` (the one lazy-open path, deduped by `initializingInstances`), so whichever comes first opens the index: the first search, the graph's `getOrCreateInstance`/semantic-edge request, an explicit reindex, or the delayed boot catch-up. Desktop is unchanged (eager open at init).
- What "open" costs was measured, not guessed: `open()` loads the id maps only; the graph (vectors) is rehydrated inside the worker on the first write/search. New bench shape `after (v3, open only: id maps)` = **20.1 MB** vs **140.2 MB** with the graph loaded (20k × 1536). What used to pull the graph in at boot was the startup completeness validation writing to the store — that is now what gets deferred/paced.
- Validation is scheduled through one `scheduleValidation(inst)` (per-instance dedupe; immediate on desktop, boot delay + crash backoff on mobile). `ensureIndex` also schedules instead of starting validation synchronously, and validation refuses to run alongside a full build (previously nothing stopped the two from double-writing the same chunks).
- Mobile boot catch-up: after the backoff delay, configured indexes are opened and validated **in sequence** (never two graphs rehydrating at once). If nothing changed, the index stays in the 20 MB "open only" state.
- Settings hint (mobile only, `SettingContainer`): when the selected index's recorded vector width is ≥ 1024, a "Memory on mobile" hint suggests a 384/768-dim model. The width is recorded into `EmbeddingIndexConfig.dimensions` from the store's metadata on open and from the first vector written during a build, so the settings UI never has to open the index to know it.

## Step 4 — pacing + crash-backoff for the embedding build

- New shared `src/search/bulkPacing.ts`, used by both `LexicalSearchService` and `VectorStoreService`: batch/checkpoint pauses (mobile-only real pauses), `BULK_CHECKPOINT_INTERVAL`, `MOBILE_BULK_BASE_DELAY_MS`/max, `BulkAttemptMarker` (localStorage `s2b-<indexer>-bulk-attempts:<vaultId>`, so the lexical key is unchanged and the embedding indexer gets `s2b-embedding-bulk-attempts:<vaultId>`), `scheduleBulkRun`, `orderForBulkIndexing` (PDFs last). The measurement comments moved with the constants. **I chose extraction over duplication**; only `BULK_BATCH_SIZE = 25` stayed lexical-specific (the embedding side paces per embedding request instead).
- The two ~100-line embed loops (validation and full build) were near-identical copies; they are now one `embedFilesInBatches`. Behavioural changes beyond pacing:
  - Files are read **one at a time as the batch fills** (PDFs last). The old loops pre-read the entire corpus into memory before the first embedding call.
  - Every `BULK_CHECKPOINT_INTERVAL` notes → `store.flush()` (new `VectorStore.flush()`, through the worker) so the HNSW graph topology is persisted, plus the checkpoint pause. Batch pause after every embedding request.
  - Crash marker set before the first read, cleared on completion or user cancel; a scheduled run after a kill waits `15s × 2^attempts` (cap 5 min) on mobile.
  - Resume: rows are durable per `upsert`, and validation only embeds missing/stale notes (per-note mtime), so a killed run resumes rather than restarts. A note's **chunk 0 is written last** and `listNoteMeta` counts a note only through its `#0` row (key cursor, no vector reads), so a kill *between the chunks of one note* leaves rows validation treats as absent and re-indexes — no schema change needed (review finding). To make that actually true, `HNSWVectorStore.loadGraph` now **re-links document rows that have no topology node** (written after the last graph save). Before, those rows were unsearchable after a reopen while still counting as indexed — validation saw their mtime and never repaired them. The checkpoint interval now only bounds how much re-linking a reopen has to do.

## Step 5 — orphaned vector database cleanup

- `src/vectorstore/orphanedDatabases.ts`: enumerates via `indexedDB.databases()` (guarded; `null` when unsupported), filters by this vault's prefix, diffs against configured indexes. **Ownership is not decided by prefix alone**: vault slugs can be prefixes of each other on the same origin (`smart2brain-test-vault` vs `smart2brain-test-vault-3` — both exist on my machine), so each candidate is opened read-only and attributed only if the provider/model recorded inside it reproduces the exact name under this vault's slug. Legacy `-hnsw-index` sidecars are attributed through their main DB and are always orphans in v3; a sidecar whose main DB is gone cannot be attributed and is left alone (review finding). Unattributable databases are never offered for deletion.
- Per-DB size isn't exposed by any API; the probe reports chunk count × dims × 4 bytes as a lower bound, plus `navigator.storage.estimate()` for the origin total.
- Settings: `OrphanedVectorDatabases.svelte` under the index list (`SettingContainer` + native button), rendered only when orphans exist; confirmation via `ConfirmModal`; state is module-level so the search and graph tabs agree after a deletion.

## Bench (`bun run bench:vector-memory`, 20k × 1536)

| shape | before this PR | after |
|---|---|---|
| before (build session) | 332.6 MB | 332.8 MB |
| before (load peak) | 464.4 MB | 464.5 MB |
| after (v3, Float32Array) | 140.2 MB | 140.2 MB |
| after (v3, open only: id maps) | — | 20.1 MB (new shape) |

Unchanged as required; the new row is the measurement behind "cheap metadata may still load".

## Verification

- Unit: `test/search/bulkPacing.test.ts`, `test/vectorstore/VectorStoreService.lazyOpen.test.ts` (mobile opens nothing at boot, once on first use under concurrent callers, desktop eager; validation embeds only missing/stale; marker set/cleared and doubles the delay), `HNSWVectorStore.resume.test.ts` (re-link after an interrupted build, with/without any checkpoint), `orphanedDatabases.test.ts` (fake-indexeddb: neighbouring-vault DB left alone, sidecars, shells, deletion), `embeddingMemoryHint.test.ts`. `check`/`format`/`lint`/`test` clean (1628 tests).
- Live in `S2B WT1` (desktop): the vault's oMLX key still 401s, so I retargeted the `sap-hai` provider's baseUrl at a local mock OpenAI embeddings server (key untouched), built the index (378 notes, 47 batches, `dev:errors` clean), recorded dims = 1536, crash marker cleared, semantic search returned hits in 37 ms. The orphan row found the vault's one real orphan (a legacy sidecar), the confirm modal + delete removed it (`indexedDB.databases()` verified) and the row disappeared. Restored baseUrl/index selection afterwards, cleared the mock vectors from that index, stopped the server.
- **Not verified on device**: the mobile-only paths (deferred open, boot backoff, real pauses, the hint) are covered by tests with `Platform.isMobile` mocked only. The issue's acceptance figure (fresh-boot footprint < ~1.1 GB with a 1536-dim model, graph view without a kill) needs Leo's reference iPhone.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._