### PR TITLE
fix(provider-setup): keep providerId valid across the commit's rename

### DIFF
--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -214,6 +214,9 @@ const headerStatusProps = $state<{ provider: string }>({
 });
 let displayName = $state("");
 let displayNameError = $state<string | null>(null);
+// Whether the name field currently has focus. Gates the stored-name sync effect below so
+// it can't overwrite what the user is typing (the input binds `displayName` two-way).
+let isEditingDisplayName = $state(false);
 // Number of display-name saves currently in flight. `displayNameError` still holds its
 // previous value until an await settles, so without this Done could enable mid-save on a
 // name whose validity isn't known yet — and the commit's slug is derived from that same
@@ -240,8 +243,13 @@ function getTemplateLogo(id: ProviderTemplateId): Component<LogoProps> {
 	return TEMPLATE_LOGOS[id] ?? GenericAIIcon;
 }
 
+// Mirror the stored name into the input — but not while the user is typing in it. With
+// `bind:value` the input reads this back, so an unguarded sync (this effect re-runs on any
+// providerMeta change, e.g. the commit's rename) would overwrite an in-progress edit.
 $effect(() => {
-	displayName = providerMeta?.displayName ?? "";
+	const stored = providerMeta?.displayName ?? "";
+	if (untrack(() => isEditingDisplayName)) return;
+	displayName = stored;
 });
 
 async function handleSelectTemplate(id: ProviderTemplateId) {
@@ -327,6 +335,7 @@ let blurSeq = 0;
 
 async function handleDisplayNameBlur(nextName: string) {
 	const seq = ++blurSeq;
+	isEditingDisplayName = false;
 	const trimmedName = nextName.trim();
 	if (!trimmedName || trimmedName === providerMeta?.displayName) {
 		displayName = providerMeta?.displayName ?? "";
@@ -343,13 +352,13 @@ async function handleDisplayNameBlur(nextName: string) {
 	// disagree with the ID derived from it.
 	if (isCommitting) {
 		await commitSettled();
-		// The user may have refocused and blurred again while we waited. This invocation's
-		// value is then stale: writing it would clobber the newer edit in storage, and the
-		// `displayName = trimmedName` below would yank it out of the input. The newer blur
-		// persists what is current, so drop this one. (`displayName` can't be used as the
-		// staleness signal — the input is passed `value={displayName}`, not `bind:`, so it
-		// doesn't track typing.)
-		if (blurSeq !== seq) return;
+		// The user may have edited the field while we waited. This invocation's value is then
+		// stale: writing it would clobber the newer edit in storage, and the
+		// `displayName = trimmedName` below would yank it out of the input. Two ways to be
+		// superseded, and both need checking — a newer blur (the counter), or typing with no
+		// second blur, which never re-enters this handler and is only visible through the
+		// live binding on the input.
+		if (blurSeq !== seq || displayName.trim() !== trimmedName) return;
 		// Re-check against the post-commit meta: if the commit stored this very name, the
 		// write is redundant. `providerMeta` is now keyed by the settled `providerId`.
 		if (trimmedName === providerMeta?.displayName) {
@@ -543,10 +552,16 @@ const canFinish = $derived(
       name="Provider name"
       desc="Name this provider instance so you can distinguish it later."
     >
+      <!-- bind:, not a one-way value=: a blur deferred behind an in-flight commit needs to
+           know whether the user has since typed something newer, and only a live binding
+           tracks that (a blur counter misses typing without a second blur). -->
       <Text
         inputType="text"
-        value={displayName}
+        bind:value={displayName}
         placeholder={providerDefinition?.displayName ?? "New Provider"}
+        onfocus={() => {
+          isEditingDisplayName = true;
+        }}
         onblur={(value: string) => void handleDisplayNameBlur(value)}
       />
     </SettingItem>

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -214,18 +214,6 @@ const headerStatusProps = $state<{ provider: string }>({
 });
 let displayName = $state("");
 let displayNameError = $state<string | null>(null);
-// Whether the name field currently has focus.
-let isEditingDisplayName = $state(false);
-// Whether a blurred name is still on its way to storage. Blur clears the focus flag
-// immediately, but a write deferred behind an in-flight commit hasn't landed yet — without
-// this, the sync effect would overwrite the pending value with the stored one during the
-// commit's rename, and the resumed handler would read its own clobbering as a newer edit
-// and drop the name entirely.
-let unsavedDisplayName = $state<string | null>(null);
-// The field is the user's while either holds: don't sync stored state over it.
-function hasUnsavedDisplayName() {
-	return isEditingDisplayName || unsavedDisplayName !== null;
-}
 // Number of display-name saves currently in flight. `displayNameError` still holds its
 // previous value until an await settles, so without this Done could enable mid-save on a
 // name whose validity isn't known yet — and the commit's slug is derived from that same
@@ -252,14 +240,8 @@ function getTemplateLogo(id: ProviderTemplateId): Component<LogoProps> {
 	return TEMPLATE_LOGOS[id] ?? GenericAIIcon;
 }
 
-// Mirror the stored name into the input — but never on top of a value the user owns. With
-// `bind:value` the input reads this back, and this effect re-runs on any providerMeta
-// change (notably the commit's own rename), so an unguarded sync would clobber both an
-// in-progress edit and a blurred edit still waiting to be written.
 $effect(() => {
-	const stored = providerMeta?.displayName ?? "";
-	if (untrack(() => hasUnsavedDisplayName())) return;
-	displayName = stored;
+	displayName = providerMeta?.displayName ?? "";
 });
 
 async function handleSelectTemplate(id: ProviderTemplateId) {
@@ -278,15 +260,6 @@ async function handleSelectTemplate(id: ProviderTemplateId) {
 // the Done button can stay disabled across the commit's awaits — closing mid-rename would
 // race the ID change, and `markSubmitted` only lands after it.
 let isCommitting = $state(false);
-// Resolves when the in-flight commit finishes, so a blur that lands mid-commit can wait for
-// `providerId` to become authoritative instead of writing against an ID being renamed away.
-let commitDone: Promise<void> | null = null;
-// A waiting blur only needs to know the commit has *finished* — whether it succeeded is
-// commitProvider's business, and letting a rejection through here would escape the blur
-// handler's try/catch as an unhandled rejection.
-async function commitSettled() {
-	await commitDone?.catch(() => {});
-}
 
 // Promotes a draft to a fully configured provider the moment its connection validates.
 // This replaces the old "Add Provider" button: display name / auth / trusted all
@@ -295,101 +268,48 @@ async function commitSettled() {
 async function commitProvider() {
 	if (isConfigured || isCommitting) return;
 	isCommitting = true;
-	// Publish the in-flight commit so a concurrent blur can await it (see commitSettled).
-	// Assigned before the first await so a blur in the same tick already sees it.
-	commitDone = runCommit();
 	try {
-		await commitDone;
+		// Rename the draft to a slug derived from the final display name — this is the
+		// only point where the ID changes. Doing it once (not on every name edit) keeps
+		// downstream references stable while producing a human-readable, recoverable ID.
+		const name = displayName.trim() || (providerMeta?.displayName ?? "");
+		const base = slugifyProviderName(name);
+		if (base && base !== providerId) {
+			// Collide only against configured providers (minus this draft). Unconfigured
+			// providers are stale drafts, not real conflicts — counting them would push a
+			// legitimately-named provider to "openai-2".
+			const otherIds = new Set(data.getConfiguredProviders().filter((id) => id !== providerId));
+			let finalId = base;
+			let n = 2;
+			while (otherIds.has(finalId)) finalId = `${base}-${n++}`;
+			try {
+				await data.renameProvider(providerId, finalId);
+				modal.selectedProvider = finalId;
+				providerId = finalId;
+			} catch {
+				// keep draft ID if rename somehow fails
+			}
+		}
+		data.setProviderConfigured(providerId, true);
+		// Mark submitted BEFORE any await — the provider is now committed. Otherwise closing
+		// the modal during the fetchQuery below (e.g. right after seeing "Connected") would
+		// hit onClose with isSubmitted still false and delete the just-configured provider.
+		modal.markSubmitted();
+		// The auth query re-keys on providerId, so it re-fires under the new ID after a
+		// rename — refetch so the inline status stays "Connected" rather than flashing.
+		await modal.plugin.queryClient.fetchQuery(getProviderStateQueryOptions(providerId));
+		invalidateProviderState(providerId);
 	} finally {
 		isCommitting = false;
-		commitDone = null;
 	}
 }
-
-async function runCommit() {
-	// Rename the draft to a slug derived from the final display name — this is the
-	// only point where the ID changes. Doing it once (not on every name edit) keeps
-	// downstream references stable while producing a human-readable, recoverable ID.
-	const name = displayName.trim() || (providerMeta?.displayName ?? "");
-	const base = slugifyProviderName(name);
-	if (base && base !== providerId) {
-		// Collide only against configured providers (minus this draft). Unconfigured
-		// providers are stale drafts, not real conflicts — counting them would push a
-		// legitimately-named provider to "openai-2".
-		const otherIds = new Set(data.getConfiguredProviders().filter((id) => id !== providerId));
-		let finalId = base;
-		let n = 2;
-		while (otherIds.has(finalId)) finalId = `${base}-${n++}`;
-		try {
-			await data.renameProvider(providerId, finalId);
-			modal.selectedProvider = finalId;
-			providerId = finalId;
-		} catch {
-			// keep draft ID if rename somehow fails
-		}
-	}
-	data.setProviderConfigured(providerId, true);
-	// Mark submitted BEFORE any await — the provider is now committed. Otherwise closing
-	// the modal during the fetchQuery below (e.g. right after seeing "Connected") would
-	// hit onClose with isSubmitted still false and delete the just-configured provider.
-	modal.markSubmitted();
-	// The auth query re-keys on providerId, so it re-fires under the new ID after a
-	// rename — refetch so the inline status stays "Connected" rather than flashing.
-	await modal.plugin.queryClient.fetchQuery(getProviderStateQueryOptions(providerId));
-	invalidateProviderState(providerId);
-}
-
-// Monotonic id per blur, so a handler that had to wait out a commit can tell whether a
-// newer blur has superseded it before it writes.
-let blurSeq = 0;
 
 async function handleDisplayNameBlur(nextName: string) {
-	const seq = ++blurSeq;
-	isEditingDisplayName = false;
 	const trimmedName = nextName.trim();
 	if (!trimmedName || trimmedName === providerMeta?.displayName) {
-		unsavedDisplayName = null;
 		displayName = providerMeta?.displayName ?? "";
 		displayNameError = null;
 		return;
-	}
-	// Claim the field until this value reaches storage (or is superseded), so the sync
-	// effect can't overwrite it while we wait out a commit.
-	unsavedDisplayName = trimmedName;
-	try {
-		await saveDisplayName(trimmedName, seq);
-	} finally {
-		// Only release the claim if it's still ours — a newer blur may have taken it.
-		if (blurSeq === seq) unsavedDisplayName = null;
-	}
-}
-
-async function saveDisplayName(trimmedName: string, seq: number) {
-	// A commit in flight is mid-rename: `renameProvider` re-keys providerMeta synchronously
-	// but then awaits its save, and `providerId` is only reassigned after that await — so a
-	// blur landing in that window would write against an ID that no longer exists, throw
-	// "Provider not found", and strand Done disabled on a provider that connected fine.
-	// Don't drop the name, though: the commit captured whatever `displayName` held when it
-	// started, which may differ from what the user has since typed. Defer the write until
-	// the commit settles and `providerId` is authoritative again, so the stored name can't
-	// disagree with the ID derived from it.
-	if (isCommitting) {
-		await commitSettled();
-		// The user may have edited the field while we waited, which makes this invocation's
-		// value stale: writing it would clobber the newer edit in storage, and the
-		// `displayName = trimmedName` below would yank it out of the input. Two ways to be
-		// superseded, and both need checking — a newer blur (the counter), or typing with no
-		// second blur, which never re-enters this handler and shows up only in the bound
-		// value. The claim above is what makes that second comparison trustworthy: nothing
-		// else can write `displayName` while this save is pending, so a difference here is
-		// the user's typing rather than the sync effect.
-		if (blurSeq !== seq || displayName.trim() !== trimmedName) return;
-		// Re-check against the post-commit meta: if the commit stored this very name, the
-		// write is redundant. `providerMeta` is now keyed by the settled `providerId`.
-		if (trimmedName === providerMeta?.displayName) {
-			displayNameError = null;
-			return;
-		}
 	}
 	pendingDisplayNameSaves += 1;
 	try {
@@ -577,16 +497,16 @@ const canFinish = $derived(
       name="Provider name"
       desc="Name this provider instance so you can distinguish it later."
     >
-      <!-- bind:, not a one-way value=: a blur deferred behind an in-flight commit needs to
-           know whether the user has since typed something newer, and only a live binding
-           tracks that (a blur counter misses typing without a second blur). -->
+      <!-- Disabled while the commit runs. The commit renames the draft to a slug derived
+           from this name, and `providerId` only catches up after `renameProvider` awaits
+           its save — an edit landing in that window would write against an ID that no
+           longer exists. The window is a rename plus one settings write, and disabling
+           makes it unreachable rather than something to reconcile afterwards. -->
       <Text
         inputType="text"
-        bind:value={displayName}
+        value={displayName}
+        disabled={isCommitting}
         placeholder={providerDefinition?.displayName ?? "New Provider"}
-        onfocus={() => {
-          isEditingDisplayName = true;
-        }}
         onblur={(value: string) => void handleDisplayNameBlur(value)}
       />
     </SettingItem>

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -282,12 +282,23 @@ async function commitProvider() {
 			let finalId = base;
 			let n = 2;
 			while (otherIds.has(finalId)) finalId = `${base}-${n++}`;
-			try {
-				await data.renameProvider(providerId, finalId);
+			// `renameProvider` re-keys everything synchronously and only awaits its persist,
+			// so take the promise without awaiting and point `providerId` at the new ID in
+			// the same turn. Awaiting first would leave `providerId` naming a key that no
+			// longer exists for the length of a settings write — the window every "Provider
+			// not found" failure in this modal came from.
+			const renamed = data.renameProvider(providerId, finalId);
+			// Its validation guards reject rather than throw (it's async), so confirm the
+			// re-key actually happened before adopting the new ID.
+			const oldId = providerId;
+			if (data.getProviderMeta(finalId) && !data.getProviderMeta(oldId)) {
 				modal.selectedProvider = finalId;
 				providerId = finalId;
+			}
+			try {
+				await renamed;
 			} catch {
-				// keep draft ID if rename somehow fails
+				// keep whichever ID is live if the persist fails
 			}
 		}
 		data.setProviderConfigured(providerId, true);
@@ -497,11 +508,12 @@ const canFinish = $derived(
       name="Provider name"
       desc="Name this provider instance so you can distinguish it later."
     >
-      <!-- Disabled while the commit runs. The commit renames the draft to a slug derived
-           from this name, and `providerId` only catches up after `renameProvider` awaits
-           its save — an edit landing in that window would write against an ID that no
-           longer exists. The window is a rename plus one settings write, and disabling
-           makes it unreachable rather than something to reconcile afterwards. -->
+      <!-- Disabled while the commit runs: it derives the provider's permanent ID from this
+           name, so editing it mid-flight has nothing sensible to mean. Note this is not
+           what makes the rename safe — disabling a focused input fires a blur, and Svelte
+           only flushes `isCommitting` to the DOM after the effect has already entered the
+           commit, so that blur lands *inside* the window rather than before it. The fix is
+           in commitProvider, which no longer leaves `providerId` stale across an await. -->
       <Text
         inputType="text"
         value={displayName}

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -260,6 +260,15 @@ async function handleSelectTemplate(id: ProviderTemplateId) {
 // the Done button can stay disabled across the commit's awaits — closing mid-rename would
 // race the ID change, and `markSubmitted` only lands after it.
 let isCommitting = $state(false);
+// Resolves when the in-flight commit finishes, so a blur that lands mid-commit can wait for
+// `providerId` to become authoritative instead of writing against an ID being renamed away.
+let commitDone: Promise<void> | null = null;
+// A waiting blur only needs to know the commit has *finished* — whether it succeeded is
+// commitProvider's business, and letting a rejection through here would escape the blur
+// handler's try/catch as an unhandled rejection.
+async function commitSettled() {
+	await commitDone?.catch(() => {});
+}
 
 // Promotes a draft to a fully configured provider the moment its connection validates.
 // This replaces the old "Add Provider" button: display name / auth / trusted all
@@ -268,40 +277,48 @@ let isCommitting = $state(false);
 async function commitProvider() {
 	if (isConfigured || isCommitting) return;
 	isCommitting = true;
+	// Publish the in-flight commit so a concurrent blur can await it (see commitSettled).
+	// Assigned before the first await so a blur in the same tick already sees it.
+	commitDone = runCommit();
 	try {
-		// Rename the draft to a slug derived from the final display name — this is the
-		// only point where the ID changes. Doing it once (not on every name edit) keeps
-		// downstream references stable while producing a human-readable, recoverable ID.
-		const name = displayName.trim() || (providerMeta?.displayName ?? "");
-		const base = slugifyProviderName(name);
-		if (base && base !== providerId) {
-			// Collide only against configured providers (minus this draft). Unconfigured
-			// providers are stale drafts, not real conflicts — counting them would push a
-			// legitimately-named provider to "openai-2".
-			const otherIds = new Set(data.getConfiguredProviders().filter((id) => id !== providerId));
-			let finalId = base;
-			let n = 2;
-			while (otherIds.has(finalId)) finalId = `${base}-${n++}`;
-			try {
-				await data.renameProvider(providerId, finalId);
-				modal.selectedProvider = finalId;
-				providerId = finalId;
-			} catch {
-				// keep draft ID if rename somehow fails
-			}
-		}
-		data.setProviderConfigured(providerId, true);
-		// Mark submitted BEFORE any await — the provider is now committed. Otherwise closing
-		// the modal during the fetchQuery below (e.g. right after seeing "Connected") would
-		// hit onClose with isSubmitted still false and delete the just-configured provider.
-		modal.markSubmitted();
-		// The auth query re-keys on providerId, so it re-fires under the new ID after a
-		// rename — refetch so the inline status stays "Connected" rather than flashing.
-		await modal.plugin.queryClient.fetchQuery(getProviderStateQueryOptions(providerId));
-		invalidateProviderState(providerId);
+		await commitDone;
 	} finally {
 		isCommitting = false;
+		commitDone = null;
 	}
+}
+
+async function runCommit() {
+	// Rename the draft to a slug derived from the final display name — this is the
+	// only point where the ID changes. Doing it once (not on every name edit) keeps
+	// downstream references stable while producing a human-readable, recoverable ID.
+	const name = displayName.trim() || (providerMeta?.displayName ?? "");
+	const base = slugifyProviderName(name);
+	if (base && base !== providerId) {
+		// Collide only against configured providers (minus this draft). Unconfigured
+		// providers are stale drafts, not real conflicts — counting them would push a
+		// legitimately-named provider to "openai-2".
+		const otherIds = new Set(data.getConfiguredProviders().filter((id) => id !== providerId));
+		let finalId = base;
+		let n = 2;
+		while (otherIds.has(finalId)) finalId = `${base}-${n++}`;
+		try {
+			await data.renameProvider(providerId, finalId);
+			modal.selectedProvider = finalId;
+			providerId = finalId;
+		} catch {
+			// keep draft ID if rename somehow fails
+		}
+	}
+	data.setProviderConfigured(providerId, true);
+	// Mark submitted BEFORE any await — the provider is now committed. Otherwise closing
+	// the modal during the fetchQuery below (e.g. right after seeing "Connected") would
+	// hit onClose with isSubmitted still false and delete the just-configured provider.
+	modal.markSubmitted();
+	// The auth query re-keys on providerId, so it re-fires under the new ID after a
+	// rename — refetch so the inline status stays "Connected" rather than flashing.
+	await modal.plugin.queryClient.fetchQuery(getProviderStateQueryOptions(providerId));
+	invalidateProviderState(providerId);
 }
 
 async function handleDisplayNameBlur(nextName: string) {
@@ -315,10 +332,18 @@ async function handleDisplayNameBlur(nextName: string) {
 	// but then awaits its save, and `providerId` is only reassigned after that await — so a
 	// blur landing in that window would write against an ID that no longer exists, throw
 	// "Provider not found", and strand Done disabled on a provider that connected fine.
-	// The commit already slugifies the name it captured; nothing is lost by ignoring this.
+	// Don't drop the name, though: the commit captured whatever `displayName` held when it
+	// started, which may differ from what the user has since typed. Defer the write until
+	// the commit settles and `providerId` is authoritative again, so the stored name can't
+	// disagree with the ID derived from it.
 	if (isCommitting) {
-		displayName = providerMeta?.displayName ?? trimmedName;
-		return;
+		await commitSettled();
+		// Re-check against the post-commit meta: if the commit stored this very name, the
+		// write is redundant. `providerMeta` is now keyed by the settled `providerId`.
+		if (trimmedName === providerMeta?.displayName) {
+			displayNameError = null;
+			return;
+		}
 	}
 	pendingDisplayNameSaves += 1;
 	try {

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -214,9 +214,18 @@ const headerStatusProps = $state<{ provider: string }>({
 });
 let displayName = $state("");
 let displayNameError = $state<string | null>(null);
-// Whether the name field currently has focus. Gates the stored-name sync effect below so
-// it can't overwrite what the user is typing (the input binds `displayName` two-way).
+// Whether the name field currently has focus.
 let isEditingDisplayName = $state(false);
+// Whether a blurred name is still on its way to storage. Blur clears the focus flag
+// immediately, but a write deferred behind an in-flight commit hasn't landed yet — without
+// this, the sync effect would overwrite the pending value with the stored one during the
+// commit's rename, and the resumed handler would read its own clobbering as a newer edit
+// and drop the name entirely.
+let unsavedDisplayName = $state<string | null>(null);
+// The field is the user's while either holds: don't sync stored state over it.
+function hasUnsavedDisplayName() {
+	return isEditingDisplayName || unsavedDisplayName !== null;
+}
 // Number of display-name saves currently in flight. `displayNameError` still holds its
 // previous value until an await settles, so without this Done could enable mid-save on a
 // name whose validity isn't known yet — and the commit's slug is derived from that same
@@ -243,12 +252,13 @@ function getTemplateLogo(id: ProviderTemplateId): Component<LogoProps> {
 	return TEMPLATE_LOGOS[id] ?? GenericAIIcon;
 }
 
-// Mirror the stored name into the input — but not while the user is typing in it. With
-// `bind:value` the input reads this back, so an unguarded sync (this effect re-runs on any
-// providerMeta change, e.g. the commit's rename) would overwrite an in-progress edit.
+// Mirror the stored name into the input — but never on top of a value the user owns. With
+// `bind:value` the input reads this back, and this effect re-runs on any providerMeta
+// change (notably the commit's own rename), so an unguarded sync would clobber both an
+// in-progress edit and a blurred edit still waiting to be written.
 $effect(() => {
 	const stored = providerMeta?.displayName ?? "";
-	if (untrack(() => isEditingDisplayName)) return;
+	if (untrack(() => hasUnsavedDisplayName())) return;
 	displayName = stored;
 });
 
@@ -338,10 +348,23 @@ async function handleDisplayNameBlur(nextName: string) {
 	isEditingDisplayName = false;
 	const trimmedName = nextName.trim();
 	if (!trimmedName || trimmedName === providerMeta?.displayName) {
+		unsavedDisplayName = null;
 		displayName = providerMeta?.displayName ?? "";
 		displayNameError = null;
 		return;
 	}
+	// Claim the field until this value reaches storage (or is superseded), so the sync
+	// effect can't overwrite it while we wait out a commit.
+	unsavedDisplayName = trimmedName;
+	try {
+		await saveDisplayName(trimmedName, seq);
+	} finally {
+		// Only release the claim if it's still ours — a newer blur may have taken it.
+		if (blurSeq === seq) unsavedDisplayName = null;
+	}
+}
+
+async function saveDisplayName(trimmedName: string, seq: number) {
 	// A commit in flight is mid-rename: `renameProvider` re-keys providerMeta synchronously
 	// but then awaits its save, and `providerId` is only reassigned after that await — so a
 	// blur landing in that window would write against an ID that no longer exists, throw
@@ -352,12 +375,14 @@ async function handleDisplayNameBlur(nextName: string) {
 	// disagree with the ID derived from it.
 	if (isCommitting) {
 		await commitSettled();
-		// The user may have edited the field while we waited. This invocation's value is then
-		// stale: writing it would clobber the newer edit in storage, and the
+		// The user may have edited the field while we waited, which makes this invocation's
+		// value stale: writing it would clobber the newer edit in storage, and the
 		// `displayName = trimmedName` below would yank it out of the input. Two ways to be
 		// superseded, and both need checking — a newer blur (the counter), or typing with no
-		// second blur, which never re-enters this handler and is only visible through the
-		// live binding on the input.
+		// second blur, which never re-enters this handler and shows up only in the bound
+		// value. The claim above is what makes that second comparison trustworthy: nothing
+		// else can write `displayName` while this save is pending, so a difference here is
+		// the user's typing rather than the sync effect.
 		if (blurSeq !== seq || displayName.trim() !== trimmedName) return;
 		// Re-check against the post-commit meta: if the commit stored this very name, the
 		// write is redundant. `providerMeta` is now keyed by the settled `providerId`.

--- a/src/views/provider-setup/ProviderSetup.svelte
+++ b/src/views/provider-setup/ProviderSetup.svelte
@@ -321,7 +321,12 @@ async function runCommit() {
 	invalidateProviderState(providerId);
 }
 
+// Monotonic id per blur, so a handler that had to wait out a commit can tell whether a
+// newer blur has superseded it before it writes.
+let blurSeq = 0;
+
 async function handleDisplayNameBlur(nextName: string) {
+	const seq = ++blurSeq;
 	const trimmedName = nextName.trim();
 	if (!trimmedName || trimmedName === providerMeta?.displayName) {
 		displayName = providerMeta?.displayName ?? "";
@@ -338,6 +343,13 @@ async function handleDisplayNameBlur(nextName: string) {
 	// disagree with the ID derived from it.
 	if (isCommitting) {
 		await commitSettled();
+		// The user may have refocused and blurred again while we waited. This invocation's
+		// value is then stale: writing it would clobber the newer edit in storage, and the
+		// `displayName = trimmedName` below would yank it out of the input. The newer blur
+		// persists what is current, so drop this one. (`displayName` can't be used as the
+		// staleness signal — the input is passed `value={displayName}`, not `bind:`, so it
+		// doesn't track typing.)
+		if (blurSeq !== seq) return;
 		// Re-check against the post-commit meta: if the commit stored this very name, the
 		// write is redundant. `providerMeta` is now keyed by the settled `providerId`.
 		if (trimmedName === providerMeta?.displayName) {


### PR DESCRIPTION
Follow-up to #461, fixing a regression that PR introduced — and ultimately the underlying race that caused it.

## The root cause

`commitProvider` renames the draft to a slug derived from the display name, and `providerId` only caught up **after** `renameProvider` awaited its persist:

```js
await data.renameProvider(providerId, finalId);   // re-keys sync, then awaits saveSettings
modal.selectedProvider = finalId;
providerId = finalId;                              // ← only now
```

For the length of a settings write, `providerId` named a key that had already been deleted. Anything writing through it in that window got `Provider not found` — which set `displayNameError` and left **Done** disabled on a provider that had connected fine.

## The fix

`renameProvider` re-keys everything synchronously and only awaits its persist. So take the promise without awaiting, point `providerId` at the new ID in the same turn, then await:

```js
const renamed = data.renameProvider(providerId, finalId);
const oldId = providerId;
if (data.getProviderMeta(finalId) && !data.getProviderMeta(oldId)) {
    modal.selectedProvider = finalId;
    providerId = finalId;
}
try { await renamed; } catch { /* keep whichever ID is live */ }
```

`providerId` is never stale across an await, so there is no window to land in. Its validation guards reject rather than throw (async function), hence the check that the re-key actually happened before adopting the new ID.

## What #461 got wrong, and the detours

#461 guarded the blur handler with an early return while committing, reasoning *"the commit already slugifies the name it captured; nothing is lost."* But the commit captures `displayName` — including text typed but not blurred — while the early return reverted the input to the **stored** name. Type a name, let it connect, blur mid-commit: ID `my-provider`, display name `OpenAI Compatible`. Mismatched, typed name lost.

Two approaches were tried and abandoned before the one above:

1. **Defer and reconcile** — publish the commit as an awaitable promise, have the blur wait, then detect supersession. Needed a sequence counter, a two-way binding plus content comparison, and two more flags to stop the sync effect clobbering either. Three rounds of findings, each fix uncovering the next gap.
2. **`disabled={isCommitting}` as the fix** — on the premise that disabling a focused input fires its blur *before* the commit's first await. That premise was wrong: the `$effect` enters `commitProvider` and sets `isCommitting` synchronously, then awaits; Svelte flushes `disabled` to the DOM only afterwards, so the blur lands *inside* the window.

The disable is kept, but as UI honesty rather than a fix — editing a name that is being turned into the provider's permanent ID has nothing sensible to mean. `handleDisplayNameBlur` and the stored-name sync effect are back to their pre-PR shape.

## Verification

`check` 0 errors, `format` / `lint` clean, `test` **1651 passed** / 112 files, production `build` succeeds.

Not driven live. Worth a manual pass: type a provider name, let it connect, confirm the ID and displayed name agree and the name survives a reload.

Blocks the 2.0.2 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._