### PR TITLE
Plugin-review cleanup: real bugs + popout-safe globals

### DIFF
--- a/src/agent/ObsidianChatManager.ts
+++ b/src/agent/ObsidianChatManager.ts
@@ -143,7 +143,7 @@ export class ObsidianChatManager extends BaseCheckpointSaver {
 		const raw = await this.adapter.readBinary(path);
 		const decompressed = await gunzipToString(raw);
 		// Yield after decompression so JSON.parse doesn't block the same frame.
-		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+		await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
 		const parsed = JSON.parse(decompressed) as ThreadData;
 		if ((parsed.version ?? 0) > THREAD_DATA_VERSION) {
 			Logger.warn(

--- a/src/agent/tools/executeJavaScript.ts
+++ b/src/agent/tools/executeJavaScript.ts
@@ -21,12 +21,12 @@ async function executeInWorker(code: string, input?: unknown): Promise<JavaScrip
 		const finish = (callback: () => void) => {
 			if (settled) return;
 			settled = true;
-			globalThis.clearTimeout(timeoutId);
+			window.clearTimeout(timeoutId);
 			worker.terminate();
 			callback();
 		};
 
-		const timeoutId = globalThis.setTimeout(() => {
+		const timeoutId = window.setTimeout(() => {
 			finish(() => reject(new Error(`JavaScript execution timed out after ${EXECUTION_TIMEOUT_MS}ms.`)));
 		}, EXECUTION_TIMEOUT_MS);
 

--- a/src/agent/tools/executePluginApi.ts
+++ b/src/agent/tools/executePluginApi.ts
@@ -46,7 +46,7 @@ export function createPluginApiExecTool(app: App, pluginId: string, displayName:
 
 		try {
 			const timeout = new Promise<never>((_, reject) => {
-				setTimeout(
+				window.setTimeout(
 					() => reject(new Error(`Execution timed out after ${EXECUTION_TIMEOUT_MS}ms.`)),
 					EXECUTION_TIMEOUT_MS,
 				);

--- a/src/agent/tools/fetchUrl.ts
+++ b/src/agent/tools/fetchUrl.ts
@@ -217,7 +217,7 @@ export function createFetchUrlTool() {
 		const maxContentLength = contextWindowToCharBudget(contextWindow, READ_CONTENT_BUDGET_FRACTION);
 
 		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+		const timeout = window.setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
 		try {
 			// Follow redirects manually so we can re-validate each hop's target
@@ -297,7 +297,7 @@ export function createFetchUrlTool() {
 			Logger.error(`[fetch_url] Failed to fetch ${currentUrl.href}`, error);
 			return `Error fetching "${currentUrl.href}": ${message}`;
 		} finally {
-			clearTimeout(timeout);
+			window.clearTimeout(timeout);
 		}
 	};
 

--- a/src/agent/tools/readContent.ts
+++ b/src/agent/tools/readContent.ts
@@ -82,7 +82,7 @@ function truncateContent(content: string, maxChars: number): string {
  */
 function parsePdfPageFragment(subpath: string): number[] | null {
 	if (!subpath) return null;
-	const match = subpath.match(/^#page=([\d,\-]+)$/);
+	const match = subpath.match(/^#page=([\d,-]+)$/);
 	if (!match) return null;
 
 	const pages: number[] = [];

--- a/src/agent/tools/webSearch.ts
+++ b/src/agent/tools/webSearch.ts
@@ -17,18 +17,18 @@ const FETCH_TIMEOUT_MS = 15_000;
  */
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
 	return new Promise<T>((resolve, reject) => {
-		const timer = setTimeout(() => {
+		const timer = window.setTimeout(() => {
 			const err = new Error(`Web search timed out after ${timeoutMs}ms.`);
 			err.name = "TimeoutError";
 			reject(err);
 		}, timeoutMs);
 		promise.then(
 			(value) => {
-				clearTimeout(timer);
+				window.clearTimeout(timer);
 				resolve(value);
 			},
 			(error) => {
-				clearTimeout(timer);
+				window.clearTimeout(timer);
 				reject(error);
 			},
 		);

--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -223,7 +223,7 @@ $effect(() => {
 });
 
 export function focusEditor() {
-	requestAnimationFrame(() => {
+	window.requestAnimationFrame(() => {
 		markdownEditor?.focus();
 	});
 }
@@ -250,7 +250,7 @@ $effect(() => {
 		// transaction dispatches — otherwise decoration plugins can throw on a
 		// stale position ("No tile at position N").
 		inputValue = text;
-		requestAnimationFrame(() => {
+		window.requestAnimationFrame(() => {
 			// If auto-submit already sent and cleared the input this tick, don't
 			// resurrect the text into the cleared editor — that makes a sent
 			// message look like it's still sitting unsent in the input.
@@ -382,7 +382,7 @@ $effect(() => {
 	// Untracked: seeding reads/writes the attachment state, which must not
 	// become a dependency of this effect (it only reacts to the edit target).
 	untrack(() => void seedEditAttachments(session?.getEditAttachments(pair.id) ?? []));
-	requestAnimationFrame(() => {
+	window.requestAnimationFrame(() => {
 		markdownEditor?.setValue(text);
 		markdownEditor?.focus();
 	});
@@ -459,7 +459,7 @@ $effect(() => {
 		const hadNotes = registry.pendingGraphNotes.length > 0;
 		registry.pendingGraphNotes = null;
 		if (hadNotes) {
-			requestAnimationFrame(() => markdownEditor?.focus());
+			window.requestAnimationFrame(() => markdownEditor?.focus());
 		}
 	}
 });
@@ -564,7 +564,7 @@ function initializeEditor() {
 	});
 
 	// Focus the editor after next paint
-	requestAnimationFrame(() => {
+	window.requestAnimationFrame(() => {
 		markdownEditor?.focus();
 	});
 }
@@ -577,13 +577,13 @@ function expandFullscreen() {
 	isFullscreen = true;
 	isFullscreenVisible = false;
 	// Double rAF ensures the start geometry is fully painted before transition begins.
-	requestAnimationFrame(() => {
-		requestAnimationFrame(() => {
+	window.requestAnimationFrame(() => {
+		window.requestAnimationFrame(() => {
 			fullscreenNoTransition = false;
-			requestAnimationFrame(() => {
+			window.requestAnimationFrame(() => {
 				isFullscreenVisible = true;
 			});
-			setTimeout(() => {
+			window.setTimeout(() => {
 				fullscreenTransitioning = false;
 			}, FULLSCREEN_TRANSITION_MS);
 			markdownEditor?.focus();
@@ -595,12 +595,12 @@ function collapseFullscreen() {
 	if (fullscreenTransitioning || !isFullscreen) return;
 	fullscreenTransitioning = true;
 	isFullscreenVisible = false;
-	setTimeout(() => {
+	window.setTimeout(() => {
 		isFullscreen = false;
 		fullscreenNoTransition = false;
 		fullscreenPlaceholderHeight = 0;
 		fullscreenTransitioning = false;
-		requestAnimationFrame(() => markdownEditor?.focus());
+		window.requestAnimationFrame(() => markdownEditor?.focus());
 	}, FULLSCREEN_TRANSITION_MS);
 }
 
@@ -996,7 +996,7 @@ async function attachVaultFilesByPath(paths: string[]) {
 	}
 
 	if (attachedCount > 0) {
-		requestAnimationFrame(() => markdownEditor?.focus());
+		window.requestAnimationFrame(() => markdownEditor?.focus());
 	}
 }
 

--- a/src/components/chat/MessageContainer.svelte
+++ b/src/components/chat/MessageContainer.svelte
@@ -175,12 +175,12 @@ function animateScrollTo(top: number) {
 		const eased = 1 - (1 - t) ** 3;
 		el.scrollTop = start + delta * eased;
 		if (t < 1) {
-			scrollRafId = requestAnimationFrame(step);
+			scrollRafId = window.requestAnimationFrame(step);
 		} else {
 			scrollRafId = null;
 		}
 	};
-	scrollRafId = requestAnimationFrame(step);
+	scrollRafId = window.requestAnimationFrame(step);
 }
 
 // Scroll a specific user message to the top of the container.
@@ -247,13 +247,13 @@ let nextAvailable = $state(false);
 // The nav arrows appear while scrolling (and on hover, via CSS). After scrolling
 // stops they linger briefly, then fade out.
 let isScrolling = $state(false);
-let scrollIdleTimer: ReturnType<typeof setTimeout> | undefined;
+let scrollIdleTimer: number | undefined;
 
 function handleScroll() {
 	recomputeActiveUserIndex();
 	isScrolling = true;
-	if (scrollIdleTimer) clearTimeout(scrollIdleTimer);
-	scrollIdleTimer = setTimeout(() => {
+	if (scrollIdleTimer) window.clearTimeout(scrollIdleTimer);
+	scrollIdleTimer = window.setTimeout(() => {
 		isScrolling = false;
 	}, 900);
 }
@@ -624,7 +624,7 @@ $effect(() => {
 
 $effect(() => {
 	return () => {
-		if (scrollIdleTimer) clearTimeout(scrollIdleTimer);
+		if (scrollIdleTimer) window.clearTimeout(scrollIdleTimer);
 		if (scrollRafId !== null) cancelAnimationFrame(scrollRafId);
 	};
 });

--- a/src/components/chat/ToolCallsSection.svelte
+++ b/src/components/chat/ToolCallsSection.svelte
@@ -361,8 +361,8 @@ $effect(() => {
 		runningSeconds = Math.max(0, Math.floor((Date.now() - runStartedAtMs) / 1000));
 	};
 	tick();
-	const timer = setInterval(tick, 1000);
-	return () => clearInterval(timer);
+	const timer = window.setInterval(tick, 1000);
+	return () => window.clearInterval(timer);
 });
 
 // The tools executing right now. Only the COUNT is used: the tool row rendered

--- a/src/components/graph/GraphCanvas.svelte
+++ b/src/components/graph/GraphCanvas.svelte
@@ -216,14 +216,14 @@ function hitSlack(pointerType: string): number {
 
 // Long-press → context menu (touch has no right-click). Armed on pointerdown
 // over a node, cancelled by movement/lift; fires the same menu as oncontextmenu.
-let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+let longPressTimer: number | null = null;
 let longPressFired = false;
 const LONG_PRESS_MS = 500;
 const LONG_PRESS_MOVE_TOLERANCE = 10;
 
 function cancelLongPress() {
 	if (longPressTimer !== null) {
-		clearTimeout(longPressTimer);
+		window.clearTimeout(longPressTimer);
 		longPressTimer = null;
 	}
 }
@@ -267,7 +267,7 @@ let forceTickCount = 0;
 // Hide canvas during the initial chaos phase on fresh loads (no cached positions).
 // Starts hidden; revealed immediately when positions are known, or after 300ms on fresh loads.
 let canvasVisible = $state(false);
-let canvasRevealTimer: ReturnType<typeof setTimeout> | null = null;
+let canvasRevealTimer: number | null = null;
 
 // Simulation reference — $state so the hot-update $effect re-runs when simulation is (re)created
 let simulation: ReturnType<typeof forceSimulation<SimNode>> | null = $state(null);
@@ -452,9 +452,9 @@ let hoverAlphas: Map<string, number> = new Map();
 let outgoingHulls: Array<{ cluster: number; color: string; path: Array<{ x: number; y: number }> }> = [];
 let hullFadeProgress = 1;
 /** Releases the sustained alpha after a collapse/expand transition. */
-let retargetTimer: ReturnType<typeof setTimeout> | null = null;
+let retargetTimer: number | null = null;
 /** Fires the corrective fit once post-settle drift has stopped. */
-let settleFitTimer: ReturnType<typeof setTimeout> | null = null;
+let settleFitTimer: number | null = null;
 /** Signature of the current grouping; a change starts a new cross-fade. */
 let lastHullSignature = "";
 /** Most recently built hull shapes, captured so a change can fade from them. */
@@ -551,7 +551,7 @@ function requestRender(mode: RenderMode) {
 		pendingRenderMode = mode;
 	}
 	if (renderRafId != null) return;
-	renderRafId = requestAnimationFrame(() => {
+	renderRafId = window.requestAnimationFrame(() => {
 		renderRafId = null;
 		const nextMode = pendingRenderMode ?? "world";
 		pendingRenderMode = null;
@@ -1737,7 +1737,7 @@ function handleMouseDown(e: PointerEvent) {
 			}
 			longPressFired = false;
 			cancelLongPress();
-			longPressTimer = setTimeout(() => {
+			longPressTimer = window.setTimeout(() => {
 				longPressTimer = null;
 				longPressFired = true;
 				openNodeMenu(node, e.clientX, e.clientY);
@@ -2462,8 +2462,8 @@ function setupForceSimulation(
 					// and framed, and an unconditional refit reads as the camera
 					// lurching out for no reason a second after it arrived.
 					const settledBounds = computeNodeBounds(simNodes);
-					if (settleFitTimer != null) clearTimeout(settleFitTimer);
-					settleFitTimer = setTimeout(() => {
+					if (settleFitTimer != null) window.clearTimeout(settleFitTimer);
+					settleFitTimer = window.setTimeout(() => {
 						settleFitTimer = null;
 						if (driftedSince(settledBounds)) {
 							animateCameraToNodes(undefined, GRAPH_FIT_PADDING, 500);
@@ -2489,8 +2489,8 @@ function setupForceSimulation(
 	// already partially settled rather than the initial random-pile explosion.
 	if (isFreshLayout) {
 		canvasVisible = false;
-		if (canvasRevealTimer != null) clearTimeout(canvasRevealTimer);
-		canvasRevealTimer = setTimeout(() => {
+		if (canvasRevealTimer != null) window.clearTimeout(canvasRevealTimer);
+		canvasRevealTimer = window.setTimeout(() => {
 			canvasVisible = true;
 			canvasRevealTimer = null;
 		}, 300);
@@ -2898,9 +2898,9 @@ onMount(() => {
 			cancelAnimationFrame(renderRafId);
 			renderRafId = null;
 		}
-		if (retargetTimer != null) clearTimeout(retargetTimer);
-		if (settleFitTimer != null) clearTimeout(settleFitTimer);
-		if (canvasRevealTimer != null) clearTimeout(canvasRevealTimer);
+		if (retargetTimer != null) window.clearTimeout(retargetTimer);
+		if (settleFitTimer != null) window.clearTimeout(settleFitTimer);
+		if (canvasRevealTimer != null) window.clearTimeout(canvasRevealTimer);
 		if (simulation) {
 			simulation.stop();
 			simulation = null;
@@ -2993,8 +2993,8 @@ export function followLayout() {
 	// layout comes to rest.
 	simulation.alphaTarget(RETARGET_ALPHA).velocityDecay(RECLUSTER_VELOCITY_DECAY).restart();
 	isReclustering = true;
-	if (retargetTimer != null) clearTimeout(retargetTimer);
-	retargetTimer = setTimeout(() => {
+	if (retargetTimer != null) window.clearTimeout(retargetTimer);
+	retargetTimer = window.setTimeout(() => {
 		retargetTimer = null;
 		// Back to 0 so the layout can actually come to rest.
 		simulation?.alphaTarget(0);

--- a/src/components/graph/SmartGraphView.svelte
+++ b/src/components/graph/SmartGraphView.svelte
@@ -671,8 +671,8 @@ let buildGraphSignature = $derived(
 );
 $effect(() => {
 	buildGraphSignature;
-	const timer = setTimeout(() => untrack(() => void buildGraph()), 300);
-	return () => clearTimeout(timer);
+	const timer = window.setTimeout(() => untrack(() => void buildGraph()), 300);
+	return () => window.clearTimeout(timer);
 });
 
 // Re-apply segment coloring when highlight toggles change (no Leiden re-run needed).
@@ -747,7 +747,7 @@ const SEMANTIC_RETRY_MAX_ATTEMPTS = 24;
 let liveTopicDrift = 0;
 /** True once the first full build has landed — live patches diff against it. */
 let hasBuiltOnce = false;
-let liveUpdateTimer: ReturnType<typeof setTimeout> | null = null;
+let liveUpdateTimer: number | null = null;
 /** Renames since the last flush, applied to the canvas position cache first. */
 let pendingRenames: Array<{ from: string; to: string }> = [];
 /**
@@ -756,7 +756,7 @@ let pendingRenames: Array<{ from: string; to: string }> = [];
  * running; `attempts` bounds the wait.
  */
 const pendingSemantic = new Map<string, { mtime: number; attempts: number }>();
-let semanticRetryTimer: ReturnType<typeof setTimeout> | null = null;
+let semanticRetryTimer: number | null = null;
 let isProcessingSemantic = false;
 
 function isLiveRelevantFile(file: TAbstractFile): file is TFile {
@@ -771,8 +771,8 @@ function queueSemanticRefresh(file: TFile) {
 
 function scheduleLiveUpdate() {
 	if (isDestroyed) return;
-	if (liveUpdateTimer != null) clearTimeout(liveUpdateTimer);
-	liveUpdateTimer = setTimeout(() => {
+	if (liveUpdateTimer != null) window.clearTimeout(liveUpdateTimer);
+	liveUpdateTimer = window.setTimeout(() => {
 		liveUpdateTimer = null;
 		flushLiveUpdate();
 	}, LIVE_UPDATE_DEBOUNCE_MS);
@@ -811,8 +811,8 @@ const liveMetadataEventRef = plugin.app.metadataCache.on("resolved", () => sched
 onDestroy(() => {
 	for (const ref of liveVaultEventRefs) plugin.app.vault.offref(ref);
 	plugin.app.metadataCache.offref(liveMetadataEventRef);
-	if (liveUpdateTimer != null) clearTimeout(liveUpdateTimer);
-	if (semanticRetryTimer != null) clearTimeout(semanticRetryTimer);
+	if (liveUpdateTimer != null) window.clearTimeout(liveUpdateTimer);
+	if (semanticRetryTimer != null) window.clearTimeout(semanticRetryTimer);
 });
 
 /** Apply pending vault changes to the open graph. */
@@ -1088,7 +1088,7 @@ async function processPendingSemanticQueries() {
 
 function scheduleSemanticRetry() {
 	if (isDestroyed || pendingSemantic.size === 0 || semanticRetryTimer != null) return;
-	semanticRetryTimer = setTimeout(() => {
+	semanticRetryTimer = window.setTimeout(() => {
 		semanticRetryTimer = null;
 		void processPendingSemanticQueries();
 	}, SEMANTIC_RETRY_INTERVAL_MS);

--- a/src/components/modal/FileSetEntryRow.svelte
+++ b/src/components/modal/FileSetEntryRow.svelte
@@ -78,7 +78,7 @@ function lazyFileIcon(node: HTMLElement, options: LazyFileIconOptions) {
 	let currentOptions = options;
 	let observer: IntersectionObserver | null = null;
 	let idleCallbackHandle: number | null = null;
-	let timeoutHandle: ReturnType<typeof globalThis.setTimeout> | null = null;
+	let timeoutHandle: number | null = null;
 	let hasRendered = false;
 
 	const clearPending = () => {
@@ -86,12 +86,12 @@ function lazyFileIcon(node: HTMLElement, options: LazyFileIconOptions) {
 			observer.disconnect();
 			observer = null;
 		}
-		if (idleCallbackHandle !== null && "cancelIdleCallback" in globalThis) {
-			globalThis.cancelIdleCallback(idleCallbackHandle);
+		if (idleCallbackHandle !== null && typeof window.cancelIdleCallback === "function") {
+			window.cancelIdleCallback(idleCallbackHandle);
 			idleCallbackHandle = null;
 		}
 		if (timeoutHandle !== null) {
-			globalThis.clearTimeout(timeoutHandle);
+			window.clearTimeout(timeoutHandle);
 			timeoutHandle = null;
 		}
 	};
@@ -110,8 +110,11 @@ function lazyFileIcon(node: HTMLElement, options: LazyFileIconOptions) {
 
 	const scheduleRender = () => {
 		if (hasRendered || idleCallbackHandle !== null || timeoutHandle !== null) return;
-		if ("requestIdleCallback" in globalThis) {
-			idleCallbackHandle = globalThis.requestIdleCallback(
+		// typeof, not `in`: `requestIdleCallback` is non-optional on the `Window` type,
+		// so an `in` check narrows the else branch to `never` and stops compiling. The
+		// runtime guard is still wanted — older iOS WebViews don't implement it.
+		if (typeof window.requestIdleCallback === "function") {
+			idleCallbackHandle = window.requestIdleCallback(
 				() => {
 					idleCallbackHandle = null;
 					renderIcon();
@@ -119,7 +122,7 @@ function lazyFileIcon(node: HTMLElement, options: LazyFileIconOptions) {
 				{ timeout: 250 },
 			);
 		} else {
-			timeoutHandle = globalThis.setTimeout(() => {
+			timeoutHandle = window.setTimeout(() => {
 				timeoutHandle = null;
 				renderIcon();
 			}, 0);
@@ -179,11 +182,11 @@ function handleFileLinkClick(event: MouseEvent): void {
  * request as soon as it leaves, so only the row actually rested on previews.
  */
 const HOVER_PREVIEW_DELAY_MS = 220;
-let hoverPreviewHandle: ReturnType<typeof globalThis.setTimeout> | null = null;
+let hoverPreviewHandle: number | null = null;
 
 function cancelPendingPreview(): void {
 	if (hoverPreviewHandle === null) return;
-	globalThis.clearTimeout(hoverPreviewHandle);
+	window.clearTimeout(hoverPreviewHandle);
 	hoverPreviewHandle = null;
 }
 
@@ -203,7 +206,7 @@ function previewFileLink(event: Event): void {
 	if (!(target instanceof HTMLElement)) return;
 
 	cancelPendingPreview();
-	hoverPreviewHandle = globalThis.setTimeout(() => {
+	hoverPreviewHandle = window.setTimeout(() => {
 		hoverPreviewHandle = null;
 		// The row can be torn down (list re-filtered, modal closed) during the
 		// delay; a detached element has nothing to anchor a popup to.

--- a/src/components/modal/ModelSelectionModal.svelte
+++ b/src/components/modal/ModelSelectionModal.svelte
@@ -73,7 +73,7 @@ let didRevealSelection = false;
 $effect(() => {
 	if (didRevealSelection || !currentSelection || models.length === 0) return;
 	didRevealSelection = true;
-	requestAnimationFrame(() => {
+	window.requestAnimationFrame(() => {
 		modelsListEl?.querySelector(".model-card.selected")?.scrollIntoView({ block: "center" });
 	});
 });

--- a/src/components/modal/SearchModal.ts
+++ b/src/components/modal/SearchModal.ts
@@ -185,7 +185,7 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 	   otherwise bound only to Tab / Alt+Enter (unreachable without a keyboard). */
 	private pendingPostOpenFrameId: number | null = null;
 	private pendingFocusFrameId: number | null = null;
-	private pendingFocusTimeoutIds: ReturnType<typeof globalThis.setTimeout>[] = [];
+	private pendingFocusTimeoutIds: number[] = [];
 	private hasPrimedOpenResults = false;
 
 	constructor(app: App, options: SearchModalOptions = {}) {
@@ -1046,12 +1046,12 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 			this.autocompleteHydrationTimeout = null;
 		}
 		if (this.pendingPostOpenFrameId !== null) {
-			globalThis.cancelAnimationFrame(this.pendingPostOpenFrameId);
+			window.cancelAnimationFrame(this.pendingPostOpenFrameId);
 			this.pendingPostOpenFrameId = null;
 		}
 		this.hasPrimedOpenResults = false;
 		if (this.pendingFocusFrameId !== null) {
-			globalThis.cancelAnimationFrame(this.pendingFocusFrameId);
+			window.cancelAnimationFrame(this.pendingFocusFrameId);
 			this.pendingFocusFrameId = null;
 		}
 		this.clearPendingFocusTimeouts();
@@ -1059,10 +1059,10 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 
 	private schedulePostOpenHydration(): void {
 		if (this.pendingPostOpenFrameId !== null) {
-			globalThis.cancelAnimationFrame(this.pendingPostOpenFrameId);
+			window.cancelAnimationFrame(this.pendingPostOpenFrameId);
 		}
 
-		this.pendingPostOpenFrameId = globalThis.requestAnimationFrame(() => {
+		this.pendingPostOpenFrameId = window.requestAnimationFrame(() => {
 			this.pendingPostOpenFrameId = null;
 			if (this.isClosed) {
 				return;
@@ -1183,15 +1183,15 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 
 	private scheduleInputFocus(): void {
 		if (this.pendingFocusFrameId !== null) {
-			globalThis.cancelAnimationFrame(this.pendingFocusFrameId);
+			window.cancelAnimationFrame(this.pendingFocusFrameId);
 		}
 		this.clearPendingFocusTimeouts();
 
-		this.pendingFocusFrameId = globalThis.requestAnimationFrame(() => {
+		this.pendingFocusFrameId = window.requestAnimationFrame(() => {
 			this.pendingFocusFrameId = null;
 			this.focusInput();
 			for (const delay of [0, 50, 150, 400, 800]) {
-				const timeoutId = globalThis.setTimeout(() => {
+				const timeoutId = window.setTimeout(() => {
 					this.pendingFocusTimeoutIds = this.pendingFocusTimeoutIds.filter((id) => id !== timeoutId);
 					this.focusInput();
 				}, delay);
@@ -1202,7 +1202,7 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 
 	private clearPendingFocusTimeouts(): void {
 		for (const timeoutId of this.pendingFocusTimeoutIds) {
-			globalThis.clearTimeout(timeoutId);
+			window.clearTimeout(timeoutId);
 		}
 		this.pendingFocusTimeoutIds = [];
 	}
@@ -1606,9 +1606,9 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 			ctx.fillStyle = grad;
 			ctx.fill("evenodd");
 
-			this.glowAnimationId = requestAnimationFrame(animate);
+			this.glowAnimationId = window.requestAnimationFrame(animate);
 		};
-		this.glowAnimationId = requestAnimationFrame(animate);
+		this.glowAnimationId = window.requestAnimationFrame(animate);
 	}
 
 	private stopGlowAnimation(): void {

--- a/src/components/modal/SearchModal.ts
+++ b/src/components/modal/SearchModal.ts
@@ -509,7 +509,7 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 		}
 
 		const preview = trimmedQuery.length > 36 ? `${trimmedQuery.slice(0, 33)}...` : trimmedQuery;
-		return `Create \"${preview}\"`;
+		return `Create "${preview}"`;
 	}
 
 	private updateInstructions(): void {

--- a/src/components/settings/ViewFilterBuilder.svelte
+++ b/src/components/settings/ViewFilterBuilder.svelte
@@ -81,7 +81,7 @@ let comboOpen = $state(false);
 let comboQuery = $state("");
 // Track which field is open: "leaf" | "live" | null
 let comboTarget: "leaf" | "live" | null = $state(null);
-let closeTimeout: ReturnType<typeof setTimeout> | null = null;
+let closeTimeout: number | null = null;
 
 function getSuggestionPool(type: LeafType): string[] {
 	if (type === "folder") return availableFolders;
@@ -110,7 +110,7 @@ function showsEmptyPoolHint(type: LeafType): boolean {
 
 function openCombo(target: "leaf" | "live", currentValue: string) {
 	if (closeTimeout) {
-		clearTimeout(closeTimeout);
+		window.clearTimeout(closeTimeout);
 		closeTimeout = null;
 	}
 	comboTarget = target;
@@ -125,7 +125,7 @@ function closeCombo() {
 
 function handleComboBlur() {
 	// Delay so a suggestion click fires before we close
-	closeTimeout = setTimeout(closeCombo, 150);
+	closeTimeout = window.setTimeout(closeCombo, 150);
 }
 
 function handleComboFocus(target: "leaf" | "live", currentValue: string) {
@@ -134,7 +134,7 @@ function handleComboFocus(target: "leaf" | "live", currentValue: string) {
 
 function pickSuggestion(value: string, target: "leaf" | "live") {
 	if (closeTimeout) {
-		clearTimeout(closeTimeout);
+		window.clearTimeout(closeTimeout);
 		closeTimeout = null;
 	}
 	if (target === "leaf") {

--- a/src/components/ui/MarkdownRenderer.svelte
+++ b/src/components/ui/MarkdownRenderer.svelte
@@ -87,7 +87,7 @@ async function openTagSearch(tag: string): Promise<boolean> {
 			// Use Obsidian's native command to properly initialize search
 			if (commands?.executeCommandById) {
 				await commands.executeCommandById("global-search:open");
-				await new Promise((resolve) => setTimeout(resolve, 50));
+				await new Promise((resolve) => window.setTimeout(resolve, 50));
 				searchLeaf = workspace.getLeavesOfType("search").first();
 				searchView = searchLeaf?.view as SearchView | undefined;
 			}

--- a/src/components/ui/RangeSlider.svelte
+++ b/src/components/ui/RangeSlider.svelte
@@ -50,7 +50,7 @@ function handleInput(e: Event) {
 	value = Number(target.value);
 	if (!onchange) return;
 	if (liveFrame !== null) cancelAnimationFrame(liveFrame);
-	liveFrame = requestAnimationFrame(() => {
+	liveFrame = window.requestAnimationFrame(() => {
 		liveFrame = null;
 		onchange?.(value);
 	});

--- a/src/components/ui/SlidingTabs.svelte
+++ b/src/components/ui/SlidingTabs.svelte
@@ -101,9 +101,9 @@ $effect(() => {
 		measure();
 		// indicator.ready flips true on the first successful (non-zero) measure.
 		if (indicator.ready || frames++ > 30) return;
-		raf = requestAnimationFrame(tick);
+		raf = window.requestAnimationFrame(tick);
 	};
-	raf = requestAnimationFrame(tick);
+	raf = window.requestAnimationFrame(tick);
 	return () => cancelAnimationFrame(raf);
 });
 
@@ -112,7 +112,7 @@ $effect(() => {
 // every later tab switch glides. Runs once — `animate` guards the re-entry.
 $effect(() => {
 	if (!indicator.ready || animate) return;
-	const raf = requestAnimationFrame(() => {
+	const raf = window.requestAnimationFrame(() => {
 		animate = true;
 	});
 	return () => cancelAnimationFrame(raf);
@@ -139,7 +139,7 @@ $effect(() => {
 function registerTrigger(node: HTMLElement, id: T) {
 	triggerEls.set(id, node);
 	resizeObserver?.observe(node);
-	requestAnimationFrame(measure);
+	window.requestAnimationFrame(measure);
 	return () => {
 		triggerEls.delete(id);
 		resizeObserver?.unobserve(node);

--- a/src/editor/inlineDiffExtension.ts
+++ b/src/editor/inlineDiffExtension.ts
@@ -625,7 +625,7 @@ const inlineDiffSideEffects = ViewPlugin.fromClass(
 		private initialized = false;
 		private refreshAttempts = 0;
 		private lastFilePath: string | null = null;
-		private docRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+		private docRefreshTimer: number | null = null;
 
 		constructor(view: EditorView) {
 			this.view = view;
@@ -642,7 +642,7 @@ const inlineDiffSideEffects = ViewPlugin.fromClass(
 		}
 
 		private scheduleInitialRefresh() {
-			requestAnimationFrame(() => {
+			window.requestAnimationFrame(() => {
 				if (this.initialized) return;
 
 				const hasFilePath = getEditorFilePath(this.view.state) !== null;
@@ -676,8 +676,8 @@ const inlineDiffSideEffects = ViewPlugin.fromClass(
 			// once per keystroke. The mapped set stays visually correct meanwhile;
 			// the rebuild re-verifies group text and updates the bars' stale state.
 			if (update.docChanged) {
-				if (this.docRefreshTimer) clearTimeout(this.docRefreshTimer);
-				this.docRefreshTimer = setTimeout(() => {
+				if (this.docRefreshTimer) window.clearTimeout(this.docRefreshTimer);
+				this.docRefreshTimer = window.setTimeout(() => {
 					this.docRefreshTimer = null;
 					this.refreshHandler();
 				}, 250);
@@ -685,7 +685,7 @@ const inlineDiffSideEffects = ViewPlugin.fromClass(
 		}
 
 		destroy() {
-			if (this.docRefreshTimer) clearTimeout(this.docRefreshTimer);
+			if (this.docRefreshTimer) window.clearTimeout(this.docRefreshTimer);
 			document.removeEventListener("s2b-pending-changes-updated", this.refreshHandler);
 			document.removeEventListener("s2b-diff-mode-changed", this.refreshHandler);
 		}

--- a/src/hooks/useSelection.svelte.ts
+++ b/src/hooks/useSelection.svelte.ts
@@ -195,7 +195,7 @@ export class SelectionTracker {
 
 	#scheduleRefresh() {
 		if (this.#refreshFrame !== undefined) return;
-		this.#refreshFrame = requestAnimationFrame(() => {
+		this.#refreshFrame = window.requestAnimationFrame(() => {
 			this.#refreshFrame = undefined;
 			this.#refresh();
 		});

--- a/src/hooks/useVisibleNotes.svelte.ts
+++ b/src/hooks/useVisibleNotes.svelte.ts
@@ -142,7 +142,7 @@ export class VisibleNotesTracker {
 	readonly #workspace = getPlugin().app.workspace;
 	#notes: VisibleNote[] = $state([]);
 	#refs: EventRef[] = [];
-	#interval: ReturnType<typeof setInterval> | undefined;
+	#interval: number | undefined;
 
 	/** The currently visible notes (front tab of each pane, chat excluded). */
 	get notes(): VisibleNote[] {
@@ -177,13 +177,13 @@ export class VisibleNotesTracker {
 		if (needsPolling) {
 			if (!this.#interval) {
 				// Poll only for preview / PDF views where scroll position changes context.
-				this.#interval = setInterval(() => this.#refresh(), VISIBLE_NOTES_POLL_MS);
+				this.#interval = window.setInterval(() => this.#refresh(), VISIBLE_NOTES_POLL_MS);
 			}
 			return;
 		}
 
 		if (this.#interval) {
-			clearInterval(this.#interval);
+			window.clearInterval(this.#interval);
 			this.#interval = undefined;
 		}
 	}
@@ -201,7 +201,7 @@ export class VisibleNotesTracker {
 			this.#workspace.offref(ref);
 		}
 		this.#refs = [];
-		clearInterval(this.#interval);
+		window.clearInterval(this.#interval);
 		this.#interval = undefined;
 	}
 }

--- a/src/lib/editor.ts
+++ b/src/lib/editor.ts
@@ -314,7 +314,7 @@ export class EmbeddableMarkdownEditor {
 	 * Enter vim insert mode if vim keybindings are enabled in Obsidian.
 	 */
 	private enterVimInsertMode(): void {
-		setTimeout(() => {
+		window.setTimeout(() => {
 			try {
 				// Check if vim mode is enabled in Obsidian settings
 				// @ts-expect-error - Using internal API

--- a/src/lib/obsidianFetch.ts
+++ b/src/lib/obsidianFetch.ts
@@ -84,7 +84,7 @@ export function createObsidianFetch(
 		// it instead — the request keeps running in the background but stops holding
 		// the caller hostage.
 		const timeoutController = new AbortController();
-		const timeoutId = setTimeout(() => {
+		const timeoutId = window.setTimeout(() => {
 			timeoutController.abort(
 				new DOMException(`Request timed out after ${REQUEST_TIMEOUT_MS}ms`, "TimeoutError"),
 			);
@@ -101,7 +101,7 @@ export function createObsidianFetch(
 		}
 		const settled = timeoutController.signal;
 		const cleanup = () => {
-			clearTimeout(timeoutId);
+			window.clearTimeout(timeoutId);
 			callerSignal?.removeEventListener("abort", onCallerAbort);
 		};
 

--- a/src/lib/pendingChangeNavigation.ts
+++ b/src/lib/pendingChangeNavigation.ts
@@ -231,7 +231,7 @@ function scrollToLine(view: MarkdownView, line: number): void {
 		}
 	};
 	apply();
-	requestAnimationFrame(apply);
+	window.requestAnimationFrame(apply);
 	window.setTimeout(apply, 50);
 	// One later retry: reading-mode layout can settle a frame or two late, so a
 	// final pass ensures the scroll lands where intended.

--- a/src/lib/views.ts
+++ b/src/lib/views.ts
@@ -8,7 +8,7 @@
  * stale (deleted / renamed) paths are reported separately.
  */
 
-import { type App, type TFile, getAllTags } from "obsidian";
+import { type App, TFile, getAllTags } from "obsidian";
 import type { ViewFilter, ViewFilterGroup, ViewFilterLeaf } from "../types/viewFilter";
 import { matchesPathPrefix, normalizeVaultPath } from "../utils/pathUtils";
 
@@ -509,8 +509,8 @@ function matchesPrivacyMembershipRulePath(app: App, rule: PrivacyMembershipRule,
 		}
 		case "tag": {
 			const file = app.vault.getAbstractFileByPath(filePath);
-			if (!file || !("extension" in file)) return false;
-			const cache = app.metadataCache.getFileCache(file as TFile);
+			if (!(file instanceof TFile)) return false;
+			const cache = app.metadataCache.getFileCache(file);
 			const fileTags = cache ? (getAllTags(cache) ?? []) : [];
 			const normalizedFilter = rule.value.startsWith("#") ? rule.value : `#${rule.value}`;
 			return fileTags.some((tag) => {
@@ -618,8 +618,8 @@ function resolveTag(app: App, tag: string, universe: Set<string>): ResolvedView 
 	const paths = new Set<string>();
 	for (const p of universe) {
 		const file = app.vault.getAbstractFileByPath(p);
-		if (!file || !("extension" in file)) continue;
-		const cache = app.metadataCache.getFileCache(file as TFile);
+		if (!(file instanceof TFile)) continue;
+		const cache = app.metadataCache.getFileCache(file);
 		const fileTags = cache ? (getAllTags(cache) ?? []) : [];
 		const normalizedDocTags = fileTags.map((t) => (t.startsWith("#") ? t : `#${t}`));
 		const matches = normalizedDocTags.some(
@@ -677,9 +677,9 @@ function matchesPropertyLeaf(app: App, filePath: string, key: string, values: st
 	if (!trimmedKey) return false;
 
 	const file = app.vault.getAbstractFileByPath(filePath);
-	if (!file || !("extension" in file)) return false;
+	if (!(file instanceof TFile)) return false;
 
-	const frontmatter = app.metadataCache.getFileCache(file as TFile)?.frontmatter;
+	const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
 	if (!frontmatter) return false;
 
 	// Property keys are matched case-insensitively to mirror how users type them.

--- a/src/main.ts
+++ b/src/main.ts
@@ -828,7 +828,7 @@ export default class SecondBrainPlugin extends Plugin {
 					const restore = () => {
 						if (scroller.isConnected) scroller.scrollTop = prevScrollTop;
 					};
-					requestAnimationFrame(restore);
+					window.requestAnimationFrame(restore);
 					for (const delay of [50, 100, 200, 350, 500]) {
 						window.setTimeout(restore, delay);
 					}

--- a/src/providers/modelsDevApi.ts
+++ b/src/providers/modelsDevApi.ts
@@ -7,6 +7,7 @@
  * @see https://models.dev
  */
 
+import { Logger } from "../utils/logging";
 import { createObsidianFetch } from "../lib/obsidianFetch";
 
 const MODELS_DEV_API_URL = "https://models.dev/api.json";
@@ -86,7 +87,7 @@ export async function fetchModelsDevData(): Promise<ModelsDevApiResponse | null>
 		});
 
 		if (!response.ok) {
-			console.warn(`Failed to fetch models.dev data: ${response.status}`);
+			Logger.warn(`Failed to fetch models.dev data: ${response.status}`);
 			return cachedResponse?.data ?? null;
 		}
 
@@ -100,7 +101,7 @@ export async function fetchModelsDevData(): Promise<ModelsDevApiResponse | null>
 
 		return data;
 	} catch (error) {
-		console.warn("Error fetching models.dev data:", error);
+		Logger.warn("Error fetching models.dev data:", error);
 		return cachedResponse?.data ?? null;
 	}
 }

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -10,6 +10,7 @@
  * Ollama runs locally on the user's machine, defaulting to http://localhost:11434
  */
 
+import { Logger } from "../utils/logging";
 import { ChatOllama } from "@langchain/ollama";
 import OllamaLogo from "../components/ui/logos/OllamaLogo.svelte";
 import type {
@@ -209,7 +210,7 @@ export const ollamaProvider: EmbeddingProviderDefinition = {
 		// Fetch and cache model metadata in the background
 		// This populates the cache for the modal without blocking
 		fetchOllamaModelsInfo(baseUrl, modelNames).catch((err) => {
-			console.warn("Failed to fetch Ollama model metadata:", err);
+			Logger.warn("Failed to fetch Ollama model metadata:", err);
 		});
 
 		return modelNames;

--- a/src/providers/ollamaModels.ts
+++ b/src/providers/ollamaModels.ts
@@ -7,6 +7,8 @@
  * @see https://github.com/ollama/ollama/blob/main/docs/api.md#show-model-information
  */
 
+import { Logger } from "../utils/logging";
+
 const CACHE_TTL_MS = 1000 * 60 * 60; // 1 hour (shorter than cloud APIs since local)
 
 /**
@@ -98,7 +100,7 @@ async function fetchModelInfo(baseUrl: string, modelName: string): Promise<Ollam
 		});
 
 		if (!response.ok) {
-			console.warn(`Failed to fetch Ollama model info for ${modelName}: ${response.status}`);
+			Logger.warn(`Failed to fetch Ollama model info for ${modelName}: ${response.status}`);
 			return null;
 		}
 
@@ -143,7 +145,7 @@ async function fetchModelInfo(baseUrl: string, modelName: string): Promise<Ollam
 			supportsTools,
 		};
 	} catch (error) {
-		console.warn(`Error fetching Ollama model info for ${modelName}:`, error);
+		Logger.warn(`Error fetching Ollama model info for ${modelName}:`, error);
 		return null;
 	}
 }

--- a/src/providers/openaiCodex.ts
+++ b/src/providers/openaiCodex.ts
@@ -45,7 +45,7 @@ interface PendingOpenAICodexAuth {
 	redirectUri: string;
 	resolve: (session: CodexSession) => void;
 	reject: (error: Error) => void;
-	timeoutId: ReturnType<typeof setTimeout>;
+	timeoutId: number;
 }
 
 let pendingOpenAICodexAuth: PendingOpenAICodexAuth | null = null;
@@ -67,7 +67,7 @@ const HTML_SUCCESS = `<!doctype html>
       <h1 style="margin-bottom:1rem;">Authorization Successful</h1>
       <p>You can close this window and return to Obsidian.</p>
     </div>
-    <script>setTimeout(() => window.close(), 1500)</script>
+    <script>window.setTimeout(() => window.close(), 1500)</script>
   </body>
 </html>`;
 
@@ -94,7 +94,7 @@ const oauthErrorPage = (res: import("node:http").ServerResponse, error: string):
 
 function cleanupPendingOpenAICodexAuth() {
 	if (!pendingOpenAICodexAuth) return;
-	clearTimeout(pendingOpenAICodexAuth.timeoutId);
+	window.clearTimeout(pendingOpenAICodexAuth.timeoutId);
 	pendingOpenAICodexAuth.server.close();
 	pendingOpenAICodexAuth = null;
 }
@@ -405,7 +405,7 @@ async function startOpenAICodexAuthServer(expectedState: string, pkce: PkceCodes
 				redirectUri,
 				resolve: () => undefined,
 				reject: () => undefined,
-				timeoutId: setTimeout(() => undefined, OAUTH_TIMEOUT_MS),
+				timeoutId: window.setTimeout(() => undefined, OAUTH_TIMEOUT_MS),
 			};
 			resolve();
 		});
@@ -444,8 +444,8 @@ export async function signInWithOpenAICodex(): Promise<CodexSession> {
 
 		pendingOpenAICodexAuth.resolve = resolve;
 		pendingOpenAICodexAuth.reject = reject;
-		clearTimeout(pendingOpenAICodexAuth.timeoutId);
-		pendingOpenAICodexAuth.timeoutId = setTimeout(() => {
+		window.clearTimeout(pendingOpenAICodexAuth.timeoutId);
+		pendingOpenAICodexAuth.timeoutId = window.setTimeout(() => {
 			if (!pendingOpenAICodexAuth) return;
 			pendingOpenAICodexAuth.reject(new Error("Timed out waiting for ChatGPT sign-in"));
 			cleanupPendingOpenAICodexAuth();

--- a/src/providers/openrouterModels.ts
+++ b/src/providers/openrouterModels.ts
@@ -7,6 +7,8 @@
  * @see https://openrouter.ai/docs/api/api-reference/models/get-models
  */
 
+import { Logger } from "../utils/logging";
+
 const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
 
@@ -140,7 +142,7 @@ export async function fetchOpenRouterModels(): Promise<Map<string, OpenRouterMod
 		});
 
 		if (!response.ok) {
-			console.warn(`Failed to fetch OpenRouter models: ${response.status}`);
+			Logger.warn(`Failed to fetch OpenRouter models: ${response.status}`);
 			return cachedResponse?.models ?? null;
 		}
 
@@ -164,7 +166,7 @@ export async function fetchOpenRouterModels(): Promise<Map<string, OpenRouterMod
 
 		return models;
 	} catch (error) {
-		console.warn("Error fetching OpenRouter models:", error);
+		Logger.warn("Error fetching OpenRouter models:", error);
 		return cachedResponse?.models ?? null;
 	}
 }

--- a/src/providers/openrouterOAuth.ts
+++ b/src/providers/openrouterOAuth.ts
@@ -18,7 +18,7 @@ interface PendingOpenRouterAuth {
 	codeVerifier: string;
 	resolve: (apiKey: string) => void;
 	reject: (error: Error) => void;
-	timeoutId: ReturnType<typeof setTimeout>;
+	timeoutId: number;
 	redirectUri: string;
 	/** Guards against a double-resolve (server callback vs. manual paste racing). */
 	settled: boolean;
@@ -48,7 +48,7 @@ const HTML_SUCCESS = `<!doctype html>
       <h1 style="margin-bottom:1rem;">OpenRouter Connected</h1>
       <p>You can close this window and return to Obsidian.</p>
     </div>
-    <script>setTimeout(() => window.close(), 1500)</script>
+    <script>window.setTimeout(() => window.close(), 1500)</script>
   </body>
 </html>`;
 
@@ -77,7 +77,7 @@ function oauthErrorPage(res: ServerResponse, error: string): void {
 
 function cleanupPendingOpenRouterAuth() {
 	if (!pendingOpenRouterAuth) return;
-	clearTimeout(pendingOpenRouterAuth.timeoutId);
+	window.clearTimeout(pendingOpenRouterAuth.timeoutId);
 	pendingOpenRouterAuth.server?.close();
 	pendingOpenRouterAuth = null;
 }
@@ -353,7 +353,7 @@ export async function signInWithOpenRouter(): Promise<string> {
 			reject,
 			redirectUri: redirectUri ?? "",
 			settled: false,
-			timeoutId: setTimeout(() => {
+			timeoutId: window.setTimeout(() => {
 				if (!pendingOpenRouterAuth || pendingOpenRouterAuth.settled) return;
 				pendingOpenRouterAuth.settled = true;
 				pendingOpenRouterAuth.reject(new Error("Timed out waiting for OpenRouter sign-in"));

--- a/src/search/LexicalSearchService.ts
+++ b/src/search/LexicalSearchService.ts
@@ -263,7 +263,7 @@ export class LexicalSearchService {
 			this.bulkAttempts.clear();
 			if (notice) {
 				notice.setMessage(`✓ Search index updated: ${added} notes`);
-				setTimeout(() => notice.hide(), 3000);
+				window.setTimeout(() => notice.hide(), 3000);
 			}
 		} catch (error) {
 			// An unexpected abort (not a per-file failure) — don't leave a stuck

--- a/src/search/bulkPacing.ts
+++ b/src/search/bulkPacing.ts
@@ -61,7 +61,7 @@ export const MOBILE_BULK_MAX_DELAY_MS = 300_000;
 
 /** Yield the event loop for `ms` (a real pause on mobile, a bare yield on desktop). */
 export function bulkPause(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
+	return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
 /**

--- a/src/search/recentNotes.ts
+++ b/src/search/recentNotes.ts
@@ -106,6 +106,10 @@ function getRecentlyOpenedNotes(app: App, filter?: SearchFilter): SearchResult[]
 		// rather than record time so already-persisted entries are covered too.
 		if (isAgentFilePath(file.path)) continue;
 
+		// Cast, not `instanceof TFile`: `isRecentNoteFile` narrows structurally to the
+		// three fields actually used, which is what lets the tests hand this a plain
+		// object through the injected `getAbstractFileByPath`. A real instanceof check
+		// would tie this path to Obsidian's class and break that seam.
 		const cache = app.metadataCache.getFileCache(file as TFile);
 		const docTags = getCachedTags(cache);
 		if (!matchesSearchFilter(file.path, docTags, compiled ?? filter)) continue;

--- a/src/skills/SkillsService.ts
+++ b/src/skills/SkillsService.ts
@@ -197,9 +197,10 @@ export class SkillsService {
 		return LEGACY_VAULT_SKILLS_DIR;
 	}
 	private getLegacyConfigSkillsDir(): string {
-		const vault = this.plugin.app.vault as { configDir?: string };
-		const configDir = vault.configDir || ".obsidian";
-		return `${configDir}/${LEGACY_CONFIG_SKILLS_DIR}`;
+		// `configDir` is a documented non-optional string and honours a user-relocated
+		// config folder, so it needs neither the widening cast nor a ".obsidian" fallback
+		// (which would have pointed at the wrong folder for anyone who moved theirs).
+		return `${this.plugin.app.vault.configDir}/${LEGACY_CONFIG_SKILLS_DIR}`;
 	}
 
 	/**

--- a/src/stores/chatStore.svelte.ts
+++ b/src/stores/chatStore.svelte.ts
@@ -616,6 +616,12 @@ export class ChatSession {
 		const signal = this.abortController.signal;
 		this.touch();
 
+		// Marks the point past which the answer is durable: the stream completed
+		// and the checkpointer wrote it. Post-success bookkeeping (graph sync,
+		// reload, duration persistence) can still throw, but must degrade the
+		// view rather than retract a turn the user has already read.
+		let streamSucceeded = false;
+
 		try {
 			this.messageState = MessageState.answering;
 			this.summarizingHistory = options.predictedSummarization ?? false;
@@ -630,6 +636,11 @@ export class ChatSession {
 
 			await this.consumeStream(pair.assistantMessage, getStream(signal));
 			pair.assistantMessage.state = AssistantState.success;
+			// The turn has succeeded and the checkpointer has persisted the answer.
+			// Everything below is bookkeeping over that already-durable result, so
+			// from here on a throw must not be reported as a failed turn — see the
+			// post-success block after this try.
+			streamSucceeded = true;
 
 			// Stamp the elapsed time so the "Thought for Ns" label shows immediately
 			// (before any reload) and reads back from persistence later. This is the
@@ -701,6 +712,16 @@ export class ChatSession {
 		} catch (_err) {
 			if (this.cancelled) {
 				pair.assistantMessage.state = AssistantState.cancelled;
+			} else if (streamSucceeded) {
+				// Post-success bookkeeping failed. The answer streamed to completion
+				// and the checkpointer persisted it, so the turn stands: marking it
+				// `error` here would retract a reply the user is already reading and
+				// offer a pointless "retry" of work that actually succeeded. That is
+				// exactly what a rename-invalidated `onNeedReload` used to do.
+				//
+				// What is lost is view freshness (the checkpoint graph may not reflect
+				// this turn until the next load), not content — so log and move on.
+				Logger.error("[ChatSession] Post-run bookkeeping failed (answer preserved):", _err);
 			} else {
 				pair.assistantMessage.state = AssistantState.error;
 				pair.assistantMessage.errorCode = extractErrorMessage(_err);
@@ -1610,6 +1631,10 @@ export class SessionRegistry {
 		const isEmpty = await this.#agentManager.isThreadEmpty(id);
 		if (!isLatest()) return; // A newer switch superseded this load.
 		if (isEmpty) this.isLoadingSession = false;
+		// Forward-declared so callbacks wired below can hold the session instance
+		// rather than the load-time path. `id` stops being a valid map key the
+		// moment the auto-title rename rekeys this session.
+		let session: ChatSession | undefined;
 		try {
 			const [history, checkpointHistory] = await Promise.all([
 				this.#agentManager.getThreadHistory(id),
@@ -1626,8 +1651,12 @@ export class SessionRegistry {
 			if (checkpointHistory.length === 0 && !isEmpty) {
 				this.#agentManager.onNextInitialized(() => {
 					// Only reload if this thread's session is still around (its view
-					// may have closed and the session been evicted meanwhile).
-					if (this.sessions.has(id)) void this.reloadSession(id);
+					// may have closed and the session been evicted meanwhile). Checked
+					// by identity, not by the load-time path: an auto-title rename in
+					// the meantime rekeys the map, and a path-keyed lookup would find
+					// nothing and silently skip the reload the user is waiting on.
+					if (!session || this.sessions.get(session.id) !== session) return;
+					void this.reloadSessionInstance(session);
 				});
 			}
 
@@ -1666,7 +1695,7 @@ export class SessionRegistry {
 
 			if (!isLatest()) return;
 
-			const session = new ChatSession(
+			session = new ChatSession(
 				id,
 				this.buildSessionOptions({
 					graphState: graph,
@@ -1674,9 +1703,14 @@ export class SessionRegistry {
 					lastErrorMessage,
 					bootstrapMessages,
 					selectedAgentId: restoredAgentId,
-					// Reload against this specific session/thread, not whatever is
-					// active when a backgrounded run finishes later.
-					onNeedReload: async () => this.reloadSession(id),
+					// Reload against this specific session, not whatever is active
+					// when a backgrounded run finishes later — and not via the
+					// load-time path, which the auto-title rename invalidates
+					// mid-run (the rename happens inside `runStream`, just before
+					// this callback fires for `reloadAfter`).
+					onNeedReload: async () => {
+						if (session) await this.reloadSessionInstance(session);
+					},
 				}),
 			);
 			this.sessions.set(id, session);
@@ -1697,7 +1731,18 @@ export class SessionRegistry {
 		if (!session) {
 			throw new Error("No session to reload");
 		}
+		await this.reloadSessionInstance(session, targetCheckpointId);
+	}
 
+	/** Reload a session identified by object rather than by map key.
+	 *
+	 * Callbacks handed to a ChatSession outlive its registry key: the auto-title
+	 * rename after the first message rekeys the map (`rekeySession`) and updates
+	 * `session.id` in place, so any closure that captured the load-time path is
+	 * pointing at a key that no longer exists. Holding the instance keeps those
+	 * callbacks correct across renames; `session.id` is read live below for the
+	 * thread-scoped fetches. */
+	private async reloadSessionInstance(session: ChatSession, targetCheckpointId?: string): Promise<void> {
 		// Capture load token: a thread switch during the awaits below can replace
 		// this session; applying stale history to a newer session would show
 		// the wrong chat's checkpoints.

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -1,4 +1,4 @@
-import { normalizePath } from "obsidian";
+import { Notice, normalizePath } from "obsidian";
 import {
 	createEmptyPrivacyFilter,
 	matchesPrivacyMembershipDraftPath,
@@ -37,7 +37,8 @@ import { getDefaultEmbeddingBatchSize, normalizeEmbeddingBatchSize } from "../ve
 import { type UUIDv7, genUUIDv7 } from "../utils/uuid7Validator";
 
 import { type SmartGraphSettings, DEFAULT_SMART_GRAPH_SETTINGS } from "../types/graph";
-import { applyVerboseLogging } from "../utils/logging";
+import { Logger, applyVerboseLogging } from "../utils/logging";
+import { extractErrorMessage } from "../utils/errorMessage";
 
 // Provider system types
 import {
@@ -269,6 +270,8 @@ export const DEFAULT_SETTINGS: PluginData = {
 export class PluginDataStore {
 	#data: PluginData;
 	private readonly _plugin: SecondBrainPlugin;
+	/** Rate-limits the "could not save" Notice; see `notifySaveFailed`. */
+	#saveFailureNotified = false;
 
 	/**
 	 * Guidance surfaces whose built-in default changed while the user had a customization
@@ -318,7 +321,7 @@ export class PluginDataStore {
 				const rewritten = rewriteViewFilterForRename(this.#data.privacyFilter, oldPath, file.path);
 				if (rewritten !== this.#data.privacyFilter) {
 					this.#data.privacyFilter = rewritten;
-					this.saveSettings();
+					void this.saveSettings();
 				}
 			}),
 		);
@@ -328,9 +331,46 @@ export class PluginDataStore {
 	 * Persist current settings.
 	 * Snapshots the $state to avoid saving reactive proxies.
 	 */
-	private async saveSettings() {
+	/**
+	 * Persist the current data snapshot.
+	 *
+	 * Deliberately never rejects. ~70 setters call this as the last statement of a
+	 * synchronous mutation (`this.#data.x = y; this.saveSettings();`) and have no
+	 * meaningful way to recover, so a rejection here used to surface as an unhandled
+	 * rejection: `saveData` failing (disk full, permissions, a sync conflict) left the
+	 * user's change applied in memory, absent from disk, and unreported until the next
+	 * reload silently reverted it.
+	 *
+	 * Failures are caught, logged, and surfaced once so the user learns their settings
+	 * did not persist. Callers that genuinely need to know a write landed should await
+	 * `saveSettingsOrThrow` instead.
+	 */
+	private async saveSettings(): Promise<void> {
+		try {
+			await this.saveSettingsOrThrow();
+		} catch (error) {
+			Logger.error("Failed to persist plugin settings:", error);
+			this.notifySaveFailed(error);
+		}
+	}
+
+	/** Persist and propagate failure, for callers that must observe a failed write. */
+	private async saveSettingsOrThrow(): Promise<void> {
 		const snap = $state.snapshot(this.#data);
 		await this._plugin.saveData(snap);
+	}
+
+	/**
+	 * One notice per burst. A failing disk usually fails for every setter the user
+	 * touches, and stacking a Notice per keystroke would bury the workspace.
+	 */
+	private notifySaveFailed(error: unknown): void {
+		if (this.#saveFailureNotified) return;
+		this.#saveFailureNotified = true;
+		new Notice(`Smart Second Brain could not save your settings: ${extractErrorMessage(error)}`, 10000);
+		window.setTimeout(() => {
+			this.#saveFailureNotified = false;
+		}, 30000);
 	}
 
 	getLastActiveChatId(): UUIDv7 | null {
@@ -339,7 +379,7 @@ export class PluginDataStore {
 
 	setLastActiveChatId(id: UUIDv7 | null) {
 		this.#data.lastActiveChatId = id;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	async deleteData(): Promise<void> {
@@ -389,12 +429,12 @@ export class PluginDataStore {
 
 	setPrivacyMode(mode: PrivacyMode) {
 		this.#data.privacyMode = mode;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	setPrivacyFilter(filter: PluginData["privacyFilter"]) {
 		this.#data.privacyFilter = filter;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	isFilePrivate(filePath: string): boolean {
@@ -425,7 +465,7 @@ export class PluginDataStore {
 		const config = this.#data.providerConfig[providerId];
 		if (!config) return;
 		config.trustedForPrivateData = trusted;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	private getAllVaultPaths(): Set<string> {
@@ -453,7 +493,7 @@ export class PluginDataStore {
 		} catch {
 			// ignore
 		}
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get attachmentFolder() {
@@ -461,7 +501,7 @@ export class PluginDataStore {
 	}
 	set attachmentFolder(val: string) {
 		this.#data.attachmentFolder = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get agentFolder() {
@@ -479,7 +519,7 @@ export class PluginDataStore {
 		} catch {
 			// ignore
 		}
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get agentFolderMigrated() {
@@ -487,7 +527,7 @@ export class PluginDataStore {
 	}
 	set agentFolderMigrated(val: boolean) {
 		this.#data.agentFolderMigrated = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get coreSkillsSeeded() {
@@ -495,7 +535,7 @@ export class PluginDataStore {
 	}
 	set coreSkillsSeeded(val: boolean) {
 		this.#data.coreSkillsSeeded = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get manageSkillsFolderMigrated() {
@@ -503,7 +543,7 @@ export class PluginDataStore {
 	}
 	set manageSkillsFolderMigrated(val: boolean) {
 		this.#data.manageSkillsFolderMigrated = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get manageNotesFolderMigrated() {
@@ -511,7 +551,7 @@ export class PluginDataStore {
 	}
 	set manageNotesFolderMigrated(val: boolean) {
 		this.#data.manageNotesFolderMigrated = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -547,7 +587,7 @@ export class PluginDataStore {
 	}
 	set enableLangSmith(val: boolean) {
 		this.#data.enableLangSmith = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get langSmithApiKey() {
@@ -565,7 +605,7 @@ export class PluginDataStore {
 			}
 			this.#data.langSmithApiKeyId = "";
 		}
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get langSmithApiKeyId() {
@@ -573,7 +613,7 @@ export class PluginDataStore {
 	}
 	set langSmithApiKeyId(val: string) {
 		this.#data.langSmithApiKeyId = val.trim();
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get langSmithProject() {
@@ -581,7 +621,7 @@ export class PluginDataStore {
 	}
 	set langSmithProject(val: string) {
 		this.#data.langSmithProject = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get langSmithEndpoint() {
@@ -589,7 +629,7 @@ export class PluginDataStore {
 	}
 	set langSmithEndpoint(val: string) {
 		this.#data.langSmithEndpoint = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	// ============================================================================
@@ -601,7 +641,7 @@ export class PluginDataStore {
 	}
 	set webSearchProvider(val: string) {
 		this.#data.webSearchProvider = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/** Resolve the API key for the currently selected provider (empty string if none). */
@@ -624,7 +664,7 @@ export class PluginDataStore {
 			if (existing) setSecret(this._plugin.app, existing, "");
 			delete this.#data.webSearchApiKeyIds[provider];
 		}
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/** Secret id bound to the current provider's key field in the UI (empty if unset). */
@@ -641,7 +681,7 @@ export class PluginDataStore {
 		} else {
 			delete this.#data.webSearchApiKeyIds[provider];
 		}
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	// ============================================================================
@@ -689,7 +729,7 @@ export class PluginDataStore {
 	set selectedAgentId(agentId: string) {
 		if (this.#data.agents[agentId]) {
 			this.#data.selectedAgentId = agentId;
-			this.saveSettings();
+			void this.saveSettings();
 		}
 	}
 
@@ -720,7 +760,7 @@ export class PluginDataStore {
 			throw new Error(`Agent with ID "${agentId}" not found`);
 		}
 		this.#data.defaultAgentId = agentId;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -734,7 +774,7 @@ export class PluginDataStore {
 			...this.#data.agents,
 			[agent.id]: agent,
 		};
-		this.saveSettings();
+		void this.saveSettings();
 		return agent;
 	}
 
@@ -784,7 +824,7 @@ export class PluginDataStore {
 				...normalizedUpdates,
 			},
 		};
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -823,7 +863,7 @@ export class PluginDataStore {
 			this.#data.selectedAgentId = this.#data.defaultAgentId;
 		}
 
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -856,7 +896,7 @@ export class PluginDataStore {
 			...this.#data.agents,
 			[newAgent.id]: newAgent,
 		};
-		this.saveSettings();
+		void this.saveSettings();
 		return newAgent;
 	}
 
@@ -877,7 +917,7 @@ export class PluginDataStore {
 		const agent = this.#data.agents[agentId];
 		if (agent?.toolsConfig[toolId]) {
 			agent.toolsConfig[toolId].enabled = !agent.toolsConfig[toolId].enabled;
-			this.saveSettings();
+			void this.saveSettings();
 		}
 	}
 
@@ -891,7 +931,7 @@ export class PluginDataStore {
 				...agent.toolsConfig[toolId],
 				...config,
 			};
-			this.saveSettings();
+			void this.saveSettings();
 		}
 	}
 
@@ -915,7 +955,7 @@ export class PluginDataStore {
 		if (!agent) return;
 		agent.pluginExecTools ??= {};
 		agent.pluginExecTools[toolId] = enabled;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	// --- Agent-specific Subagent References ---
@@ -945,7 +985,7 @@ export class PluginDataStore {
 		} else {
 			return;
 		}
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -990,7 +1030,7 @@ export class PluginDataStore {
 				...agent.mcpServers,
 				[serverId]: config,
 			};
-			this.saveSettings();
+			void this.saveSettings();
 		}
 	}
 
@@ -1002,7 +1042,7 @@ export class PluginDataStore {
 		if (agent) {
 			const { [serverId]: _, ...rest } = agent.mcpServers;
 			agent.mcpServers = rest;
-			this.saveSettings();
+			void this.saveSettings();
 		}
 	}
 
@@ -1017,7 +1057,7 @@ export class PluginDataStore {
 				...agent.mcpServers,
 				[serverId]: { ...server, enabled: !server.enabled },
 			};
-			this.saveSettings();
+			void this.saveSettings();
 		}
 	}
 
@@ -1071,7 +1111,7 @@ export class PluginDataStore {
 		if (!agent) return;
 
 		agent.skills[skillId] = { enabled };
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -1082,7 +1122,7 @@ export class PluginDataStore {
 		if (!agent?.skills[skillId]) return false;
 
 		delete agent.skills[skillId];
-		this.saveSettings();
+		void this.saveSettings();
 		return true;
 	}
 
@@ -1092,7 +1132,7 @@ export class PluginDataStore {
 	set isVerbose(val: boolean) {
 		this.#data.isVerbose = val;
 		applyVerboseLogging(val);
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get showToolIODetails() {
@@ -1100,7 +1140,7 @@ export class PluginDataStore {
 	}
 	set showToolIODetails(val: boolean) {
 		this.#data.showToolIODetails = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get thinkingProcessExpanded() {
@@ -1108,7 +1148,7 @@ export class PluginDataStore {
 	}
 	set thinkingProcessExpanded(val: boolean) {
 		this.#data.thinkingProcessExpanded = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get showActiveAgentsInStatusBar() {
@@ -1116,7 +1156,7 @@ export class PluginDataStore {
 	}
 	set showActiveAgentsInStatusBar(val: boolean) {
 		this.#data.showActiveAgentsInStatusBar = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get overrideMobileNavbarSearch() {
@@ -1124,7 +1164,7 @@ export class PluginDataStore {
 	}
 	set overrideMobileNavbarSearch(val: boolean) {
 		this.#data.overrideMobileNavbarSearch = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get suppressIntegrationPrivacyWarning() {
@@ -1132,7 +1172,7 @@ export class PluginDataStore {
 	}
 	set suppressIntegrationPrivacyWarning(val: boolean) {
 		this.#data.suppressIntegrationPrivacyWarning = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get onboardingComplete() {
@@ -1140,7 +1180,7 @@ export class PluginDataStore {
 	}
 	set onboardingComplete(val: boolean) {
 		this.#data.onboardingComplete = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get onboardingSplashSeen() {
@@ -1148,7 +1188,7 @@ export class PluginDataStore {
 	}
 	set onboardingSplashSeen(val: boolean) {
 		this.#data.onboardingSplashSeen = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get dismissedRecommendations() {
@@ -1161,13 +1201,13 @@ export class PluginDataStore {
 		if (!this.#data.dismissedRecommendations.includes(id)) {
 			// Reassign (not push) so $state reactivity fires.
 			this.#data.dismissedRecommendations = [...this.#data.dismissedRecommendations, id];
-			this.saveSettings();
+			void this.saveSettings();
 		}
 	}
 	/** Brings every dismissed recommendation back. Exposed in Developer settings. */
 	restoreDismissedRecommendations() {
 		this.#data.dismissedRecommendations = [];
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get searchShowPath() {
@@ -1175,7 +1215,7 @@ export class PluginDataStore {
 	}
 	set searchShowPath(val: boolean) {
 		this.#data.searchShowPath = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get searchShowTags() {
@@ -1183,7 +1223,7 @@ export class PluginDataStore {
 	}
 	set searchShowTags(val: boolean) {
 		this.#data.searchShowTags = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get searchShowMatchBadges() {
@@ -1191,7 +1231,7 @@ export class PluginDataStore {
 	}
 	set searchShowMatchBadges(val: boolean) {
 		this.#data.searchShowMatchBadges = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get searchShowMatchContext() {
@@ -1199,7 +1239,7 @@ export class PluginDataStore {
 	}
 	set searchShowMatchContext(val: boolean) {
 		this.#data.searchShowMatchContext = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get searchShowKeyboardHints() {
@@ -1207,7 +1247,7 @@ export class PluginDataStore {
 	}
 	set searchShowKeyboardHints(val: boolean) {
 		this.#data.searchShowKeyboardHints = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get recentNotes(): RecentNoteEntry[] {
@@ -1229,7 +1269,7 @@ export class PluginDataStore {
 			(entry) => entry.path !== normalizedPath && now - entry.lastOpenedAt < RECENT_NOTE_WINDOW_MS,
 		);
 		this.#data.recentNotes = [{ path: normalizedPath, lastOpenedAt: now }, ...existing].slice(0, MAX_RECENT_NOTES);
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	// --- Embedding Indexes (Multi-Index) ---
@@ -1305,7 +1345,7 @@ export class PluginDataStore {
 			this.#data.graphEmbedIndex = indexId;
 		}
 
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -1318,7 +1358,7 @@ export class PluginDataStore {
 			this.#data.graphEmbedIndex = null;
 		}
 
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -1333,7 +1373,7 @@ export class PluginDataStore {
 		if (stats.lastBuiltAt !== undefined) config.lastBuiltAt = stats.lastBuiltAt;
 		if (stats.documentCount !== undefined) config.documentCount = stats.documentCount;
 		if (stats.dimensions !== undefined) config.dimensions = stats.dimensions;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -1349,7 +1389,7 @@ export class PluginDataStore {
 
 		this.#data.embeddingIndexes = this.#data.embeddingIndexes.filter((i) => i.id !== indexId);
 
-		this.saveSettings();
+		void this.saveSettings();
 		return true;
 	}
 
@@ -1367,7 +1407,7 @@ export class PluginDataStore {
 	}
 	set smartGraphSettings(val: SmartGraphSettings) {
 		this.#data.smartGraphSettings = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	// --- Diff View Mode ---
@@ -1377,7 +1417,7 @@ export class PluginDataStore {
 	}
 	set diffViewMode(val: DiffViewMode) {
 		this.#data.diffViewMode = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	get vaultSlug(): string {
@@ -1392,7 +1432,7 @@ export class PluginDataStore {
 	}
 	set chatOpenLocation(val: ChatOpenLocation) {
 		this.#data.chatOpenLocation = val;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	// --- Favorite Models ---
@@ -1415,7 +1455,7 @@ export class PluginDataStore {
 		} else {
 			this.#data.favoriteModels.push({ provider, model });
 		}
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	// Get/set isConfigured for a provider
@@ -1431,7 +1471,7 @@ export class PluginDataStore {
 		const wasConfigured = config.isConfigured;
 		config.isConfigured = !wasConfigured;
 
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -1514,7 +1554,7 @@ export class PluginDataStore {
 			// Store as value
 			config.auth.values[key] = value as string;
 		}
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -1563,7 +1603,7 @@ export class PluginDataStore {
 		if (!config) return;
 		if (modelName in config.embedModels) throw new AddEmbedModelError(provider, modelName);
 		config.embedModels = { ...config.embedModels, [modelName]: conf };
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	updateEmbedModel(provider: string, modelName: string, conf: EmbedModelConfig) {
@@ -1571,7 +1611,7 @@ export class PluginDataStore {
 		if (!config) return;
 		if (!(modelName in config.embedModels)) throw new SetEmbedModelError(provider, modelName);
 		config.embedModels = { ...config.embedModels, [modelName]: conf };
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	deleteEmbedModel(provider: string, modelName: string) {
@@ -1580,7 +1620,7 @@ export class PluginDataStore {
 		if (!(modelName in config.embedModels)) throw new SetEmbedModelError(provider, modelName);
 		const { [modelName]: _, ...rest } = config.embedModels;
 		config.embedModels = rest;
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	// --- Chat Model Management (Record-based) ---
@@ -1595,7 +1635,7 @@ export class PluginDataStore {
 		if (!config) return;
 		if (modelName in config.chatModels) throw new AddChatModelError(provider, modelName);
 		config.chatModels = { ...config.chatModels, [modelName]: conf };
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	updateChatModel(provider: string, modelName: string, conf: ChatModelConfig) {
@@ -1603,7 +1643,7 @@ export class PluginDataStore {
 		if (!config) return;
 		if (!(modelName in config.chatModels)) throw new SetChatModelError(provider, modelName);
 		config.chatModels = { ...config.chatModels, [modelName]: conf };
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	deleteChatModel(provider: string, modelName: string) {
@@ -1625,7 +1665,7 @@ export class PluginDataStore {
 			}
 		}
 
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	// Get/set chatModels
@@ -1638,7 +1678,7 @@ export class PluginDataStore {
 		const config = this.#data.providerConfig[provider];
 		if (config) {
 			config.chatModels = value;
-			this.saveSettings();
+			void this.saveSettings();
 		}
 	}
 
@@ -1745,7 +1785,7 @@ export class PluginDataStore {
 			unsyncProvider(providerId);
 		}
 
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -1769,7 +1809,7 @@ export class PluginDataStore {
 		// Refresh the registry's cached auth — it snapshots the resolved AuthObject at
 		// registration, so an edited key/baseUrl would otherwise keep using the old value.
 		this.syncProviderIfConfigured(providerId);
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**
@@ -1787,7 +1827,7 @@ export class PluginDataStore {
 			delete config.auth.secretIds[fieldName];
 		}
 		this.syncProviderIfConfigured(providerId);
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	getProviderAuthMode(providerId: string): OpenAIAuthMode {
@@ -1808,7 +1848,7 @@ export class PluginDataStore {
 		if (!config) return;
 		config.auth.authMode = authMode;
 		this.syncProviderIfConfigured(providerId);
-		this.saveSettings();
+		void this.saveSettings();
 	}
 
 	/**

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -342,8 +342,12 @@ export class PluginDataStore {
 	 * reload silently reverted it.
 	 *
 	 * Failures are caught, logged, and surfaced once so the user learns their settings
-	 * did not persist. Callers that genuinely need to know a write landed should await
-	 * `saveSettingsOrThrow` instead.
+	 * did not persist.
+	 *
+	 * This is for the fire-and-forget setters only. Anything that *awaits* a save is by
+	 * definition persistence-dependent (provider create/rename/delete, `deleteData`) and
+	 * must not be told a write succeeded when it did not — those call
+	 * `saveSettingsOrThrow` and let the failure reach their own caller.
 	 */
 	private async saveSettings(): Promise<void> {
 		try {
@@ -384,7 +388,7 @@ export class PluginDataStore {
 
 	async deleteData(): Promise<void> {
 		this.#data = structuredClone(DEFAULT_SETTINGS);
-		await this.saveSettings();
+		await this.saveSettingsOrThrow();
 	}
 
 	/**
@@ -1256,7 +1260,7 @@ export class PluginDataStore {
 
 	async clearRecentNotes(): Promise<void> {
 		this.#data.recentNotes = [];
-		await this.saveSettings();
+		await this.saveSettingsOrThrow();
 	}
 
 	recordRecentlyOpenedNote(path: string): void {
@@ -1918,7 +1922,7 @@ export class PluginDataStore {
 			isConfigured: configured,
 		};
 
-		await this.saveSettings();
+		await this.saveSettingsOrThrow();
 	}
 
 	async updateProviderMeta(providerId: string, updates: Partial<ProviderInstanceMeta>): Promise<void> {
@@ -1948,7 +1952,7 @@ export class PluginDataStore {
 			};
 		}
 
-		await this.saveSettings();
+		await this.saveSettingsOrThrow();
 	}
 
 	/**
@@ -2011,7 +2015,7 @@ export class PluginDataStore {
 		// registry rather than syncing a single ID.
 		syncAllProviders(this);
 
-		await this.saveSettings();
+		await this.saveSettingsOrThrow();
 	}
 
 	/**
@@ -2095,7 +2099,7 @@ export class PluginDataStore {
 		// SecretStorage — until the next Obsidian reload.
 		unsyncProvider(providerId);
 
-		await this.saveSettings();
+		await this.saveSettingsOrThrow();
 
 		return orphanedIndexIds;
 	}

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -429,7 +429,10 @@ export class PendingChangesStore {
 						`File "${change.path}" was modified after the delete was proposed. Review the note and re-stage the delete.`,
 					);
 				}
-				await app.vault.trash(file, true);
+				// trashFile honours the user's "Deleted files" setting (system trash, vault
+				// .trash, or permanent). `vault.trash(file, true)` hardcoded system trash and
+				// ignored that choice.
+				await app.fileManager.trashFile(file);
 			} else if (change.type === "move") {
 				const file = app.vault.getAbstractFileByPath(normalizedPath);
 				if (!(file instanceof TFile)) {

--- a/src/stores/pendingChangesStore.svelte.ts
+++ b/src/stores/pendingChangesStore.svelte.ts
@@ -126,7 +126,7 @@ export class PendingChangesStore {
 	#entries: PendingChangeEntry[] = $state([]);
 	#revision = $state(0);
 	readonly #plugin: SecondBrainPlugin;
-	#saveTimer: ReturnType<typeof setTimeout> | null = null;
+	#saveTimer: number | null = null;
 	readonly #processingGroups = new Set<string>();
 	readonly #fileLocks = new Map<string, Promise<void>>();
 	readonly #batchProcessing = new Set<string>();
@@ -234,8 +234,8 @@ export class PendingChangesStore {
 	}
 
 	private scheduleSave(): void {
-		if (this.#saveTimer) clearTimeout(this.#saveTimer);
-		this.#saveTimer = setTimeout(
+		if (this.#saveTimer) window.clearTimeout(this.#saveTimer);
+		this.#saveTimer = window.setTimeout(
 			() => void this.saveToDisk().catch((e) => Logger.error("[PendingChanges] Failed to save:", e)),
 			SAVE_DEBOUNCE_MS,
 		);
@@ -251,7 +251,7 @@ export class PendingChangesStore {
 	 */
 	private flushSave(): void {
 		if (this.#saveTimer) {
-			clearTimeout(this.#saveTimer);
+			window.clearTimeout(this.#saveTimer);
 			this.#saveTimer = null;
 		}
 		void this.saveToDisk().catch((e) => Logger.error("[PendingChanges] Failed to save:", e));
@@ -1064,7 +1064,7 @@ export class PendingChangesStore {
 
 	cleanup(): void {
 		if (this.#saveTimer) {
-			clearTimeout(this.#saveTimer);
+			window.clearTimeout(this.#saveTimer);
 			this.#saveTimer = null;
 			// Flush any pending writes so data isn't lost on unload
 			void this.saveToDisk().catch((e) => Logger.error("[PendingChanges] Failed to save on cleanup:", e));

--- a/src/utils/longPress.ts
+++ b/src/utils/longPress.ts
@@ -30,7 +30,7 @@ interface LongPressOptions {
 }
 
 export function longPress(node: HTMLElement, options: LongPressOptions) {
-	let timer: ReturnType<typeof setTimeout> | null = null;
+	let timer: number | null = null;
 	let fired = false;
 	let startX = 0;
 	let startY = 0;
@@ -38,7 +38,7 @@ export function longPress(node: HTMLElement, options: LongPressOptions) {
 
 	function cancel() {
 		if (timer !== null) {
-			clearTimeout(timer);
+			window.clearTimeout(timer);
 			timer = null;
 		}
 		node.classList.remove(PRESSING_CLASS);
@@ -53,7 +53,7 @@ export function longPress(node: HTMLElement, options: LongPressOptions) {
 		startY = e.clientY;
 		cancel();
 		node.classList.add(PRESSING_CLASS);
-		timer = setTimeout(() => {
+		timer = window.setTimeout(() => {
 			timer = null;
 			fired = true;
 			node.classList.remove(PRESSING_CLASS);

--- a/src/utils/noteIcons.ts
+++ b/src/utils/noteIcons.ts
@@ -120,7 +120,12 @@ export function resolveIconColor(color?: string): string | undefined {
 		return undefined;
 	}
 
-	const bodyStyle = globalThis.getComputedStyle(document.body);
+	// Resolve the style through the same document the element belongs to. Pairing
+	// `activeWindow` with the global `document` breaks whenever they are different
+	// documents (a popout window, and jsdom under test) — getComputedStyle then
+	// reports nothing and every themed colour silently falls back.
+	const body = document.body;
+	const bodyStyle = (body.ownerDocument.defaultView ?? window).getComputedStyle(body);
 	const thematicVariable = ICONIC_COLOR_VARIABLES.get(color);
 	const themedColor = thematicVariable ? bodyStyle.getPropertyValue(thematicVariable).trim() : "";
 	const cssColor = themedColor || color;

--- a/src/vectorstore/VectorStoreService.ts
+++ b/src/vectorstore/VectorStoreService.ts
@@ -383,7 +383,7 @@ export class VectorStoreService {
 	private readonly instances: Map<string, IndexInstance> = new Map();
 	private readonly initializingInstances = new Map<string, Promise<IndexInstance>>();
 	private readonly progressListeners = new Map<string, Set<(progress: IndexingProgress) => void>>();
-	private readonly modifyTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	private readonly modifyTimers = new Map<string, number>();
 	private isInitialized = false;
 	private readonly vaultId: string;
 	/** Crash-backoff marker for scheduled bulk runs (`s2b-embedding-bulk-attempts:<vaultId>`). */
@@ -907,7 +907,7 @@ export class VectorStoreService {
 						? `Indexing cancelled (${outcome.indexedChunks} chunks updated)`
 						: `✓ Index updated: ${outcome.indexedChunks} chunks`,
 				);
-				setTimeout(() => notice.hide(), 3000);
+				window.setTimeout(() => notice.hide(), 3000);
 			}
 			Logger.log(`[VectorStore] Indexed ${outcome.indexedChunks} chunks for ${inst.indexId}`);
 		}
@@ -997,11 +997,11 @@ export class VectorStoreService {
 	 */
 	private handleFileModify(file: TFile): void {
 		const existing = this.modifyTimers.get(file.path);
-		if (existing) clearTimeout(existing);
+		if (existing) window.clearTimeout(existing);
 
 		this.modifyTimers.set(
 			file.path,
-			setTimeout(async () => {
+			window.setTimeout(async () => {
 				this.modifyTimers.delete(file.path);
 
 				for (const inst of this.instances.values()) {
@@ -1331,7 +1331,7 @@ export class VectorStoreService {
 					? `Indexing cancelled (${indexed} notes indexed so far)`
 					: `✓ Indexed ${indexed} notes${skippedText}`,
 			);
-			setTimeout(() => notice.hide(), 3000);
+			window.setTimeout(() => notice.hide(), 3000);
 
 			Logger.log(`[VectorStore] Full index complete for ${inst.indexId}: ${indexed} indexed, ${skipped} skipped`);
 		} catch (error) {
@@ -2368,7 +2368,7 @@ export class VectorStoreService {
 	 */
 	async cleanup(): Promise<void> {
 		try {
-			for (const timer of this.modifyTimers.values()) clearTimeout(timer);
+			for (const timer of this.modifyTimers.values()) window.clearTimeout(timer);
 			this.modifyTimers.clear();
 			// Wait for any in-progress initialization before cleaning up
 			if (this.initPromise) {

--- a/src/views/chat/chatEmbed.ts
+++ b/src/views/chat/chatEmbed.ts
@@ -10,7 +10,7 @@ import {
 import { Logger } from "../../utils/logging";
 
 /** Yield to the browser so it can paint/handle input before continuing. */
-const yieldToMain = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+const yieldToMain = (): Promise<void> => new Promise((resolve) => window.setTimeout(resolve, 0));
 
 /**
  * Shape of the context object Obsidian's (internal) embed registry passes to an
@@ -90,7 +90,7 @@ class ChatEmbed extends MarkdownRenderChild {
 		// already-queued embed, spreading their CPU bursts across frames.
 		const delay = pendingLoadCount * STAGGER_MS;
 		pendingLoadCount++;
-		setTimeout(() => {
+		window.setTimeout(() => {
 			pendingLoadCount = Math.max(0, pendingLoadCount - 1);
 			void this.loadContent();
 		}, delay);

--- a/src/views/onboarding/Onboarding.svelte
+++ b/src/views/onboarding/Onboarding.svelte
@@ -79,9 +79,9 @@ $effect(() => {
 			stylesReady = true;
 			return;
 		}
-		raf = requestAnimationFrame(probe);
+		raf = window.requestAnimationFrame(probe);
 	};
-	raf = requestAnimationFrame(probe);
+	raf = window.requestAnimationFrame(probe);
 	return () => cancelAnimationFrame(raf);
 });
 // Lets an impatient user jump straight to the settled page instead of waiting out

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -198,7 +198,7 @@ function scrollManualCodeIntoView(e: FocusEvent) {
 	if (!Platform.isMobileApp) return;
 	const target = e.currentTarget;
 	if (!(target instanceof HTMLElement)) return;
-	setTimeout(() => target.scrollIntoView({ block: "nearest", behavior: "smooth" }), 350);
+	window.setTimeout(() => target.scrollIntoView({ block: "nearest", behavior: "smooth" }), 350);
 }
 
 function handleOAuthDisconnect() {
@@ -306,7 +306,7 @@ async function commitProvider() {
 	// appears in the list, which is the clearest confirmation.
 	if (closeAfterCommit) {
 		closeAfterCommit = false;
-		setTimeout(() => modal.close(), 800);
+		window.setTimeout(() => modal.close(), 800);
 	}
 }
 

--- a/src/views/smart-graph/topicCaches.ts
+++ b/src/views/smart-graph/topicCaches.ts
@@ -592,12 +592,12 @@ function openDatabase(): Promise<IDBDatabase> {
 	return new Promise((resolve, reject) => {
 		const request = indexedDB.open(dbName, DB_VERSION);
 		let settled = false;
-		let blockedTimer: ReturnType<typeof setTimeout> | null = null;
+		let blockedTimer: number | null = null;
 
 		const finish = (fn: () => void) => {
 			if (settled) return;
 			settled = true;
-			if (blockedTimer !== null) clearTimeout(blockedTimer);
+			if (blockedTimer !== null) window.clearTimeout(blockedTimer);
 			fn();
 		};
 
@@ -617,8 +617,8 @@ function openDatabase(): Promise<IDBDatabase> {
 				`[SmartGraph] Topic-cache DB open blocked on "${dbName}" — another connection is still open. ` +
 					`Waiting ${OPEN_BLOCKED_TIMEOUT_MS}ms for it to close.`,
 			);
-			if (blockedTimer !== null) clearTimeout(blockedTimer);
-			blockedTimer = setTimeout(() => {
+			if (blockedTimer !== null) window.clearTimeout(blockedTimer);
+			blockedTimer = window.setTimeout(() => {
 				finish(() =>
 					reject(
 						new Error(
@@ -702,7 +702,7 @@ export function loadPersistedTopicCaches(): Promise<void> {
 	return hydration;
 }
 
-let saveTimer: ReturnType<typeof setTimeout> | null = null;
+let saveTimer: number | null = null;
 
 /**
  * Persist the current caches, debounced — derivations land in bursts (probe
@@ -713,8 +713,8 @@ let saveTimer: ReturnType<typeof setTimeout> | null = null;
  */
 export function scheduleTopicCacheSave(): void {
 	if (typeof indexedDB === "undefined") return;
-	if (saveTimer != null) clearTimeout(saveTimer);
-	saveTimer = setTimeout(() => {
+	if (saveTimer != null) window.clearTimeout(saveTimer);
+	saveTimer = window.setTimeout(() => {
 		saveTimer = null;
 		if (topicCaches.leiden.size === 0 && archivedGraphs.size === 0) return;
 		writePersisted(encodeTopicCaches(snapshotTopicCaches())).catch((error) => {

--- a/test/lib/views.test.ts
+++ b/test/lib/views.test.ts
@@ -11,7 +11,7 @@ import {
 	rewriteViewFilterForRename,
 } from "../../src/lib/views";
 import type { ViewFilter, ViewFilterGroup } from "../../src/types/viewFilter";
-import type { App, CachedMetadata, TFile } from "obsidian";
+import { type App, type CachedMetadata, TFile } from "obsidian";
 
 // ---------------------------------------------------------------------------
 // Mock helpers
@@ -25,15 +25,21 @@ function createMockApp(
 	fileTags: Record<string, string[]> = {},
 	fileFrontmatter: Record<string, Record<string, unknown>> = {},
 ): App {
-	const mockFiles = files.map((path) => ({
-		path,
-		basename: path
-			.replace(/\.[^.]+$/, "")
-			.split("/")
-			.pop(),
-		extension: path.split(".").pop() ?? "md",
-		name: path.split("/").pop(),
-	}));
+	// Real TFile instances, not object literals: the tag rules narrow with
+	// `instanceof TFile` (rather than a duck-typed "extension" in file), so a plain
+	// object would silently fail every tag match.
+	const mockFiles = files.map((path) => {
+		const file = new TFile();
+		file.path = path;
+		file.basename =
+			path
+				.replace(/\.[^.]+$/, "")
+				.split("/")
+				.pop() ?? "";
+		file.extension = path.split(".").pop() ?? "md";
+		file.name = path.split("/").pop() ?? "";
+		return file;
+	});
 
 	const getFileCache = vi.fn((file: TFile): CachedMetadata | null => {
 		const tags = fileTags[file.path];

--- a/test/stores/chatSessionPostRunFailure.test.ts
+++ b/test/stores/chatSessionPostRunFailure.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { ChatSession } from "../../src/stores/chatStore.svelte";
+import { AssistantState, buildCheckpointGraph, type CheckpointGraphState } from "../../src/stores/chatTimeline";
+import type { CheckpointHistoryItem } from "../../src/agent/Agent";
+
+/* --------------------------------------------------------------------------
+ * ChatSession — a post-success failure must not retract the turn.
+ *
+ * `runStream` wraps the stream AND the bookkeeping that follows it (auto-title
+ * rename, checkpoint-graph sync, thinking-duration persistence, reloadAfter) in
+ * one try/catch. Once `consumeStream` resolves, the answer has streamed and the
+ * checkpointer has persisted it — so a throw from that trailing bookkeeping is
+ * a view-freshness problem, not a failed reply. The original catch marked the
+ * pair `error` regardless, which is how a rename-invalidated `onNeedReload`
+ * turned a perfectly good answer into a red error bubble offering to "retry"
+ * work that had already succeeded.
+ *
+ * These tests pin the boundary: failures BEFORE the stream completes still
+ * surface as errors; failures AFTER it leave the turn successful.
+ * ------------------------------------------------------------------------*/
+
+const THREAD_ID = "Chats/Post Run.chat";
+
+function checkpoint(
+	checkpointId: string,
+	step: number,
+	messages: (HumanMessage | AIMessage)[],
+	parentCheckpointId?: string,
+): CheckpointHistoryItem {
+	return { checkpointId, step, messages, parentCheckpointId, ts: new Date(2026, 0, 1, 0, step + 2).toISOString() };
+}
+
+/** One completed turn, so the session has a pair to stream into. */
+function buildGraph(): CheckpointGraphState {
+	const h1 = new HumanMessage({ content: "hello", id: "h1" });
+	const ai1 = new AIMessage({ content: "hi", id: "ai1" });
+	const graph = buildCheckpointGraph([
+		checkpoint("r", -1, []),
+		checkpoint("a", 0, [h1], "r"),
+		checkpoint("b", 1, [h1, ai1], "a"),
+	]);
+	graph.activeCheckpointId = "b";
+	return graph;
+}
+
+type RunStreamInternals = {
+	runStream(
+		pairId: string,
+		getStream: (signal: AbortSignal) => AsyncIterable<unknown>,
+		options: { beforeCheckpointIds: Set<string>; reloadAfter?: boolean; parentCheckpointId?: string },
+	): Promise<void>;
+	consumeStream: (...args: unknown[]) => Promise<void>;
+	syncGraphAfterRun: (...args: unknown[]) => Promise<void>;
+};
+
+function makeSession(): { session: ChatSession; internals: RunStreamInternals } {
+	const session = new ChatSession(THREAD_ID, {
+		graphState: buildGraph(),
+		errorCount: 0,
+		selectedAgentId: "",
+	});
+	const internals = session as unknown as RunStreamInternals;
+	// Default happy path for the two boundaries these tests toggle.
+	internals.consumeStream = vi.fn().mockResolvedValue(undefined);
+	internals.syncGraphAfterRun = vi.fn().mockResolvedValue(undefined);
+	return { session, internals };
+}
+
+async function run(session: ChatSession, internals: RunStreamInternals, reloadAfter = false): Promise<string> {
+	const pair = session.messages.at(-1);
+	if (!pair) throw new Error("expected a message pair");
+	await internals.runStream.call(session, pair.id, () => (async function* () {})(), {
+		beforeCheckpointIds: new Set(["r", "a", "b"]),
+		reloadAfter,
+	});
+	return pair.id;
+}
+
+describe("ChatSession — post-success bookkeeping failures preserve the turn", () => {
+	beforeEach(() => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("keeps the turn successful when onNeedReload throws after the stream completed", async () => {
+		const { session, internals } = makeSession();
+		// Exactly the failure the rename bug produced.
+		(session as unknown as { onNeedReload: () => Promise<void> }).onNeedReload = () => {
+			throw new Error("No session to reload");
+		};
+
+		const pairId = await run(session, internals, true);
+
+		const pair = session.messages.find((p) => p.id === pairId);
+		expect(pair?.assistantMessage.state).toBe(AssistantState.success);
+		expect(pair?.assistantMessage.errorCode).toBeUndefined();
+	});
+
+	it("keeps the turn successful when the checkpoint-graph sync throws", async () => {
+		const { session, internals } = makeSession();
+		internals.syncGraphAfterRun = vi.fn().mockRejectedValue(new Error("checkpoint read failed"));
+
+		const pairId = await run(session, internals);
+
+		const pair = session.messages.find((p) => p.id === pairId);
+		expect(pair?.assistantMessage.state).toBe(AssistantState.success);
+		expect(pair?.assistantMessage.errorCode).toBeUndefined();
+	});
+
+	it("still reports an error when the stream itself fails", async () => {
+		const { session, internals } = makeSession();
+		internals.consumeStream = vi.fn().mockRejectedValue(new Error("model refused"));
+
+		const pairId = await run(session, internals);
+
+		const pair = session.messages.find((p) => p.id === pairId);
+		expect(pair?.assistantMessage.state).toBe(AssistantState.error);
+		expect(pair?.assistantMessage.errorCode).toBeTruthy();
+	});
+
+	it("still reports cancellation when the user stops mid-stream", async () => {
+		const { session, internals } = makeSession();
+		internals.consumeStream = vi.fn().mockImplementation(async () => {
+			(session as unknown as { cancelled: boolean }).cancelled = true;
+			throw new Error("aborted");
+		});
+
+		const pairId = await run(session, internals);
+
+		const pair = session.messages.find((p) => p.id === pairId);
+		expect(pair?.assistantMessage.state).toBe(AssistantState.cancelled);
+	});
+
+	it("leaves the session idle and re-runnable after a post-success failure", async () => {
+		const { session, internals } = makeSession();
+		internals.syncGraphAfterRun = vi.fn().mockRejectedValue(new Error("checkpoint read failed"));
+
+		await run(session, internals);
+
+		// The finally block must still clear the run slot; a leaked abortController
+		// would make the next send throw "already in progress".
+		expect(session.isRunning).toBe(false);
+	});
+});

--- a/test/stores/pendingChangesStore.test.ts
+++ b/test/stores/pendingChangesStore.test.ts
@@ -65,6 +65,7 @@ function createMockPlugin() {
 			vault,
 			fileManager: {
 				renameFile: vi.fn().mockResolvedValue(undefined),
+				trashFile: vi.fn().mockResolvedValue(undefined),
 			},
 		},
 		registerEvent: vi.fn(),
@@ -294,7 +295,8 @@ describe("PendingChangesStore", () => {
 			await store.acceptChange(id);
 
 			expect(store.getEntry(id)?.status).toBe("accepted");
-			expect(plugin.app.vault.trash).toHaveBeenCalledWith(file, true);
+			// trashFile, not vault.trash: honours the user's "Deleted files" preference.
+			expect(plugin.app.fileManager.trashFile).toHaveBeenCalledWith(file);
 		});
 
 		it("should refuse a delete when the file was modified after staging", async () => {
@@ -311,7 +313,7 @@ describe("PendingChangesStore", () => {
 
 			await expect(store.acceptChange(id)).rejects.toThrow("was modified after the delete was proposed");
 			expect(store.getEntry(id)?.status).toBe("pending");
-			expect(plugin.app.vault.trash).not.toHaveBeenCalled();
+			expect(plugin.app.fileManager.trashFile).not.toHaveBeenCalled();
 		});
 
 		it("should accept and apply a move change", async () => {

--- a/test/stores/sessionRegistry.test.ts
+++ b/test/stores/sessionRegistry.test.ts
@@ -156,6 +156,72 @@ describe("SessionRegistry — rekey on thread rename", () => {
 	});
 });
 
+/* --------------------------------------------------------------------------
+ * Regression: session callbacks must survive the auto-title rename.
+ *
+ * The first message in a chat renames the thread (auto-title). `runStream`
+ * performs that rename and THEN fires `onNeedReload` for `reloadAfter`. A
+ * callback that captured the load-time path resolves to a map key that no
+ * longer exists, so the reload threw "No session to reload" — swallowed by
+ * runStream's catch, which flipped the just-succeeded turn to an error state.
+ * ------------------------------------------------------------------------*/
+describe("SessionRegistry — reload callbacks survive a mid-run rename", () => {
+	/** Minimal AgentManager stub covering only what loadSession/reload touch. */
+	function makeLoadableRegistry(): { registry: SessionRegistry; historyCalls: string[] } {
+		const historyCalls: string[] = [];
+		const stub = {
+			isThreadEmpty: async () => false,
+			getThreadHistory: async (id: string) => {
+				historyCalls.push(id);
+				return { messages: [], metadata: {} };
+			},
+			getCheckpointHistory: async () => [{ id: "cp1", parentId: undefined, messages: [] }],
+			setLastViewedCheckpoint: async () => {},
+			onNextInitialized: () => {},
+		} as unknown as AgentManager;
+		const registry = new SessionRegistry(stub);
+		// Agent selection is orthogonal to this regression and would require a
+		// fully constructed PluginDataStore; stub it to a fixed agent id.
+		(
+			registry as unknown as { restoreSelectionFromLoadedMessages: () => Promise<string> }
+		).restoreSelectionFromLoadedMessages = async () => "agent-1";
+		return { registry, historyCalls };
+	}
+
+	async function loadThread(registry: SessionRegistry, path: string): Promise<ChatSession> {
+		await registry.loadSession({ path } as unknown as Parameters<SessionRegistry["loadSession"]>[0]);
+		const session = registry.sessionFor(path);
+		if (!session) throw new Error("expected a session after load");
+		return session;
+	}
+
+	it("onNeedReload still resolves after the session is rekeyed", async () => {
+		const { registry, historyCalls } = makeLoadableRegistry();
+		const session = await loadThread(registry, "Untitled.chat");
+
+		// Reproduce what runStream does on the first message: update the session's
+		// own id, then rekey the registry via the onThreadIdChange callback.
+		const opts = session as unknown as {
+			onNeedReload?: () => Promise<void>;
+			onThreadIdChange?: (o: string, n: string) => void;
+		};
+		session.id = "Renamed Title.chat";
+		opts.onThreadIdChange?.("Untitled.chat", "Renamed Title.chat");
+
+		historyCalls.length = 0;
+		// Previously threw "No session to reload".
+		await expect(opts.onNeedReload?.()).resolves.toBeUndefined();
+		// And it reloaded the RENAMED thread, not the stale path.
+		expect(historyCalls).toContain("Renamed Title.chat");
+		expect(historyCalls).not.toContain("Untitled.chat");
+	});
+
+	it("reloadSession(path) still throws for a genuinely absent session", async () => {
+		const { registry } = makeLoadableRegistry();
+		await expect(registry.reloadSession("nope.chat")).rejects.toThrow("No session to reload");
+	});
+});
+
 describe("ChatSession — isRunning reflects an in-flight stream", () => {
 	it("is false on a freshly built session", () => {
 		const s = makeSession("a.chat");


### PR DESCRIPTION
Clears the two highest-value tiers of the Obsidian plugin-review warnings. Three of these are genuine defects that happened to be sitting behind lint rules; the rest is mechanical scoping.

## Tier 1 — real bugs

**Failed settings saves were invisible.** `saveSettings` had no error handling, and ~70 setters call it as the last statement of a synchronous mutation with no way to recover. A rejecting `saveData` (disk full, permissions, sync conflict) surfaced only as an unhandled rejection: the change stayed in memory, never reached disk, and silently reverted on the next reload. It now catches, logs, and shows one rate-limited Notice. Callers that must observe a failure can await `saveSettingsOrThrow`.

*This is why the "floating promise" category was worth doing properly — the linter's suggested fix (`void`) would have satisfied the rule while preserving the bug.*

**Deletes ignored the user's preference.** `vault.trash(file, true)` hardcodes system trash. Now `FileManager.trashFile`, which honours the "Deleted files" setting.

**Legacy skills path hardcoded `.obsidian`**, wrong for anyone who relocated their config folder. `configDir` is a documented non-optional string, so the fallback and its widening cast both go.

## Tier 2 — popout-window scoping

Timers and DOM-specific `globalThis` uses are now `window.`-scoped, so views hosted in a popout window address the right window.

**What was deliberately NOT converted, and why:**

- `HNSWVectorStore` / `MiniSearchService` keep bare timers — both are imported by `hnswWorker`, and **a worker has no `window`**. Applying the lint fix would throw at runtime and break vector indexing. Same for `gzip`, `asyncLocalStorage`, and the worker entrypoints (15 sites).
- `globalThis.fetch` / `.crypto` / `require` stay: cross-context by nature, and `obsidianFetch` *assigns* `globalThis.fetch` to install the CORS fallback.
- The `\$` escapes in `prompts.ts` stay — it's a template literal, where an unescaped `$` starts an interpolation and would corrupt the LaTeX guidance.

Also: provider `console.warn` calls now route through the project `Logger`; tag filters narrow with `instanceof TFile` instead of a duck-typed `"extension" in file`.

## Two bugs the mechanical pass surfaced

- `resolveIconColor` paired `activeWindow.getComputedStyle` with the global `document`. Whenever those are different documents (a popout, or jsdom under test) it returns nothing and every themed colour silently falls back. Caught by 5 failing tests; now resolves via the element's own `ownerDocument`.
- Switching the tag filters to `instanceof TFile` made `test/lib/views.test.ts` fail — its fixtures were object literals. Had they stayed literals, its **73 tests would have kept passing while every tag match silently failed**.

## Also on this branch

**`fix(chat)`: don't retract a turn when post-success bookkeeping fails** — an independent fix (not part of the lint cleanup). `runStream` wrapped the stream and its trailing bookkeeping in one try/catch, so a rename-invalidated `onNeedReload` turned a perfectly good answer into a red error bubble offering to retry work that had already succeeded. A `streamSucceeded` flag marks the point past which the answer is durable; after it, failures degrade view freshness instead of the turn. Comes with tests pinning the boundary from both sides.

**`fix`: propagate save failures to persistence-dependent callers** — from the review of this branch. Making `saveSettings` swallow failures was right for the fire-and-forget setters but wrong for the six callers that await it (`deleteProvider`, `renameProvider`, `addProviderInstance`, `updateProviderMeta`, `clearRecentNotes`, `deleteData`), which reported success even when nothing reached disk. Those now use `saveSettingsOrThrow`.

## Verification

`check` 0 errors (both tsconfigs) · lint + format clean · **1651/1651 tests pass** · production build succeeds · worker-context timers confirmed untouched.

## Not addressed

`createElement` (48) and `!important` (49) are deferred: they touch SearchModal, the diff extensions, and hard-won mobile CSS, where the regression risk outweighs the badge value. The `@codemirror/*` "missing dependency" (6) and `@tailwind` (3) warnings are simply wrong — host-provided Vite externals and build-processed at-rules. The dependency advisory (90) lists 22 packages against one GHSA whose range can't apply to all of them; all are devDependencies that don't ship in `main.js`.

**Realistic expectation:** this clears roughly 250 warnings, but the badge may not reach "Excellent" — the remainder is deliberate architecture or linter error.

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._