### PR TITLE
feat(chat): show topic name in graph reference attachment pill

### DIFF
--- a/src/components/chat/ContextTray.svelte
+++ b/src/components/chat/ContextTray.svelte
@@ -20,6 +20,9 @@ const BASENAME_RE = /(?:.*\/)?([^/]+?)(?:\.\w+)?$/;
 interface Props {
 	/** Graph note paths set externally (e.g. from Messenger.pendingGraphNotes). */
 	graphPaths?: string[];
+	/** Name of the topic(s) `graphPaths` exactly matches, or null/undefined if
+	 * the selection isn't a whole topic (e.g. Messenger.graphSelectionTopicLabel). */
+	topicLabel?: string | null;
 	/** Content attachments (files whose bytes/content are inlined into the message). */
 	attachments?: ChatAttachment[];
 	/** Remove a content attachment. */
@@ -32,6 +35,7 @@ interface Props {
 
 let {
 	graphPaths = [],
+	topicLabel = null,
 	attachments = [],
 	onRemoveAttachment,
 	onPromoteToAttachment,
@@ -87,6 +91,10 @@ const activeGraphPaths = $derived(graphPaths.filter((p) => !graphDismissed.has(p
 $effect(() => {
 	if (activeGraphPaths.length === 0 && graphExpanded) graphExpanded = false;
 });
+// The topic name only describes the full, untouched selection — once the user
+// dismisses any member from this chat's tray, the remaining notes no longer
+// are that topic, so fall back to the count-based label.
+const effectiveTopicLabel = $derived(graphDismissed.size === 0 ? topicLabel : null);
 
 // --- One-way outputs. Derived, not synced through effects, per the repo's
 // Svelte guidance. Exposed as getter functions (Svelte disallows exporting
@@ -288,12 +296,16 @@ onDestroy(() => {
           class="chip-body s2b-pill s2b-pill--interactive"
           title={graphExpanded
             ? "Graph selection — click to collapse"
-            : `${activeGraphPaths.length} note${activeGraphPaths.length === 1 ? "" : "s"} from graph — click to expand`}
+            : effectiveTopicLabel
+              ? `${effectiveTopicLabel} — click to expand`
+              : `${activeGraphPaths.length} note${activeGraphPaths.length === 1 ? "" : "s"} from graph — click to expand`}
           aria-expanded={graphExpanded}
           onclick={() => (graphExpanded = !graphExpanded)}
         >
           <div class="chip-icon" use:icon={"git-fork"} style="--icon-size: 12px"></div>
-          <span>{activeGraphPaths.length} Graph Note{activeGraphPaths.length === 1 ? "" : "s"}</span>
+          <span>
+            {effectiveTopicLabel ?? `${activeGraphPaths.length} Graph Note${activeGraphPaths.length === 1 ? "" : "s"}`}
+          </span>
           <div class="chip-icon chip-chevron" use:icon={graphExpanded ? "chevron-up" : "chevron-down"} style="--icon-size: 12px"></div>
         </button>
         <button

--- a/src/components/chat/ContextTray.svelte
+++ b/src/components/chat/ContextTray.svelte
@@ -86,17 +86,30 @@ let graphDismissed = $state(new Set<string>());
 // Graph selections can be large (lasso-select of many nodes). Collapse them into
 // a single summary chip by default; expand on demand to review/remove individuals.
 let graphExpanded = $state(false);
-// `graphPaths` is a fresh array every time the registry adopts a new selection
-// (SmartGraphView always assigns `[...paths]`), so identity distinguishes "the same
-// selection, edited by dismissal" from "a new selection that happens to share paths
-// with the old one". Reset dismissals on that boundary: without it, dismissing a note
-// then re-selecting the same or an overlapping topic would filter fresh paths through
-// stale exclusions, silently shrinking (or emptying) a selection the user never
-// touched — and, since the topic label requires an exact match, permanently hide the
-// name for a selection gesture that has nothing to do with the earlier dismissal.
+// `graphPaths` changes for two different reasons, which need opposite treatment:
+//  1. A genuinely new selection (topic click, panel row, lasso) — may share paths
+//     with the old one (re-selecting the same/an overlapping topic), but the user's
+//     old dismissals shouldn't carry over: without a reset, stale exclusions would
+//     filter fresh paths out of a selection the user never touched, shrinking the
+//     count or (since the topic label requires an exact match) permanently hiding
+//     the name for a selection gesture that has nothing to do with the dismissal.
+//  2. A background live-patch pruning vault-deleted notes out of the *current*
+//     selection (SmartGraphView's live-patch handler): this republishes a fresh
+//     array too, but it's the same selection minus some notes — a note the user
+//     explicitly dismissed must stay dismissed, not reappear because of unrelated
+//     vault maintenance.
+// Distinguish them by membership rather than array identity: case 2 only ever
+// removes paths (never introduces one, and never brings the count back up), so a
+// *strictly smaller* selection where every remaining path already existed is a
+// prune and must NOT reset dismissals. Anything else — a new path appearing, or
+// the same-size-or-larger selection re-arriving (re-selecting the same topic after
+// editing it by hand) — is case 1 and must reset.
+let previousGraphPaths: string[] = [];
 $effect(() => {
-	void graphPaths; // establish the dependency; the reset itself is unconditional
-	graphDismissed = new Set();
+	const isPrune =
+		graphPaths.length < previousGraphPaths.length && graphPaths.every((p) => previousGraphPaths.includes(p));
+	if (!isPrune) graphDismissed = new Set();
+	previousGraphPaths = graphPaths;
 });
 const activeGraphPaths = $derived(graphPaths.filter((p) => !graphDismissed.has(p)));
 // Once every graph note is dismissed there's nothing to expand.

--- a/src/components/chat/ContextTray.svelte
+++ b/src/components/chat/ContextTray.svelte
@@ -23,6 +23,10 @@ interface Props {
 	/** Name of the topic(s) `graphPaths` exactly matches, or null/undefined if
 	 * the selection isn't a whole topic (e.g. Messenger.graphSelectionTopicLabel). */
 	topicLabel?: string | null;
+	/** True when `graphPaths` was republished by background vault maintenance
+	 * (a live patch pruning deleted notes) rather than a new user selection
+	 * gesture (e.g. Messenger.graphSelectionIsMaintenance). */
+	graphSelectionIsMaintenance?: boolean;
 	/** Content attachments (files whose bytes/content are inlined into the message). */
 	attachments?: ChatAttachment[];
 	/** Remove a content attachment. */
@@ -36,6 +40,7 @@ interface Props {
 let {
 	graphPaths = [],
 	topicLabel = null,
+	graphSelectionIsMaintenance = false,
 	attachments = [],
 	onRemoveAttachment,
 	onPromoteToAttachment,
@@ -87,29 +92,26 @@ let graphDismissed = $state(new Set<string>());
 // a single summary chip by default; expand on demand to review/remove individuals.
 let graphExpanded = $state(false);
 // `graphPaths` changes for two different reasons, which need opposite treatment:
-//  1. A genuinely new selection (topic click, panel row, lasso) — may share paths
-//     with the old one (re-selecting the same/an overlapping topic), but the user's
-//     old dismissals shouldn't carry over: without a reset, stale exclusions would
-//     filter fresh paths out of a selection the user never touched, shrinking the
-//     count or (since the topic label requires an exact match) permanently hiding
-//     the name for a selection gesture that has nothing to do with the dismissal.
+//  1. A genuinely new selection gesture (topic click, panel row, lasso, Shift-click,
+//     drilling into one cluster of a larger selection) — may be a subset of, equal
+//     to, or disjoint from the old one, but the user's old dismissals shouldn't
+//     carry over regardless of shape: without a reset, stale exclusions would filter
+//     fresh paths out of a selection the user never touched, and (since the topic
+//     label requires an exact match) permanently hide the name for a selection
+//     gesture that has nothing to do with the earlier dismissal.
 //  2. A background live-patch pruning vault-deleted notes out of the *current*
-//     selection (SmartGraphView's live-patch handler): this republishes a fresh
-//     array too, but it's the same selection minus some notes — a note the user
-//     explicitly dismissed must stay dismissed, not reappear because of unrelated
-//     vault maintenance.
-// Distinguish them by membership rather than array identity: case 2 only ever
-// removes paths (never introduces one, and never brings the count back up), so a
-// *strictly smaller* selection where every remaining path already existed is a
-// prune and must NOT reset dismissals. Anything else — a new path appearing, or
-// the same-size-or-larger selection re-arriving (re-selecting the same topic after
-// editing it by hand) — is case 1 and must reset.
-let previousGraphPaths: string[] = [];
+//     selection (SmartGraphView's live-patch handler): this republishes a fresh,
+//     shrunk array too, but it's the same selection minus some notes — a note the
+//     user explicitly dismissed must stay dismissed, not reappear because of
+//     unrelated vault maintenance.
+// These can't be told apart from the paths alone — a user picking a smaller
+// selection also produces a subset, so shape is not a valid signal (see the prior
+// `isPrune`-by-membership attempt). SmartGraphView knows which case it is by
+// construction (only its live-patch handler sets `graphSelectionIsMaintenance`), so
+// it's threaded through as an explicit flag instead of inferred here.
 $effect(() => {
-	const isPrune =
-		graphPaths.length < previousGraphPaths.length && graphPaths.every((p) => previousGraphPaths.includes(p));
-	if (!isPrune) graphDismissed = new Set();
-	previousGraphPaths = graphPaths;
+	void graphPaths; // establish the dependency; the reset itself is unconditional
+	if (!graphSelectionIsMaintenance) graphDismissed = new Set();
 });
 const activeGraphPaths = $derived(graphPaths.filter((p) => !graphDismissed.has(p)));
 // Once every graph note is dismissed there's nothing to expand.

--- a/src/components/chat/ContextTray.svelte
+++ b/src/components/chat/ContextTray.svelte
@@ -86,18 +86,25 @@ let graphDismissed = $state(new Set<string>());
 // Graph selections can be large (lasso-select of many nodes). Collapse them into
 // a single summary chip by default; expand on demand to review/remove individuals.
 let graphExpanded = $state(false);
+// `graphPaths` is a fresh array every time the registry adopts a new selection
+// (SmartGraphView always assigns `[...paths]`), so identity distinguishes "the same
+// selection, edited by dismissal" from "a new selection that happens to share paths
+// with the old one". Reset dismissals on that boundary: without it, dismissing a note
+// then re-selecting the same or an overlapping topic would filter fresh paths through
+// stale exclusions, silently shrinking (or emptying) a selection the user never
+// touched — and, since the topic label requires an exact match, permanently hide the
+// name for a selection gesture that has nothing to do with the earlier dismissal.
+$effect(() => {
+	void graphPaths; // establish the dependency; the reset itself is unconditional
+	graphDismissed = new Set();
+});
 const activeGraphPaths = $derived(graphPaths.filter((p) => !graphDismissed.has(p)));
 // Once every graph note is dismissed there's nothing to expand.
 $effect(() => {
 	if (activeGraphPaths.length === 0 && graphExpanded) graphExpanded = false;
 });
 // The topic name only describes the full, untouched selection — once the user
-// dismisses any member of THIS selection from the tray, the remaining notes no
-// longer are that topic, so fall back to the count-based label. Compare against
-// `graphPaths.length` rather than `graphDismissed.size`: dismissals accumulate
-// across selections in the same mounted chat, so a stale dismissal from an
-// earlier (now-replaced) selection must not suppress the label for a later,
-// still-untouched one.
+// dismisses any member of it, the remaining notes no longer are that topic.
 const effectiveTopicLabel = $derived(activeGraphPaths.length === graphPaths.length ? topicLabel : null);
 
 // --- One-way outputs. Derived, not synced through effects, per the repo's

--- a/src/components/chat/ContextTray.svelte
+++ b/src/components/chat/ContextTray.svelte
@@ -92,9 +92,13 @@ $effect(() => {
 	if (activeGraphPaths.length === 0 && graphExpanded) graphExpanded = false;
 });
 // The topic name only describes the full, untouched selection — once the user
-// dismisses any member from this chat's tray, the remaining notes no longer
-// are that topic, so fall back to the count-based label.
-const effectiveTopicLabel = $derived(graphDismissed.size === 0 ? topicLabel : null);
+// dismisses any member of THIS selection from the tray, the remaining notes no
+// longer are that topic, so fall back to the count-based label. Compare against
+// `graphPaths.length` rather than `graphDismissed.size`: dismissals accumulate
+// across selections in the same mounted chat, so a stale dismissal from an
+// earlier (now-replaced) selection must not suppress the label for a later,
+// still-untouched one.
+const effectiveTopicLabel = $derived(activeGraphPaths.length === graphPaths.length ? topicLabel : null);
 
 // --- One-way outputs. Derived, not synced through effects, per the repo's
 // Svelte guidance. Exposed as getter functions (Svelte disallows exporting

--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -1318,6 +1318,7 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
         bind:this={contextTrayRef}
         graphPaths={registry.graphSelection}
         topicLabel={registry.graphSelectionTopicLabel}
+        graphSelectionIsMaintenance={registry.graphSelectionIsMaintenance}
         {attachments}
         onRemoveAttachment={removeAttachment}
         onPromoteToAttachment={promoteVisibleNoteToAttachment}

--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -1317,6 +1317,7 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
       <ContextTray
         bind:this={contextTrayRef}
         graphPaths={registry.graphSelection}
+        topicLabel={registry.graphSelectionTopicLabel}
         {attachments}
         onRemoveAttachment={removeAttachment}
         onPromoteToAttachment={promoteVisibleNoteToAttachment}

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -1373,20 +1373,42 @@ function clusterLabel(cluster: number): string {
 }
 
 /**
- * Name the topics `paths` exactly matches under `communities` (path → cluster
- * index), or null if it isn't an exact match — used only by the live-patch
- * handler, whose `communities` is current but whose canvas isn't yet (see
- * `handleSelectionChange`'s `topicLabelOverride` doc). Mirrors
- * `getNodePathsForClusters`'s exclusion of unsorted notes (`cluster == null`
- * never matches, even if `UNSORTED_CLUSTER` is itself focused) — but unlike
- * the canvas method, doesn't resolve collapsed topic nodes back to their
- * members, so a selection touching a currently-collapsed topic conservatively
- * falls back to null (count-based label) rather than risk a wrong match.
+ * Name the topics `paths` exactly matches under `communities` (path → raw
+ * Leiden community id), or null if it isn't an exact match — used only by the
+ * live-patch handler, whose `communities` is current but whose canvas isn't
+ * yet (see `handleSelectionChange`'s `topicLabelOverride` doc).
+ *
+ * `focusedClusters` holds *segment indices* (`segments[i]`, assigned `i` by
+ * `resolveAndApplySegments`/`resolveSegmentsByLeiden` after sorting and
+ * dropping undersized communities) — not raw community ids. The two numeric
+ * spaces aren't interchangeable: sorting and drops mean a segment's index can
+ * differ from its `communityId`. Map through `segments[i].communityId` (set
+ * by `resolveAndApplySegments`, already current — it runs synchronously
+ * inside `applyLivePatch`, before this is called) rather than comparing
+ * `communities` values against `focusedClusters` directly.
+ *
+ * Mirrors `getNodePathsForClusters`'s exclusion of unsorted notes (`cluster
+ * == null` never matches, even if `UNSORTED_CLUSTER` is itself focused) —
+ * but unlike the canvas method, doesn't resolve collapsed topic nodes back
+ * to their members, so a selection touching a currently-collapsed topic
+ * conservatively falls back to null (count-based label) rather than risk a
+ * wrong match.
  */
 function topicLabelForCommunities(communities: Record<string, number>, paths: string[]): string[] | null {
 	if (focusedClusters.size === 0 || paths.length === 0) return null;
+	const focusedCommunityIds = new Set(
+		[...focusedClusters].flatMap((cluster) => {
+			const id = segments[cluster]?.communityId;
+			return id === undefined ? [] : [id];
+		}),
+	);
+	// Every focused segment must have resolved to a real community id — if
+	// segments haven't caught up either (shouldn't happen, but this is exactly
+	// the kind of ordering assumption that bit the canvas-based check), bail
+	// out to the safe count-based fallback rather than risk a wrong match.
+	if (focusedCommunityIds.size !== focusedClusters.size) return null;
 	const topicPaths = Object.entries(communities)
-		.filter(([, cluster]) => focusedClusters.has(cluster))
+		.filter(([, communityId]) => focusedCommunityIds.has(communityId))
 		.map(([path]) => path);
 	const selected = new Set(paths);
 	if (topicPaths.length !== selected.size || !topicPaths.every((path) => selected.has(path))) return null;

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -1217,6 +1217,9 @@ function handleSelectionChange(paths: string[]) {
 	if (messenger) {
 		// Ambient: mirror the live graph selection into every open chat's tray.
 		messenger.graphSelection = [...paths];
+		// Callers set focusedClusters/selectedPaths before calling in, so this
+		// derivation is already current for the selection just adopted above.
+		messenger.graphSelectionTopicLabel = selectedTopicLabels?.join(", ") ?? null;
 	}
 }
 
@@ -1303,6 +1306,8 @@ function handleOpenAllSelected() {
 async function handleSendToChat() {
 	const paths = selectedPaths;
 	if (paths.length === 0) return;
+	// Read before the awaits below give the user a chance to change the selection.
+	const topicLabel = selectedTopicLabels?.join(", ") ?? null;
 
 	// Reveal an existing chat (uncollapsing its sidebar) or create one.
 	const { workspace } = plugin.app;
@@ -1317,6 +1322,7 @@ async function handleSendToChat() {
 	if (messenger) {
 		// Ambient selection (shown in every chat) …
 		messenger.graphSelection = [...paths];
+		messenger.graphSelectionTopicLabel = topicLabel;
 		// … plus a one-shot signal so the just-opened/focused chat grabs focus.
 		messenger.pendingGraphNotes = [...paths];
 	} else {

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -861,7 +861,35 @@ function flushLiveUpdate() {
 				drift++;
 			}
 		}
+		// `focusedClusters`/`focusedSegmentIds` hold indices into `segments` — but
+		// `applyLivePatch` below rebuilds `segments` from scratch (sorted by size,
+		// undersized ones dropped), so an index that pointed at "Marine Ecology"
+		// can point at a different topic, or nothing, once it returns. Capture what
+		// community each focused index actually meant *before* that happens, so it
+		// can be re-resolved to wherever that same community landed afterward —
+		// otherwise the focus silently follows the wrong topic (or none) post-patch,
+		// which breaks topic highlighting/panel rows generally, not just the label.
+		const focusedCommunityIdsBeforePatch = new Set(
+			[...focusedClusters].flatMap((cluster) => {
+				const id = segments[cluster]?.communityId;
+				return id === undefined ? [] : [id];
+			}),
+		);
+
 		applyLivePatch(patch.data, communities, drift);
+
+		// Re-resolve focus to the rebuilt `segments` array by community identity.
+		if (focusedClusters.size > 0) {
+			const nextFocusedClusters = new Set(
+				segments.flatMap((segment, index) =>
+					segment.communityId !== undefined && focusedCommunityIdsBeforePatch.has(segment.communityId)
+						? [index]
+						: [],
+				),
+			);
+			focusedClusters = nextFocusedClusters;
+			focusedSegmentIds = new Set([...nextFocusedClusters].flatMap((c) => (segments[c] ? [segments[c].id] : [])));
+		}
 
 		// A removed note can't stay selected — mirror the pruned selection out so
 		// chat trays don't keep offering a note that no longer exists.

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -870,7 +870,7 @@ function flushLiveUpdate() {
 			const surviving = selectedPaths.filter((path) => !removed.has(path));
 			if (surviving.length !== selectedPaths.length) {
 				canvasComponent?.selectNodesByPaths(surviving);
-				handleSelectionChange(surviving, true);
+				handleSelectionChange(surviving, true, topicLabelForCommunities(communities, surviving));
 			}
 		}
 
@@ -1219,8 +1219,18 @@ function handleFocusCluster(cluster: number, pan = false, multi = true) {
  * cluster) also produces a subset of the prior selection, so shape alone
  * can't tell the two apart. Per-chat dismissals should survive maintenance
  * pruning but reset on every real selection change, however it was made.
+ *
+ * `topicLabelOverride` lets the same maintenance caller supply a label it
+ * already computed synchronously against the just-updated `communities`,
+ * instead of falling through to `selectedTopicLabels`. That derivation reads
+ * `canvasComponent`'s `simNodes`, which the canvas only rebuilds from
+ * `graphData` on its own next reactive flush — still stale in the same
+ * synchronous block that just reassigned `graphData` via `applyLivePatch`.
+ * Every other caller sets `focusedClusters`/`selectedPaths` and calls in
+ * synchronously too, but through *this* component's own reactive graph
+ * (`segments`, `effectiveClusterLabels`), which is current already.
  */
-function handleSelectionChange(paths: string[], isMaintenance = false) {
+function handleSelectionChange(paths: string[], isMaintenance = false, topicLabelOverride?: string[] | null) {
 	selectedPaths = paths;
 	const messenger = getSessionRegistry();
 	if (messenger) {
@@ -1228,8 +1238,10 @@ function handleSelectionChange(paths: string[], isMaintenance = false) {
 		messenger.graphSelection = [...paths];
 		messenger.graphSelectionIsMaintenance = isMaintenance;
 		// Callers set focusedClusters/selectedPaths before calling in, so this
-		// derivation is already current for the selection just adopted above.
-		messenger.graphSelectionTopicLabel = selectedTopicLabels?.join(", ") ?? null;
+		// derivation is already current for the selection just adopted above —
+		// except the maintenance caller, which passes its own override (see above).
+		const labels = topicLabelOverride !== undefined ? topicLabelOverride : selectedTopicLabels;
+		messenger.graphSelectionTopicLabel = labels?.join(", ") ?? null;
 	}
 }
 
@@ -1352,6 +1364,35 @@ function handleClearSelection() {
 	handleSelectionChange([]);
 }
 
+/** Same naming ladder (and same fallbacks) the canvas uses for a topic node, so
+ * every surface calls a topic exactly what its pill did. */
+function clusterLabel(cluster: number): string {
+	return cluster === UNSORTED_CLUSTER
+		? "Unsorted"
+		: (effectiveClusterLabels[cluster] ?? segments[cluster]?.label ?? `Topic ${cluster}`);
+}
+
+/**
+ * Name the topics `paths` exactly matches under `communities` (path → cluster
+ * index), or null if it isn't an exact match — used only by the live-patch
+ * handler, whose `communities` is current but whose canvas isn't yet (see
+ * `handleSelectionChange`'s `topicLabelOverride` doc). Mirrors
+ * `getNodePathsForClusters`'s exclusion of unsorted notes (`cluster == null`
+ * never matches, even if `UNSORTED_CLUSTER` is itself focused) — but unlike
+ * the canvas method, doesn't resolve collapsed topic nodes back to their
+ * members, so a selection touching a currently-collapsed topic conservatively
+ * falls back to null (count-based label) rather than risk a wrong match.
+ */
+function topicLabelForCommunities(communities: Record<string, number>, paths: string[]): string[] | null {
+	if (focusedClusters.size === 0 || paths.length === 0) return null;
+	const topicPaths = Object.entries(communities)
+		.filter(([, cluster]) => focusedClusters.has(cluster))
+		.map(([path]) => path);
+	const selected = new Set(paths);
+	if (topicPaths.length !== selected.size || !topicPaths.every((path) => selected.has(path))) return null;
+	return [...focusedClusters].map(clusterLabel);
+}
+
 /**
  * Name the topics the current selection consists of, or null if it isn't one.
  *
@@ -1369,14 +1410,7 @@ let selectedTopicLabels: string[] | null = $derived.by(() => {
 	const topicPaths = new Set(canvasComponent?.getNodePathsForClusters(focusedClusters) ?? []);
 	const selected = new Set(selectedPaths);
 	if (topicPaths.size !== selected.size || ![...topicPaths].every((path) => selected.has(path))) return null;
-	// Same naming ladder (and same fallbacks) the canvas uses for a topic node,
-	// so the bar calls a topic exactly what its pill did — including the
-	// `UNSORTED_CLUSTER` sentinel, which is negative and so indexes no segment.
-	return [...focusedClusters].map((cluster) =>
-		cluster === UNSORTED_CLUSTER
-			? "Unsorted"
-			: (effectiveClusterLabels[cluster] ?? segments[cluster]?.label ?? `Topic ${cluster}`),
-	);
+	return [...focusedClusters].map(clusterLabel);
 });
 
 async function handleImmerse() {

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -870,7 +870,7 @@ function flushLiveUpdate() {
 			const surviving = selectedPaths.filter((path) => !removed.has(path));
 			if (surviving.length !== selectedPaths.length) {
 				canvasComponent?.selectNodesByPaths(surviving);
-				handleSelectionChange(surviving);
+				handleSelectionChange(surviving, true);
 			}
 		}
 
@@ -1210,13 +1210,23 @@ function handleFocusCluster(cluster: number, pan = false, multi = true) {
  * Every path that changes the selection routes through here — canvas lasso,
  * topic label, panel row — so the graph and each open chat's context tray can
  * never disagree about what is selected.
+ *
+ * `isMaintenance` marks the one caller (the live-patch handler below) that
+ * republishes a *shrunk* version of the existing selection because notes were
+ * deleted out from under it — not a new user gesture. A chat tray needs this
+ * distinction verbatim, not inferred from path-set shape: a user picking a
+ * smaller selection (Shift-click, deselecting a topic, drilling into one
+ * cluster) also produces a subset of the prior selection, so shape alone
+ * can't tell the two apart. Per-chat dismissals should survive maintenance
+ * pruning but reset on every real selection change, however it was made.
  */
-function handleSelectionChange(paths: string[]) {
+function handleSelectionChange(paths: string[], isMaintenance = false) {
 	selectedPaths = paths;
 	const messenger = getSessionRegistry();
 	if (messenger) {
 		// Ambient: mirror the live graph selection into every open chat's tray.
 		messenger.graphSelection = [...paths];
+		messenger.graphSelectionIsMaintenance = isMaintenance;
 		// Callers set focusedClusters/selectedPaths before calling in, so this
 		// derivation is already current for the selection just adopted above.
 		messenger.graphSelectionTopicLabel = selectedTopicLabels?.join(", ") ?? null;
@@ -1322,6 +1332,7 @@ async function handleSendToChat() {
 	if (messenger) {
 		// Ambient selection (shown in every chat) …
 		messenger.graphSelection = [...paths];
+		messenger.graphSelectionIsMaintenance = false;
 		messenger.graphSelectionTopicLabel = topicLabel;
 		// … plus a one-shot signal so the just-opened/focused chat grabs focus.
 		messenger.pendingGraphNotes = [...paths];

--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -1362,6 +1362,13 @@ export class SessionRegistry {
 	 * the user has since edited by hand). Mirrors `graphSelection`'s ambient
 	 * scope — set alongside it everywhere it's assigned. */
 	graphSelectionTopicLabel: string | null = $state(null);
+	/** True when the current `graphSelection` value was republished by background
+	 * vault maintenance (a live patch pruning deleted notes out of the existing
+	 * selection) rather than a new user gesture. A chat tray's per-note dismissals
+	 * must survive maintenance pruning but reset on every real selection change —
+	 * and that distinction can't be inferred from the paths alone, since a user
+	 * picking a smaller selection also shrinks the path set. */
+	graphSelectionIsMaintenance: boolean = $state(false);
 	pendingAttachmentPaths: string[] | null = $state(null);
 	pendingAutoSubmit: boolean = $state(false);
 	/** When set, only the Input bound to this thread path consumes the pending

--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -1357,6 +1357,11 @@ export class SessionRegistry {
 	 * shows up in whichever chat the user switches to while it stays selected.
 	 * Per-chat exclusions are tracked locally in each ContextTray. */
 	graphSelection: string[] = $state([]);
+	/** Name of the topic(s) `graphSelection` exactly matches, or null if the
+	 * selection isn't a whole topic (lasso, panel row, or a topic selection
+	 * the user has since edited by hand). Mirrors `graphSelection`'s ambient
+	 * scope — set alongside it everywhere it's assigned. */
+	graphSelectionTopicLabel: string | null = $state(null);
 	pendingAttachmentPaths: string[] | null = $state(null);
 	pendingAutoSubmit: boolean = $state(false);
 	/** When set, only the Input bound to this thread path consumes the pending


### PR DESCRIPTION
## Summary
- When a graph selection exactly matches one or more topics (clicked topic label, panel row, or a fold/re-select of a focused topic), the chat composer's graph attachment pill now shows the topic name(s) instead of a bare count — e.g. "Marine Ecology" instead of "80 Graph Notes".
- Multiple topics selected together join their names.
- Falls back to the existing count-based label ("N Graph Notes") for lasso-selects/arbitrary selections, or once the user dismisses any individual note from the pill in that chat (the remaining set no longer matches the topic).

Reuses the existing `selectedTopicLabels` derivation in `SmartGraphView.svelte` (already used by "Immerse") — no new label-resolution logic. Threaded through a new `SessionRegistry.graphSelectionTopicLabel` ambient field, mirroring `graphSelection`.

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run format`
- [x] One-shot dev build succeeds
- [x] Manually verified in slot vault (S2B WT1):
  - [x] Clicking a topic label shows the topic name in the composer pill
  - [x] Expanding the pill still lists individual note basenames
  - [x] Dismissing one member note falls back to the count-based label

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._