### PR TITLE
styles.css: no !important left; drop display: contents and text-indent

### DIFF
--- a/src/components/chat/Input.svelte
+++ b/src/components/chat/Input.svelte
@@ -108,16 +108,15 @@ const sendButtonStyle = $derived.by(() => {
 	const hoverColor = "color-mix(in srgb, var(--text-accent) 84%, black 16%)";
 	const disabledColor = "color-mix(in srgb, var(--text-accent) 68%, var(--background-primary) 32%)";
 
+	// Only custom properties go inline. Sizing and colour live in the
+	// `.chat-input-container button.send-message-button` rules below — an inline
+	// `width`/`background` would beat every stylesheet rule, including the mobile
+	// touch-target sizes, which is what used to force `!important` everywhere.
 	return [
 		"--s2b-button-icon-size: var(--icon-xs)",
 		`--send-button-bg: ${baseColor}`,
 		`--send-button-bg-hover: ${hoverColor}`,
 		`--send-button-bg-disabled: ${disabledColor}`,
-		"background: var(--send-button-bg)",
-		"color: var(--text-on-accent)",
-		"width: 1.75rem",
-		"height: 1.75rem",
-		"min-width: 1.75rem",
 	].join("; ");
 });
 
@@ -1566,8 +1565,8 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
 
   /* Circular, matching the attach button (already `999px`) and the reference
      design. The 6px radius made it the odd one out in the action row. */
-  :global(.send-message-button) {
-    border-radius: 999px !important;
+  :global(.chat-input-container button.send-message-button) {
+    border-radius: 999px;
   }
 
   /* Tighter still on mobile, where vertical space is scarce and the card
@@ -1671,13 +1670,17 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
     visibility: hidden;
   }
 
-  :global(.send-message-button) {
-    background: var(--send-button-bg) !important;
-    color: var(--text-on-accent) !important;
-    width: 1.75rem !important;
-    height: 1.75rem !important;
-    min-width: 1.75rem !important;
-    min-height: 1.75rem !important;
+  /* `.chat-input-container button.…` (0,2,1) out-specifies every core button
+     and `.clickable-icon` rule, mobile variants included, so nothing here needs
+     `!important` — which also lets the touch-target rules in styles.css win on
+     specificity alone. */
+  :global(.chat-input-container button.send-message-button) {
+    background: var(--send-button-bg);
+    color: var(--text-on-accent);
+    width: 1.75rem;
+    height: 1.75rem;
+    min-width: 1.75rem;
+    min-height: 1.75rem;
     flex: 0 0 auto;
     aspect-ratio: 1;
   }
@@ -1693,32 +1696,32 @@ async function promoteVisibleNoteToAttachment(note: VisibleNote) {
   }
 
   /* Bump the send target to a comfortable touch size on mobile. */
-  :global(.is-mobile .send-message-button) {
-    width: 2.75rem !important;
-    height: 2.75rem !important;
-    min-width: 2.75rem !important;
-    min-height: 2.75rem !important;
+  :global(.is-mobile .chat-input-container button.send-message-button) {
+    width: 2.75rem;
+    height: 2.75rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
   }
 
-  :global(.send-message-button:hover:not(:disabled)) {
-    background: var(--send-button-bg-hover) !important;
-    color: var(--text-on-accent) !important;
+  :global(.chat-input-container button.send-message-button:hover:not(:disabled)) {
+    background: var(--send-button-bg-hover);
+    color: var(--text-on-accent);
   }
 
-  :global(.send-message-button:disabled) {
-    background: var(--send-button-bg-disabled) !important;
-    color: color-mix(in srgb, var(--text-on-accent) 82%, transparent) !important;
-    opacity: 1 !important;
+  :global(.chat-input-container button.send-message-button:disabled) {
+    background: var(--send-button-bg-disabled);
+    color: color-mix(in srgb, var(--text-on-accent) 82%, transparent);
+    opacity: 1;
   }
 
-  :global(.chat-input-icon-button.clickable-icon) {
-    width: 1.75rem !important;
-    height: 1.75rem !important;
-    min-width: 1.75rem !important;
-    min-height: 1.75rem !important;
-    max-width: 1.75rem !important;
-    max-height: 1.75rem !important;
-    padding: 0 !important;
+  :global(.chat-input-container .chat-input-icon-button.clickable-icon) {
+    width: 1.75rem;
+    height: 1.75rem;
+    min-width: 1.75rem;
+    min-height: 1.75rem;
+    max-width: 1.75rem;
+    max-height: 1.75rem;
+    padding: 0;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/src/components/chat/MessageContainer.svelte
+++ b/src/components/chat/MessageContainer.svelte
@@ -1301,20 +1301,24 @@ $effect(() => {
   .message-nav :global(button) {
     color: var(--text-muted);
     /* Override Obsidian's .clickable-icon defaults (padding, min-width, hover
-       box-shadow/background) so the arrows are a tight, chrome-free icon box. */
-    background: transparent !important;
-    box-shadow: none !important;
-    width: var(--icon-s) !important;
-    height: var(--icon-s) !important;
-    min-width: 0 !important;
-    padding: 2px !important;
+       box-shadow/background) so the arrows are a tight, chrome-free icon box.
+       The scoped `.message-nav` ancestor plus the element (0,2,1) already
+       out-specifies core's `.clickable-icon` / `.is-mobile .clickable-icon`
+       (0,2,0), and leaves the mobile touch-target rule in styles.css
+       (`body.is-mobile .message-nav button`) able to win on specificity. */
+    background: transparent;
+    box-shadow: none;
+    width: var(--icon-s);
+    height: var(--icon-s);
+    min-width: 0;
+    padding: 2px;
     box-sizing: content-box;
     border-radius: 4px;
   }
 
   .message-nav :global(button:hover) {
     color: var(--text-normal);
-    background: transparent !important;
-    box-shadow: none !important;
+    background: transparent;
+    box-shadow: none;
   }
 </style>

--- a/src/components/modal/SearchModal.ts
+++ b/src/components/modal/SearchModal.ts
@@ -1349,9 +1349,9 @@ export class SearchModal extends SuggestModal<SearchSuggestion> {
 			);
 		}
 
-		// The static resets live on `.s2b-search-input` (styles.css); only the
-		// theme-dependent leading inset is set here.
-		inputEl.addClass("s2b-search-input");
+		// Only the theme-dependent leading inset is set here; the static resets
+		// live on `.s2b-inline-input` (styles.css). Inline `!important` because
+		// Cupertino pins `padding-inline-start` on `.prompt-input` at that priority.
 		const leadingInset = hasChips || !usesCupertinoTheme ? "0" : "36px";
 		inputEl.style.setProperty("padding-left", leadingInset, "important");
 		inputEl.style.setProperty("padding-inline-start", leadingInset, "important");

--- a/src/styles.css
+++ b/src/styles.css
@@ -191,22 +191,32 @@ button.s2b-pill--interactive:hover {
 	padding-right: calc(var(--prompt-input-height, 40px) - 12px);
 }
 
+/* Chips sit inline before the input. A real flex box (not `display: contents`,
+   which Obsidian's baseline WebView only partially supports) that wraps like
+   its parent and shares the same 4px gap, so the chips still flow with the
+   input as one row and break onto the next line together. */
 .s2b-inline-chips {
-	display: contents;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 4px;
+	flex: 0 1 auto;
+	min-width: 0;
 }
 
 /* Centred on the container's axis rather than a fixed offset, so they track
-   whatever height it takes. `bottom: auto` and the `!important` on `top` are
-   both load-bearing: core sets its own `top` for these (computed ~25.7px, sized
-   for the taller empty-state container) and wins without them, which left the
-   clear "x" 5px above the container top and 13px below it — visibly high once
-   the container settles at 52px. */
+   whatever height it takes. `bottom: auto` is load-bearing: core positions
+   these from `top` (computed ~25.7px, sized for the taller empty-state
+   container) and its own `bottom`, which left the clear "x" 5px above the
+   container top and 13px below it — visibly high once the container settles at
+   52px. The two-class container selector out-specifies core's
+   `.is-mobile .prompt-input-cta` / `.prompt-input-container .search-input-clear-button`. */
 .s2b-inline-chips-container.prompt-input-container > .search-input-icon,
 .s2b-inline-chips-container.prompt-input-container > .search-input-clear-button,
 .s2b-inline-chips-container.prompt-input-container > .prompt-input-cta {
 	position: absolute;
-	top: 50% !important;
-	bottom: auto !important;
+	top: 50%;
+	bottom: auto;
 	transform: translateY(-50%);
 	z-index: 1;
 }
@@ -220,17 +230,22 @@ button.s2b-pill--interactive:hover {
 	right: 8px;
 }
 
-.s2b-inline-input {
+/* The re-parented `.prompt-input`. Naming the modal (`.prompt`), the container
+   and the element out-specifies every core rule for it, up to
+   `.is-mobile .prompt-input[type="text"]:not(:placeholder-shown)` (0,4,0), so
+   none of these need `!important`. The leading inset is the one property a
+   theme (Cupertino) pins with `!important`; `updateInlineInputSpacing` sets it
+   inline at the same priority, so the `0` here is only the default-theme rest. */
+.prompt.s2b-search-modal .prompt-input-container input.s2b-inline-input {
 	flex: 1 1 0;
 	min-width: 0;
 	width: auto;
 	align-self: center;
-	padding-left: 0 !important;
-	padding-inline-start: 0 !important;
-	padding-right: 0 !important;
-	padding-inline-end: 0 !important;
-	margin-left: 0 !important;
-	text-indent: 0 !important;
+	padding-left: 0;
+	padding-inline-start: 0;
+	padding-right: 0;
+	padding-inline-end: 0;
+	margin-left: 0;
 	/* Mobile Obsidian gives `.prompt-input` its own pill: a 44px radius plus a
 	   visible border. Normally that IS the search field, but our inline-chips
 	   wrapper re-parents it inside `.prompt-input-container`, which already draws
@@ -243,12 +258,12 @@ button.s2b-pill--interactive:hover {
 	   text-field chrome for `-webkit-appearance: auto`, and that outline survives
 	   `border`/`background`/`box-shadow` overrides — verified on-device, where the
 	   pill was still drawn with computed `border-width: 0`. */
-	appearance: none !important;
-	-webkit-appearance: none !important;
-	background: transparent !important;
-	border: none !important;
-	border-radius: 0 !important;
-	box-shadow: none !important;
+	appearance: none;
+	-webkit-appearance: none;
+	background: transparent;
+	border: none;
+	border-radius: 0;
+	box-shadow: none;
 
 	/* Text dropped ~6px the moment the first character was typed. Mobile core
 	   sizes BOTH `.prompt-input-container` and `.prompt-input` to a fixed 52px,
@@ -264,14 +279,17 @@ button.s2b-pill--interactive:hover {
 	   so the input collapses to its line box; the container then centres it (see
 	   the `align-items` override below). Verified on-device: 15px above and
 	   below in BOTH the empty and typed states, so nothing moves as you type. */
-	height: auto !important;
-	min-height: 0 !important;
-	padding-top: 0 !important;
-	padding-bottom: 0 !important;
+	height: auto;
+	min-height: 0;
+	padding-top: 0;
+	padding-bottom: 0;
 }
 
-.s2b-inline-input-content.s2b-inline-input-content-has-chips .s2b-inline-input {
-	margin-left: 2px !important;
+.prompt.s2b-search-modal
+	.prompt-input-container
+	.s2b-inline-input-content.s2b-inline-input-content-has-chips
+	input.s2b-inline-input {
+	margin-left: 2px;
 }
 
 .s2b-inline-chip {
@@ -1102,10 +1120,12 @@ button.s2b-pill--interactive:hover {
 	/* Message action footers (edit / copy / regenerate / branch navigator).
 	   These use Tailwind `opacity-0 group-hover:opacity-100 pointer-events-none
 	   group-hover:pointer-events-auto` — override to always-visible on touch. */
-	.message-footer {
-		opacity: 1 !important;
-		transform: none !important;
-		pointer-events: auto !important;
+	/* `body` is the extra weight that beats the Tailwind utilities on the element
+	   (each a single class); `translate-y-*` writes `transform`, so reset that too. */
+	body .message-footer {
+		opacity: 1;
+		transform: none;
+		pointer-events: auto;
 	}
 
 	/* Pending-change bar chevrons and diff-mode toggle. Both sit at `opacity: 0`
@@ -1122,21 +1142,22 @@ button.s2b-pill--interactive:hover {
 	/* Code-block copy button lives in `<pre>` and is revealed on `pre:hover`.
 	   Show it persistently on touch so code is copyable. Code blocks appear in
 	   chat messages and in tool-call output, so cover both containers. */
-	.message-text pre .clickable-icon,
-	.tool-output-content pre .clickable-icon {
-		opacity: 1 !important;
+	body .message-text pre .clickable-icon,
+	body .tool-output-content pre .clickable-icon {
+		opacity: 1;
 	}
 
 	/* Shared picker-row trailing action (PickerOptionRow) — revealed on
-	   :hover/:focus-within; always show on touch. */
-	.picker-option-action {
-		opacity: 1 !important;
+	   :hover/:focus-within; always show on touch. The row ancestor plus `body`
+	   out-specifies the component's scoped `.picker-option-action` rule. */
+	body .picker-option-row .picker-option-action {
+		opacity: 1;
 	}
 
 	/* Generic hover-reveal hook: any element that fades in on group-hover
 	   (collapse chevron, …) tagged with this class shows on touch. */
-	.s2b-hover-reveal {
-		opacity: 1 !important;
+	body .s2b-hover-reveal {
+		opacity: 1;
 	}
 }
 
@@ -1435,8 +1456,8 @@ button.s2b-pill--interactive.s2b-pill--active:hover {
 
 /* Model-management grids are fixed 2/3 columns; a phone can't fit that without
    clipping model names. Collapse to a single column on mobile. */
-.is-mobile .s2b-model-grid {
-	grid-template-columns: 1fr !important;
+body.is-mobile .s2b-model-grid {
+	grid-template-columns: 1fr;
 }
 
 /* Touch tap-target floors. Several icon buttons are sized to their glyph
@@ -1450,37 +1471,37 @@ button.s2b-pill--interactive.s2b-pill--active:hover {
 }
 
 /* Message action rows (edit / copy / regenerate) and the composer's icon
-   buttons pin themselves to `--icon-s` with `min-width: 0 !important` in
-   component scope, which lands them at ~30x26 — roughly half the 44px touch
-   floor and the smallest hit areas in the chat. The component rules win on
-   `!important`, so the mobile override has to match it to raise the floor.
+   buttons pin themselves to `--icon-s` in component scope, which lands them
+   at ~30x26 — roughly half the 44px touch floor and the smallest hit areas in
+   the chat. Every selector here names `body.is-mobile` plus the same ancestors
+   the component rules use, so it out-specifies them without `!important`.
    Padding (not width/height) does the growing, so the glyph keeps its size
    and only the tappable box expands. */
-.is-mobile .footer-actions button,
-.is-mobile .attach-context-button.clickable-icon,
-.is-mobile .chat-input-icon-button.clickable-icon,
-.is-mobile .graph-controls .clickable-icon,
-.is-mobile .s2b-bottom-sheet .clickable-icon,
-.is-mobile .provider-icon-button.clickable-icon,
-.is-mobile .pcb-action-icon,
-.is-mobile .s2b-diff-nav-btn,
-.is-mobile .s2b-diff-toggle-btn {
-	min-width: 44px !important;
-	min-height: 44px !important;
-	padding: 10px !important;
-	box-sizing: border-box !important;
+body.is-mobile .footer-actions button,
+body.is-mobile .attach-context-button.clickable-icon,
+body.is-mobile .chat-input-container .chat-input-icon-button.clickable-icon,
+body.is-mobile .graph-controls .clickable-icon,
+body.is-mobile .s2b-bottom-sheet .clickable-icon,
+body.is-mobile .provider-icon-button.clickable-icon,
+body.is-mobile .pcb-action-icon,
+body.is-mobile .s2b-diff-nav-btn,
+body.is-mobile .s2b-diff-toggle-btn {
+	min-width: 44px;
+	min-height: 44px;
+	padding: 10px;
+	box-sizing: border-box;
 }
 
 /* The in-note bar's Accept/Reject are the same 2px-padded controls, but they
    may still carry a text label (the container query only drops it below 320px),
    so square 44px padding would balloon them. Raise the tappable height and let
    the inline padding stay proportional to the content. */
-.is-mobile .s2b-diff-accept-btn,
-.is-mobile .s2b-diff-reject-btn {
-	min-height: 44px !important;
-	padding-block: 10px !important;
-	padding-inline: 12px !important;
-	box-sizing: border-box !important;
+body.is-mobile .s2b-diff-accept-btn,
+body.is-mobile .s2b-diff-reject-btn {
+	min-height: 44px;
+	padding-block: 10px;
+	padding-inline: 12px;
+	box-sizing: border-box;
 }
 
 /* The attach and send buttons are deliberately `border-radius: 999px` on
@@ -1489,16 +1510,16 @@ button.s2b-pill--interactive.s2b-pill--active:hover {
    touch floor above, 999px makes them full circles, which felt too far from
    the input's own softer 22px corner. Squircle them down instead of going
    fully square, so they still read as buttons rather than tiles. */
-.is-mobile .attach-context-button.clickable-icon,
-.is-mobile .send-message-button {
-	border-radius: 20px !important;
+body.is-mobile .attach-context-button.clickable-icon,
+body.is-mobile .chat-input-container button.send-message-button {
+	border-radius: 20px;
 }
 
 /* The model/agent pills are text buttons rather than icon boxes — give them
    the vertical floor without forcing a square, so the label still sets width. */
-.is-mobile .model-select-btn.clickable-icon {
-	min-height: 44px !important;
-	padding-block: 8px !important;
+body.is-mobile .model-select-btn.clickable-icon {
+	min-height: 44px;
+	padding-block: 8px;
 }
 
 /* The message-nav cluster (jump/step through messages) stacks four 22px
@@ -1507,21 +1528,21 @@ button.s2b-pill--interactive.s2b-pill--active:hover {
    horizontal grab area but keep the rows at 36px — still a comfortable target
    in the dominant (vertical) axis of a stacked list. The code-copy button sits
    inside `<pre>` and gets the full square. */
-.is-mobile .message-nav button {
-	min-width: 44px !important;
-	min-height: 36px !important;
-	padding: 6px !important;
-	box-sizing: border-box !important;
+body.is-mobile .message-nav button {
+	min-width: 44px;
+	min-height: 36px;
+	padding: 6px;
+	box-sizing: border-box;
 }
 
 /* Code blocks render in chat messages AND in tool-call output
    (`.tool-output-content`), so key off `pre` rather than a single container. */
-.is-mobile .message-text pre .clickable-icon,
-.is-mobile .tool-output-content pre .clickable-icon {
-	min-width: 44px !important;
-	min-height: 44px !important;
-	padding: 10px !important;
-	box-sizing: border-box !important;
+body.is-mobile .message-text pre .clickable-icon,
+body.is-mobile .tool-output-content pre .clickable-icon {
+	min-width: 44px;
+	min-height: 44px;
+	padding: 10px;
+	box-sizing: border-box;
 }
 
 /* Chat markdown tables. `.message-text` is `!w-full !max-w-full`, so a table
@@ -1612,19 +1633,12 @@ button.s2b-pill--interactive.s2b-pill--active:hover {
 	flex: 1;
 	min-height: 0;
 }
-/* Phone sheet: push core's header/close buttons below the notch. Themes such as
-   Cupertino pin `top` with !important, so this must too. */
+/* Phone sheet: push core's header/close buttons below the notch. Core and
+   themes (Cupertino pins it with `!important`) position these from `top`, so
+   rather than fight that, shift the button by the inset on top of whatever
+   `top` they chose. */
 .modal .s2b-modal-sheet-header-button {
-	top: calc(var(--safe-area-inset-top, 0px) + var(--size-4-3)) !important;
-}
-
-/* Search modal input: neutralise theme padding so the inline chips sit flush.
-   Themes (Cupertino, Baseline) set these with !important, hence the override. */
-.s2b-search-modal .s2b-search-input {
-	padding-right: 0 !important;
-	padding-inline-end: 0 !important;
-	margin-left: 0 !important;
-	text-indent: 0 !important;
+	translate: 0 var(--safe-area-inset-top, 0px);
 }
 /* Search modal glow: the gradient overlay replaces the modal's own border. */
 /* SuggestModal's element carries `.prompt`, not `.modal`; naming it beats core's

--- a/src/styles.css
+++ b/src/styles.css
@@ -237,7 +237,11 @@ button.s2b-pill--interactive:hover {
    theme (Cupertino) pins with `!important`; `updateInlineInputSpacing` sets it
    inline at the same priority, so the `0` here is only the default-theme rest. */
 .prompt.s2b-search-modal .prompt-input-container input.s2b-inline-input {
-	flex: 1 1 0;
+	/* A real basis, not 0: the chips are one flex item now, so when they fill
+	   the row the input must wrap onto the next line with usable width rather
+	   than shrink to nothing beside them. 6em is the wrap threshold; it still
+	   grows to take whatever is left. */
+	flex: 1 1 6em;
 	min-width: 0;
 	width: auto;
 	align-self: center;


### PR DESCRIPTION
## Summary

Clears the plugin review's remaining CSS findings: **50 × `!important`**, **2 × `text-indent`**, **1 × `display: contents`**. `src/styles.css` now contains no `!important` at all (the word survives only in comments).

Every override is rewritten to win on specificity, which meant understanding what each one was actually fighting:

- **The re-parented search input.** Core's strongest rule for it is `.is-mobile .prompt-input[type=text]:not(:placeholder-shown)` (0,4,0); naming the modal, container and element (`.prompt.s2b-search-modal .prompt-input-container input.s2b-inline-input`, (0,4,1)) beats it. The only theme `!important` on this element (Cupertino's `padding-inline-start`) was already handled by the inline style `updateInlineInputSpacing` sets, so the CSS never needed to fight it. The `.s2b-search-input` twin rule from #465 duplicated this block on the same element and is removed along with its `addClass`. Neither core nor Baseline/Cupertino sets `text-indent`, so both resets go.
- **Mobile touch targets and touch reveals.** These needed `!important` only because *our own* component rules used it (send button, composer icon buttons, message-nav). The component rules now use `.chat-input-container button.send-message-button` / scoped-ancestor selectors and no `!important`; the global rules name `body.is-mobile` plus the same ancestors and win on specificity. The send button also had inline `width/height/background` from `sendButtonStyle` — inline styles were the true reason for `!important` there, and they were silently defeating the 2.75rem mobile size (measured 28 px before, 44 px after). Only the custom properties stay inline.
- **Phone-sheet header button.** Cupertino pins its `top` with `!important`; instead of out-shouting it, the button is shifted by the safe-area inset with `translate`, on top of whatever `top` core or the theme chose.
- **Chips wrapper** is a real flex box (same 4 px gap, wraps with the input) instead of `display: contents`.

### Verified live (slot vault)
- Default theme, desktop: input resets (padding 0, no border/radius/background, line-box height), chips flex + tint, clear button centred, glow border.
- Mobile emulation (`app.emulateMobile`): input pill stripped, CTA centred, send button 44 × 44 / radius 20, attach 44 × 44, model pill min-height 44.
- Cupertino, desktop: JS-set 36 px inset still wins; right padding 0; height collapses to the line box.
- Not verifiable here: `@media (hover: none)` reveals (emulation keeps a mouse) and the `is-phone`-only sheet header offset. Both are pure specificity/property changes; worth a glance on a phone.

## Test plan
- [x] `bun run check`, `format`, `lint`, `test` (1652), `bun run build`
- [x] Live checks above

_AI assistance: written with AI coding agents from the maintainer's brief; reviewed and tested by the maintainer._