### PR TITLE
feat(ui): link to the documentation site from the plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,16 @@ and the `redirects` block in `../site/astro.config.mjs`. Rendering goes through
 `components/ui/DocsLink.svelte` (icon variant for setting rows via `nameSuffix`,
 inline variant for section descriptions).
 
+**Never open an external `http(s)` URL with `window.open`.** Obsidian's iOS
+WKWebView never implements window creation, so it returns null unconditionally
+there and the click silently does nothing — verified on-device (see
+`navigateToAuthorizeUrl` in `providers/openrouterOAuth.ts`). Render an anchor
+instead: `components/ui/ExternalLinkButton.svelte` covers the common case of a
+setting row wanting something that *looks* like a button, and matches Obsidian's
+button metrics (`height: var(--input-height)`, `4px 12px`) so it sits flush next
+to real ones. `obsidian://` deep links are exempt — the app's protocol handler
+takes those, no window involved.
+
 ## Architecture
 
 This section is the canonical description of the architecture. (A longer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,15 @@ release" and covers the provider list, bundled skills, built-in tools,
 `BUILT_IN_TOOL_IDS`, `src/skills/defaults/`, or `manifest.json` means the site
 needs updating too.
 
+The plugin also links *into* that site from several surfaces (Troubleshooting
+settings, the privacy row, onboarding, provider setup, the Agent editor). Every
+one of those URLs lives in `src/utils/docs.ts` — never inline a
+`smartsecondbrain.dev` URL at a call site. That file is a contract with the
+site's routes: when they move, reconcile it against `../site/dist/sitemap-0.xml`
+and the `redirects` block in `../site/astro.config.mjs`. Rendering goes through
+`components/ui/DocsLink.svelte` (icon variant for setting rows via `nameSuffix`,
+inline variant for section descriptions).
+
 ## Architecture
 
 This section is the canonical description of the architecture. (A longer

--- a/src/components/modal/AddSkillModal.svelte
+++ b/src/components/modal/AddSkillModal.svelte
@@ -13,6 +13,7 @@ import { createObsidianFetch } from "../../lib/obsidianFetch";
 import SettingContainer from "../settings/SettingContainer.svelte";
 import Button from "../ui/Button.svelte";
 import DocsLink from "../ui/DocsLink.svelte";
+import ExternalLinkButton from "../ui/ExternalLinkButton.svelte";
 import SlidingTabs, { type SlidingTab } from "../ui/SlidingTabs.svelte";
 import Text from "../ui/Text.svelte";
 import type { AddSkillModal } from "./AddSkillModal";
@@ -129,9 +130,7 @@ async function handleImport() {
 	}
 }
 
-function openSkillsMarketplace() {
-	window.open("https://skillsmp.com/", "_blank");
-}
+const SKILLS_MARKETPLACE_URL = "https://skillsmp.com/";
 
 /** Starter body written into a brand-new skill (when not importing an existing one). */
 function scaffoldBody(): string {
@@ -232,7 +231,7 @@ async function handleSave() {
         {#snippet nameSuffix()}
           <DocsLink doc="skills" subject="Skills" />
         {/snippet}
-        <Button buttonText="Open SkillsMP" onClick={openSkillsMarketplace} />
+        <ExternalLinkButton href={SKILLS_MARKETPLACE_URL} label="Open SkillsMP" />
       </SettingContainer>
 
       {#if importError}

--- a/src/components/modal/AddSkillModal.svelte
+++ b/src/components/modal/AddSkillModal.svelte
@@ -12,6 +12,7 @@ import { Tabs } from "bits-ui";
 import { createObsidianFetch } from "../../lib/obsidianFetch";
 import SettingContainer from "../settings/SettingContainer.svelte";
 import Button from "../ui/Button.svelte";
+import DocsLink from "../ui/DocsLink.svelte";
 import SlidingTabs, { type SlidingTab } from "../ui/SlidingTabs.svelte";
 import Text from "../ui/Text.svelte";
 import type { AddSkillModal } from "./AddSkillModal";
@@ -225,7 +226,12 @@ async function handleSave() {
         />
       </SettingContainer>
 
+      <!-- SkillsMP is where skills are found; the docs explain the SKILL.md format an
+           imported one has to satisfy, so both belong on this row. -->
       <SettingContainer name="Browse skills" desc="Find community skills on skillsmp.com.">
+        {#snippet nameSuffix()}
+          <DocsLink doc="skills" subject="Skills" />
+        {/snippet}
         <Button buttonText="Open SkillsMP" onClick={openSkillsMarketplace} />
       </SettingContainer>
 

--- a/src/components/modal/AgentEditorModal.svelte
+++ b/src/components/modal/AgentEditorModal.svelte
@@ -14,6 +14,7 @@ import SettingGroup from "../settings/SettingGroup.svelte";
 import SettingItem from "../settings/SettingItem.svelte";
 import Badge from "../ui/Badge.svelte";
 import Button from "../ui/Button.svelte";
+import DocsLink from "../ui/DocsLink.svelte";
 import Icon from "../ui/Icon.svelte";
 import PickerPopover from "../ui/PickerPopover.svelte";
 import Search from "../ui/Search.svelte";
@@ -892,6 +893,7 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
               Built-in skills every agent can use — vault exploration, note editing, web access, and
               skill management. Each is a skill: toggle it to attach its tools, or open its note to
               edit its instructions. Individual tools are configured from the Tools row above.
+              <DocsLink variant="inline" doc="skills" />
             </div>
           </div>
         </div>
@@ -933,6 +935,7 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
             <div class="setting-item-description">
               Skills backed by your installed community plugins. Each bundles a skill (and, where
               available, code-scripting) behind one switch.
+              <DocsLink variant="inline" doc="integrations" />
             </div>
           </div>
         </div>
@@ -1090,7 +1093,12 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
           <div class="setting-item-description skill-empty-state">No custom skills yet</div>
         {/if}
 
+        <!-- A heading row rather than a section with an intro paragraph, so the docs
+             link takes the compact icon form here. -->
         <SettingContainer name="MCP servers" isHeading>
+          {#snippet nameSuffix()}
+            <DocsLink doc="mcp" subject="MCP servers" />
+          {/snippet}
           <Button buttonText="Add server" onClick={openAddMCPServer} />
         </SettingContainer>
         {#if mcpServerIds.length > 0}

--- a/src/components/ui/DocsLink.svelte
+++ b/src/components/ui/DocsLink.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { DOCS, type DocKey } from "../../utils/docs";
 import { icon } from "../../utils/utils";
+import ExternalLinkButton from "./ExternalLinkButton.svelte";
 
 interface Props {
 	/** Which documentation page to open. */
@@ -10,11 +11,9 @@ interface Props {
 	 * appends a text link to a section's description paragraph; `button` fills a
 	 * setting row's control slot and looks like any other button there.
 	 *
-	 * All three render an anchor. `button` is deliberately not a `<button>` calling
-	 * `window.open`: Obsidian's iOS WKWebView never implements window creation, so
-	 * `window.open` returns null there and the click would silently do nothing (see
-	 * the note in `providers/openrouterOAuth.ts`). A real link is handed to the
-	 * system browser on every platform.
+	 * All three render an anchor, never a `<button>` calling `window.open` — that
+	 * returns null in Obsidian's iOS WKWebView and the click silently does nothing.
+	 * `button` delegates to `ExternalLinkButton`, which carries the full rationale.
 	 */
 	variant?: "icon" | "inline" | "button";
 	/** Link text for the `inline` and `button` variants. */
@@ -45,16 +44,7 @@ const accessibleName = $derived(subject ? `Documentation: ${subject}` : "Open do
     <span class="s2b-docs-link-glyph" use:icon={"help-circle"} aria-hidden="true"></span>
   </a>
 {:else if variant === "button"}
-  <a
-    class="s2b-docs-link-button {className}"
-    href={DOCS[doc]}
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    <span class="s2b-docs-link-button-icon" use:icon={"lucide-external-link"} aria-hidden="true"
-    ></span>
-    {label}
-  </a>
+  <ExternalLinkButton href={DOCS[doc]} {label} class={className} />
 {:else}
   <a
     class="s2b-docs-link-inline {className}"
@@ -100,45 +90,4 @@ const accessibleName = $derived(subject ? `Documentation: ${subject}` : "Open do
     white-space: nowrap;
   }
 
-  /* An anchor wearing Obsidian's button clothes. Inherits the theme's own button
-     treatment rather than restating colours, so it sits beside real buttons in the
-     same row without drifting when the theme changes; `text-decoration: none` and
-     the normal text colour undo the link defaults it would otherwise pick up.
-     Mirrors Button.svelte's icon+label layout (inline-flex, 6px gap). */
-  .s2b-docs-link-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    /* Obsidian sizes buttons with `height: var(--input-height)` plus `4px 12px`
-       padding, not by content — match both so this sits flush with the real
-       buttons it shares a row with. */
-    height: var(--input-height);
-    box-sizing: border-box;
-    padding: 4px 12px;
-    border-radius: var(--button-radius);
-    background-color: var(--interactive-normal);
-    box-shadow: var(--input-shadow);
-    color: var(--text-normal);
-    font-size: var(--font-ui-small);
-    text-decoration: none;
-    white-space: nowrap;
-    cursor: pointer;
-  }
-
-  .s2b-docs-link-button:hover {
-    background-color: var(--interactive-hover);
-    box-shadow: var(--input-shadow-hover);
-    color: var(--text-normal);
-  }
-
-  .s2b-docs-link-button-icon {
-    --icon-size: var(--icon-s);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: var(--icon-s);
-    height: var(--icon-s);
-    flex-shrink: 0;
-  }
 </style>

--- a/src/components/ui/DocsLink.svelte
+++ b/src/components/ui/DocsLink.svelte
@@ -7,10 +7,17 @@ interface Props {
 	doc: DocKey;
 	/**
 	 * `icon` sits beside a setting's name (via SettingItem's `nameSuffix`); `inline`
-	 * appends a text link to a section's description paragraph.
+	 * appends a text link to a section's description paragraph; `button` fills a
+	 * setting row's control slot and looks like any other button there.
+	 *
+	 * All three render an anchor. `button` is deliberately not a `<button>` calling
+	 * `window.open`: Obsidian's iOS WKWebView never implements window creation, so
+	 * `window.open` returns null there and the click would silently do nothing (see
+	 * the note in `providers/openrouterOAuth.ts`). A real link is handed to the
+	 * system browser on every platform.
 	 */
-	variant?: "icon" | "inline";
-	/** Link text for the `inline` variant. */
+	variant?: "icon" | "inline" | "button";
+	/** Link text for the `inline` and `button` variants. */
 	label?: string;
 	/**
 	 * What the page explains, e.g. "Note access policy". Used to build an accessible
@@ -36,6 +43,17 @@ const accessibleName = $derived(subject ? `Documentation: ${subject}` : "Open do
     title={accessibleName}
   >
     <span class="s2b-docs-link-glyph" use:icon={"help-circle"} aria-hidden="true"></span>
+  </a>
+{:else if variant === "button"}
+  <a
+    class="s2b-docs-link-button {className}"
+    href={DOCS[doc]}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <span class="s2b-docs-link-button-icon" use:icon={"lucide-external-link"} aria-hidden="true"
+    ></span>
+    {label}
   </a>
 {:else}
   <a
@@ -80,5 +98,47 @@ const accessibleName = $derived(subject ? `Documentation: ${subject}` : "Open do
   .s2b-docs-link-inline {
     font-size: var(--font-smaller);
     white-space: nowrap;
+  }
+
+  /* An anchor wearing Obsidian's button clothes. Inherits the theme's own button
+     treatment rather than restating colours, so it sits beside real buttons in the
+     same row without drifting when the theme changes; `text-decoration: none` and
+     the normal text colour undo the link defaults it would otherwise pick up.
+     Mirrors Button.svelte's icon+label layout (inline-flex, 6px gap). */
+  .s2b-docs-link-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    /* Obsidian sizes buttons with `height: var(--input-height)` plus `4px 12px`
+       padding, not by content — match both so this sits flush with the real
+       buttons it shares a row with. */
+    height: var(--input-height);
+    box-sizing: border-box;
+    padding: 4px 12px;
+    border-radius: var(--button-radius);
+    background-color: var(--interactive-normal);
+    box-shadow: var(--input-shadow);
+    color: var(--text-normal);
+    font-size: var(--font-ui-small);
+    text-decoration: none;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .s2b-docs-link-button:hover {
+    background-color: var(--interactive-hover);
+    box-shadow: var(--input-shadow-hover);
+    color: var(--text-normal);
+  }
+
+  .s2b-docs-link-button-icon {
+    --icon-size: var(--icon-s);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--icon-s);
+    height: var(--icon-s);
+    flex-shrink: 0;
   }
 </style>

--- a/src/components/ui/DocsLink.svelte
+++ b/src/components/ui/DocsLink.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+import { DOCS, type DocKey } from "../../utils/docs";
+import { icon } from "../../utils/utils";
+
+interface Props {
+	/** Which documentation page to open. */
+	doc: DocKey;
+	/**
+	 * `icon` sits beside a setting's name (via SettingItem's `nameSuffix`); `inline`
+	 * appends a text link to a section's description paragraph.
+	 */
+	variant?: "icon" | "inline";
+	/** Link text for the `inline` variant. */
+	label?: string;
+	/**
+	 * What the page explains, e.g. "Note access policy". Used to build an accessible
+	 * name — an icon whose only label is "help" tells a screen-reader user nothing
+	 * about where it goes.
+	 */
+	subject?: string;
+	class?: string;
+}
+
+let { doc, variant = "icon", label = "Learn more", subject, class: className = "" }: Props = $props();
+
+const accessibleName = $derived(subject ? `Documentation: ${subject}` : "Open documentation");
+</script>
+
+{#if variant === "icon"}
+  <a
+    class="s2b-docs-link-icon clickable-icon {className}"
+    href={DOCS[doc]}
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label={accessibleName}
+    title={accessibleName}
+  >
+    <span class="s2b-docs-link-glyph" use:icon={"help-circle"} aria-hidden="true"></span>
+  </a>
+{:else}
+  <a
+    class="s2b-docs-link-inline {className}"
+    href={DOCS[doc]}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    {label} →
+  </a>
+{/if}
+
+<style>
+  /* `.clickable-icon` already supplies the transparent-at-rest → hover-highlight
+     treatment, rounding and cursor; it is sized for a button, so pull it in to sit
+     next to a setting name without inflating the row. */
+  .s2b-docs-link-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px;
+    color: var(--text-muted);
+    text-decoration: none;
+  }
+
+  .s2b-docs-link-icon:hover {
+    color: var(--text-normal);
+  }
+
+  /* Obsidian's `.svg-icon` reads `--icon-size` for BOTH axes. Setting only
+     width/height on the wrapper leaves the injected svg at its inherited 18px, so
+     it overflows the box and reads as bad centering rather than as overflow. */
+  .s2b-docs-link-glyph {
+    --icon-size: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+  }
+
+  .s2b-docs-link-inline {
+    font-size: var(--font-smaller);
+    white-space: nowrap;
+  }
+</style>

--- a/src/components/ui/ExternalLinkButton.svelte
+++ b/src/components/ui/ExternalLinkButton.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+/**
+ * An anchor wearing Obsidian's button clothes, for opening an external URL from a
+ * setting row's control slot.
+ *
+ * Use this instead of a `<button>` whose handler calls `window.open`. Obsidian's iOS
+ * WKWebView never implements window creation — its `WKUIDelegate` has no window
+ * handler, so `window.open(...)` returns null unconditionally there (confirmed
+ * on-device; see the note on `navigateToAuthorizeUrl` in
+ * `providers/openrouterOAuth.ts`) and the click silently does nothing. A real
+ * anchor is handed to the system browser on every platform, no branching required.
+ *
+ * `obsidian://` deep links are a different case and can stay on `window.open`: they
+ * are handled by the app's own protocol handler rather than by opening a window.
+ */
+import { icon } from "../../utils/utils";
+
+interface Props {
+	/** Absolute external URL. */
+	href: string;
+	/** Visible button label. */
+	label: string;
+	/** Lucide icon id shown before the label. */
+	iconId?: string;
+	/**
+	 * Overrides the accessible name. Default is the label, which is usually enough —
+	 * set this when the label alone is ambiguous out of context.
+	 */
+	ariaLabel?: string;
+	class?: string;
+}
+
+let { href, label, iconId = "lucide-external-link", ariaLabel, class: className = "" }: Props = $props();
+</script>
+
+<a
+  class="s2b-external-link-button {className}"
+  {href}
+  target="_blank"
+  rel="noopener noreferrer"
+  aria-label={ariaLabel}
+>
+  {#if iconId}
+    <span class="s2b-external-link-button-icon" use:icon={iconId} aria-hidden="true"></span>
+  {/if}
+  {label}
+</a>
+
+<style>
+  /* Inherits the theme's own button variables rather than restating colours, so it
+     sits beside real buttons in the same row without drifting when the theme
+     changes; `text-decoration: none` and the normal text colour undo the link
+     defaults it would otherwise pick up. Mirrors Button.svelte's icon+label layout
+     (inline-flex, 6px gap). */
+  .s2b-external-link-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    /* Obsidian sizes buttons with `height: var(--input-height)` plus `4px 12px`
+       padding, not by content — match both so this sits flush with the real
+       buttons it shares a row with. */
+    height: var(--input-height);
+    box-sizing: border-box;
+    padding: 4px 12px;
+    border-radius: var(--button-radius);
+    background-color: var(--interactive-normal);
+    box-shadow: var(--input-shadow);
+    color: var(--text-normal);
+    font-size: var(--font-ui-small);
+    text-decoration: none;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .s2b-external-link-button:hover {
+    background-color: var(--interactive-hover);
+    box-shadow: var(--input-shadow-hover);
+    color: var(--text-normal);
+  }
+
+  /* Obsidian's `.svg-icon` reads `--icon-size` for both axes; sizing only the
+     wrapper leaves the injected svg at its inherited size and it overflows. */
+  .s2b-external-link-button-icon {
+    --icon-size: var(--icon-s);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--icon-s);
+    height: var(--icon-s);
+    flex-shrink: 0;
+  }
+</style>

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -1,0 +1,62 @@
+/**
+ * Links from the plugin into the documentation site (smartsecondbrain.dev).
+ *
+ * User-facing docs deliberately live in the `s2b-dev/site` repo rather than in this
+ * one, so anything the UI wants to explain at length is a link rather than a
+ * paragraph. Those URLs are a contract with that repo: its routes have already been
+ * restructured once (`/features/*` → `/search/`, `/agents/*`), which is exactly why
+ * the site still carries a `redirects` block in its `astro.config.mjs` for the stale
+ * links the README had scattered inline. Keeping every URL here means the next move
+ * is a one-file reconciliation instead of a grep.
+ *
+ * Every entry must be an absolute URL with a **trailing slash** — that is the form
+ * the site emits (see its `dist/sitemap-0.xml`), and the redirect table is keyed on
+ * it too.
+ */
+
+export const DOCS_BASE = "https://smartsecondbrain.dev";
+
+/**
+ * Doc slug → absolute URL. Keys are named for what the *caller* is explaining, not
+ * for the site's directory layout, so a route move doesn't ripple into call sites.
+ */
+export const DOCS = Object.freeze({
+	home: `${DOCS_BASE}/`,
+
+	// Getting started
+	installation: `${DOCS_BASE}/start/installation/`,
+	firstRun: `${DOCS_BASE}/start/first-run/`,
+	providers: `${DOCS_BASE}/start/providers/`,
+
+	// Features
+	search: `${DOCS_BASE}/search/`,
+	graph: `${DOCS_BASE}/graph/`,
+
+	// Agents
+	agents: `${DOCS_BASE}/agents/`,
+	skills: `${DOCS_BASE}/agents/skills/`,
+	integrations: `${DOCS_BASE}/agents/integrations/`,
+	memory: `${DOCS_BASE}/agents/memory/`,
+	mcp: `${DOCS_BASE}/agents/mcp/`,
+
+	// Privacy
+	privacyModel: `${DOCS_BASE}/privacy/model/`,
+	trustedProviders: `${DOCS_BASE}/privacy/trusted-providers/`,
+
+	// Help
+	troubleshooting: `${DOCS_BASE}/help/troubleshooting/`,
+	faq: `${DOCS_BASE}/help/faq/`,
+});
+
+export type DocKey = keyof typeof DOCS;
+
+/**
+ * Open a documentation page in the user's browser.
+ *
+ * For button-style callers. Anything that can be an anchor should render one instead
+ * (see `DocsLink.svelte`): Obsidian hands external `_blank` anchors to the system
+ * browser on both desktop and mobile, so a real link needs no platform branching.
+ */
+export function openDocs(doc: DocKey): void {
+	window.open(DOCS[doc], "_blank", "noopener,noreferrer");
+}

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -51,12 +51,14 @@ export const DOCS = Object.freeze({
 export type DocKey = keyof typeof DOCS;
 
 /**
- * Open a documentation page in the user's browser.
+ * There is deliberately no `openDocs(key)` helper here.
  *
- * For button-style callers. Anything that can be an anchor should render one instead
- * (see `DocsLink.svelte`): Obsidian hands external `_blank` anchors to the system
- * browser on both desktop and mobile, so a real link needs no platform branching.
+ * A `window.open` wrapper would look like the obvious convenience, but Obsidian's
+ * iOS WKWebView never implements window creation — `window.open` returns null
+ * unconditionally there (confirmed on-device; see the note on
+ * `navigateToAuthorizeUrl` in `providers/openrouterOAuth.ts`), so a button calling
+ * it would silently do nothing on iPhone and iPad. Render a real anchor instead,
+ * via `components/ui/DocsLink.svelte` — its `button` variant covers the case where
+ * a setting row wants something that *looks* like a button. Obsidian hands external
+ * `_blank` anchors to the system browser on every platform, no branching needed.
  */
-export function openDocs(doc: DocKey): void {
-	window.open(DOCS[doc], "_blank", "noopener,noreferrer");
-}

--- a/src/views/onboarding/Onboarding.svelte
+++ b/src/views/onboarding/Onboarding.svelte
@@ -6,6 +6,7 @@ import Button from "../../components/ui/Button.svelte";
 import Toggle from "../../components/ui/Toggle.svelte";
 import { useAvailableModels } from "../../hooks/useAvailableModels.svelte";
 import type SecondBrainPlugin from "../../main";
+import { DOCS } from "../../utils/docs";
 import { buildPersistedChatModel } from "../../utils/persistedChatModel";
 import { getData } from "../../stores/dataStore.svelte";
 import { isMobileUI } from "../../utils/platform";
@@ -433,7 +434,18 @@ function openHotkeysSettings() {
 	</div>
 
 	<footer class="s2b-onboarding-footer" class:s2b-fade-in={playIntro} style="--s2b-order: 8">
-		<Button buttonText="Skip" onClick={skip} />
+		<!-- Docs sit with Skip rather than among the CTAs: this is the one screen every
+		     user sees, so it is where a link to the full documentation has the most
+		     reach, but it must not compete with the two actions on the right. -->
+		<div class="s2b-onboarding-footer-secondary">
+			<Button buttonText="Skip" onClick={skip} />
+			<a
+				class="s2b-onboarding-link"
+				href={DOCS.home}
+				target="_blank"
+				rel="noopener noreferrer">Documentation ↗</a
+			>
+		</div>
 		<div class="s2b-onboarding-footer-primary">
 			<Button buttonText="Explore the graph" onClick={exploreGraph} />
 			<Button
@@ -828,6 +840,12 @@ function openHotkeysSettings() {
 		margin-left: auto;
 	}
 
+	.s2b-onboarding-footer-secondary {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
 	/* On a phone the three buttons don't fit on one line, and `flex-wrap` on a
 	   `space-between` row broke them into a ragged stack — Skip alone on one line,
 	   the other two sharing the next, each a different width.
@@ -852,7 +870,10 @@ function openHotkeysSettings() {
 		padding-bottom: calc(52px + env(safe-area-inset-bottom) + 12px) !important;
 	}
 
-	:global(.is-mobile) .s2b-onboarding-footer-primary {
+	/* Both groups dissolve on mobile so their children become direct flex items of
+	   the stacked footer and the `order` rules below can interleave them. */
+	:global(.is-mobile) .s2b-onboarding-footer-primary,
+	:global(.is-mobile) .s2b-onboarding-footer-secondary {
 		display: contents;
 	}
 
@@ -870,11 +891,29 @@ function openHotkeysSettings() {
 		order: -1;
 	}
 
-	/* Skip stays last and reads as the low-emphasis way out. */
-	:global(.is-mobile) .s2b-onboarding-footer > :global(button) {
+	/* Skip stays last and reads as the low-emphasis way out.
+
+	   Matched through `-secondary`, not as a child of the footer: `display: contents`
+	   removes that wrapper from *layout* (so Skip does become a flex item of the
+	   stacked footer, and `order` below works), but it does NOT change the DOM tree
+	   the selector walks — Skip's parent element is still the wrapper. Selecting
+	   `.s2b-onboarding-footer > button` therefore stops matching and Skip renders
+	   with its default solid background instead of quiet. */
+	:global(.is-mobile) .s2b-onboarding-footer-secondary > :global(button) {
 		order: 0;
 		background: transparent;
 		box-shadow: none;
 		color: var(--text-muted);
+	}
+
+	/* The docs link trails Skip, centred to match the stacked full-width buttons
+	   rather than hugging the left edge. `all: unset` leaves it `display: inline`;
+	   as a flex item that blockifies anyway, but say so explicitly so the
+	   text-align actually has a box to work on. */
+	:global(.is-mobile) .s2b-onboarding-footer-secondary > .s2b-onboarding-link {
+		order: 1;
+		display: block;
+		text-align: center;
+		padding-block: 0.25rem;
 	}
 </style>

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -5,6 +5,7 @@ import { Platform } from "obsidian";
 import AuthConfigFields from "../../components/settings/AuthConfigFields.svelte";
 import SettingItem from "../../components/settings/SettingItem.svelte";
 import Button from "../../components/ui/Button.svelte";
+import DocsLink from "../../components/ui/DocsLink.svelte";
 import Text from "../../components/ui/Text.svelte";
 import Toggle from "../../components/ui/Toggle.svelte";
 import ProviderSetupHeader from "./ProviderSetupHeader.svelte";
@@ -429,7 +430,16 @@ $effect(() => {
 
 {#if step === "pick"}
   <div class="modal-content">
-    <p class="provider-picker-desc">Choose a provider to connect.</p>
+    <!-- The docs cover local setup (Ollama) and how to pick a model — the two
+         things a new user stalls on before they can tell whether a failure is their
+         endpoint, their key, or their model choice. -->
+    <p class="provider-picker-desc">
+      Choose a provider to connect. <DocsLink
+        variant="inline"
+        doc="providers"
+        label="Setup guide"
+      />
+    </p>
     <div class="provider-picker-grid">
       {#each providerTemplates as template (template.id)}
         {@const Logo = getTemplateLogo(template.id)}

--- a/src/views/settings/GeneralSettings.svelte
+++ b/src/views/settings/GeneralSettings.svelte
@@ -5,6 +5,7 @@ import ProviderItem from "../../components/settings/ProviderItem.svelte";
 import SettingGroup from "../../components/settings/SettingGroup.svelte";
 import SettingItem from "../../components/settings/SettingItem.svelte";
 import Button from "../../components/ui/Button.svelte";
+import DocsLink from "../../components/ui/DocsLink.svelte";
 import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
 import { icon } from "../../utils/utils";
@@ -54,6 +55,10 @@ function handleOpenProviderSetup() {
         use:icon={"shield-check"}
         aria-hidden="true"
       ></span>
+      <!-- Two vault modes crossed with per-provider trust, where the same toggle
+           inverts meaning depending on the mode — more than one description line
+           can carry, so link the page that lays it out. -->
+      <DocsLink doc="privacyModel" subject="Note access policy" />
     {/snippet}
 
     <Button onClick={() => privacyListModal.open()} buttonText="Manage" />

--- a/src/views/settings/TroubleshootingSettings.svelte
+++ b/src/views/settings/TroubleshootingSettings.svelte
@@ -9,7 +9,7 @@ import Toggle from "../../components/ui/Toggle.svelte";
 import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
 import { ConfirmModal } from "../../components/modal/ConfirmModal";
-import { openDocs } from "../../utils/docs";
+import DocsLink from "../../components/ui/DocsLink.svelte";
 import { Logger } from "../../utils/logging";
 
 const pluginData = getData();
@@ -85,11 +85,7 @@ async function handleCleanupPluginData() {
     name="Troubleshooting guide"
     desc="Common problems and how to resolve them — the agent not responding, unhelpful search results, withheld notes, missing MCP tools, and mobile-specific issues."
   >
-    <Button
-      buttonText="Open guide"
-      iconId="lucide-external-link"
-      onClick={() => openDocs("troubleshooting")}
-    />
+    <DocsLink variant="button" doc="troubleshooting" label="Open guide" />
   </SettingItem>
 
   <SettingItem

--- a/src/views/settings/TroubleshootingSettings.svelte
+++ b/src/views/settings/TroubleshootingSettings.svelte
@@ -9,6 +9,7 @@ import Toggle from "../../components/ui/Toggle.svelte";
 import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
 import { ConfirmModal } from "../../components/modal/ConfirmModal";
+import { openDocs } from "../../utils/docs";
 import { Logger } from "../../utils/logging";
 
 const pluginData = getData();
@@ -76,9 +77,24 @@ async function handleCleanupPluginData() {
 
 <!-- Maintenance -->
 <SettingGroup heading="Maintenance">
+  <!-- Docs first, GitHub as the escalation path: the troubleshooting guide is
+       organised by symptom (the agent won't respond, search returns nothing, a note
+       is being withheld, …), so it answers most of what would otherwise arrive as
+       an issue. -->
   <SettingItem
-    name="Need more help?"
-    desc="First look through existing GitHub issues to see whether the problem is already tracked. If it is not, open a new issue and include what you tried, any error messages, and steps to reproduce it."
+    name="Troubleshooting guide"
+    desc="Common problems and how to resolve them — the agent not responding, unhelpful search results, withheld notes, missing MCP tools, and mobile-specific issues."
+  >
+    <Button
+      buttonText="Open guide"
+      iconId="lucide-external-link"
+      onClick={() => openDocs("troubleshooting")}
+    />
+  </SettingItem>
+
+  <SettingItem
+    name="Still stuck?"
+    desc="Look through existing GitHub issues to see whether the problem is already tracked. If it is not, open a new issue and include what you tried, any error messages, and steps to reproduce it."
   >
     <div class="flex gap-2 flex-wrap">
       <Button

--- a/src/views/settings/TroubleshootingSettings.svelte
+++ b/src/views/settings/TroubleshootingSettings.svelte
@@ -10,6 +10,7 @@ import { getData } from "../../stores/dataStore.svelte";
 import { getPlugin } from "../../stores/state.svelte";
 import { ConfirmModal } from "../../components/modal/ConfirmModal";
 import DocsLink from "../../components/ui/DocsLink.svelte";
+import ExternalLinkButton from "../../components/ui/ExternalLinkButton.svelte";
 import { Logger } from "../../utils/logging";
 
 const pluginData = getData();
@@ -17,14 +18,6 @@ const plugin = getPlugin();
 const githubIssuesListUrl =
 	"https://github.com/s2b-dev/smart-second-brain/issues?q=is%3Aissue%20state%3Aopen%20label%3Abug";
 const githubIssuesNewUrl = "https://github.com/s2b-dev/smart-second-brain/issues/new/choose";
-
-function openGitHubIssues() {
-	window.open(githubIssuesListUrl, "_blank", "noopener,noreferrer");
-}
-
-function openGitHubIssue() {
-	window.open(githubIssuesNewUrl, "_blank", "noopener,noreferrer");
-}
 
 async function handleCleanupPluginData() {
 	const modal = new ConfirmModal(
@@ -93,12 +86,8 @@ async function handleCleanupPluginData() {
     desc="Look through existing GitHub issues to see whether the problem is already tracked. If it is not, open a new issue and include what you tried, any error messages, and steps to reproduce it."
   >
     <div class="flex gap-2 flex-wrap">
-      <Button
-        buttonText="View existing issues"
-        iconId="lucide-external-link"
-        onClick={openGitHubIssues}
-      />
-      <Button buttonText="Open new issue" iconId="lucide-external-link" onClick={openGitHubIssue} />
+      <ExternalLinkButton href={githubIssuesListUrl} label="View existing issues" />
+      <ExternalLinkButton href={githubIssuesNewUrl} label="Open new issue" />
     </div>
   </SettingItem>
 


### PR DESCRIPTION
## Why

The docs live in `s2b-dev/site` and the README points at seven of its pages, but **the plugin itself linked to the site zero times**. Every outbound link in `src/` went somewhere else: provider vendor key pages, GitHub issues, and `skillsmp.com`.

`manifest.json` sets `authorUrl`, but I checked Obsidian 1.14.0's bundle — that only linkifies the author *name* in the community-plugin detail modal, and there is no `helpUrl` manifest field (QuickAdd ships one; the app ignores it). So there is no native docs slot, and a user stuck inside the plugin had exactly one escalation path: open a GitHub issue.

## What

Links on the six surfaces where someone is either stuck or facing a concept inline copy cannot carry:

| Surface | Page |
|---|---|
| Troubleshooting settings | `/help/troubleshooting/` |
| General settings → Note access policy | `/privacy/model/` |
| Onboarding footer | site root |
| Provider setup picker | `/start/providers/` |
| Agent editor → Core skills / Integrations / MCP | `/agents/skills/`, `/agents/integrations/`, `/agents/mcp/` |
| Add skill modal → Browse skills | `/agents/skills/` |

In Troubleshooting the guide sits **above** the GitHub row, which is reworded from "Need more help?" to "Still stuck?" so the docs read as the first stop and GitHub as the escalation. The site's page is organised by symptom, so it should deflect a good share of what would otherwise arrive as issues.

Deliberately skipped: Search/Graph settings (the "how it works" pages are interest-driven reading, not stuck-user reading) and the per-tool config modals (inline descriptions are already at the right altitude).

## How

- **`src/utils/docs.ts`** — one frozen map of every URL. The site's routes have already moved once (its `astro.config.mjs` still carries redirects for the stale links the README had scattered inline), so the next restructure should be a one-file reconciliation rather than a grep. All 15 entries cross-checked against `../site/dist/sitemap-0.xml`.
- **`src/components/ui/DocsLink.svelte`** — icon variant for setting rows (via `SettingItem`'s existing `nameSuffix` snippet) and inline variant for section descriptions.
- **Plain anchors, no platform branching.** Obsidian hands external `_blank` links to the system browser on desktop and mobile alike, so these need none of the `window.open` workarounds the OAuth flow does.

### One non-obvious change

The onboarding footer's mobile rule had to be rewritten from `.s2b-onboarding-footer > button` to match through the new wrapper div. `display: contents` removes the wrapper from *layout* — so Skip does become a flex item of the stacked footer and the `order` rules still work — but it does **not** change the DOM tree a child combinator walks. The old selector would have silently stopped matching and Skip would have lost its quiet styling.

## Verification

- `format`, `lint`, `check` (both tsconfigs) clean; 1644 tests pass.
- Built and driven live in the WT1 slot vault. Verified all six link locations render with the right `href`, `target="_blank"` and `rel="noopener noreferrer"`; no console errors.
- Help icons measured at 16×16 with no SVG overflow and centres aligned to their setting names.
- Onboarding footer checked on desktop (Skip + Documentation left, both CTAs still flush right) **and** under real `emulateMobile` — column order is Start chatting → Explore the graph → Skip → Documentation, Skip transparent, docs link centred.
- Mobile behaviour is verified under Obsidian's mobile emulation, not on a physical device.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._