### PR TITLE
Drop stdio MCP; keep process spawning and eval out of the bundle

### DIFF
--- a/src/agent/AgentManager.ts
+++ b/src/agent/AgentManager.ts
@@ -1184,30 +1184,15 @@ export class AgentManager {
 		mcpServers: Record<string, unknown> | undefined,
 	): Promise<boolean> {
 		if (!mcpServers || Object.keys(mcpServers).length === 0) return true;
-		let servers = mcpServers;
-
-		// stdio transport spawns a local process (Node child_process/stdio), which
-		// Obsidian's mobile WebView lacks. HTTP MCP has no such dependency, so on
-		// mobile drop only the stdio servers and load the rest. If that leaves no
-		// servers, skip entirely (avoids evaluating the SDK for nothing).
-		if (!Platform.isDesktopApp) {
-			const httpServers = Object.fromEntries(
-				Object.entries(mcpServers).filter(([, cfg]) => (cfg as { transport?: string })?.transport !== "stdio"),
-			);
-			const droppedStdio = Object.keys(mcpServers).length - Object.keys(httpServers).length;
-			if (droppedStdio > 0) {
-				Logger.log(`Skipping ${droppedStdio} stdio MCP server(s): stdio transport is desktop-only.`);
-			}
-			if (Object.keys(httpServers).length === 0) return true;
-			servers = httpServers;
-		}
 
 		try {
 			// Dynamically import so the MCP SDK (and its top-level Node builtin
-			// imports) is only evaluated when MCP is actually used on desktop —
-			// never at plugin load, which would crash the whole plugin.
+			// imports) is only evaluated when MCP is actually used — never at plugin
+			// load, which would crash the whole plugin. Only HTTP servers exist
+			// (the stdio transport is aliased out of the bundle, see vite.config.ts),
+			// so this works the same on desktop and mobile.
 			const { MultiServerMCPClient } = await import("@langchain/mcp-adapters");
-			const mcpConfig = { mcpServers: servers } as ConstructorParameters<typeof MultiServerMCPClient>[0];
+			const mcpConfig = { mcpServers } as ConstructorParameters<typeof MultiServerMCPClient>[0];
 			Logger.log("Initializing MCP client...", mcpConfig);
 
 			// Patch global fetch once for the manager's lifetime — MCP tools read

--- a/src/components/graph/pixiRenderer.ts
+++ b/src/components/graph/pixiRenderer.ts
@@ -7,6 +7,10 @@
  * and reactive state.
  */
 
+// Pixi's eval-free code paths (uniform/UBO/shader sync without `new Function`).
+// Must run before the first renderer is created; the eval-based originals are
+// aliased out of the bundle in vite.config.ts.
+import "pixi.js/unsafe-eval";
 import { Application, CanvasSource, Container, Graphics, Sprite, Text, TextStyle, Texture, Ticker } from "pixi.js";
 import { Viewport } from "pixi-viewport";
 import { edgeAlphaZoomLift, nodeDrawRadius, zoomNodeScale } from "../../utils/graphUtils";

--- a/src/components/modal/AgentEditorModal.svelte
+++ b/src/components/modal/AgentEditorModal.svelte
@@ -650,18 +650,6 @@ function toggleMCPServer(serverId: string) {
 }
 
 function buildMCPConfig(serverId: string, config: MCPServerConfig) {
-	if (config.transport === "stdio") {
-		return {
-			mcpServers: {
-				[serverId]: {
-					transport: "stdio" as const,
-					command: config.command,
-					args: config.args,
-					env: config.env,
-				},
-			},
-		};
-	}
 	return {
 		mcpServers: {
 			[serverId]: { transport: "http" as const, url: config.url, headers: config.headers },
@@ -1110,18 +1098,11 @@ function getServerToolsState(serverId: string): MCPServerToolsState | undefined 
               <ManagedEntityItem
                 class="mcp-entity"
                 name={config.displayName}
-                desc={config.transport === "stdio"
-                  ? `${config.command} ${config.args.join(" ")}`
-                  : config.url}
-                meta={config.transport === "stdio"
-                  ? "Local stdio MCP server"
-                  : "Remote HTTP MCP server"}
+                desc={config.url}
+                meta="Remote HTTP MCP server"
               >
                 {#snippet badges()}
-                  <Badge
-                    label={config.transport === "stdio" ? "Local" : "HTTP"}
-                    tone={config.transport === "stdio" ? "success" : "accent"}
-                  />
+                  <Badge label="HTTP" tone="accent" />
                   <Badge
                     interactive
                     onclick={() => toggleToolsList(serverId)}

--- a/src/components/modal/MCPServerModal.svelte
+++ b/src/components/modal/MCPServerModal.svelte
@@ -8,6 +8,7 @@ import type { MCPServerConfig } from "../../types/plugin";
 import { getData } from "../../stores/dataStore.svelte";
 import { Logger } from "../../utils/logging";
 import Button from "../ui/Button.svelte";
+import CircularLoader from "../ui/CircularLoader.svelte";
 import Icon from "../ui/Icon.svelte";
 import Text from "../ui/Text.svelte";
 import { confirmDelete } from "./ConfirmModal";
@@ -95,11 +96,45 @@ function restoreForm(snapshot: FormSnapshot) {
 	headers = snapshot.headers;
 }
 
-// Test connection state
-let isTesting = $state(false);
-let testError = $state<string | null>(null);
-let discoveredTools = $state<{ name: string; description?: string }[]>([]);
-let testSuccess = $state(false);
+// Connection probe. There is no "Test connection" button: like the provider
+// setup modal, the connection is checked automatically whenever the URL or
+// headers change, and the verdict lives in the footer next to the actions.
+// `probeKey` identifies the config being checked; a result is only shown while
+// it still matches, so a stale probe finishing late can never mislabel the
+// current form, and a pending debounce reads as "checking" rather than as a
+// verdict for a config that was never probed.
+type DiscoveredTool = { name: string; description?: string };
+type ProbeResult = { key: string; ok: boolean; error?: string; tools: DiscoveredTool[] };
+type ConnectionStatus = "idle" | "checking" | "connected" | "failed";
+const PROBE_DEBOUNCE_MS = 700;
+
+let probe = $state<ProbeResult | null>(null);
+const probeTarget = $derived.by(() => {
+	const trimmed = url.trim();
+	if (!trimmed) return null;
+	try {
+		new URL(trimmed);
+	} catch {
+		return null;
+	}
+	return trimmed;
+});
+const probeKey = $derived(probeTarget === null ? null : `${probeTarget}\n${headers}`);
+const connectionStatus = $derived.by<ConnectionStatus>(() => {
+	if (probeKey === null) return "idle";
+	if (probe?.key !== probeKey) return "checking";
+	return probe.ok ? "connected" : "failed";
+});
+const discoveredTools = $derived(connectionStatus === "connected" && probe ? probe.tools : []);
+
+$effect(() => {
+	const key = probeKey;
+	const target = probeTarget;
+	const headerText = headers;
+	if (key === null || target === null) return;
+	const timer = window.setTimeout(() => void probeConnection(key, target, headerText), PROBE_DEBOUNCE_MS);
+	return () => window.clearTimeout(timer);
+});
 
 onMount(() => {
 	modal.setTitle(isEditing ? `Edit MCP Server: ${capturedExistingConfig?.displayName}` : "Add MCP Server");
@@ -208,10 +243,6 @@ function applyImportedJson(text: string): string | null {
 	url = (entry.url as string).trim();
 	headers = stringifyRecord(entry.headers, ": ");
 
-	// A pasted config describes a different server than the one just probed.
-	testSuccess = false;
-	testError = null;
-	discoveredTools = [];
 	return null;
 }
 
@@ -345,38 +376,29 @@ async function handleDelete() {
 }
 
 /**
- * Build a config object for testing from current form state
+ * The adapter wraps transport failures as `Failed to connect to streamable HTTP
+ * server "<id>, url: <url>": Error: <cause>` — the id is our internal probe
+ * label and the URL is the field right above the status, so only the cause is
+ * worth showing.
  */
-function buildTestConfig() {
-	const testServerId = "test-server";
-	return {
-		mcpServers: {
-			[testServerId]: {
-				transport: "http" as const,
-				url: url.trim(),
-				headers: parseHeaders(headers),
-			},
-		},
-	};
+function describeProbeError(err: unknown): string {
+	const message = err instanceof Error ? err.message : String(err);
+	const cause = message.replace(/^Failed to connect to [^"]*"[^"]*":\s*/, "").replace(/^Error:\s*/, "");
+	return cause.trim() || "Connection failed";
 }
 
 /**
- * Test the MCP server connection and discover tools
+ * Probe the server described by `target` + `headerText` and record the verdict
+ * under `key`. The result is dropped if the form has moved on by the time it
+ * lands (see `probeKey`).
  */
-async function handleTestConnection() {
-	// Validate form first
-	const error = validateForm();
-	if (error) {
-		new Notice(error);
-		return;
-	}
-
-	// Reset state
-	isTesting = true;
-	testError = null;
-	discoveredTools = [];
-	testSuccess = false;
-
+async function probeConnection(key: string, target: string, headerText: string): Promise<void> {
+	const config = {
+		mcpServers: {
+			"probe-server": { transport: "http" as const, url: target, headers: parseHeaders(headerText) },
+		},
+	};
+	let result: ProbeResult;
 	try {
 		// Ref-counted global-fetch patch for CORS bypass — safe under concurrency
 		// (unlike the old _originalFetch flag + finally-restore, which corrupted
@@ -384,37 +406,29 @@ async function handleTestConnection() {
 		const patch = installObsidianFetch();
 		let mcpClient: MultiServerMCPClient | undefined;
 		try {
-			const config = buildTestConfig();
-			Logger.log("Testing MCP connection with config:", config);
-
+			Logger.debug("Probing MCP connection:", config);
 			const { MultiServerMCPClient } = await import("@langchain/mcp-adapters");
 			mcpClient = new MultiServerMCPClient(config);
 			const tools = await mcpClient.getTools();
-
-			discoveredTools = tools.map((t) => ({
-				name: t.name,
-				description: (t as { description?: string }).description,
-			}));
-			testSuccess = true;
-
-			new Notice(`Connection successful! Found ${tools.length} tool(s).`);
+			result = {
+				key,
+				ok: true,
+				tools: tools.map((t) => ({ name: t.name, description: (t as { description?: string }).description })),
+			};
 		} finally {
-			// Close the client so the open session doesn't dangle after a one-off
-			// connection test.
+			// Close the client so the open session doesn't dangle after a one-off probe.
 			try {
 				await mcpClient?.close();
 			} catch (closeErr) {
-				Logger.debug("MCP client close failed after test:", closeErr);
+				Logger.debug("MCP client close failed after probe:", closeErr);
 			}
 			patch.release();
 		}
 	} catch (err) {
-		Logger.error("MCP connection test failed:", err);
-		testError = err instanceof Error ? err.message : "Connection failed";
-		new Notice(`Connection failed: ${testError}`);
-	} finally {
-		isTesting = false;
+		Logger.debug("MCP connection probe failed:", err);
+		result = { key, ok: false, error: describeProbeError(err), tools: [] };
 	}
+	if (key === probeKey) probe = result;
 }
 </script>
 
@@ -467,13 +481,9 @@ async function handleTestConnection() {
         name="Server URL"
         desc="The URL of the MCP server — or paste the server's JSON config to fill this form"
       >
-        <Text
-          id="mcp-server-url"
-          inputType="text"
-          value={url}
-          placeholder="https://mcp.example.com/mcp"
-          onblur={(v) => (url = v)}
-        />
+        <!-- Bound, not committed on blur: the probe below debounces on every
+             keystroke, so the verdict tracks what is in the field. -->
+        <Text id="mcp-server-url" inputType="text" bind:value={url} placeholder="https://mcp.example.com/mcp" />
       </SettingContainer>
 
       <SettingContainer
@@ -490,23 +500,10 @@ async function handleTestConnection() {
       </SettingContainer>
   </SettingGroup>
 
-  <!-- Test sits directly above its own results, so the outcome appears where the
-       user just clicked rather than at the far end of the modal. -->
-  <div class="mcp-test-row">
-    <Button
-      buttonText={isTesting ? "Testing…" : "Test connection"}
-      onClick={handleTestConnection}
-      disabled={isTesting}
-    />
-  </div>
-
-  <!-- Test Results -->
-  {#if testSuccess && discoveredTools.length > 0}
-    <div class="mcp-test-results success">
-      <div class="mcp-test-header">
-        <Icon name="check-circle" />
-        <span>Connection successful - {discoveredTools.length} tool(s) available</span>
-      </div>
+  <!-- Discovered tools. Shown only once the probe connects, so the panel doubles
+       as the visible proof that the URL and headers are right. -->
+  {#if connectionStatus === "connected" && discoveredTools.length > 0}
+    <div class="mcp-tools-panel">
       <div class="mcp-tools-list">
         {#each discoveredTools as tool (tool.name)}
           <div class="mcp-tool-item">
@@ -518,33 +515,36 @@ async function handleTestConnection() {
         {/each}
       </div>
     </div>
-  {:else if testSuccess && discoveredTools.length === 0}
-    <div class="mcp-test-results warning">
-      <div class="mcp-test-header">
-        <Icon name="alert-triangle" />
-        <span>Connected but no tools found</span>
-      </div>
-    </div>
-  {:else if testError}
-    <div class="mcp-test-results error">
-      <div class="mcp-test-header">
-        <Icon name="x-circle" />
-        <span>Connection failed</span>
-      </div>
-      <p class="mcp-test-error">{testError}</p>
-    </div>
   {/if}
 
-  <!-- Actions. `modal-button-container` is Obsidian's own footer class, so these
-       sit where a core modal's buttons do. Only the three verbs that resolve the
-       modal live here — Delete at the left edge, away from the confirm button so
-       a destructive click isn't adjacent to the one people aim for. Testing is a
-       form action, not a way out of the modal, so it sits with the fields above. -->
+  <!-- Footer. `modal-button-container` is Obsidian's own footer class, so the
+       buttons sit where a core modal's do. The connection verdict takes the
+       space between Delete and Cancel/Save, the same place the provider setup
+       modal reports its status: it is checked automatically, so nothing here
+       needs pressing. Delete stays at the left edge, away from the confirm
+       button, so a destructive click isn't adjacent to the one people aim for. -->
   <div class="modal-button-container mcp-actions">
     {#if isEditing}
       <Button buttonText="Delete" styles="mod-warning" onClick={handleDelete} />
     {/if}
-    <div class="flex-1"></div>
+    <div class="mcp-connection-status" role="status" aria-live="polite">
+      {#if connectionStatus === "checking"}
+        <CircularLoader size={16} color="var(--text-muted)" />
+        <span class="mcp-connection-text">Checking connection…</span>
+      {:else if connectionStatus === "connected"}
+        <span class="mcp-connection-icon is-success"><Icon name="check-circle" size="xs" /></span>
+        <span class="mcp-connection-text is-success">
+          {discoveredTools.length === 0
+            ? "Connected — no tools offered"
+            : `Connected — ${discoveredTools.length} tool${discoveredTools.length === 1 ? "" : "s"}`}
+        </span>
+      {:else if connectionStatus === "failed"}
+        <span class="mcp-connection-icon is-error"><Icon name="x-circle" size="xs" /></span>
+        <span class="mcp-connection-text is-error">{probe?.error ?? "Connection failed"}</span>
+      {:else}
+        <span class="mcp-connection-text is-muted">Enter the server URL — the connection is checked automatically.</span>
+      {/if}
+    </div>
     <Button buttonText="Cancel" onClick={() => modal.close()} />
     <Button buttonText={isEditing ? "Save" : "Add Server"} cta={true} onClick={handleSave} />
   </div>
@@ -606,11 +606,6 @@ async function handleTestConnection() {
     background: var(--background-modifier-hover);
   }
 
-  .mcp-test-row {
-    display: flex;
-    justify-content: flex-start;
-  }
-
   /* Wide-control settings row: keep the native label/description column, but let
      the control take the full width on its own line beneath it. Obsidian already
      does exactly this on phones; this opts specific desktop rows into the same
@@ -653,8 +648,8 @@ async function handleTestConnection() {
   }
 
   /* `modal-button-container` supplies the border, padding and spacing; this only
-     adds what it doesn't: a flex row so the `.flex-1` spacer can push Cancel/Save
-     right while Delete/Test stay left, and wrapping for narrow panes. */
+     adds what it doesn't: a flex row so the status can fill the middle and push
+     Cancel/Save right while Delete stays left, and wrapping for narrow panes. */
   .mcp-actions {
     display: flex;
     align-items: center;
@@ -673,56 +668,51 @@ async function handleTestConnection() {
     align-items: stretch;
   }
 
-  /* Test Results Styles */
-  .mcp-test-results {
+  /* Connection verdict in the footer — mirrors `.provider-connection-status`
+     in the provider setup modal. Takes the free space between the button
+     groups and wraps long error messages instead of pushing the buttons out. */
+  .mcp-connection-status {
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-2);
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .mcp-connection-icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .mcp-connection-text {
+    font-size: var(--font-ui-small);
+    overflow-wrap: anywhere;
+  }
+
+  .mcp-connection-text.is-muted {
+    color: var(--text-muted);
+  }
+
+  .is-success {
+    color: var(--text-success, #4caf50);
+  }
+
+  .mcp-connection-text.is-success {
+    font-weight: 500;
+  }
+
+  .is-error {
+    color: var(--text-error, #f44336);
+  }
+
+  .mcp-tools-panel {
     padding: 12px;
     border-radius: 6px;
     border: 1px solid var(--background-modifier-border);
   }
 
-  .mcp-test-results.success {
-    background: rgba(var(--color-green-rgb, 76, 175, 80), 0.1);
-    border-color: var(--text-success, #4caf50);
-  }
-
-  .mcp-test-results.warning {
-    background: rgba(var(--color-yellow-rgb, 255, 193, 7), 0.1);
-    border-color: var(--text-warning, #ffc107);
-  }
-
-  .mcp-test-results.error {
-    background: rgba(var(--color-red-rgb, 244, 67, 54), 0.1);
-    border-color: var(--text-error, #f44336);
-  }
-
-  .mcp-test-header {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-weight: 500;
-  }
-
-  .mcp-test-results.success .mcp-test-header {
-    color: var(--text-success, #4caf50);
-  }
-
-  .mcp-test-results.warning .mcp-test-header {
-    color: var(--text-warning, #ffc107);
-  }
-
-  .mcp-test-results.error .mcp-test-header {
-    color: var(--text-error, #f44336);
-  }
-
-  .mcp-test-error {
-    margin: 8px 0 0 0;
-    font-size: 0.85rem;
-    color: var(--text-muted);
-    font-family: var(--font-monospace);
-  }
-
   .mcp-tools-list {
-    margin-top: 12px;
     display: flex;
     flex-direction: column;
     gap: 6px;

--- a/src/components/modal/MCPServerModal.svelte
+++ b/src/components/modal/MCPServerModal.svelte
@@ -555,7 +555,9 @@ async function handleTestConnection() {
     display: flex;
     flex-direction: column;
     gap: 16px;
-    padding: 8px 0;
+    /* Top only: the modal's own padding already separates the footer from the
+       bottom edge, and the flex gap spaces the rows. */
+    padding: 8px 0 0;
   }
 
   /* Import banner. Transient feedback for a paste — colour comes from Obsidian's
@@ -658,6 +660,10 @@ async function handleTestConnection() {
     align-items: center;
     flex-wrap: wrap;
     gap: 8px;
+    /* Core gives the footer a large top margin for modals whose body sits flush
+       against it; here the flex gap already provides the spacing, so the two
+       stacked and left a visible hole between "Test connection" and the buttons. */
+    margin-top: 0;
   }
 
   /* Phone: core stacks `.modal-button-container` into a column; the row-oriented

--- a/src/components/modal/MCPServerModal.svelte
+++ b/src/components/modal/MCPServerModal.svelte
@@ -156,6 +156,10 @@ const connectionStatus = $derived.by<ConnectionStatus>(() => {
 	return probe.ok ? "connected" : "failed";
 });
 const discoveredTools = $derived(connectionStatus === "connected" && probe ? probe.tools : []);
+// Like the provider modal's Done: the confirm button only unlocks once the
+// connection has actually validated, so a server can't be saved on a URL that
+// was never reached — and a held (cross-origin) probe has to be released first.
+const canSave = $derived(connectionStatus === "connected");
 
 $effect(() => {
 	const key = probeKey;
@@ -377,6 +381,7 @@ function validateForm(): string | null {
 }
 
 function handleSave() {
+	if (!canSave) return;
 	const error = validateForm();
 	if (error) {
 		new Notice(error);
@@ -596,7 +601,7 @@ async function probeConnection(key: string, target: string, headerText: string):
          the confirm pair onto two lines. -->
     <div class="mcp-actions-primary">
       <Button buttonText="Cancel" onClick={() => modal.close()} />
-      <Button buttonText={isEditing ? "Save" : "Add Server"} cta={true} onClick={handleSave} />
+      <Button buttonText={isEditing ? "Save" : "Add Server"} cta={canSave} disabled={!canSave} onClick={handleSave} />
     </div>
   </div>
 </div>

--- a/src/components/modal/MCPServerModal.svelte
+++ b/src/components/modal/MCPServerModal.svelte
@@ -99,29 +99,59 @@ function restoreForm(snapshot: FormSnapshot) {
 // Connection probe. There is no "Test connection" button: like the provider
 // setup modal, the connection is checked automatically whenever the URL or
 // headers change, and the verdict lives in the footer next to the actions.
+//
+// The probe fires when a field is *left* (blur / Enter), not per keystroke: the
+// headers may carry a bearer token, and probing every intermediate value while
+// a URL is typed would hand that token to whichever host each prefix happens
+// to name. `url` is only committed on blur (see the field), and the headers
+// the probe sends are the last committed textarea value, `probeHeaders`.
+//
+// Editing adds one more guard: if the URL now points at a different origin
+// than the saved server and there are headers, the probe is held until the
+// user asks for it, so credentials stored for host A are never sent to host B
+// as a side effect of retyping the URL. Saving, and every agent run after it,
+// sends them anyway — that is the user's explicit decision; the hold only
+// covers the moment before it.
+//
 // `probeKey` identifies the config being checked; a result is only shown while
 // it still matches, so a stale probe finishing late can never mislabel the
-// current form, and a pending debounce reads as "checking" rather than as a
+// current form, and a pending probe reads as "checking" rather than as a
 // verdict for a config that was never probed.
 type DiscoveredTool = { name: string; description?: string };
 type ProbeResult = { key: string; ok: boolean; error?: string; tools: DiscoveredTool[] };
-type ConnectionStatus = "idle" | "checking" | "connected" | "failed";
-const PROBE_DEBOUNCE_MS = 700;
+type ConnectionStatus = "idle" | "held" | "checking" | "connected" | "failed";
 
 let probe = $state<ProbeResult | null>(null);
-const probeTarget = $derived.by(() => {
-	const trimmed = url.trim();
-	if (!trimmed) return null;
+// Seeded from the initial headers on purpose (IIFE, as the other captured initial values above).
+let probeHeaders = $state((() => headers)());
+/** Key of a cross-origin config the user explicitly asked to check anyway. */
+let heldKeyReleased = $state<string | null>(null);
+
+function originOf(value: string): string | null {
 	try {
-		new URL(trimmed);
+		return new URL(value).origin;
 	} catch {
 		return null;
 	}
-	return trimmed;
+}
+const savedOrigin = (() => (initialConfig ? originOf(initialConfig.url) : null))();
+
+const probeTarget = $derived.by(() => {
+	const trimmed = url.trim();
+	return trimmed && originOf(trimmed) !== null ? trimmed : null;
 });
-const probeKey = $derived(probeTarget === null ? null : `${probeTarget}\n${headers}`);
+const probeKey = $derived(probeTarget === null ? null : `${probeTarget}\n${probeHeaders}`);
+const probeHeld = $derived(
+	probeKey !== null &&
+		probeTarget !== null &&
+		savedOrigin !== null &&
+		probeHeaders.trim().length > 0 &&
+		originOf(probeTarget) !== savedOrigin &&
+		heldKeyReleased !== probeKey,
+);
 const connectionStatus = $derived.by<ConnectionStatus>(() => {
 	if (probeKey === null) return "idle";
+	if (probeHeld) return "held";
 	if (probe?.key !== probeKey) return "checking";
 	return probe.ok ? "connected" : "failed";
 });
@@ -130,10 +160,9 @@ const discoveredTools = $derived(connectionStatus === "connected" && probe ? pro
 $effect(() => {
 	const key = probeKey;
 	const target = probeTarget;
-	const headerText = headers;
-	if (key === null || target === null) return;
-	const timer = window.setTimeout(() => void probeConnection(key, target, headerText), PROBE_DEBOUNCE_MS);
-	return () => window.clearTimeout(timer);
+	const headerText = probeHeaders;
+	if (key === null || target === null || probeHeld) return;
+	void probeConnection(key, target, headerText);
 });
 
 onMount(() => {
@@ -242,6 +271,7 @@ function applyImportedJson(text: string): string | null {
 
 	url = (entry.url as string).trim();
 	headers = stringifyRecord(entry.headers, ": ");
+	probeHeaders = headers;
 
 	return null;
 }
@@ -481,9 +511,16 @@ async function probeConnection(key: string, target: string, headerText: string):
         name="Server URL"
         desc="The URL of the MCP server — or paste the server's JSON config to fill this form"
       >
-        <!-- Bound, not committed on blur: the probe below debounces on every
-             keystroke, so the verdict tracks what is in the field. -->
-        <Text id="mcp-server-url" inputType="text" bind:value={url} placeholder="https://mcp.example.com/mcp" />
+        <!-- Committed on blur/Enter, not per keystroke — see the probe notes in
+             the script for why the connection check must not chase typing. -->
+        <Text
+          id="mcp-server-url"
+          inputType="text"
+          value={url}
+          placeholder="https://mcp.example.com/mcp"
+          onchange={(v) => (url = v)}
+          onblur={(v) => (url = v)}
+        />
       </SettingContainer>
 
       <SettingContainer
@@ -495,6 +532,7 @@ async function probeConnection(key: string, target: string, headerText: string):
           id="mcp-server-headers"
           class="mcp-textarea"
           bind:value={headers}
+          onblur={(v) => (probeHeaders = v)}
           placeholder={"Authorization: Bearer token\nX-Custom-Header: value"}
         />
       </SettingContainer>
@@ -528,7 +566,16 @@ async function probeConnection(key: string, target: string, headerText: string):
       <Button buttonText="Delete" styles="mod-warning" onClick={handleDelete} />
     {/if}
     <div class="mcp-connection-status" role="status" aria-live="polite">
-      {#if connectionStatus === "checking"}
+      {#if connectionStatus === "held"}
+        <span class="mcp-connection-icon is-muted"><Icon name="shield-alert" size="xs" /></span>
+        <span class="mcp-connection-text is-muted">
+          Different host than the saved server — headers are not sent until you
+          <button type="button" class="mcp-connection-link" onclick={() => (heldKeyReleased = probeKey)}>
+            check now
+          </button>
+          or save.
+        </span>
+      {:else if connectionStatus === "checking"}
         <CircularLoader size={16} color="var(--text-muted)" />
         <span class="mcp-connection-text">Checking connection…</span>
       {:else if connectionStatus === "connected"}
@@ -545,8 +592,12 @@ async function probeConnection(key: string, target: string, headerText: string):
         <span class="mcp-connection-text is-muted">Enter the server URL — the connection is checked automatically.</span>
       {/if}
     </div>
-    <Button buttonText="Cancel" onClick={() => modal.close()} />
-    <Button buttonText={isEditing ? "Save" : "Add Server"} cta={true} onClick={handleSave} />
+    <!-- Kept together so a long status wraps its own text instead of splitting
+         the confirm pair onto two lines. -->
+    <div class="mcp-actions-primary">
+      <Button buttonText="Cancel" onClick={() => modal.close()} />
+      <Button buttonText={isEditing ? "Save" : "Add Server"} cta={true} onClick={handleSave} />
+    </div>
   </div>
 </div>
 
@@ -653,7 +704,6 @@ async function probeConnection(key: string, target: string, headerText: string):
   .mcp-actions {
     display: flex;
     align-items: center;
-    flex-wrap: wrap;
     gap: 8px;
     /* Core gives the footer a large top margin for modals whose body sits flush
        against it; here the flex gap already provides the spacing, so the two
@@ -668,6 +718,11 @@ async function probeConnection(key: string, target: string, headerText: string):
     align-items: stretch;
   }
 
+  :global(.is-phone) .mcp-actions-primary {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   /* Connection verdict in the footer — mirrors `.provider-connection-status`
      in the provider setup modal. Takes the free space between the button
      groups and wraps long error messages instead of pushing the buttons out. */
@@ -675,14 +730,44 @@ async function probeConnection(key: string, target: string, headerText: string):
     display: flex;
     align-items: center;
     gap: var(--size-4-2);
-    flex: 1 1 auto;
+    /* Zero basis: the status takes whatever is left and wraps its text, rather
+       than claiming its content width and forcing the buttons onto a new line. */
+    flex: 1 1 0;
     min-width: 0;
+  }
+
+  .mcp-actions-primary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+  }
+
+  /* Inline "check now" inside the held-status sentence: reads as a link, not a control. */
+  .mcp-connection-link {
+    display: inline;
+    padding: 0;
+    border: none;
+    box-shadow: none;
+    background: transparent;
+    color: var(--text-accent);
+    font-size: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+  .mcp-connection-link:hover {
+    color: var(--text-accent-hover);
+    background: transparent;
   }
 
   .mcp-connection-icon {
     display: inline-flex;
     align-items: center;
     flex-shrink: 0;
+  }
+
+  .mcp-connection-icon.is-muted {
+    color: var(--text-muted);
   }
 
   .mcp-connection-text {

--- a/src/components/modal/MCPServerModal.svelte
+++ b/src/components/modal/MCPServerModal.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
 import type { MultiServerMCPClient } from "@langchain/mcp-adapters";
-import { Notice, Platform } from "obsidian";
+import { Notice } from "obsidian";
 import { onMount } from "svelte";
 import { installObsidianFetch } from "../../lib/obsidianFetch";
 import type SecondBrainPlugin from "../../main";
-import type { MCPHTTPServerConfig, MCPServerConfig, MCPStdioServerConfig, MCPTransportType } from "../../types/plugin";
+import type { MCPServerConfig } from "../../types/plugin";
 import { getData } from "../../stores/dataStore.svelte";
 import { Logger } from "../../utils/logging";
 import Button from "../ui/Button.svelte";
-import Dropdown from "../ui/Dropdown.svelte";
 import Icon from "../ui/Icon.svelte";
 import Text from "../ui/Text.svelte";
 import { confirmDelete } from "./ConfirmModal";
@@ -61,24 +60,13 @@ let name = $state(initialConfig?.displayName ?? "");
 // owns that toggle. Carry the existing value through so saving an edit to a
 // disabled server doesn't silently re-enable it; new servers start enabled.
 const enabled = (() => initialConfig?.enabled ?? true)();
-// stdio is desktop-only; if a mobile user opens an existing stdio server
-// (e.g. synced from desktop), fall back to http so the dropdown selection
-// stays valid rather than showing an absent option.
-let transport = $state<MCPTransportType>(Platform.isDesktopApp ? (initialConfig?.transport ?? "http") : "http");
 
-// stdio-specific fields
-let command = $state((initialConfig as MCPStdioServerConfig)?.command ?? "");
-let args = $state((initialConfig as MCPStdioServerConfig)?.args?.join(" ") ?? "");
-let envVars = $state(
-	Object.entries((initialConfig as MCPStdioServerConfig)?.env ?? {})
-		.map(([k, v]) => `${k}=${v}`)
-		.join("\n"),
-);
-
-// HTTP-specific fields
-let url = $state((initialConfig as MCPHTTPServerConfig)?.url ?? "");
+// HTTP is the only transport: a stdio server would spawn a local process, which
+// is shell access the plugin deliberately does not ship (see the stdio shim in
+// src/lib/shims/). Pasted configs describing one are rejected with a message.
+let url = $state(initialConfig?.url ?? "");
 let headers = $state(
-	Object.entries((initialConfig as MCPHTTPServerConfig)?.headers ?? {})
+	Object.entries(initialConfig?.headers ?? {})
 		.map(([k, v]) => `${k}: ${v}`)
 		.join("\n"),
 );
@@ -90,10 +78,6 @@ let headers = $state(
 // pre-paste values are snapshotted so the banner can offer a one-click undo.
 type FormSnapshot = {
 	name: string;
-	transport: MCPTransportType;
-	command: string;
-	args: string;
-	envVars: string;
 	url: string;
 	headers: string;
 };
@@ -102,15 +86,11 @@ let importError = $state<string | null>(null);
 let importUndo = $state<FormSnapshot | null>(null);
 
 function snapshotForm(): FormSnapshot {
-	return { name, transport, command, args, envVars, url, headers };
+	return { name, url, headers };
 }
 
 function restoreForm(snapshot: FormSnapshot) {
 	name = snapshot.name;
-	transport = snapshot.transport;
-	command = snapshot.command;
-	args = snapshot.args;
-	envVars = snapshot.envVars;
 	url = snapshot.url;
 	headers = snapshot.headers;
 }
@@ -121,61 +101,9 @@ let testError = $state<string | null>(null);
 let discoveredTools = $state<{ name: string; description?: string }[]>([]);
 let testSuccess = $state(false);
 
-// Transport options. stdio spawns a local process (Node child_process), which
-// is desktop-only — AgentManager skips all MCP loading on mobile, so don't let
-// mobile users configure a transport that would silently never load.
-const transportOptions = [
-	{ display: "Remote Server (HTTP)", value: "http" as MCPTransportType },
-	...(Platform.isDesktopApp ? [{ display: "Local Command (stdio)", value: "stdio" as MCPTransportType }] : []),
-];
-
 onMount(() => {
 	modal.setTitle(isEditing ? `Edit MCP Server: ${capturedExistingConfig?.displayName}` : "Add MCP Server");
 });
-
-function parseArgs(input: string): string[] {
-	// Split by spaces, but respect quoted strings
-	const result: string[] = [];
-	let current = "";
-	let inQuote = false;
-	let quoteChar = "";
-
-	for (const char of input) {
-		if ((char === '"' || char === "'") && !inQuote) {
-			inQuote = true;
-			quoteChar = char;
-		} else if (char === quoteChar && inQuote) {
-			inQuote = false;
-			quoteChar = "";
-		} else if (char === " " && !inQuote) {
-			if (current) {
-				result.push(current);
-				current = "";
-			}
-		} else {
-			current += char;
-		}
-	}
-	if (current) {
-		result.push(current);
-	}
-	return result;
-}
-
-function parseEnvVars(input: string): Record<string, string> {
-	const result: Record<string, string> = {};
-	for (const line of input.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed || !trimmed.includes("=")) continue;
-		const eqIndex = trimmed.indexOf("=");
-		const key = trimmed.slice(0, eqIndex).trim();
-		const value = trimmed.slice(eqIndex + 1).trim();
-		if (key) {
-			result[key] = value;
-		}
-	}
-	return result;
-}
 
 function parseHeaders(input: string): Record<string, string> {
 	const result: Record<string, string> = {};
@@ -200,7 +128,8 @@ function parseHeaders(input: string): Record<string, string> {
  * (or `mcp.servers`) and spells the transport `type` rather than `transport`.
  * A bare single-server object (no wrapper) is accepted too, since that's what
  * people often copy out of a README. Everything is normalised onto our own
- * `MCPServerConfig` shape.
+ * `MCPServerConfig` shape. Only remote (HTTP/SSE) entries qualify; a local
+ * command (stdio) entry is refused with an explanation.
  *
  * This only fills the fields — it doesn't save. The user still reviews and
  * confirms, so a malformed or hostile snippet can't configure a server behind
@@ -260,14 +189,11 @@ function applyImportedJson(text: string): string | null {
 	// the URL still lands somewhere useful rather than being dropped silently.
 	const isStdio = declared === "stdio" || (!declared && !hasUrl && hasCommand);
 
-	if (isStdio && !Platform.isDesktopApp) {
-		return "This is a local (stdio) server, which is desktop-only";
+	if (isStdio) {
+		return "This is a local command (stdio) server. Smart Second Brain only connects to MCP servers over HTTP.";
 	}
-	if (!isStdio && !hasUrl) {
+	if (!hasUrl) {
 		return "Remote server entry is missing a `url`";
-	}
-	if (isStdio && !hasCommand) {
-		return "Local server entry is missing a `command`";
 	}
 
 	// Only name an unnamed form — never clobber a name the user already typed.
@@ -279,16 +205,8 @@ function applyImportedJson(text: string): string | null {
 		name = displayName ?? entryKey ?? "";
 	}
 
-	if (isStdio) {
-		transport = "stdio";
-		command = (entry.command as string).trim();
-		args = Array.isArray(entry.args) ? entry.args.filter((a): a is string => typeof a === "string").join(" ") : "";
-		envVars = stringifyRecord(entry.env, "=");
-	} else {
-		transport = "http";
-		url = (entry.url as string).trim();
-		headers = stringifyRecord(entry.headers, ": ");
-	}
+	url = (entry.url as string).trim();
+	headers = stringifyRecord(entry.headers, ": ");
 
 	// A pasted config describes a different server than the one just probed.
 	testSuccess = false;
@@ -385,19 +303,13 @@ function validateForm(): string | null {
 		}
 	}
 
-	if (transport === "stdio") {
-		if (!command.trim()) {
-			return "Command is required for stdio transport";
-		}
-	} else {
-		if (!url.trim()) {
-			return "URL is required for HTTP transport";
-		}
-		try {
-			new URL(url.trim());
-		} catch {
-			return "Invalid URL format";
-		}
+	if (!url.trim()) {
+		return "URL is required";
+	}
+	try {
+		new URL(url.trim());
+	} catch {
+		return "Invalid URL format";
 	}
 
 	return null;
@@ -412,25 +324,13 @@ function handleSave() {
 
 	const newServerId = generateServerId(name);
 
-	let config: MCPServerConfig;
-	if (transport === "stdio") {
-		config = {
-			displayName: name.trim(),
-			transport: "stdio",
-			enabled,
-			command: command.trim(),
-			args: parseArgs(args),
-			env: parseEnvVars(envVars),
-		};
-	} else {
-		config = {
-			displayName: name.trim(),
-			transport: "http",
-			enabled,
-			url: url.trim(),
-			headers: parseHeaders(headers),
-		};
-	}
+	const config: MCPServerConfig = {
+		displayName: name.trim(),
+		transport: "http",
+		enabled,
+		url: url.trim(),
+		headers: parseHeaders(headers),
+	};
 
 	onSave(newServerId, config);
 	modal.close();
@@ -449,31 +349,6 @@ async function handleDelete() {
  */
 function buildTestConfig() {
 	const testServerId = "test-server";
-
-	if (transport === "stdio") {
-		return {
-			mcpServers: {
-				[testServerId]: {
-					transport: "stdio" as const,
-					command: command.trim(),
-					args: parseArgs(args),
-					env: parseEnvVars(envVars),
-				},
-			},
-		};
-	}
-	if (transport === "http") {
-		return {
-			mcpServers: {
-				[testServerId]: {
-					transport: "http" as const,
-					url: url.trim(),
-					headers: parseHeaders(headers),
-				},
-			},
-		};
-	}
-
 	return {
 		mcpServers: {
 			[testServerId]: {
@@ -524,8 +399,8 @@ async function handleTestConnection() {
 
 			new Notice(`Connection successful! Found ${tools.length} tool(s).`);
 		} finally {
-			// Close the client so a stdio server's spawned child process / open
-			// session doesn't dangle after a one-off connection test.
+			// Close the client so the open session doesn't dangle after a one-off
+			// connection test.
 			try {
 				await mcpClient?.close();
 			} catch (closeErr) {
@@ -584,59 +459,6 @@ async function handleTestConnection() {
       />
     </SettingContainer>
 
-    <!-- Only worth asking when there's a real choice: stdio is desktop-only, so
-         on mobile this is a single-option dropdown. -->
-    {#if transportOptions.length > 1}
-      <SettingContainer name="Transport" desc="How to connect to this server">
-        <Dropdown
-          id="mcp-server-transport"
-          type="options"
-          dropdown={transportOptions}
-          selected={transport}
-          onchange={(v) => (transport = v)}
-        />
-      </SettingContainer>
-    {/if}
-
-    {#if transport === "stdio"}
-      <SettingContainer
-        class="mcp-row--stacked"
-        name="Command"
-        desc="The executable to run, plus its arguments — or paste the server's JSON config to fill this form"
-      >
-        <div class="mcp-command-row">
-          <Text
-            id="mcp-server-command"
-            inputType="text"
-            class="mcp-command-input"
-            value={command}
-            placeholder="npx"
-            onblur={(v) => (command = v)}
-          />
-          <Text
-            id="mcp-server-arguments"
-            inputType="text"
-            class="mcp-args-input"
-            value={args}
-            placeholder="-y @modelcontextprotocol/server-filesystem /path"
-            onblur={(v) => (args = v)}
-          />
-        </div>
-      </SettingContainer>
-
-      <SettingContainer
-        class="mcp-row--stacked"
-        name="Environment variables"
-        desc="Optional — one per line, KEY=VALUE"
-      >
-        <TextArea
-          id="mcp-server-env"
-          class="mcp-textarea"
-          bind:value={envVars}
-          placeholder={"API_KEY=your-key\nDEBUG=true"}
-        />
-      </SettingContainer>
-    {:else}
       <!-- Import is advertised in the description rather than with a control:
            ⌘V into any field already does it, so a button would occupy permanent
            space to duplicate a shortcut people reach for by reflex. -->
@@ -666,7 +488,6 @@ async function handleTestConnection() {
           placeholder={"Authorization: Bearer token\nX-Custom-Header: value"}
         />
       </SettingContainer>
-    {/if}
   </SettingGroup>
 
   <!-- Test sits directly above its own results, so the outcome appears where the
@@ -808,33 +629,6 @@ async function handleTestConnection() {
   /* Inputs default to their intrinsic width, which is what truncated the URL. */
   :global(.mcp-row--stacked .setting-item-control input[type="text"]) {
     width: 100%;
-  }
-
-  /* Command + args on one line: the executable is short and fixed-ish, the
-     argument list is long, so give the args the remaining space. */
-  .mcp-command-row {
-    display: flex;
-    gap: 8px;
-    width: 100%;
-  }
-
-  .mcp-command-row :global(.mcp-command-input) {
-    flex: 0 1 30%;
-    min-width: 0;
-  }
-
-  .mcp-command-row :global(.mcp-args-input) {
-    flex: 1 1 auto;
-    min-width: 0;
-  }
-
-  /* Phone: two inputs side by side get too narrow to read. */
-  :global(.is-phone) .mcp-command-row {
-    flex-direction: column;
-  }
-
-  :global(.is-phone) .mcp-command-row :global(.mcp-command-input) {
-    flex: 1 1 auto;
   }
 
   :global(.mcp-textarea) {

--- a/src/components/modal/MCPServerModal.svelte
+++ b/src/components/modal/MCPServerModal.svelte
@@ -159,7 +159,19 @@ const discoveredTools = $derived(connectionStatus === "connected" && probe ? pro
 // Like the provider modal's Done: the confirm button only unlocks once the
 // connection has actually validated, so a server can't be saved on a URL that
 // was never reached — and a held (cross-origin) probe has to be released first.
-const canSave = $derived(connectionStatus === "connected");
+// The one exception is an edit that leaves the connection alone (a rename, or
+// no change at all): that must stay saveable while the server happens to be
+// down, so it is gated on the *saved* config being untouched rather than on a
+// live probe of it.
+function normalizeHeaders(record: Record<string, string> | undefined): string {
+	return JSON.stringify(Object.entries(record ?? {}).sort(([a], [b]) => a.localeCompare(b)));
+}
+const connectionUnchanged = $derived(
+	initialConfig !== null &&
+		url.trim() === initialConfig.url &&
+		normalizeHeaders(parseHeaders(headers)) === normalizeHeaders(initialConfig.headers),
+);
+const canSave = $derived(connectionStatus === "connected" || (isEditing && connectionUnchanged));
 
 $effect(() => {
 	const key = probeKey;

--- a/src/lib/shims/anthropicAgentToolset.ts
+++ b/src/lib/shims/anthropicAgentToolset.ts
@@ -1,0 +1,65 @@
+/**
+ * Build-time replacement for `@anthropic-ai/sdk/tools/agent-toolset/node.mjs`.
+ *
+ * That module is the SDK's local "agent toolset": a bash session, file
+ * read/write/edit/glob/grep tools and skill-archive setup, all built on
+ * `child_process`, `fs` and friends. The SDK's worker environment imports it
+ * dynamically, so Vite inlines it into the bundle even though nothing in the
+ * plugin ever calls it — and it is the last `child_process` user once the MCP
+ * stdio transport is gone. `vite.config.ts` swaps it for this file, which
+ * mirrors the export surface and fails loudly if anything reaches it.
+ */
+
+function unavailable(name: string): never {
+	throw new Error(`Anthropic SDK agent toolset (${name}) is not available in Smart Second Brain.`);
+}
+
+export function betaAgentToolset20260401(): never {
+	return unavailable("betaAgentToolset20260401");
+}
+
+export function resolvePath(): never {
+	return unavailable("resolvePath");
+}
+
+export class BashSession {
+	constructor() {
+		unavailable("BashSession");
+	}
+}
+
+export function betaBashTool(): never {
+	return unavailable("betaBashTool");
+}
+
+export function betaReadTool(): never {
+	return unavailable("betaReadTool");
+}
+
+export function betaWriteTool(): never {
+	return unavailable("betaWriteTool");
+}
+
+export function betaEditTool(): never {
+	return unavailable("betaEditTool");
+}
+
+export function betaGlobTool(): never {
+	return unavailable("betaGlobTool");
+}
+
+export function betaGrepTool(): never {
+	return unavailable("betaGrepTool");
+}
+
+export async function setupSkills(): Promise<() => Promise<void>> {
+	return unavailable("setupSkills");
+}
+
+export async function resolveSkillVersion(): Promise<string> {
+	return unavailable("resolveSkillVersion");
+}
+
+export async function extractSkillArchive(): Promise<void> {
+	return unavailable("extractSkillArchive");
+}

--- a/src/lib/shims/mcpJsonSchemaValidator.ts
+++ b/src/lib/shims/mcpJsonSchemaValidator.ts
@@ -1,0 +1,10 @@
+/**
+ * Build-time replacement for `@modelcontextprotocol/sdk/validation/ajv-provider.js`.
+ *
+ * The SDK's default JSON-schema validator is `ajv`, which compiles schemas with
+ * `new Function` — dynamic code execution the plugin review flags. The SDK also
+ * ships a `@cfworker/json-schema` provider that interprets schemas without
+ * generating code; `vite.config.ts` aliases the ajv module here so the client
+ * picks that one up under the name it imports.
+ */
+export { CfWorkerJsonSchemaValidator as AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker-provider.js";

--- a/src/lib/shims/mcpStdioTransport.ts
+++ b/src/lib/shims/mcpStdioTransport.ts
@@ -1,0 +1,27 @@
+/**
+ * Build-time replacement for `@modelcontextprotocol/sdk/client/stdio.js`.
+ *
+ * The real module spawns a local process through `child_process`, which is the
+ * one thing that gives an Obsidian plugin shell access — and the reason the
+ * plugin review flags "Shell Execution". Smart Second Brain only speaks MCP over
+ * HTTP, so `vite.config.ts` aliases the SDK's stdio transport to this file: the
+ * bundle then contains no `child_process` at all, and a config that somehow still
+ * names a stdio server fails loudly here instead of spawning anything.
+ *
+ * `@langchain/mcp-adapters` imports only `StdioClientTransport`; the other two
+ * exports mirror the SDK's surface so the alias stays a drop-in.
+ */
+
+export const DEFAULT_INHERITED_ENV_VARS: string[] = [];
+
+export function getDefaultEnvironment(): Record<string, string> {
+	return {};
+}
+
+export class StdioClientTransport {
+	constructor() {
+		throw new Error(
+			"MCP stdio transport is not available in Smart Second Brain — connect to the server over HTTP.",
+		);
+	}
+}

--- a/src/lib/shims/pixiNoEval.ts
+++ b/src/lib/shims/pixiNoEval.ts
@@ -1,0 +1,37 @@
+/**
+ * Build-time replacements for the Pixi.js modules that generate code with
+ * `new Function` (uniform/UBO/shader sync and particle update generators, plus
+ * the `unsafeEvalSupported` probe).
+ *
+ * The graph renderer imports `pixi.js/unsafe-eval`, Pixi's own eval-free
+ * implementation, which swaps these generators out at runtime — but the
+ * originals would still sit in the bundle as dead code, and the plugin review
+ * scans the bundle text for dynamic code execution. `vite.config.ts` therefore
+ * aliases each of them here. None of these should ever be called; if one is,
+ * the polyfill was not installed and the error says so.
+ */
+
+function notInstalled(name: string): never {
+	throw new Error(`Pixi ${name} requires eval; import "pixi.js/unsafe-eval" before creating the renderer.`);
+}
+
+/** Replaces `utils/browser/unsafeEvalSupported`: the eval-free polyfills make the probe moot. */
+export function unsafeEvalSupported(): boolean {
+	return true;
+}
+
+export function createUboSyncFunction(): never {
+	return notInstalled("createUboSyncFunction");
+}
+
+export function generateShaderSyncCode(): never {
+	return notInstalled("generateShaderSyncCode");
+}
+
+export function generateUniformsSync(): never {
+	return notInstalled("generateUniformsSync");
+}
+
+export function generateParticleUpdateFunction(): never {
+	return notInstalled("generateParticleUpdateFunction");
+}

--- a/src/stores/dataMigrations.ts
+++ b/src/stores/dataMigrations.ts
@@ -1,7 +1,7 @@
 import type { PluginData } from "../types/plugin";
 
 /** Increment this when making any breaking change to PluginData. Add a corresponding entry to MIGRATIONS. */
-export const CURRENT_SCHEMA_VERSION = 12;
+export const CURRENT_SCHEMA_VERSION = 13;
 
 type Migration = (data: PluginData) => void;
 
@@ -172,6 +172,21 @@ const MIGRATIONS: Migration[] = [
 			const grepNotes = agent.toolsConfig?.grep_notes as unknown as Record<string, unknown> | undefined;
 			if (grepNotes) {
 				grepNotes.settings = undefined;
+			}
+		}
+	},
+	// v12 → v13: the stdio MCP transport was removed — it spawned local processes
+	//            (`child_process`), i.e. shell access the plugin no longer ships. Any
+	//            stdio server entry is dropped; the transport type is `"http"` only from
+	//            here on, so a leftover entry would fail type narrowing everywhere it is read.
+	(data) => {
+		for (const agent of Object.values(data.agents ?? {})) {
+			const servers = agent.mcpServers as unknown as
+				| Record<string, { transport?: string } | undefined>
+				| undefined;
+			if (!servers) continue;
+			for (const [id, server] of Object.entries(servers)) {
+				if (server?.transport === "stdio") delete servers[id];
 			}
 		}
 	},

--- a/src/stores/dataStore.svelte.ts
+++ b/src/stores/dataStore.svelte.ts
@@ -1078,20 +1078,11 @@ export class PluginDataStore {
 		for (const [id, config] of Object.entries(agent.mcpServers)) {
 			if (!config.enabled) continue;
 
-			if (config.transport === "stdio") {
-				result[id] = {
-					transport: "stdio",
-					command: config.command,
-					args: config.args,
-					...(config.env && Object.keys(config.env).length > 0 && { env: config.env }),
-				};
-			} else {
-				result[id] = {
-					transport: "http",
-					url: config.url,
-					...(config.headers && Object.keys(config.headers).length > 0 && { headers: config.headers }),
-				};
-			}
+			result[id] = {
+				transport: "http",
+				url: config.url,
+				...(config.headers && Object.keys(config.headers).length > 0 && { headers: config.headers }),
+			};
 		}
 
 		return result;

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -80,11 +80,11 @@ export interface EmbeddingIndexConfig {
 // ============================================================================
 
 /**
- * Transport type for MCP servers
- * - stdio: Local processes (recommended)
- * - http: Streamable HTTP (recommended for remote servers)
+ * Transport type for MCP servers. Only Streamable HTTP is supported: a stdio
+ * transport would spawn local processes (`child_process`), which is shell access
+ * the plugin deliberately does not have.
  */
-export type MCPTransportType = "stdio" | "http";
+export type MCPTransportType = "http";
 
 /**
  * Base configuration shared by all MCP server types
@@ -99,20 +99,7 @@ interface MCPServerBaseConfig {
 }
 
 /**
- * Configuration for stdio-based MCP servers (local processes)
- */
-export interface MCPStdioServerConfig extends MCPServerBaseConfig {
-	transport: "stdio";
-	/** Command to execute */
-	command: string;
-	/** Arguments to pass to the command */
-	args: string[];
-	/** Environment variables */
-	env?: Record<string, string>;
-}
-
-/**
- * Configuration for HTTP-based MCP servers (Streamable HTTP - recommended for remote)
+ * Configuration for HTTP-based MCP servers (Streamable HTTP)
  */
 export interface MCPHTTPServerConfig extends MCPServerBaseConfig {
 	transport: "http";
@@ -123,9 +110,9 @@ export interface MCPHTTPServerConfig extends MCPServerBaseConfig {
 }
 
 /**
- * Union type for all MCP server configurations
+ * MCP server configuration (HTTP is the only transport).
  */
-export type MCPServerConfig = MCPStdioServerConfig | MCPHTTPServerConfig;
+export type MCPServerConfig = MCPHTTPServerConfig;
 
 /**
  * Record of MCP server configurations keyed by server ID

--- a/test/stores/dataMigrations.test.ts
+++ b/test/stores/dataMigrations.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import "../__mocks__/obsidian";
+import { CURRENT_SCHEMA_VERSION, runMigrations } from "../../src/stores/dataMigrations";
+import type { PluginData } from "../../src/types/plugin";
+
+describe("dataMigrations", () => {
+	it("v12 → v13 drops stdio MCP servers and keeps HTTP ones", () => {
+		const data = {
+			schemaVersion: 12,
+			agents: {
+				a1: {
+					mcpServers: {
+						local: { displayName: "local", transport: "stdio", command: "npx", args: [], enabled: true },
+						remote: {
+							displayName: "remote",
+							transport: "http",
+							url: "http://localhost:3000/mcp",
+							enabled: true,
+						},
+					},
+				},
+				a2: {},
+			},
+		} as unknown as PluginData;
+
+		runMigrations(data);
+
+		expect(data.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+		expect(Object.keys(data.agents.a1.mcpServers)).toEqual(["remote"]);
+		expect(data.agents.a2.mcpServers).toBeUndefined();
+	});
+});

--- a/test/stores/dataStore.test.ts
+++ b/test/stores/dataStore.test.ts
@@ -365,15 +365,14 @@ describe("PluginDataStore – Agent MCP Servers", () => {
 	it("should set and get MCP server for agent", () => {
 		store.setAgentMCPServer(DEFAULT_AGENT_ID, "my-server", {
 			displayName: "my-server",
-			transport: "stdio",
-			command: "npx",
-			args: ["-y", "@modelcontextprotocol/server-everything"],
+			transport: "http",
+			url: "http://localhost:3000/mcp",
 			enabled: true,
 		});
 
 		const servers = store.getAgentMCPServers(DEFAULT_AGENT_ID);
 		expect(servers["my-server"]).toBeDefined();
-		expect(servers["my-server"].transport).toBe("stdio");
+		expect(servers["my-server"].transport).toBe("http");
 		expect(servers["my-server"].enabled).toBe(true);
 	});
 
@@ -392,9 +391,8 @@ describe("PluginDataStore – Agent MCP Servers", () => {
 	it("should toggle MCP server enabled state", () => {
 		store.setAgentMCPServer(DEFAULT_AGENT_ID, "toggle-me", {
 			displayName: "toggle-me",
-			transport: "stdio",
-			command: "cmd",
-			args: [],
+			transport: "http",
+			url: "http://localhost:3000/mcp",
 			enabled: true,
 		});
 
@@ -405,16 +403,14 @@ describe("PluginDataStore – Agent MCP Servers", () => {
 	it("should convert MCP config for client (only enabled servers)", () => {
 		store.setAgentMCPServer(DEFAULT_AGENT_ID, "enabled-server", {
 			displayName: "enabled-server",
-			transport: "stdio",
-			command: "npx",
-			args: ["-y", "server"],
+			transport: "http",
+			url: "http://localhost:3001/mcp",
 			enabled: true,
 		});
 		store.setAgentMCPServer(DEFAULT_AGENT_ID, "disabled-server", {
 			displayName: "disabled-server",
-			transport: "stdio",
-			command: "npx",
-			args: [],
+			transport: "http",
+			url: "http://localhost:3002/mcp",
 			enabled: false,
 		});
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -144,17 +144,58 @@ const MODULE_SHIMS: Array<[pattern: RegExp, shim: string]> = [
 	],
 ];
 
-function shimModules(): Plugin {
+/**
+ * Patterns that must not survive into the production bundle. Checked after
+ * minification, so comments (which mention these names freely) are gone and
+ * only live code and string literals remain. A hit fails the build — that is
+ * the point: a dependency moving a file out from under {@link MODULE_SHIMS}
+ * must surface as a red build, not as a quietly restored capability.
+ */
+const FORBIDDEN_BUNDLE_PATTERNS: Array<[label: string, pattern: RegExp]> = [
+	["child_process", /child_process/],
+	["spawn()", /\.spawn\(/],
+	["execFile", /execFile/],
+	["new Function()", /new Function\(/],
+	["eval()", /[^\w.$]eval\(/],
+];
+
+function shimModules(isProduction: boolean): Plugin {
+	const applied = new Set<number>();
 	return {
 		name: "shim-modules",
 		enforce: "pre",
 		async resolveId(source, importer, options) {
 			const resolved = await this.resolve(source, importer, { ...options, skipSelf: true });
 			if (!resolved) return null;
-			for (const [pattern, shim] of MODULE_SHIMS) {
-				if (pattern.test(resolved.id)) return resolve(configDir, shim);
+			for (const [index, [pattern, shim]] of MODULE_SHIMS.entries()) {
+				if (pattern.test(resolved.id)) {
+					applied.add(index);
+					return resolve(configDir, shim);
+				}
 			}
 			return null;
+		},
+		generateBundle(_options, bundle) {
+			const missing = MODULE_SHIMS.filter((_, index) => !applied.has(index)).map(([pattern]) => String(pattern));
+			if (missing.length > 0) {
+				throw new Error(
+					`shim-modules: no dependency module matched ${missing.join(", ")} — did a package move the file? ` +
+						"Update MODULE_SHIMS in vite.config.ts.",
+				);
+			}
+			if (!isProduction) return;
+			for (const output of Object.values(bundle)) {
+				if (output.type !== "chunk") continue;
+				for (const [label, pattern] of FORBIDDEN_BUNDLE_PATTERNS) {
+					const match = pattern.exec(output.code);
+					if (!match) continue;
+					const at = Math.max(0, match.index - 80);
+					throw new Error(
+						`shim-modules: production bundle ${output.fileName} still contains ${label} near: ` +
+							`…${output.code.slice(at, match.index + 80)}…`,
+					);
+				}
+			}
 		},
 		transform(code, id) {
 			// @langchain/mcp-adapters keeps the stdio option schema (never reachable
@@ -184,7 +225,7 @@ export default defineConfig(({ mode }) => {
 
 	return {
 		plugins: [
-			shimModules(),
+			shimModules(!isDevelopment),
 			svelte({
 				preprocess: vitePreprocess(),
 				onwarn: (warning, handler) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 // vite.config.ts
 import { svelte, vitePreprocess } from "@sveltejs/vite-plugin-svelte";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import { copyFileSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -120,6 +120,53 @@ const PROCESS_SHIM =
 
 const BANNER = PROCESS_SHIM;
 
+/**
+ * Dependency modules swapped for shims in `src/lib/shims/`, matched on the
+ * RESOLVED file path (so a relative `./skills.mjs` inside one package cannot be
+ * confused with another's). Together these keep two capabilities out of the
+ * bundle that the plugin never uses but Obsidian's plugin review flags:
+ *
+ * - process spawning (`child_process`): the MCP SDK's stdio transport and the
+ *   Anthropic SDK's local agent toolset (bash/grep/skills);
+ * - dynamic code execution (`new Function`): the MCP SDK's ajv validator
+ *   (replaced by the SDK's own cfworker provider) and Pixi's code generators
+ *   (replaced at runtime by `pixi.js/unsafe-eval`, imported in pixiRenderer.ts).
+ *
+ * Each shim's header says what it replaces and why.
+ */
+const MODULE_SHIMS: Array<[pattern: RegExp, shim: string]> = [
+	[/\/@modelcontextprotocol\/sdk\/dist\/esm\/client\/stdio\.js$/, "src/lib/shims/mcpStdioTransport.ts"],
+	[/\/@modelcontextprotocol\/sdk\/dist\/esm\/validation\/ajv-provider\.js$/, "src/lib/shims/mcpJsonSchemaValidator.ts"],
+	[/\/@anthropic-ai\/sdk\/tools\/agent-toolset\/node\.mjs$/, "src/lib/shims/anthropicAgentToolset.ts"],
+	[
+		/\/pixi\.js\/lib\/.*\/(unsafeEvalSupported|createUboSyncFunction|GenerateShaderSyncCode|generateUniformsSync|generateParticleUpdateFunction)\.mjs$/,
+		"src/lib/shims/pixiNoEval.ts",
+	],
+];
+
+function shimModules(): Plugin {
+	return {
+		name: "shim-modules",
+		enforce: "pre",
+		async resolveId(source, importer, options) {
+			const resolved = await this.resolve(source, importer, { ...options, skipSelf: true });
+			if (!resolved) return null;
+			for (const [pattern, shim] of MODULE_SHIMS) {
+				if (pattern.test(resolved.id)) return resolve(configDir, shim);
+			}
+			return null;
+		},
+		transform(code, id) {
+			// @langchain/mcp-adapters keeps the stdio option schema (never reachable
+			// here) and its description names `child_process.spawn` — a literal that
+			// reads as shell access to a bundle scan. Reword the doc string only.
+			if (!id.endsWith("/@langchain/mcp-adapters/dist/types.js")) return null;
+			const reworded = code.replace("Node's `child_process.spawn`", "Node's process spawning");
+			return reworded === code ? null : { code: reworded, map: null };
+		},
+	};
+}
+
 const setOutDir = (mode: string) => {
 	switch (mode) {
 		case "development":
@@ -137,6 +184,7 @@ export default defineConfig(({ mode }) => {
 
 	return {
 		plugins: [
+			shimModules(),
 			svelte({
 				preprocess: vitePreprocess(),
 				onwarn: (warning, handler) => {


### PR DESCRIPTION
## Summary

Follow-up to #465 for the two **behaviour** findings that came from bundled dependencies rather than our code: **Shell Execution** (`child_process`) and **Dynamic Code Execution** (`new Function`). After this PR the production bundle contains no `child_process`, `spawn`, `execFile`, `eval(` or `new Function` at all (verified by grepping `build/prod/main.js`), and it is ~140 kB smaller.

### MCP is HTTP-only
- The server modal loses the transport picker and the command / arguments / environment fields; pasting a stdio config into it is refused with an explanation instead of silently importing.
- `MCPTransportType` is `"http"` only; `MCPStdioServerConfig` is gone. The agent editor, data store and `AgentManager.loadMCPTools` drop their stdio branches (MCP now loads identically on desktop and mobile).
- Data migration **v12 → v13** removes any stored stdio server (with a unit test).

### Build-time module shims (`vite.config.ts` → `src/lib/shims/`)
A small `shimModules` Vite plugin matches on **resolved** module paths and swaps four dependency modules:
- `@modelcontextprotocol/sdk/client/stdio.js` → throws if ever constructed (removes `child_process` + cross-spawn).
- `@modelcontextprotocol/sdk/validation/ajv-provider.js` → the SDK's own `@cfworker/json-schema` provider, which interprets schemas instead of compiling them with `new Function`. Tool-result validation still runs.
- `@anthropic-ai/sdk/tools/agent-toolset/node.mjs` → a stub. This is the SDK's local bash/grep/skills toolset; its worker environment imports it dynamically, so Vite inlined it even though nothing here calls it. It was the last `child_process` user.
- Pixi's five code-generator modules (`unsafeEvalSupported`, `createUboSyncFunction`, `generateShaderSyncCode`, `generateUniformsSync`, `generateParticleUpdateFunction`) → stubs; `pixiRenderer.ts` imports **`pixi.js/unsafe-eval`**, Pixi's supported eval-free implementation, so the stubs are never reached.
- The one remaining literal `child_process.spawn` was a doc string in `@langchain/mcp-adapters`' stdio option schema; the plugin rewords it in that module only.

### Docs to update (site repo)
`agents/mcp.md` and `help/troubleshooting.md` on smartsecondbrain.dev still describe the stdio transport and its mobile caveat; both need trimming to HTTP-only.

## Test plan
- [x] `bun run check`, `format`, `lint`, `test` (1652 passing), `bun run build`
- [x] Bundle grep: 0 × `child_process` / `spawn(` / `execFile` / `eval(` / `new Function`
- [x] Live (slot vault): smart graph renders on the eval-free Pixi path, no console errors
- [ ] Live: add / edit / test-connect an HTTP MCP server; open an agent that previously had a stdio server and confirm it is gone after migration

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._