### PR TITLE
fix(provider-setup): show connection status in the modal body

### DIFF
--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -209,9 +209,8 @@ let headerStatusHost: HTMLSpanElement | null = null;
 let headerStatusComponent: ReturnType<typeof mount> | null = null;
 // Reactive prop bag for the imperatively-mounted header status component. Mutating these
 // fields propagates to the mounted subtree (Svelte 5 mount props are reactive via $state).
-const headerStatusProps = $state<{ provider: string; showStatus: boolean }>({
+const headerStatusProps = $state<{ provider: string }>({
 	provider: untrack(() => providerId),
-	showStatus: false,
 });
 let displayName = $state("");
 let displayNameError = $state<string | null>(null);
@@ -332,8 +331,8 @@ function renderHeaderLogo() {
 	if (step !== "configure") return;
 	const title = modal.titleEl;
 	const header = title.parentElement;
-	// Don't let the title stretch — it would push the status/trust icons onto a new
-	// line, where they collide with the absolutely-positioned .modal-close-button.
+	// Don't let the title stretch — it would push the trust icon onto a new line, where
+	// it collides with the absolutely-positioned .modal-close-button.
 	// Zero the inline margins too: Obsidian's .modal-title uses auto side-margins that
 	// resolve to a large value in a flex row, opening a gap on either side of the title.
 	title.setCssStyles({ margin: "0", flex: "0 0 auto" });
@@ -366,11 +365,11 @@ function renderHeaderLogo() {
 			props: { width: 32, height: 32 },
 		});
 
-		// Status + trust icons after the title (icon → name → status → trust).
+		// Trust icon after the title (logo → name → trust).
 		// Recreating the host must also recreate the component: leaving the old one mounted
 		// kept it rendering into the now-detached span while the `!headerStatusComponent`
-		// guard below suppressed a remount, so the connection check silently vanished from
-		// the header. Tear both down together.
+		// guard below suppressed a remount, so the icon silently vanished from the header.
+		// Tear both down together.
 		if (!headerStatusHost || headerStatusHost.parentElement !== header) {
 			if (headerStatusComponent) {
 				unmount(headerStatusComponent);
@@ -411,11 +410,10 @@ $effect(() => {
 	};
 });
 
-// Keep the imperatively-mounted header status component's props in sync with the modal's
-// reactive state (provider id after rename, and the empty-state gate).
+// Keep the imperatively-mounted header component's props in sync with the modal's reactive
+// state (the provider id changes once, when a committed draft is renamed to its slug).
 $effect(() => {
 	headerStatusProps.provider = providerId;
-	headerStatusProps.showStatus = hasCredentials;
 });
 
 // Live commit: once the connection validates on the configure step, promote the draft to

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -214,10 +214,15 @@ const headerStatusProps = $state<{ provider: string }>({
 });
 let displayName = $state("");
 let displayNameError = $state<string | null>(null);
-// True while a display-name save is in flight. `displayNameError` still holds its previous
-// value until the await settles, so without this Done could enable mid-save on a name whose
-// validity isn't known yet — and the commit's slug is derived from that same name.
-let isSavingDisplayName = $state(false);
+// Number of display-name saves currently in flight. `displayNameError` still holds its
+// previous value until an await settles, so without this Done could enable mid-save on a
+// name whose validity isn't known yet — and the commit's slug is derived from that same
+// name. A counter rather than a boolean: blurring twice before the first save settles
+// would otherwise let the first completion clear the flag while the second is still
+// running, reopening the commit gate and letting `renameProvider` move the ID out from
+// under it.
+let pendingDisplayNameSaves = $state(0);
+const isSavingDisplayName = $derived(pendingDisplayNameSaves > 0);
 const isTrusted = $derived(data.isProviderTrusted(providerId));
 
 // Logos per template for the picker grid. Templates without a dedicated logo
@@ -306,7 +311,7 @@ async function handleDisplayNameBlur(nextName: string) {
 		displayNameError = null;
 		return;
 	}
-	isSavingDisplayName = true;
+	pendingDisplayNameSaves += 1;
 	try {
 		await data.updateProviderMeta(providerId, { displayName: trimmedName });
 		displayName = trimmedName;
@@ -315,7 +320,7 @@ async function handleDisplayNameBlur(nextName: string) {
 	} catch (e) {
 		displayNameError = e instanceof Error ? e.message : "Invalid name";
 	} finally {
-		isSavingDisplayName = false;
+		pendingDisplayNameSaves -= 1;
 	}
 }
 

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -248,8 +248,10 @@ async function handleSelectTemplate(id: ProviderTemplateId) {
 }
 
 // Guards the one-time live commit so it never re-runs once the provider is configured
-// or while a commit is already in flight (the effect can re-fire mid-await).
-let isCommitting = false;
+// or while a commit is already in flight (the effect can re-fire mid-await). Reactive so
+// the Done button can stay disabled across the commit's awaits — closing mid-rename would
+// race the ID change, and `markSubmitted` only lands after it.
+let isCommitting = $state(false);
 
 // Promotes a draft to a fully configured provider the moment its connection validates.
 // This replaces the old "Add Provider" button: display name / auth / trusted all
@@ -434,6 +436,14 @@ const connectionStatus = $derived.by<ConnectionStatus>(() => {
 const connectionError = $derived(
 	query.data && !query.data.success ? (query.data.message ?? "Authentication failed") : "Authentication failed",
 );
+
+// Done must track the *commit*, not just the connection. A valid connection alone isn't
+// enough to leave safely: the commit effect skips while `displayNameError` is set, so
+// closing then would hit onClose with an uncommitted draft and delete it along with the
+// credentials the user just entered; and closing mid-commit races `renameProvider`, whose
+// ID change lands before `markSubmitted`. Editing an already-configured provider has
+// nothing to commit, so it's ready as soon as it validates.
+const canFinish = $derived(connectionStatus === "connected" && isConfigured && !isCommitting && !displayNameError);
 </script>
 
 {#if step === "pick"}
@@ -545,6 +555,11 @@ const connectionError = $derived(
       {:else if connectionStatus === "connected"}
         <span class="provider-connection-icon is-success" use:icon={"check-circle"}></span>
         <span class="provider-connection-text is-success">Connected</span>
+        {#if displayNameError}
+          <!-- Connected, but the commit is blocked: say why, so a disabled Done isn't a
+               dead end the user has to guess at. -->
+          <span class="provider-connection-text is-muted">— fix the provider name to finish</span>
+        {/if}
       {:else if connectionStatus === "failed"}
         <span class="provider-connection-icon is-error" use:icon={"x-circle"}></span>
         <span class="provider-connection-text is-error">{connectionError}</span>
@@ -555,12 +570,7 @@ const connectionError = $derived(
       {/if}
     </div>
 
-    <Button
-      buttonText="Done"
-      cta={connectionStatus === "connected"}
-      disabled={connectionStatus !== "connected"}
-      onClick={() => modal.close()}
-    />
+    <Button buttonText="Done" cta={canFinish} disabled={!canFinish} onClick={() => modal.close()} />
   </div>
 {/snippet}
 

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -5,6 +5,7 @@ import { Platform } from "obsidian";
 import AuthConfigFields from "../../components/settings/AuthConfigFields.svelte";
 import SettingItem from "../../components/settings/SettingItem.svelte";
 import Button from "../../components/ui/Button.svelte";
+import CircularLoader from "../../components/ui/CircularLoader.svelte";
 import DocsLink from "../../components/ui/DocsLink.svelte";
 import Text from "../../components/ui/Text.svelte";
 import Toggle from "../../components/ui/Toggle.svelte";
@@ -30,6 +31,7 @@ import {
 	getProviderDefinition,
 } from "../../providers/index";
 import { getData, slugifyProviderName } from "../../stores/dataStore.svelte";
+import { icon } from "../../utils/utils";
 import type { ProviderSetupModal } from "./ProviderSetup";
 
 interface Props {
@@ -152,11 +154,6 @@ async function handleOAuthSignIn() {
 			// Store the OAuth-obtained key as a managed secret so validation re-runs and Save enables.
 			data.setProviderAuthField(providerId, "apiKey", result.apiKey, true);
 		}
-		// A completed OAuth sign-in is a clear terminal action — once the connection
-		// validates and the provider commits, auto-close the modal so the user gets
-		// unambiguous feedback (the provider appears in the list) rather than having to
-		// spot the small green header icon. The commit effect honors this flag.
-		closeAfterCommit = true;
 		invalidateAuthState(providerId);
 	} catch (error) {
 		// A user-initiated cancel isn't a failure — clear the flow silently so the CTA
@@ -254,11 +251,6 @@ async function handleSelectTemplate(id: ProviderTemplateId) {
 // or while a commit is already in flight (the effect can re-fire mid-await).
 let isCommitting = false;
 
-// Set by a completed OAuth sign-in: once the provider commits, auto-close the modal after
-// a short beat so the "Connected" check is briefly visible. Manual API-key entry doesn't
-// set this — the modal stays open so the user can still adjust trusted/advanced fields.
-let closeAfterCommit = false;
-
 // Promotes a draft to a fully configured provider the moment its connection validates.
 // This replaces the old "Add Provider" button: display name / auth / trusted all
 // autosave as they change, so the only remaining commit steps are slug-finalizing the
@@ -299,14 +291,6 @@ async function commitProvider() {
 		invalidateProviderState(providerId);
 	} finally {
 		isCommitting = false;
-	}
-
-	// OAuth sign-in path: the provider is now committed and shows "Connected". Close the
-	// modal after a short beat so the green check is briefly visible — the provider then
-	// appears in the list, which is the clearest confirmation.
-	if (closeAfterCommit) {
-		closeAfterCommit = false;
-		window.setTimeout(() => modal.close(), 800);
 	}
 }
 
@@ -374,7 +358,15 @@ function renderHeaderLogo() {
 		});
 
 		// Status + trust icons after the title (icon → name → status → trust).
+		// Recreating the host must also recreate the component: leaving the old one mounted
+		// kept it rendering into the now-detached span while the `!headerStatusComponent`
+		// guard below suppressed a remount, so the connection check silently vanished from
+		// the header. Tear both down together.
 		if (!headerStatusHost || headerStatusHost.parentElement !== header) {
+			if (headerStatusComponent) {
+				unmount(headerStatusComponent);
+				headerStatusComponent = null;
+			}
 			headerStatusHost?.remove();
 			headerStatusHost = header.createSpan({ cls: "provider-setup-header-status" });
 			title.after(headerStatusHost);
@@ -426,6 +418,22 @@ $effect(() => {
 		untrack(() => void commitProvider());
 	}
 });
+
+// In-body connection status. The header carries the same verdict as a small icon, but that
+// is easy to miss — especially in onboarding, where the user has never seen this modal and
+// has no "Add" button to press, so nothing tells them the provider took. The status row
+// below is the primary signal; the header icon stays as a secondary cue.
+type ConnectionStatus = "idle" | "checking" | "connected" | "failed";
+const connectionStatus = $derived.by<ConnectionStatus>(() => {
+	if (!hasCredentials) return "idle";
+	if (query.isPending || query.isFetching) return "checking";
+	if (query.data?.success) return "connected";
+	if (query.data !== undefined) return "failed";
+	return "idle";
+});
+const connectionError = $derived(
+	query.data && !query.data.success ? (query.data.message ?? "Authentication failed") : "Authentication failed",
+);
 </script>
 
 {#if step === "pick"}
@@ -520,8 +528,41 @@ $effect(() => {
     {:else}
       <AuthConfigFields provider={providerId} afterRequired={trustedToggle} />
     {/if}
+
+    {@render connectionStatusRow()}
   </div>
 {/if}
+
+{#snippet connectionStatusRow()}
+  <!-- The modal has no submit button (auth autosaves and the provider commits itself the
+       moment validation passes), so without this row a successful setup looks identical to
+       an untouched form. Spell the verdict out, and give the user an explicit way to leave. -->
+  <div class="provider-connection-row">
+    <div class="provider-connection-status" role="status" aria-live="polite">
+      {#if connectionStatus === "checking"}
+        <CircularLoader size={16} color="var(--text-muted)" />
+        <span class="provider-connection-text">Checking connection…</span>
+      {:else if connectionStatus === "connected"}
+        <span class="provider-connection-icon is-success" use:icon={"check-circle"}></span>
+        <span class="provider-connection-text is-success">Connected</span>
+      {:else if connectionStatus === "failed"}
+        <span class="provider-connection-icon is-error" use:icon={"x-circle"}></span>
+        <span class="provider-connection-text is-error">{connectionError}</span>
+      {:else}
+        <span class="provider-connection-text is-muted">
+          Enter your credentials above — the connection is checked automatically.
+        </span>
+      {/if}
+    </div>
+
+    <Button
+      buttonText="Done"
+      cta={connectionStatus === "connected"}
+      disabled={connectionStatus !== "connected"}
+      onClick={() => modal.close()}
+    />
+  </div>
+{/snippet}
 
 {#snippet trustedToggle()}
   <SettingItem
@@ -586,6 +627,59 @@ $effect(() => {
     color: var(--text-success, #4caf50);
     font-size: var(--font-ui-small);
     font-weight: 500;
+  }
+
+  .provider-connection-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--size-4-3);
+    margin-top: var(--size-4-2);
+    padding: var(--size-4-3);
+    border-top: 1px solid var(--background-modifier-border);
+  }
+
+  .provider-connection-status {
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-2);
+    min-width: 0;
+  }
+
+  .provider-connection-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+  }
+
+  /* The action injects a bare <svg>, which defaults to 100%/auto and overflows the box. */
+  .provider-connection-icon :global(svg) {
+    width: 16px;
+    height: 16px;
+  }
+
+  .provider-connection-text {
+    font-size: var(--font-ui-small);
+    overflow-wrap: anywhere;
+  }
+
+  .provider-connection-text.is-muted {
+    color: var(--text-muted);
+  }
+
+  .is-success {
+    color: var(--text-success, #4caf50);
+  }
+
+  .provider-connection-text.is-success {
+    font-weight: 500;
+  }
+
+  .is-error {
+    color: var(--text-error);
   }
 
   .auth-alt-toggle {

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -215,6 +215,10 @@ const headerStatusProps = $state<{ provider: string; showStatus: boolean }>({
 });
 let displayName = $state("");
 let displayNameError = $state<string | null>(null);
+// True while a display-name save is in flight. `displayNameError` still holds its previous
+// value until the await settles, so without this Done could enable mid-save on a name whose
+// validity isn't known yet — and the commit's slug is derived from that same name.
+let isSavingDisplayName = $state(false);
 const isTrusted = $derived(data.isProviderTrusted(providerId));
 
 // Logos per template for the picker grid. Templates without a dedicated logo
@@ -303,6 +307,7 @@ async function handleDisplayNameBlur(nextName: string) {
 		displayNameError = null;
 		return;
 	}
+	isSavingDisplayName = true;
 	try {
 		await data.updateProviderMeta(providerId, { displayName: trimmedName });
 		displayName = trimmedName;
@@ -310,6 +315,8 @@ async function handleDisplayNameBlur(nextName: string) {
 		modal.refreshTitle(trimmedName);
 	} catch (e) {
 		displayNameError = e instanceof Error ? e.message : "Invalid name";
+	} finally {
+		isSavingDisplayName = false;
 	}
 }
 
@@ -416,7 +423,10 @@ $effect(() => {
 // it no-ops once configured, so later validation failures never un-configure it.
 $effect(() => {
 	if (step !== "configure") return;
-	if (query.data?.success && !isConfigured && !displayNameError) {
+	// Wait out an in-flight name save too: the commit slugifies the display name into the
+	// provider's final ID, so committing mid-save could derive it from a name that is about
+	// to be rejected. The save settling re-runs this effect.
+	if (query.data?.success && !isConfigured && !displayNameError && !isSavingDisplayName) {
 		untrack(() => void commitProvider());
 	}
 });
@@ -441,9 +451,13 @@ const connectionError = $derived(
 // enough to leave safely: the commit effect skips while `displayNameError` is set, so
 // closing then would hit onClose with an uncommitted draft and delete it along with the
 // credentials the user just entered; and closing mid-commit races `renameProvider`, whose
-// ID change lands before `markSubmitted`. Editing an already-configured provider has
-// nothing to commit, so it's ready as soon as it validates.
-const canFinish = $derived(connectionStatus === "connected" && isConfigured && !isCommitting && !displayNameError);
+// ID change lands before `markSubmitted`. A name save still in flight counts as unsettled
+// too — `displayNameError` lags the await, and the commit slugifies that same name.
+// Editing an already-configured provider has nothing to commit, so it's ready as soon as
+// it validates.
+const canFinish = $derived(
+	connectionStatus === "connected" && isConfigured && !isCommitting && !displayNameError && !isSavingDisplayName,
+);
 </script>
 
 {#if step === "pick"}

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -311,6 +311,15 @@ async function handleDisplayNameBlur(nextName: string) {
 		displayNameError = null;
 		return;
 	}
+	// A commit in flight is mid-rename: `renameProvider` re-keys providerMeta synchronously
+	// but then awaits its save, and `providerId` is only reassigned after that await — so a
+	// blur landing in that window would write against an ID that no longer exists, throw
+	// "Provider not found", and strand Done disabled on a provider that connected fine.
+	// The commit already slugifies the name it captured; nothing is lost by ignoring this.
+	if (isCommitting) {
+		displayName = providerMeta?.displayName ?? trimmedName;
+		return;
+	}
 	pendingDisplayNameSaves += 1;
 	try {
 		await data.updateProviderMeta(providerId, { displayName: trimmedName });

--- a/src/views/provider-setup/ProviderSetupHeader.svelte
+++ b/src/views/provider-setup/ProviderSetupHeader.svelte
@@ -1,89 +1,43 @@
 <script lang="ts">
-import CircularLoader from "../../components/ui/CircularLoader.svelte";
-import { createAuthStateQuery } from "../../lib/query";
 import { getData } from "../../stores/dataStore.svelte";
 import { icon } from "../../utils/utils";
 
 interface Props {
 	provider: string;
-	// Gate the status icon so it stays hidden on an untouched form (mirrors the modal's
-	// hasCredentials logic). When false, only the trust icon (if trusted) can show.
-	showStatus: boolean;
 }
 
-const { provider, showStatus }: Props = $props();
+const { provider }: Props = $props();
 
 const data = getData();
-const query = createAuthStateQuery(() => provider);
-const isChecking = $derived(query.isPending || query.isFetching);
 const isTrusted = $derived(data.isProviderTrusted(provider));
-const failureMessage = $derived(query.data && !query.data.success ? query.data.message : "Authentication failed");
 </script>
 
-<span class="provider-status-group">
-  {#if showStatus}
-    {#if isChecking}
-      <span class="provider-status-indicator" title="Checking connection" aria-label="Checking connection">
-        <CircularLoader size={18} color="var(--text-muted)" />
-      </span>
-    {:else if query.data?.success}
-      <span
-        class="provider-status-indicator provider-icon-indicator-success"
-        title="Connected"
-        aria-label="Connected"
-      >
-        <span class="provider-status-icon" use:icon={"check-circle"}></span>
-      </span>
-    {:else if query.data !== undefined}
-      <span
-        class="provider-status-indicator provider-icon-indicator-error"
-        title={failureMessage}
-        aria-label={failureMessage}
-      >
-        <span class="provider-status-icon" use:icon={"x-circle"}></span>
-      </span>
-    {/if}
-  {/if}
-
-  {#if isTrusted}
-    <span
-      class="provider-icon-indicator provider-icon-indicator-accent"
-      title="Trusted with private notes"
-      aria-label="Trusted with private notes"
-    >
-      <span class="provider-status-icon" use:icon={"shield-check"}></span>
-    </span>
-  {/if}
-</span>
+<!-- Connection status is stated in the modal body (see the "Connection" row in
+     ProviderSetup.svelte), which is where users actually look — a 20px check up here was
+     the only success signal for a long time, and it was routinely missed. Trust has no
+     body-level indicator of its own besides its toggle, so it stays. -->
+{#if isTrusted}
+  <span
+    class="provider-icon-indicator provider-icon-indicator-accent"
+    title="Trusted with private notes"
+    aria-label="Trusted with private notes"
+  >
+    <span class="provider-status-icon" use:icon={"shield-check"}></span>
+  </span>
+{/if}
 
 <style>
-  .provider-status-group {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    flex-shrink: 0;
-  }
-
-  .provider-status-indicator,
   .provider-icon-indicator {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    color: var(--text-muted);
     min-width: 20px;
     min-height: 20px;
-  }
-
-  .provider-icon-indicator-error {
-    color: var(--text-error);
+    flex-shrink: 0;
   }
 
   .provider-icon-indicator-accent {
     color: var(--text-accent);
-  }
-
-  .provider-icon-indicator-success {
-    color: var(--text-success, #4caf50);
   }
 
   .provider-status-icon {
@@ -95,7 +49,7 @@ const failureMessage = $derived(query.data && !query.data.success ? query.data.m
     flex-shrink: 0;
   }
 
-  /* Scale the injected Lucide SVG to fill the (now larger) icon box. */
+  /* Scale the injected Lucide SVG to fill the icon box. */
   .provider-status-icon :global(svg) {
     width: 20px;
     height: 20px;


### PR DESCRIPTION
## Problem

The Setup Provider modal has no submit button — auth autosaves, and the provider commits itself the moment validation passes. So a **successful setup looks identical to an untouched form**.

The only success signal was a 20px `check-circle` in the modal *title bar*. In the onboarding flow that leaves a new user with nothing telling them the provider connected, or that they may now close the modal.

Reported against an `openai-compatible` provider (SAP HAI) that had connected correctly but showed no checkmark at all. Two distinct causes:

**1. The header icon didn't always mount.** In `renderHeaderLogo`, when the header host was recreated (`parentElement !== header`), the old component was left mounted — it kept rendering into the now-detached span, while the `!headerStatusComponent` guard suppressed a remount into the new host.

**2. There was no in-body feedback at all.** The one body-level signal is a success/error border painted by `AuthConfigFields.getFieldStyles`, and that is **never applied to secret fields** — `kind: "secret"` renders a `SecretSelect`, which doesn't call it. An `openai-compatible` provider configured via a stored secret, exactly the reported case, got zero in-body confirmation.

## Changes

- **Connection status row** at the bottom of the configure step: spinner while checking, green "Connected" when valid, the provider's actual failure message when not. `role="status"` / `aria-live="polite"`.
- **Done button** beside it, giving the flow an explicit exit instead of just an `×`.
- **Removed the header connection icon.** With the body stating the status, the title-bar check was a less legible duplicate — and being the *only* signal is why it was missed. The **trust shield stays**: it has no body-level indicator besides its own toggle. The remount fix is kept, since the same bug would have hidden the trust icon.
- **Dropped the OAuth auto-close.** It was a workaround for this same problem (its comment: *"rather than having to spot the small green header icon"*), and it yanked the modal away before the user could set "Trusted with private notes". Both paths now end on the same explicit Done.

### Review follow-ups

**Done now gates on the commit, not just the connection** (Greptile P1, valid). The commit effect skips while `displayNameError` is set, so a draft could reach "Connected" with Done enabled but nothing committed — closing there hits `onClose` with an uncommitted draft and deletes it *along with the credentials just entered*. Closing mid-commit is unsafe too: `renameProvider` is awaited before `markSubmitted`. Gated on `isConfigured && !isCommitting && !displayNameError`; `isCommitting` became `$state` so the button stays disabled across the awaits. When connected but blocked on the name, the row says why rather than leaving a disabled Done unexplained.

**In-flight name saves count as unsettled** (Greptile P2, partly valid). The stated mechanism — a late write restoring stale identity state — does not hold: `saveSettings` snapshots `this.#data` *synchronously* at call time and both writers mutate that same live object first, so no snapshot can carry a pre-rename view forward; `handleDisplayNameBlur` also awaits its save before clearing `displayNameError`, which `canFinish` already required. But the in-flight window is real and narrower: while awaiting, `displayNameError` holds its *previous* value, so Done could enable on a name whose validity isn't known yet — and `commitProvider` slugifies that same name into the final ID. Tracked with `isSavingDisplayName`, gating both `canFinish` and the commit effect.

## Verification

`check` (0 errors), `format`, `lint` clean; `test` 1644 passed / 112 files; dev build succeeds.

Driven live in the `S2B WT1` vault against a local openai-compatible endpoint:

| Scenario | Row | Done |
|---|---|---|
| Valid endpoint | `Connected` + green check | enabled, `mod-cta` |
| Broken endpoint | `Connection failed: net::ERR_UNSAFE_PORT` | disabled |
| Restored | back to `Connected` | enabled, `mod-cta` |
| Colliding display name | `Connected — fix the provider name to finish` | disabled |
| Name restored | `Connected` | enabled, `mod-cta` |
| Slowed `updateProviderMeta` | `Connected` | disabled for the save, re-enabled after |

Provider names and the configured set stayed intact across reloads; `dev:errors` clean throughout. The final header-icon removal is unverified live — flagged for your own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._